### PR TITLE
feat: add v2 data sync to copy-pipeline-data

### DIFF
--- a/scripts/copy-pipeline-data.ts
+++ b/scripts/copy-pipeline-data.ts
@@ -8,7 +8,7 @@
  *   pipeline/workspace/_build/data-v2/ -> public/data-v2/ (v2)
  *
  * Each directory is cleaned before copying to ensure a fresh state.
- * Missing source directories are skipped with a warning (not an error),
+ * Missing source directories are skipped with a notice (not an error),
  * so partial pipeline runs are supported.
  *
  * Usage:
@@ -41,17 +41,20 @@ const TARGETS: SyncTarget[] = [
 ];
 
 function syncTarget(target: SyncTarget): boolean {
+  const relSrc = target.src.substring(PROJECT_ROOT.length + 1);
+  const relDest = target.dest.substring(PROJECT_ROOT.length + 1);
+
   if (!existsSync(target.src)) {
-    console.log(`  [${target.label}] Skipped: ${target.src} not found`);
+    console.log(`  [${target.label}] Skipped: ${relSrc} not found`);
     return false;
   }
 
-  console.log(`  [${target.label}] ${target.src}`);
-  console.log(`  [${target.label}] → ${target.dest}`);
+  console.log(`  [${target.label}] ${relSrc}`);
+  console.log(`  [${target.label}] → ${relDest}`);
 
   if (existsSync(target.dest)) {
     rmSync(target.dest, { recursive: true, force: true });
-    console.log(`  [${target.label}] Cleaned existing ${target.dest}`);
+    console.log(`  [${target.label}] Cleaned existing ${relDest}`);
   }
 
   cpSync(target.src, target.dest, { recursive: true });


### PR DESCRIPTION
## Summary

- `data:sync` に v2 データの sync を追加 (`_build/data-v2/` → `public/data-v2/`)
- v1/v2 を独立したディレクトリで管理し、移行時の競合を防止
- ソースディレクトリが存在しない場合は skip (部分実行対応)

## Test plan

- [x] `npm run data:sync` で v1/v2 両方 sync 確認
- [x] v2 ソースなしで v1 のみ sync (skip 表示) 確認
- [x] `npm run typecheck && npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)