### PR TITLE
feat(pipeline): add NEWER_AVAILABLE warning for unapplied resources

### DIFF
--- a/pipeline/src/lib/pipeline/__tests__/odpt-resource-warnings.test.ts
+++ b/pipeline/src/lib/pipeline/__tests__/odpt-resource-warnings.test.ts
@@ -207,7 +207,7 @@ describe('detectWarnings', () => {
 
   // --- NEWER_AVAILABLE ---
 
-  it('returns NEWER_AVAILABLE when remote has newer date than local', () => {
+  it('returns NEWER_AVAILABLE when remote has newer feed_start_date than local', () => {
     const resources = [
       makeRemote('20260301', true),
       makeRemote('20260401', false, '2026-09-28', '2026-04-01'),
@@ -258,6 +258,29 @@ describe('detectWarnings', () => {
     expect(newer).toBeDefined();
     expect(newer!.message).toContain('valid: 2026-04-01 - 2026-09-28');
     expect(newer!.message).not.toContain('date=');
+  });
+
+  it('NEWER_AVAILABLE compares by feed_start_date, not URL date param', () => {
+    // URL date= is older (20260201) but feed_start_date is newer (2026-04-01)
+    const resources = [
+      makeRemote('20260301', true),
+      makeRemote('20260201', false, '2026-09-28', '2026-04-01'),
+    ];
+    const meta = makeMeta('20260301');
+    const warnings = detectWarnings(resources, makeLocal(meta), null, now);
+    const newer = warnings.find((w) => w.type === 'NEWER_AVAILABLE');
+    // Should detect as newer based on feed_start_date, despite older URL date=
+    expect(newer).toBeDefined();
+  });
+
+  it('NEWER_AVAILABLE skips resources without feed_start_date', () => {
+    const resources = [
+      makeRemote('20260301', true),
+      { ...makeRemote('20260401', false), feed_start_date: null },
+    ];
+    const meta = makeMeta('20260301');
+    const warnings = detectWarnings(resources, makeLocal(meta), null, now);
+    expect(warnings.some((w) => w.type === 'NEWER_AVAILABLE')).toBe(false);
   });
 
   it('NEWER_AVAILABLE fires every time (not snapshot-dependent)', () => {

--- a/pipeline/src/lib/pipeline/odpt-resource-warnings.ts
+++ b/pipeline/src/lib/pipeline/odpt-resource-warnings.ts
@@ -196,14 +196,16 @@ export function detectWarnings(
     }
   }
 
-  // NEWER_AVAILABLE: remote resources newer than local that have not been applied.
+  // NEWER_AVAILABLE: remote resources with a later feed_start_date than local.
   // Unlike NEW_RESOURCE (snapshot-based, fires once), this fires every time
   // until the local data is updated, so unapplied resources stay visible.
-  if (meta) {
-    const localDate = extractDateParam(meta.url) ?? '';
+  const localFeedStart = localInRemote?.feed_start_date ?? meta.feedInfo?.startDate ?? null;
+  if (localFeedStart) {
     const newerResources = resources.filter((r) => {
-      const remoteDate = extractDateParam(r.url) ?? '';
-      return remoteDate > localDate;
+      if (!r.feed_start_date) {
+        return false;
+      }
+      return r.feed_start_date > localFeedStart;
     });
     if (newerResources.length > 0) {
       const details = newerResources


### PR DESCRIPTION
## Summary

リソースチェックで、ローカルより新しいリモートリソースが存在する場合に毎回 `NEWER_AVAILABLE` を表示する。

## Background

既存の `NEW_RESOURCE` は snapshot ベースで初回検知時のみ出力。一度 snapshot に記録されると次回以降は出ない。
`not-yet-active` のリソースはすぐ適用できないため、適用忘れが発生しやすかった。

## Changes

- `NEWER_AVAILABLE` warning type を追加 (`odpt-resource-warnings.ts`)
- ローカルの date パラメータより新しい date を持つリモートリソースを毎回検知
- snapshot に依存しないため、ローカルデータが更新されるまで常に表示される
- attention レベル (exit code 2, `RESULT:WARN`)
- テスト3件追加 (22 tests total)

## Verified

ローカル実行で kanto-bus に正しく表示されることを確認:

```
[RESULT:WARN] kanto-bus NEWER_AVAILABLE: 1 newer resource(s) available (local: date=20260301)
```

## Test plan

- [x] `npx vitest run pipeline/src/lib/pipeline/__tests__/odpt-resource-warnings.test.ts` (22 tests pass)
- [x] `npx tsx pipeline/scripts/pipeline/check-odpt-resources.ts` ローカル実行で NEWER_AVAILABLE 確認
- [x] format / lint / tsc pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)