### PR TITLE
fix(i18n): inject feed_lang base value into translation names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- i18n: GTFS base values (stop_name, trip_headsign 等) を `feed_lang` キーで translation names に注入し、`lang=ja` で英語 headsign が表示される問題を修正 (#107)。
+
+### Added
+
+- DEVELOPMENT.md: GTFS i18n 仕様 (`feed_lang` / `agency_lang` / `translations.txt`) のリファレンスセクションを追加。
+
 ## [2026.04.11]
 
 ### Added

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -340,6 +340,40 @@ Leaflet のデフォルトクリック挙動を複数箇所でオーバーライ
 - `stops.nearbyRadius`: `getStopsNearby` の検索半径 (メートル)
 - `routes.enabled`: 路線図の表示有無
 
+## GTFS i18n (多言語) の仕組み
+
+GTFS 仕様における言語関連フィールドの整理。
+
+### `feed_lang` (feed_info.txt, Required)
+
+> Default language used for the text in this dataset.
+
+- **データセット内の全テキストフィールド (stop_name, trip_headsign 等) のデフォルト言語を定義する**
+- `translations.txt` で他言語への翻訳を提供可能
+- `"mul"` (ISO 639-2): 多言語フィード。ベース値が複数言語で記述される (例: スイスの Geneve / Zurich)。各言語の翻訳は `translations.txt` で提供する前提
+
+### `agency_lang` (agency.txt, Optional)
+
+> Primary language used by this transit agency. Should be provided to help GTFS consumers choose capitalization rules and other language-specific settings for the dataset.
+
+- agency が主に使用する言語。**テキストフィールドの言語を定義するものではない**
+- 大文字化ルールなど表示設定のヒントとして利用
+- per-agency フィールド (同一フィード内で agency ごとに異なりうる)
+
+### `translations.txt` の `language` フィールド
+
+> If the language is the same as in `feed_info.feed_lang`, the original value of the field will be assumed to be the default value to use in languages without specific translations.
+
+- `feed_lang` と同じ言語の translation がある場合、**ベース値はその言語のデフォルト値として扱われる**
+- 明示的 translation (`translations.txt` のエントリ) がベース値より優先
+
+### このプロジェクトでの適用
+
+- ベース値の言語は `feed_lang` で決まる (`agency_lang` ではない)
+- Repository の `mergeSourcesV2` で、`feed_lang` キーをベース値から translation names に注入して正規化 (Issue #107)
+- `feed_lang = "mul"` の場合は注入しない (言語不定)
+- `feed_lang` が空の場合は `agency_lang` にフォールバック
+
 ## TransitRepository API 仕様
 
 全メソッドは `Result<T>` または `CollectionResult<T>` を返す。domain-level エラーは `{ success: false, error }` で表現し、呼び出し側がフォールバックを決定する。

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -350,7 +350,7 @@ GTFS 仕様における言語関連フィールドの整理。
 
 - **データセット内の全テキストフィールド (stop_name, trip_headsign 等) のデフォルト言語を定義する**
 - `translations.txt` で他言語への翻訳を提供可能
-- `"mul"` (ISO 639-2): 多言語フィード。ベース値が複数言語で記述される (例: スイスの Geneve / Zurich)。各言語の翻訳は `translations.txt` で提供する前提
+- "mul" (ISO 639-2): 多言語フィード。ベース値が複数言語で記述される (例: スイスの Genève / Zürich)。各言語の翻訳は translations.txt で提供する前提
 
 ### `agency_lang` (agency.txt, Optional)
 

--- a/src/domain/transit/i18n/__tests__/inject-origin-lang.test.ts
+++ b/src/domain/transit/i18n/__tests__/inject-origin-lang.test.ts
@@ -50,19 +50,19 @@ describe('injectOriginLang', () => {
   });
 
   describe('skips injection for undefined/empty/mul', () => {
-    it('skips when agencyLang is undefined', () => {
+    it('skips when originLang is undefined', () => {
       const names = { en: 'eng' };
       const result = injectOriginLang(names, 'base', undefined);
       expect(result).toBe(names);
     });
 
-    it('skips when agencyLang is empty string', () => {
+    it('skips when originLang is empty string', () => {
       const names = { en: 'eng' };
       const result = injectOriginLang(names, 'base', '');
       expect(result).toBe(names);
     });
 
-    it('skips when agencyLang is "mul" (multilingual)', () => {
+    it('skips when originLang is "mul" (multilingual)', () => {
       // GTFS "mul" means base values are in mixed languages;
       // translations.txt is expected to provide explicit entries.
       const names = { de: 'Genf', it: 'Ginevra' };
@@ -70,13 +70,13 @@ describe('injectOriginLang', () => {
       expect(result).toBe(names);
     });
 
-    it('skips when agencyLang is "MUL" (case-insensitive)', () => {
+    it('skips when originLang is "MUL" (case-insensitive)', () => {
       const names = { de: 'Genf' };
       const result = injectOriginLang(names, 'Genève', 'MUL');
       expect(result).toBe(names);
     });
 
-    it('skips when agencyLang is "Mul" (mixed case)', () => {
+    it('skips when originLang is "Mul" (mixed case)', () => {
       const names = { de: 'Genf' };
       const result = injectOriginLang(names, 'Genève', 'Mul');
       expect(result).toBe(names);
@@ -84,13 +84,13 @@ describe('injectOriginLang', () => {
   });
 
   describe('case-insensitive key matching', () => {
-    it('does not inject when names has uppercase variant of agencyLang', () => {
+    it('does not inject when names has uppercase variant of originLang', () => {
       const names = { JA: 'explicit-JA', en: 'eng' };
       const result = injectOriginLang(names, 'base', 'ja');
       expect(result).toBe(names);
     });
 
-    it('does not inject when agencyLang is uppercase and names has lowercase key', () => {
+    it('does not inject when originLang is uppercase and names has lowercase key', () => {
       const names = { ja: 'explicit-ja', en: 'eng' };
       const result = injectOriginLang(names, 'base', 'JA');
       expect(result).toBe(names);

--- a/src/domain/transit/i18n/__tests__/inject-origin-lang.test.ts
+++ b/src/domain/transit/i18n/__tests__/inject-origin-lang.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for inject-origin-lang.ts.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { injectOriginLang } from '../inject-origin-lang';
+
+describe('injectOriginLang', () => {
+  describe('injects base value when agency_lang key is missing', () => {
+    it('injects when names has no matching key', () => {
+      const result = injectOriginLang({ en: 'AEON ST' }, 'イオンST', 'ja');
+      expect(result).toEqual({ ja: 'イオンST', en: 'AEON ST' });
+    });
+
+    it('injects for non-Japanese agency_lang', () => {
+      const result = injectOriginLang({ ja: '東京駅' }, 'Tokyo Sta.', 'en');
+      expect(result).toEqual({ en: 'Tokyo Sta.', ja: '東京駅' });
+    });
+
+    it('injects even when baseValue is empty', () => {
+      // Empty base values are valid in GTFS
+      const result = injectOriginLang({ en: 'eng' }, '', 'ja');
+      expect(result).toEqual({ ja: '', en: 'eng' });
+    });
+
+    it('injects when names is empty', () => {
+      const result = injectOriginLang({}, '曙橋', 'ja');
+      expect(result).toEqual({ ja: '曙橋' });
+    });
+  });
+
+  describe('preserves explicit translations', () => {
+    it('does not overwrite when names already has the key', () => {
+      const result = injectOriginLang(
+        { ja: '池袋サンシャインシティ', en: 'Ikebukuro Sunshine City' },
+        '池袋SC',
+        'ja',
+      );
+      expect(result).toEqual({ ja: '池袋サンシャインシティ', en: 'Ikebukuro Sunshine City' });
+    });
+
+    it('returns the original object reference when no injection needed', () => {
+      const names = { ja: 'explicit-ja', en: 'eng' };
+      const result = injectOriginLang(names, 'base', 'ja');
+      expect(result).toBe(names);
+    });
+  });
+
+  describe('skips injection for undefined/empty/mul', () => {
+    it('skips when agencyLang is undefined', () => {
+      const names = { en: 'eng' };
+      const result = injectOriginLang(names, 'base', undefined);
+      expect(result).toBe(names);
+    });
+
+    it('skips when agencyLang is empty string', () => {
+      const names = { en: 'eng' };
+      const result = injectOriginLang(names, 'base', '');
+      expect(result).toBe(names);
+    });
+
+    it('skips when agencyLang is "mul" (multilingual)', () => {
+      // GTFS "mul" means base values are in mixed languages;
+      // translations.txt is expected to provide explicit entries.
+      const names = { de: 'Genf', it: 'Ginevra' };
+      const result = injectOriginLang(names, 'Genève', 'mul');
+      expect(result).toBe(names);
+    });
+
+    it('skips when agencyLang is "MUL" (case-insensitive)', () => {
+      const names = { de: 'Genf' };
+      const result = injectOriginLang(names, 'Genève', 'MUL');
+      expect(result).toBe(names);
+    });
+
+    it('skips when agencyLang is "Mul" (mixed case)', () => {
+      const names = { de: 'Genf' };
+      const result = injectOriginLang(names, 'Genève', 'Mul');
+      expect(result).toBe(names);
+    });
+  });
+
+  describe('case-insensitive key matching', () => {
+    it('does not inject when names has uppercase variant of agencyLang', () => {
+      const names = { JA: 'explicit-JA', en: 'eng' };
+      const result = injectOriginLang(names, 'base', 'ja');
+      expect(result).toBe(names);
+    });
+
+    it('does not inject when agencyLang is uppercase and names has lowercase key', () => {
+      const names = { ja: 'explicit-ja', en: 'eng' };
+      const result = injectOriginLang(names, 'base', 'JA');
+      expect(result).toBe(names);
+    });
+
+    it('does not inject when names has mixed-case subtag variant', () => {
+      const names = { 'ja-Hrkt': 'ひらがな', en: 'eng' };
+      const result = injectOriginLang(names, 'base', 'ja-hrkt');
+      expect(result).toBe(names);
+    });
+  });
+
+  describe('real-world scenarios', () => {
+    it('Seibu Bus: Japanese base with English-only translation', () => {
+      // agency_lang="ja", base is Japanese, translations.txt has only en
+      const result = injectOriginLang(
+        { en: 'AEON ST (Higashi-Kurume circular bus)' },
+        'イオンＳＴ（東久留米循環線）',
+        'ja',
+      );
+      expect(result).toEqual({
+        ja: 'イオンＳＴ（東久留米循環線）',
+        en: 'AEON ST (Higashi-Kurume circular bus)',
+      });
+    });
+
+    it('Toei Bus: Japanese base with explicit ja + en translations', () => {
+      // agency_lang="ja", translations.txt has both ja and en — no injection
+      const names = {
+        ja: '池袋サンシャインシティ',
+        'ja-Hrkt': 'いけぶくろさんしゃいんしてぃ',
+        en: 'Ikebukuro Sunshine City',
+      };
+      const result = injectOriginLang(names, '池袋サンシャインシティ', 'ja');
+      expect(result).toBe(names);
+    });
+
+    it('multilingual feed: base in mixed language, no injection', () => {
+      // agency_lang="mul", translations.txt expected to provide all languages
+      const names = { de: 'Genf', it: 'Ginevra', fr: 'Genève' };
+      const result = injectOriginLang(names, 'Genève', 'mul');
+      expect(result).toBe(names);
+    });
+
+    it('Italian operator: Italian base with no Italian translation key', () => {
+      // agency_lang="IT" (ACTV Venice), base is Italian
+      const result = injectOriginLang({ en: 'Venice' }, 'Venezia', 'IT');
+      expect(result).toEqual({ IT: 'Venezia', en: 'Venice' });
+    });
+
+    it('German operator: German base with no German translation key', () => {
+      // agency_lang="DE" (VAG Freiburg), base is German
+      const result = injectOriginLang({}, 'Bertoldsbrunnen', 'DE');
+      expect(result).toEqual({ DE: 'Bertoldsbrunnen' });
+    });
+  });
+});

--- a/src/domain/transit/i18n/__tests__/inject-origin-lang.test.ts
+++ b/src/domain/transit/i18n/__tests__/inject-origin-lang.test.ts
@@ -9,13 +9,13 @@ import { describe, expect, it } from 'vitest';
 import { injectOriginLang } from '../inject-origin-lang';
 
 describe('injectOriginLang', () => {
-  describe('injects base value when agency_lang key is missing', () => {
+  describe('injects base value when originLang key is missing', () => {
     it('injects when names has no matching key', () => {
       const result = injectOriginLang({ en: 'AEON ST' }, 'イオンST', 'ja');
       expect(result).toEqual({ ja: 'イオンST', en: 'AEON ST' });
     });
 
-    it('injects for non-Japanese agency_lang', () => {
+    it('injects for non-Japanese originLang', () => {
       const result = injectOriginLang({ ja: '東京駅' }, 'Tokyo Sta.', 'en');
       expect(result).toEqual({ en: 'Tokyo Sta.', ja: '東京駅' });
     });
@@ -105,7 +105,7 @@ describe('injectOriginLang', () => {
 
   describe('real-world scenarios', () => {
     it('Seibu Bus: Japanese base with English-only translation', () => {
-      // agency_lang="ja", base is Japanese, translations.txt has only en
+      // feed_lang="ja", base is Japanese, translations.txt has only en
       const result = injectOriginLang(
         { en: 'AEON ST (Higashi-Kurume circular bus)' },
         'イオンＳＴ（東久留米循環線）',
@@ -118,7 +118,7 @@ describe('injectOriginLang', () => {
     });
 
     it('Toei Bus: Japanese base with explicit ja + en translations', () => {
-      // agency_lang="ja", translations.txt has both ja and en — no injection
+      // feed_lang="ja", translations.txt has both ja and en — no injection
       const names = {
         ja: '池袋サンシャインシティ',
         'ja-Hrkt': 'いけぶくろさんしゃいんしてぃ',
@@ -129,20 +129,20 @@ describe('injectOriginLang', () => {
     });
 
     it('multilingual feed: base in mixed language, no injection', () => {
-      // agency_lang="mul", translations.txt expected to provide all languages
+      // feed_lang="mul", translations.txt expected to provide all languages
       const names = { de: 'Genf', it: 'Ginevra', fr: 'Genève' };
       const result = injectOriginLang(names, 'Genève', 'mul');
       expect(result).toBe(names);
     });
 
     it('Italian operator: Italian base with no Italian translation key', () => {
-      // agency_lang="IT" (ACTV Venice), base is Italian
+      // feed_lang="IT" (ACTV Venice), base is Italian
       const result = injectOriginLang({ en: 'Venice' }, 'Venezia', 'IT');
       expect(result).toEqual({ IT: 'Venezia', en: 'Venice' });
     });
 
     it('German operator: German base with no German translation key', () => {
-      // agency_lang="DE" (VAG Freiburg), base is German
+      // feed_lang="DE" (VAG Freiburg), base is German
       const result = injectOriginLang({}, 'Bertoldsbrunnen', 'DE');
       expect(result).toEqual({ DE: 'Bertoldsbrunnen' });
     });

--- a/src/domain/transit/i18n/inject-origin-lang.ts
+++ b/src/domain/transit/i18n/inject-origin-lang.ts
@@ -1,0 +1,72 @@
+/**
+ * Inject the base value into a translation names record under its
+ * feed language key.
+ *
+ * GTFS base values (e.g. `trip_headsign`, `stop_name`) are in the
+ * language declared by `feed_lang` (feed_info.txt). When
+ * `translations.txt` does not provide an explicit entry for that
+ * language, the resolver cannot find the base value as a language
+ * candidate — causing incorrect fallback to other languages
+ * (e.g. English shown when Japanese is expected).
+ *
+ * This function bridges the gap: if `originLang` is a concrete
+ * language code and `names` does not already contain that key, the
+ * base value is injected so the resolver treats it as a candidate
+ * for that language.
+ *
+ * Explicit translations (from `translations.txt`) always take
+ * priority — if `names` already has a matching key, the record is
+ * returned unchanged.
+ *
+ * ### `"mul"` (multilingual) handling
+ *
+ * GTFS allows `feed_lang = "mul"` (ISO 639-2) for datasets where
+ * original text is in multiple languages (e.g. Switzerland:
+ * `Genève`, `Zürich`, `Biel/Bienne` coexist in one feed). In such
+ * feeds, base values have no single definable language, and
+ * `translations.txt` is expected to supply translations for each
+ * language. When `originLang` is `"mul"`, no injection occurs — the
+ * base value remains language-unknown and the resolver falls back
+ * through the normal priority chain.
+ *
+ * ### GTFS spec reference
+ *
+ * - `feed_lang` (feed_info.txt, Required): "Default language used
+ *   for the text in this dataset."
+ * - `agency_lang` (agency.txt, Optional): "Primary language used by
+ *   this transit agency." — a display-settings hint, NOT the
+ *   language of text fields.
+ * - `translations.txt` `language` field: "If the language is the
+ *   same as in `feed_info.feed_lang`, the original value of the
+ *   field will be assumed to be the default value to use in
+ *   languages without specific translations."
+ *
+ * @param names - Existing translation entries keyed by language.
+ * @param baseValue - The raw GTFS field value (e.g. trip_headsign, stop_name).
+ * @param originLang - The language of the base value. Typically
+ *   `feed_lang` for most GTFS text fields, or `agency_lang` for
+ *   agency-specific fields. When `undefined`, empty, or `"mul"`
+ *   (multilingual), no injection occurs.
+ * @returns The original `names` if no injection is needed, or a new
+ *   record with the base value added under the `originLang` key.
+ */
+export function injectOriginLang(
+  names: Readonly<Record<string, string>>,
+  baseValue: string,
+  originLang: string | undefined,
+): Record<string, string> {
+  if (!originLang || originLang.toLowerCase() === 'mul') {
+    return names as Record<string, string>;
+  }
+
+  // Case-insensitive check: do not overwrite an explicit translation.
+  // BCP 47 language tags are case-insensitive (RFC 5646 §2.1.1).
+  const originLangLower = originLang.toLowerCase();
+  for (const key of Object.keys(names)) {
+    if (key.toLowerCase() === originLangLower) {
+      return names as Record<string, string>;
+    }
+  }
+
+  return { ...names, [originLang]: baseValue };
+}

--- a/src/domain/transit/i18n/inject-origin-lang.ts
+++ b/src/domain/transit/i18n/inject-origin-lang.ts
@@ -43,10 +43,11 @@
  *
  * @param names - Existing translation entries keyed by language.
  * @param baseValue - The raw GTFS field value (e.g. trip_headsign, stop_name).
- * @param originLang - The language of the base value. Typically
- *   `feed_lang` for most GTFS text fields, or `agency_lang` for
- *   agency-specific fields. When `undefined`, empty, or `"mul"`
- *   (multilingual), no injection occurs.
+ * @param originLang - The language of the base value. Use `feed_lang`
+ *   for GTFS text fields — do not use `agency_lang`, which is a
+ *   display-settings hint per GTFS spec, not the language of text
+ *   fields. When `undefined`, empty, or `"mul"` (multilingual),
+ *   no injection occurs.
  * @returns The original `names` if no injection is needed, or a new
  *   record with the base value added under the `originLang` key.
  */

--- a/src/domain/transit/i18n/inject-origin-lang.ts
+++ b/src/domain/transit/i18n/inject-origin-lang.ts
@@ -51,12 +51,12 @@
  *   record with the base value added under the `originLang` key.
  */
 export function injectOriginLang(
-  names: Readonly<Record<string, string>>,
+  names: Record<string, string>,
   baseValue: string,
   originLang: string | undefined,
 ): Record<string, string> {
   if (!originLang || originLang.toLowerCase() === 'mul') {
-    return names as Record<string, string>;
+    return names;
   }
 
   // Case-insensitive check: do not overwrite an explicit translation.
@@ -64,7 +64,7 @@ export function injectOriginLang(
   const originLangLower = originLang.toLowerCase();
   for (const key of Object.keys(names)) {
     if (key.toLowerCase() === originLangLower) {
-      return names as Record<string, string>;
+      return names;
     }
   }
 

--- a/src/repositories/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/__tests__/athenai-repository-v2.test.ts
@@ -222,8 +222,8 @@ describe('mergeSourcesV2', () => {
             data: [
               {
                 i: 'itfeed:ag1',
-                n: 'English Transit Co.',
-                sn: 'ETC',
+                n: 'Compagnia Trasporti',
+                sn: 'CT',
                 u: 'https://example.com',
                 l: 'en',
                 tz: 'Europe/Rome',
@@ -258,10 +258,10 @@ describe('mergeSourcesV2', () => {
                 'itfeed:r1': { en: 'Line 1' },
               },
               agency_names: {
-                'itfeed:ag1': { it: 'Compagnia Trasporti', en: 'English Transit Co.' },
+                'itfeed:ag1': { en: 'English Transit Co.' },
               },
               agency_short_names: {
-                'itfeed:ag1': { it: 'CT', en: 'ETC' },
+                'itfeed:ag1': { en: 'ETC' },
               },
             },
           },
@@ -308,12 +308,19 @@ describe('mergeSourcesV2', () => {
     it('injects agency_names base value under feed_lang, not agency_lang', () => {
       const merged = mergeSourcesV2([createFeedLangFixture()]);
       const agency = merged.agencyMap.get('itfeed:ag1');
-      // agency_name="English Transit Co." is the GTFS base value.
-      // feed_lang="it", but agency_names already has "it" from translations.txt,
-      // so no injection occurs. The existing explicit values are preserved.
+      // agency_name base value should be injected under feed_lang="it".
       expect(agency!.agency_names).toEqual({
-        it: 'Compagnia Trasporti',
         en: 'English Transit Co.',
+        it: 'Compagnia Trasporti',
+      });
+    });
+
+    it('injects agency_short_names base value under feed_lang, not agency_lang', () => {
+      const merged = mergeSourcesV2([createFeedLangFixture()]);
+      const agency = merged.agencyMap.get('itfeed:ag1');
+      expect(agency!.agency_short_names).toEqual({
+        en: 'ETC',
+        it: 'CT',
       });
     });
   });

--- a/src/repositories/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/__tests__/athenai-repository-v2.test.ts
@@ -610,7 +610,11 @@ describe('getUpcomingTimetableEntries', () => {
     expect(entry.routeDirection.stopHeadsign).toBeDefined();
     expect(entry.routeDirection.stopHeadsign!.name).toBe('Oji-eki via Park');
     // stop_headsigns translation should be resolved
-    expect(entry.routeDirection.stopHeadsign!.names).toEqual({ en: 'Oji Station via Park' });
+    // agency_lang="ja" → base value "Oji-eki via Park" is injected as ja candidate
+    expect(entry.routeDirection.stopHeadsign!.names).toEqual({
+      ja: 'Oji-eki via Park',
+      en: 'Oji Station via Park',
+    });
   });
 
   it('resolves mid-trip stop_headsign change (kyoto-city-bus pattern)', async () => {

--- a/src/repositories/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/__tests__/athenai-repository-v2.test.ts
@@ -209,12 +209,21 @@ describe('mergeSourcesV2', () => {
           kind: 'data',
           stops: {
             v: 2,
-            data: [{ i: 'itfeed:s1', n: 'Stazione Centrale', a: 45.0, o: 9.0, l: 0 }],
+            data: [{ v: 2, i: 'itfeed:s1', n: 'Stazione Centrale', a: 45.0, o: 9.0, l: 0 }],
           },
           routes: {
             v: 2,
             data: [
-              { i: 'itfeed:r1', s: 'L1', l: 'Linea 1', t: 3, c: '', tc: '', ai: 'itfeed:ag1' },
+              {
+                v: 2,
+                i: 'itfeed:r1',
+                s: 'L1',
+                l: 'Linea 1',
+                t: 3,
+                c: '',
+                tc: '',
+                ai: 'itfeed:ag1',
+              },
             ],
           },
           agency: {
@@ -241,7 +250,12 @@ describe('mergeSourcesV2', () => {
           tripPatterns: {
             v: 2,
             data: {
-              tp1: { r: 'itfeed:r1', h: 'Stazione Centrale', stops: [{ id: 'itfeed:s1' }] },
+              tp1: {
+                v: 2,
+                r: 'itfeed:r1',
+                h: 'Stazione Centrale',
+                stops: [{ id: 'itfeed:s1' }],
+              },
             },
           },
           translations: {
@@ -265,7 +279,7 @@ describe('mergeSourcesV2', () => {
               },
             },
           },
-          lookup: { v: 2, data: { stopPatterns: {} } },
+          lookup: { v: 2, data: {} },
         },
       };
     }

--- a/src/repositories/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/__tests__/athenai-repository-v2.test.ts
@@ -14,6 +14,7 @@ import {
   EXCEPTION_HOLIDAY,
 } from './fixtures/test-data-source-v2';
 import { minutesToDate } from '../../domain/transit/calendar-utils';
+import type { SourceDataV2 } from '../../datasources/transit-data-source-v2';
 
 /** Assert result is successful and return narrowed type for safe data access. */
 function assertSuccess<T>(result: {
@@ -193,6 +194,128 @@ describe('mergeSourcesV2', () => {
     expect(pattern!.stops[1]).toEqual({ id: 'bus_02', headsign: 'Oji-eki' });
     // bus_03 has no stop_headsign
     expect(pattern!.stops[2]).toEqual({ id: 'bus_03' });
+  });
+
+  describe('i18n pre-compilation uses feed_lang (not agency_lang)', () => {
+    /**
+     * Minimal fixture where feed_lang="it" but agency_lang="en".
+     * Verifies that base values are injected under feed_lang, not agency_lang.
+     */
+    function createFeedLangFixture(): SourceDataV2 {
+      return {
+        prefix: 'itfeed',
+        data: {
+          bundle_version: 2,
+          kind: 'data',
+          stops: {
+            v: 2,
+            data: [{ i: 'itfeed:s1', n: 'Stazione Centrale', a: 45.0, o: 9.0, l: 0 }],
+          },
+          routes: {
+            v: 2,
+            data: [
+              { i: 'itfeed:r1', s: 'L1', l: 'Linea 1', t: 3, c: '', tc: '', ai: 'itfeed:ag1' },
+            ],
+          },
+          agency: {
+            v: 1,
+            data: [
+              {
+                i: 'itfeed:ag1',
+                n: 'English Transit Co.',
+                sn: 'ETC',
+                u: 'https://example.com',
+                l: 'en',
+                tz: 'Europe/Rome',
+                fu: '',
+                cs: [],
+              },
+            ],
+          },
+          calendar: { v: 1, data: { services: [], exceptions: [] } },
+          feedInfo: {
+            v: 1,
+            data: { pn: 'Test', pu: 'https://example.com', l: 'it', s: '', e: '', v: '' },
+          },
+          timetable: { v: 2, data: {} },
+          tripPatterns: {
+            v: 2,
+            data: {
+              tp1: { r: 'itfeed:r1', h: 'Stazione Centrale', stops: [{ id: 'itfeed:s1' }] },
+            },
+          },
+          translations: {
+            v: 1,
+            data: {
+              headsigns: {
+                'Stazione Centrale': { en: 'Central Station' },
+              },
+              stop_headsigns: {},
+              stop_names: {
+                'itfeed:s1': { en: 'Central Station' },
+              },
+              route_names: {
+                'itfeed:r1': { en: 'Line 1' },
+              },
+              agency_names: {
+                'itfeed:ag1': { it: 'Compagnia Trasporti', en: 'English Transit Co.' },
+              },
+              agency_short_names: {
+                'itfeed:ag1': { it: 'CT', en: 'ETC' },
+              },
+            },
+          },
+          lookup: { v: 2, data: { stopPatterns: {} } },
+        },
+      };
+    }
+
+    it('injects headsign base value under feed_lang, not agency_lang', () => {
+      const merged = mergeSourcesV2([createFeedLangFixture()]);
+      const translations = merged.headsignTranslations.get('itfeed');
+      // feed_lang="it", so "Stazione Centrale" should be injected as "it" candidate
+      expect(translations!.headsigns['Stazione Centrale']).toEqual({
+        it: 'Stazione Centrale',
+        en: 'Central Station',
+      });
+      // NOT agency_lang="en" — en already exists from translations.txt
+    });
+
+    it('injects stop_names base value under feed_lang', () => {
+      const merged = mergeSourcesV2([createFeedLangFixture()]);
+      const stop = merged.stops.find((s) => s.stop_id === 'itfeed:s1');
+      expect(stop!.stop_names).toEqual({
+        it: 'Stazione Centrale',
+        en: 'Central Station',
+      });
+    });
+
+    it('injects route_long_names base value under feed_lang', () => {
+      const merged = mergeSourcesV2([createFeedLangFixture()]);
+      const route = merged.routeMap.get('itfeed:r1');
+      expect(route!.route_long_names).toEqual({
+        it: 'Linea 1',
+        en: 'Line 1',
+      });
+    });
+
+    it('injects route_short_names base value under feed_lang', () => {
+      const merged = mergeSourcesV2([createFeedLangFixture()]);
+      const route = merged.routeMap.get('itfeed:r1');
+      expect(route!.route_short_names).toEqual({ it: 'L1' });
+    });
+
+    it('injects agency_names base value under feed_lang, not agency_lang', () => {
+      const merged = mergeSourcesV2([createFeedLangFixture()]);
+      const agency = merged.agencyMap.get('itfeed:ag1');
+      // agency_name="English Transit Co." is the GTFS base value.
+      // feed_lang="it", but agency_names already has "it" from translations.txt,
+      // so no injection occurs. The existing explicit values are preserved.
+      expect(agency!.agency_names).toEqual({
+        it: 'Compagnia Trasporti',
+        en: 'English Transit Co.',
+      });
+    });
   });
 });
 

--- a/src/repositories/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/__tests__/athenai-repository-v2.test.ts
@@ -610,7 +610,7 @@ describe('getUpcomingTimetableEntries', () => {
     expect(entry.routeDirection.stopHeadsign).toBeDefined();
     expect(entry.routeDirection.stopHeadsign!.name).toBe('Oji-eki via Park');
     // stop_headsigns translation should be resolved
-    // agency_lang="ja" → base value "Oji-eki via Park" is injected as ja candidate
+    // feed_lang="ja" → base value "Oji-eki via Park" is injected as ja candidate
     expect(entry.routeDirection.stopHeadsign!.names).toEqual({
       ja: 'Oji-eki via Park',
       en: 'Oji Station via Park',

--- a/src/repositories/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository-v2.ts
@@ -61,6 +61,7 @@ import {
   formatDateKey,
   minutesToDate,
 } from '../domain/transit/calendar-utils';
+import { injectOriginLang } from '../domain/transit/i18n/inject-origin-lang';
 
 /** Set of valid AppRouteTypeValue integers. Values outside this set are normalized to -1. */
 const VALID_ROUTE_TYPE_VALUES = new Set<number>(APP_ROUTE_TYPES.map((rt) => rt.value));
@@ -173,6 +174,35 @@ async function fetchSourcesV2(
 
 /** Merge multiple v2 SourceDataV2 into a single unified dataset. */
 export function mergeSourcesV2(sources: SourceDataV2[]): MergedDataV2 {
+  // --- Feed language map ---
+  // Build prefix → feed_lang for normalizing translatable data below.
+  // GTFS base values (stop_name, trip_headsign, etc.) are in the language
+  // declared by feed_lang (feed_info.txt). We inject the base value under
+  // that language key into translation records so the resolver can find it
+  // as a language candidate. See Issue #107.
+  //
+  // feed_lang is per-feed (per-source), so a single value per prefix is
+  // correct — unlike agency_lang which is per-agency and could differ
+  // within a multi-agency feed.
+  //
+  // Fallback: when feed_lang is empty (e.g. VAG Freiburg), use the first
+  // non-empty agency_lang from the source as a best-effort approximation.
+  const feedLangByPrefix = new Map<string, string>();
+  for (const source of sources) {
+    const feedLang = source.data.feedInfo.data.l;
+    if (feedLang) {
+      feedLangByPrefix.set(source.prefix, feedLang);
+    } else {
+      // Fallback to first non-empty agency_lang
+      for (const a of source.data.agency.data) {
+        if (a.l) {
+          feedLangByPrefix.set(source.prefix, a.l);
+          break;
+        }
+      }
+    }
+  }
+
   // --- Translations ---
   // headsigns/stop_headsigns are kept per-source to preserve agency-specific
   // translations. Other maps use prefixed IDs and don't collide.
@@ -187,10 +217,23 @@ export function mergeSourcesV2(sources: SourceDataV2[]): MergedDataV2 {
   const headsignTranslations: HeadsignTranslationsByPrefix = new Map();
   for (const source of sources) {
     const t = source.data.translations.data;
+    const feedLang = feedLangByPrefix.get(source.prefix);
+
+    // Normalize headsign/stop_headsign translations: inject base value
+    // (the headsign text itself) under feed_lang when not already present.
+    const headsigns: Record<string, Record<string, string>> = {};
+    for (const [text, langMap] of Object.entries(t.headsigns)) {
+      headsigns[text] = injectOriginLang(langMap, text, feedLang);
+    }
+    const stopHeadsigns: Record<string, Record<string, string>> = {};
+    for (const [text, langMap] of Object.entries(t.stop_headsigns)) {
+      stopHeadsigns[text] = injectOriginLang(langMap, text, feedLang);
+    }
     headsignTranslations.set(source.prefix, {
-      headsigns: t.headsigns,
-      stop_headsigns: t.stop_headsigns,
+      headsigns,
+      stop_headsigns: stopHeadsigns,
     });
+
     if (t.stop_names) {
       Object.assign(translationsMap.stop_names, t.stop_names);
     }
@@ -206,6 +249,9 @@ export function mergeSourcesV2(sources: SourceDataV2[]): MergedDataV2 {
   }
 
   // --- Agencies (v1 same type) ---
+  // Each agency has its own agency_lang (a.l), so use it directly
+  // instead of the prefix-level lang. This correctly handles
+  // multi-agency GTFS feeds where agencies may have different languages.
   const agencyMap = new Map<string, Agency>();
   for (const source of sources) {
     for (const a of source.data.agency.data) {
@@ -213,8 +259,16 @@ export function mergeSourcesV2(sources: SourceDataV2[]): MergedDataV2 {
         agency_id: a.i,
         agency_name: a.n,
         agency_short_name: a.sn ?? '',
-        agency_names: translationsMap.agency_names[a.i] ?? {},
-        agency_short_names: translationsMap.agency_short_names[a.i] ?? {},
+        agency_names: injectOriginLang(
+          translationsMap.agency_names[a.i] ?? {},
+          a.n,
+          a.l || undefined,
+        ),
+        agency_short_names: injectOriginLang(
+          translationsMap.agency_short_names[a.i] ?? {},
+          a.sn ?? '',
+          a.l || undefined,
+        ),
         agency_url: a.u,
         agency_lang: a.l,
         agency_timezone: a.tz ?? '',
@@ -238,7 +292,11 @@ export function mergeSourcesV2(sources: SourceDataV2[]): MergedDataV2 {
     .map((s) => ({
       stop_id: s.i,
       stop_name: s.n,
-      stop_names: translationsMap.stop_names[s.i] ?? {},
+      stop_names: injectOriginLang(
+        translationsMap.stop_names[s.i] ?? {},
+        s.n,
+        feedLangByPrefix.get(extractPrefix(s.i)),
+      ),
       stop_lat: s.a,
       stop_lon: s.o,
       location_type: s.l,
@@ -254,13 +312,14 @@ export function mergeSourcesV2(sources: SourceDataV2[]): MergedDataV2 {
   // --- Routes ---
   const routeMap = new Map<string, Route>();
   for (const source of sources) {
+    const feedLang = feedLangByPrefix.get(source.prefix);
     for (const r of source.data.routes.data) {
       routeMap.set(r.i, {
         route_id: r.i,
         route_short_name: r.s,
-        route_short_names: {},
+        route_short_names: injectOriginLang({}, r.s, feedLang),
         route_long_name: r.l,
-        route_long_names: translationsMap.route_names[r.i] ?? {},
+        route_long_names: injectOriginLang(translationsMap.route_names[r.i] ?? {}, r.l, feedLang),
         route_type: (VALID_ROUTE_TYPE_VALUES.has(r.t) ? r.t : -1) as AppRouteTypeValue,
         route_color: r.c,
         route_text_color: r.tc,

--- a/src/repositories/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository-v2.ts
@@ -249,11 +249,11 @@ export function mergeSourcesV2(sources: SourceDataV2[]): MergedDataV2 {
   }
 
   // --- Agencies (v1 same type) ---
-  // Each agency has its own agency_lang (a.l), so use it directly
-  // instead of the prefix-level lang. This correctly handles
-  // multi-agency GTFS feeds where agencies may have different languages.
+  // agency_name is a GTFS text field, so its language is feed_lang
+  // (not agency_lang, which is a display-settings hint per GTFS spec).
   const agencyMap = new Map<string, Agency>();
   for (const source of sources) {
+    const feedLang = feedLangByPrefix.get(source.prefix);
     for (const a of source.data.agency.data) {
       agencyMap.set(a.i, {
         agency_id: a.i,
@@ -262,12 +262,12 @@ export function mergeSourcesV2(sources: SourceDataV2[]): MergedDataV2 {
         agency_names: injectOriginLang(
           translationsMap.agency_names[a.i] ?? {},
           a.n,
-          a.l || undefined,
+          feedLang,
         ),
         agency_short_names: injectOriginLang(
           translationsMap.agency_short_names[a.i] ?? {},
           a.sn ?? '',
-          a.l || undefined,
+          feedLang,
         ),
         agency_url: a.u,
         agency_lang: a.l,

--- a/src/repositories/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository-v2.ts
@@ -259,11 +259,7 @@ export function mergeSourcesV2(sources: SourceDataV2[]): MergedDataV2 {
         agency_id: a.i,
         agency_name: a.n,
         agency_short_name: a.sn ?? '',
-        agency_names: injectOriginLang(
-          translationsMap.agency_names[a.i] ?? {},
-          a.n,
-          feedLang,
-        ),
+        agency_names: injectOriginLang(translationsMap.agency_names[a.i] ?? {}, a.n, feedLang),
         agency_short_names: injectOriginLang(
           translationsMap.agency_short_names[a.i] ?? {},
           a.sn ?? '',


### PR DESCRIPTION
## Summary

- GTFS base values (stop_name, trip_headsign, etc.) are in `feed_lang` but `translations.txt` often only provides `en` entries — causing English to appear in the Japanese UI
- Normalize all translatable data in `mergeSourcesV2` by injecting the base value under its `feed_lang` key into translation names
- Covers headsigns, stop_headsigns, stop_names, route_names, agency_names, agency_short_names
- Explicit translations (from `translations.txt`) always take priority over injected values
- `feed_lang="mul"` (multilingual) is skipped; falls back to `agency_lang` when `feed_lang` is empty
- Add GTFS i18n specification reference to DEVELOPMENT.md

## GTFS spec reference

- `feed_lang` (feed_info.txt, Required): defines the default language for text in the dataset
- `agency_lang` (agency.txt, Optional): display-settings hint, NOT the language of text fields
- `translations.txt`: base values are assumed to be in `feed_lang`

## Test plan

- [x] `injectOriginLang` unit tests (19 cases: basic, skip conditions, case-insensitive, real-world scenarios)
- [x] Repository test updated for injected `ja` key
- [x] Verified with Seibu Bus stop (`?stop=sbbus:20056-01&lang=ja`) — headsign now displays in Japanese
- [x] All 2405 tests pass, lint clean, build succeeds

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)