### PR TITLE
ui: text selection guard, RouteCountBadge family, stop name i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `RouteLabel` (新規、`src/components/label/route-label.tsx`): `BaseLabel` を wrap した display-only のルート表示ラベル。`TimetableMetadata` で `PillButton` の route 内訳行と並べて視認比較するために追加。本命の `BaseBadge` 実装前の試験導入。
+- `BaseLabel` に `style` prop を追加。GTFS の `route_color` のようなランタイム hex 値を inline style で渡せるように (既存 `PillButton` / `RouteBadge` と同じパターン)。
+
 ### Changed
 
 - `MapToggleButton` (地図上の全コントロールボタン) でテキスト選択不可に。`user-select: none` と `-webkit-touch-callout: none` を適用し、iPhone などタッチデバイスでボタン上の文字列が選択状態になる問題を抑止。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,20 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - `RouteCountBadge` (新規、`src/components/badge/route-count-badge.tsx`): route の display name と `route_color` を `LabelCountBadge` に橋渡しする domain adapter。`TimetableMetadata` の route 内訳表示を PillButton から置き換え。
 - `BaseLabel` に `style` prop を追加。GTFS の `route_color` のようなランタイム hex 値を inline style で渡せるように (既存 `PillButton` / `RouteBadge` と同じパターン)。
+- `DEVELOPMENT.md` に「Stop ID lookup の選び方」セクションを追加。永続/長寿命の `stop_id` (anchor / route stops / `?stop=` 等) は `repo.getStopMetaByIds` を使い、viewport 制限のある `findStopWithMeta` を使わない判断ルールを記述。route stops と Portal の i18n 対応で同種の regression を起こした経緯も含む。
+- MockRepository の `sta_central` に `de` / `es` / `fr` の翻訳を追加し、`SUPPORTED_LANGS` 全 9 言語をカバー。anchor 翻訳の言語切替挙動を mock 上で検証可能に。
+
+### Fixed
+
+- StopHistory ドロップダウンが `stopWithMeta.stop.stop_name` (feed_lang 由来) を直接表示していた問題を修正。`getStopDisplayNames(stop, dataLang, resolveAgencyLang(agencies, stop.agency_id))` で現在表示言語に従って解決。履歴のスナップショットには既に `stop_names` 翻訳マップが含まれているため、表示層のみの修正。
+- Portal (アンカー) ドロップダウンの表示が常に保存時の `stopName` snapshot を使っていた問題を修正。`repo.getStopMetaByIds` で全データセットから fresh な `StopWithMeta` を取得し、`getStopDisplayNames` で現在表示言語に解決。viewport 外のアンカーも翻訳されるようになり、新たに追加された GTFS 翻訳にも自動追従する (anchor refresh 不要)。`AnchorEntry` のスキーマ変更なし。
+- アンカー追加/削除時の toast メッセージ (`anchor.added` / `anchor.removed`) も翻訳解決に切り替え。表示言語に応じた stop 名を表示。
 
 ### Changed
 
 - `MapToggleButton` (地図上の全コントロールボタン) でテキスト選択不可に。`user-select: none` と `-webkit-touch-callout: none` を適用し、iPhone などタッチデバイスでボタン上の文字列が選択状態になる問題を抑止。
 - `PillButton` (BottomSheet の View/Operating/Route type/Agency フィルタ、stop 詳細の timetable フィルタ、route 内訳表示) でもテキスト選択不可に。同じく `user-select: none` と `-webkit-touch-callout: none` を適用。
+- `TransitRepository.getStopMetaByIds` / `getStopMetaById` の TSDoc を強化し、「いつ使うべきか」「viewport 制限のある `findStopWithMeta` との違い」「過去の regression の経緯」を明記。`use-route-stops.ts` と `app.tsx` の `findStopWithMeta` 定義箇所にも対応するコメントと DEVELOPMENT.md への参照を追加。
 
 ## [2026.04.12]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `MapToggleButton` (地図上の全コントロールボタン) でテキスト選択不可に。`user-select: none` と `-webkit-touch-callout: none` を適用し、iPhone などタッチデバイスでボタン上の文字列が選択状態になる問題を抑止。
+
 ## [2026.04.12]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [CalVer](https://calver.org/).
 ### Changed
 
 - `MapToggleButton` (地図上の全コントロールボタン) でテキスト選択不可に。`user-select: none` と `-webkit-touch-callout: none` を適用し、iPhone などタッチデバイスでボタン上の文字列が選択状態になる問題を抑止。
+- `PillButton` (BottomSheet の View/Operating/Route type/Agency フィルタ、stop 詳細の timetable フィルタ、route 内訳表示) でもテキスト選択不可に。同じく `user-select: none` と `-webkit-touch-callout: none` を適用。
 
 ## [2026.04.12]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ### Added
 
-- `RouteLabel` (新規、`src/components/label/route-label.tsx`): `BaseLabel` を wrap した display-only のルート表示ラベル。`TimetableMetadata` で `PillButton` の route 内訳行と並べて視認比較するために追加。本命の `BaseBadge` 実装前の試験導入。
+- `RouteCountBadge` (新規、`src/components/badge/route-count-badge.tsx`): route の display name と `route_color` を `LabelCountBadge` に橋渡しする domain adapter。`TimetableMetadata` の route 内訳表示を PillButton から置き換え。
 - `BaseLabel` に `style` prop を追加。GTFS の `route_color` のようなランタイム hex 値を inline style で渡せるように (既存 `PillButton` / `RouteBadge` と同じパターン)。
 
 ### Changed

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -97,6 +97,44 @@ npm run typecheck && npm run format && npm run lint:fix && npm run build
 - `src/lib/`
   `leaflet-helpers.ts`, `map-zoom.ts`, `double-tap-zoom.ts`
 
+## Stop ID lookup の選び方
+
+`stop_id` から `StopWithMeta` を取得する方法は 2 系統あります。**stop_id の出所** によって正しい方を選ばないと、ビューポート外の stop で silently null フォールバックが発生し、表示や翻訳が壊れます。route stops 表示と Portal (anchor) で過去に同種の不具合を起こしているため、新規実装時は必ず以下を参照してください。
+
+### `repo.getStopMetaByIds(stopIds: Set<string>): StopWithMeta[]`
+
+**全データセットを scan** する同期 API (`src/repositories/transit-repository.ts`)。stop_id の地理的位置に依存しません。
+
+以下の用途には**必ずこれを使う**:
+
+- アンカー (bookmark) の表示名 / refresh — anchor は地球の裏側にあり得る
+- 履歴 (StopHistory) の name 解決 (履歴は full snapshot を持つので別経路でも可)
+- selected route の stops 描画 — route は viewport 外まで伸びる
+- URL `?stop=` パラメータからの解決
+- localStorage / 検索結果など、**永続化された / ユーザー操作の起点でない stop_id 全般**
+
+呼び出しコスト: 同期、O(N) where N = `stopIds.size`。過剰最適化を心配する必要はないので、迷ったらこちらを選ぶ。
+
+### `findStopWithMeta(stopId)` (app.tsx 内のローカル callback)
+
+**ビューポート専用** の lookup で、`radiusStops` (~1 km) と `inBoundStops` (現在のビューポート) しか見ません。ホットパス用に作られています。
+
+以下の用途のみ:
+
+- ユーザーが今クリックした map marker
+- `onStopSelected` 系の即時 selection
+- 現在地周辺で確実に viewport 内にある stop の参照
+
+**永続 ID には絶対に使わない**。アンカー / 履歴 / 選択 route の stops / `?stop=` 等に使うと、ビューポート外で null が返り、表示層は snapshot にフォールバックして翻訳/最新メタが消える。
+
+### 判断フロー
+
+1. その stop_id は **どこから来たか** ?
+    - ユーザーが今操作した直接対象 (クリックなど) → `findStopWithMeta` 可
+    - localStorage / URL / 設定 / 選択 route / 過去のセッション → `repo.getStopMetaByIds`
+2. 迷ったら `getStopMetaByIds`
+3. 新しい lookup を書くときは、コメントに「永続 ID か viewport ID か」を明記する
+
 ## Logger
 
 ### Basic Usage

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -103,7 +103,7 @@ npm run typecheck && npm run format && npm run lint:fix && npm run build
 
 ### `repo.getStopMetaByIds(stopIds: Set<string>): StopWithMeta[]`
 
-**全データセットを scan** する同期 API (`src/repositories/transit-repository.ts`)。stop_id の地理的位置に依存しません。
+**全データセットを対象**にする同期 API (`src/repositories/transit-repository.ts`)。stop_id の地理的位置に依存しません。「全データセット」は検索のスコープを意味し、データセット全体を per-call で走査するという意味ではありません。v2 リポジトリの実装は事前構築済みの `stop_id → StopWithMeta` map に対する indexed lookup なので、実コストは渡した stop_id の数に比例します (各 lookup は O(1)、全体で O(`stopIds.size`))。
 
 以下の用途には**必ずこれを使う**:
 
@@ -113,7 +113,7 @@ npm run typecheck && npm run format && npm run lint:fix && npm run build
 - URL `?stop=` パラメータからの解決
 - localStorage / 検索結果など、**永続化された / ユーザー操作の起点でない stop_id 全般**
 
-呼び出しコスト: 同期、O(N) where N = `stopIds.size`。過剰最適化を心配する必要はないので、迷ったらこちらを選ぶ。
+呼び出しコスト: 同期、O(`stopIds.size`)。過剰最適化を心配する必要はないので、迷ったらこちらを選ぶ。
 
 ### `findStopWithMeta(stopId)` (app.tsx 内のローカル callback)
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -206,18 +206,21 @@ export default function App() {
   //
   // Use this ONLY for stops that are by definition near the user at
   // the moment of the call:
-  //   - the just-clicked map marker
-  //   - a stop reached via the URL `?stop=` parameter (focus then load)
+  //   - the just-clicked map marker (radiusStops by construction)
   //   - the currently selected stop being re-resolved during pan
+  //   - any other case where the caller already has the stop on screen
   //
-  // Do NOT use this for persistent / long-lived stop IDs such as
-  // anchors (bookmarks), history entries, or stops belonging to a
-  // selected route. Those IDs may point to stops far outside the
-  // viewport, so the lookup will silently return null and the caller
-  // will fall back to a stale snapshot. For those cases call
-  // `repo.getStopMetaByIds(...)` (full-dataset scan) instead — the
-  // anchor display lookup below (`anchorStopMetaMap`) is the
-  // canonical example.
+  // Do NOT use this for persistent / long-lived / arbitrary stop IDs
+  // such as anchors (bookmarks), history entries, stops belonging to
+  // a selected route, or a `stop_id` from the URL `?stop=` parameter
+  // — `?stop=` is resolved via `repo.getStopMetaById(stopId)` in the
+  // effect below precisely because it can target a stop anywhere in
+  // the dataset, not just inside the viewport. Those IDs may point
+  // to stops far outside the viewport, so this lookup will silently
+  // return null and the caller will fall back to a stale snapshot.
+  // For those cases call `repo.getStopMetaByIds(...)` (full-dataset
+  // indexed lookup) instead — the anchor display lookup below
+  // (`anchorStopMetaMap`) is the canonical example.
   //
   // See `DEVELOPMENT.md > Stop ID lookup の選び方` for the rule and
   // historical context (route stops and anchor i18n both regressed

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -511,9 +511,15 @@ export default function App() {
         // Capture anchor data before removal (entry won't exist after removeAnchor).
         // Resolve display name from current GTFS so the toast follows
         // the user's current language even though the stored entry
-        // only has a snapshot stopName.
+        // only has a snapshot stopName. We use `lookupAnchorStopMeta`
+        // (full-dataset scan over the anchor set) rather than
+        // `findStopWithMeta` (viewport-only) here because the stop_id
+        // is a persistent anchor reference and may, in some future UI
+        // path, be triggered for an anchor that is not currently in
+        // radiusStops / inBoundStops. See `DEVELOPMENT.md > Stop ID
+        // lookup の選び方` for the rule.
         const anchor = anchors.find((a) => a.stopId === stopId);
-        const meta = findStopWithMeta(stopId);
+        const meta = lookupAnchorStopMeta(stopId);
         const stopName = meta
           ? getStopDisplayNames(
               meta.stop,
@@ -556,7 +562,16 @@ export default function App() {
         }
       }
     },
-    [isStopAnchor, anchors, removeAnchor, addAnchor, findStopWithMeta, dataLang, t],
+    [
+      isStopAnchor,
+      anchors,
+      removeAnchor,
+      addAnchor,
+      findStopWithMeta,
+      lookupAnchorStopMeta,
+      dataLang,
+      t,
+    ],
   );
 
   // Select + pan to a stop from Portal dropdown

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -29,7 +29,8 @@ import {
   nextTileIndex,
 } from './utils/settings-cycle';
 import { SUPPORTED_LANGS } from './config/supported-langs';
-import { DEFAULT_TIMEZONE } from './config/transit-defaults';
+import { DEFAULT_TIMEZONE, resolveAgencyLang } from './config/transit-defaults';
+import { getStopDisplayNames } from './domain/transit/get-stop-display-names';
 import { formatDateParts } from './utils/datetime';
 import { resolveLangChain } from './domain/transit/i18n/resolve-lang-chain';
 import { getStopParam } from './lib/query-params';
@@ -196,13 +197,59 @@ export default function App() {
     }
   }, [anchors, repo, batchUpdateAnchors]);
 
-  // Find StopWithMeta by stop_id from nearby or inBound stops
+  // Viewport-limited StopWithMeta lookup.
+  //
+  // ⚠️ This callback only searches `radiusStops` (~1 km from the user)
+  // and `inBoundStops` (current map viewport). It is intentionally
+  // narrow because it sits on the hot path of map interaction and is
+  // re-created whenever those collections change.
+  //
+  // Use this ONLY for stops that are by definition near the user at
+  // the moment of the call:
+  //   - the just-clicked map marker
+  //   - a stop reached via the URL `?stop=` parameter (focus then load)
+  //   - the currently selected stop being re-resolved during pan
+  //
+  // Do NOT use this for persistent / long-lived stop IDs such as
+  // anchors (bookmarks), history entries, or stops belonging to a
+  // selected route. Those IDs may point to stops far outside the
+  // viewport, so the lookup will silently return null and the caller
+  // will fall back to a stale snapshot. For those cases call
+  // `repo.getStopMetaByIds(...)` (full-dataset scan) instead — the
+  // anchor display lookup below (`anchorStopMetaMap`) is the
+  // canonical example.
+  //
+  // See `DEVELOPMENT.md > Stop ID lookup の選び方` for the rule and
+  // historical context (route stops and anchor i18n both regressed
+  // by reaching for this helper instead of `getStopMetaByIds`).
   const findStopWithMeta = useCallback(
     (stopId: string) =>
       radiusStops.find((s) => s.stop.stop_id === stopId) ??
       inBoundStops.find((s) => s.stop.stop_id === stopId) ??
       null,
     [radiusStops, inBoundStops],
+  );
+
+  // Pre-resolved StopWithMeta map for every anchored stop_id.
+  // Built from the repository's full dataset (not just the visible
+  // viewport) so that `Portals` can look up the latest translated
+  // display name for any anchor regardless of where it is on the map.
+  const anchorStopMetaMap = useMemo(() => {
+    if (anchors.length === 0) {
+      return new Map<string, StopWithMeta>();
+    }
+    const stopIds = new Set(anchors.map((a) => a.stopId));
+    const metas = repo.getStopMetaByIds(stopIds);
+    return new Map(metas.map((m) => [m.stop.stop_id, m]));
+  }, [anchors, repo]);
+
+  // Lookup an anchored stop's current StopWithMeta. Returns null
+  // when the anchor's stop_id is not present in the active dataset
+  // (e.g. cross-source anchor in mock mode, or a stop deleted from
+  // GTFS); callers should fall back to the AnchorEntry snapshot.
+  const lookupAnchorStopMeta = useCallback(
+    (stopId: string): StopWithMeta | null => anchorStopMetaMap.get(stopId) ?? null,
+    [anchorStopMetaMap],
   );
 
   // Wrap selectStop to also record in history
@@ -461,9 +508,21 @@ export default function App() {
   const handleToggleAnchor = useCallback(
     (stopId: string, routeTypes: AppRouteTypeValue[]) => {
       if (isStopAnchor(stopId)) {
-        // Capture anchor data before removal (entry won't exist after removeAnchor)
+        // Capture anchor data before removal (entry won't exist after removeAnchor).
+        // Resolve display name from current GTFS so the toast follows
+        // the user's current language even though the stored entry
+        // only has a snapshot stopName.
         const anchor = anchors.find((a) => a.stopId === stopId);
-        const stopName = anchor?.stopName ?? stopId;
+        const meta = findStopWithMeta(stopId);
+        const stopName = meta
+          ? getStopDisplayNames(
+              meta.stop,
+              dataLang,
+              resolveAgencyLang(meta.agencies, meta.stop.agency_id),
+            ).name ||
+            anchor?.stopName ||
+            stopId
+          : (anchor?.stopName ?? stopId);
         logger.debug(`handleToggleAnchor: removing stopId=${stopId}`);
         void removeAnchor(stopId).then((result) => {
           if (result.success) {
@@ -474,7 +533,13 @@ export default function App() {
       } else {
         const meta = findStopWithMeta(stopId);
         if (meta) {
-          logger.debug(`handleToggleAnchor: adding stopId=${stopId}, name=${meta.stop.stop_name}`);
+          const displayName =
+            getStopDisplayNames(
+              meta.stop,
+              dataLang,
+              resolveAgencyLang(meta.agencies, meta.stop.agency_id),
+            ).name || meta.stop.stop_name;
+          logger.debug(`handleToggleAnchor: adding stopId=${stopId}, name=${displayName}`);
           void addAnchor({
             stopId: meta.stop.stop_id,
             stopName: meta.stop.stop_name,
@@ -484,14 +549,14 @@ export default function App() {
           }).then((result) => {
             if (result.success) {
               toast.success(t('anchor.added'), {
-                description: `${routeTypesEmoji(routeTypes)} ${meta.stop.stop_name}`,
+                description: `${routeTypesEmoji(routeTypes)} ${displayName}`,
               });
             }
           });
         }
       }
     },
-    [isStopAnchor, anchors, removeAnchor, addAnchor, findStopWithMeta, t],
+    [isStopAnchor, anchors, removeAnchor, addAnchor, findStopWithMeta, dataLang, t],
   );
 
   // Select + pan to a stop from Portal dropdown
@@ -692,6 +757,7 @@ export default function App() {
           onHistorySelect={handleHistorySelect}
           anchors={anchors}
           onPortalSelect={handlePortalSelect}
+          lookupAnchorStopMeta={lookupAnchorStopMeta}
         />
         <TimeControls
           time={dateTime}

--- a/src/components/badge/label-count-badge.stories.tsx
+++ b/src/components/badge/label-count-badge.stories.tsx
@@ -1,0 +1,203 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { BaseLabelSize } from '../label/base-label';
+import { LabelCountBadge } from './label-count-badge';
+
+const meta = {
+  title: 'Badge/LabelCountBadge',
+  component: LabelCountBadge,
+  args: {
+    label: 'Tokyo Sakura Tram (Arakawa Line)',
+    count: 348,
+    size: 'sm',
+    labelBg: '#EC6FA8',
+    labelFg: '#FFFFFF',
+  },
+  argTypes: {
+    label: { control: 'text' },
+    count: { control: 'number' },
+    size: { control: 'inline-radio', options: ['xs', 'sm', 'md'] },
+    labelBg: { control: 'color' },
+    labelFg: { control: 'color' },
+    countBg: { control: 'color' },
+    countFg: { control: 'color' },
+    frameColor: { control: 'color' },
+  },
+} satisfies Meta<typeof LabelCountBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// --- Size variants ---
+
+export const SizeXs: Story = {
+  args: { size: 'xs' },
+};
+
+export const SizeSm: Story = {
+  args: { size: 'sm' },
+};
+
+export const SizeMd: Story = {
+  args: { size: 'md' },
+};
+
+// --- Color behavior ---
+
+/** Default: count half uses inverted colors, frame matches labelBg. */
+export const Default: Story = {};
+
+/**
+ * Frame in a neutral gray while the inner halves keep the label color.
+ * Useful when the label color is very light and needs a distinct outline.
+ */
+export const NeutralFrame: Story = {
+  args: { frameColor: '#888888' },
+};
+
+/** Strong contrast frame (black) for emphasis. */
+export const BlackFrame: Story = {
+  args: { frameColor: '#000000' },
+};
+
+/**
+ * Explicit count colors (not inverted). Useful for themes that want
+ * a specific count palette independent of the label color.
+ */
+export const ExplicitCountColors: Story = {
+  args: {
+    countBg: '#FFD4E6',
+    countFg: '#EC6FA8',
+  },
+};
+
+/**
+ * No colors at all — falls through to BaseLabel defaults (transparent
+ * background, inherited text color). The outer frame has no border
+ * color either, so only the inner text is visible with a subtle rounded
+ * outline from the browser default.
+ */
+export const NoColors: Story = {
+  args: {
+    labelBg: undefined,
+    labelFg: undefined,
+    countBg: undefined,
+    countFg: undefined,
+    frameColor: undefined,
+  },
+};
+
+// --- Label / count variants ---
+
+/** Short label (route short_name style). */
+export const ShortLabel: Story = {
+  args: { label: '都02', count: 42, labelBg: '#1976D2' },
+};
+
+/** Tram short name. */
+export const TramLabel: Story = {
+  args: { label: '荒川線', count: 124, labelBg: '#E60012' },
+};
+
+/** Single-digit count. */
+export const CountSmall: Story = {
+  args: { count: 3 },
+};
+
+/** Three-digit count. */
+export const CountLarge: Story = {
+  args: { count: 348 },
+};
+
+/** Four-digit count (locale separator check). */
+export const CountThousands: Story = {
+  args: { count: 1234 },
+};
+
+// --- Comparisons ---
+
+/** All sizes side by side. */
+export const SizeComparison: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-2">
+      <LabelCountBadge {...args} size="xs" />
+      <LabelCountBadge {...args} size="sm" />
+      <LabelCountBadge {...args} size="md" />
+    </div>
+  ),
+};
+
+/** Frame color variants side by side (same label/count). */
+export const FrameColorComparison: Story = {
+  args: { label: '都02', count: 42, labelBg: '#1976D2' },
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      {[
+        { label: 'frame = labelBg (default)', frameColor: args.labelBg },
+        { label: 'frame = gray #888', frameColor: '#888888' },
+        { label: 'frame = black', frameColor: '#000000' },
+        { label: 'frame = red', frameColor: '#DC2626' },
+      ].map(({ label, frameColor }) => (
+        <div key={label} className="flex items-center gap-2">
+          <span className="w-52 text-xs text-gray-500">{label}</span>
+          <LabelCountBadge {...args} frameColor={frameColor} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+interface SampleBadge {
+  name: string;
+  label: string;
+  count: number;
+  labelBg: string;
+  labelFg: string;
+}
+
+const sampleBadges: SampleBadge[] = [
+  { name: 'Asakusa Line', label: '浅草線', count: 312, labelBg: '#FF535F', labelFg: '#FFFFFF' },
+  { name: 'Mita Line', label: '三田線', count: 278, labelBg: '#0067B0', labelFg: '#FFFFFF' },
+  { name: 'Shinjuku Line', label: '新宿線', count: 295, labelBg: '#9FB01C', labelFg: '#FFFFFF' },
+  { name: 'Oedo Line', label: '大江戸線', count: 341, labelBg: '#CF3366', labelFg: '#FFFFFF' },
+  {
+    name: 'Arakawa Line',
+    label: 'Tokyo Sakura Tram (Arakawa Line)',
+    count: 348,
+    labelBg: '#EC6FA8',
+    labelFg: '#FFFFFF',
+  },
+];
+
+/** Multiple label/count combinations, default colors, md size. */
+export const KitchenSink: Story = {
+  args: { size: 'md' },
+  render: (args) => {
+    const sizes: BaseLabelSize[] = ['xs', 'sm', 'md'];
+    return (
+      <div className="flex flex-col gap-6">
+        {sizes.map((size) => (
+          <div key={size}>
+            <div className="mb-2 text-sm font-bold text-gray-700 dark:text-gray-300">
+              size: {size}
+            </div>
+            <div className="flex flex-col gap-1">
+              {sampleBadges.map(({ name, label, count, labelBg, labelFg }) => (
+                <div key={name} className="flex items-center gap-2">
+                  <span className="w-36 text-xs text-gray-500">{name}</span>
+                  <LabelCountBadge
+                    label={label}
+                    count={count}
+                    size={size}
+                    labelBg={labelBg}
+                    labelFg={labelFg}
+                    frameColor={args.frameColor}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  },
+};

--- a/src/components/badge/label-count-badge.tsx
+++ b/src/components/badge/label-count-badge.tsx
@@ -1,0 +1,74 @@
+import { useTranslation } from 'react-i18next';
+import { BaseLabel, type BaseLabelSize } from '../label/base-label';
+
+interface LabelCountBadgeProps {
+  /** Text for the left (label) half. */
+  label: string;
+  /** Numeric value for the right (count) half. Rendered with locale-aware formatting. */
+  count: number;
+  /** Size variant, forwarded to both inner BaseLabel instances. @default 'sm' */
+  size?: BaseLabelSize;
+  /** Background color for the label half (runtime hex, e.g. GTFS route_color). */
+  labelBg?: string;
+  /** Text color for the label half. */
+  labelFg?: string;
+  /** Background color for the count half. @default labelFg (inverted) */
+  countBg?: string;
+  /** Text color for the count half. @default labelBg (inverted) */
+  countFg?: string;
+  /** Outer frame border color. @default labelBg */
+  frameColor?: string;
+}
+
+/**
+ * Display-only badge that pairs a text label with a numeric count,
+ * rendered as a single framed capsule split into two halves.
+ *
+ * Visual structure:
+ *
+ * ```
+ * ┌─────────────────────┬─────┐
+ * │        label        │ count│
+ * └─────────────────────┴─────┘
+ * ```
+ *
+ * The outer frame uses `frameColor` (default: `labelBg`). The left
+ * half uses `labelBg` / `labelFg`, the right half defaults to the
+ * inverted colors (`labelFg` / `labelBg`) so the count stands out
+ * without needing a separate color decision at the call site.
+ *
+ * Intended for read-only badges (e.g. route breakdown in timetable
+ * metadata). For interactive filters use `PillButton` instead — the
+ * shape here deliberately avoids the pill affordance.
+ *
+ * Uses two {@link BaseLabel} instances wrapped in a flex container;
+ * their inner corners are flattened (`rounded-none`) and the outer
+ * span's `rounded` + `overflow-hidden` creates the single-capsule
+ * appearance.
+ */
+export function LabelCountBadge({
+  label,
+  count,
+  size = 'sm',
+  labelBg,
+  labelFg,
+  countBg = labelFg,
+  countFg = labelBg,
+  frameColor = labelBg,
+}: LabelCountBadgeProps) {
+  const { i18n } = useTranslation();
+  const labelStyle = labelBg ? { background: labelBg, color: labelFg } : undefined;
+  const countStyle = countBg ? { background: countBg, color: countFg } : undefined;
+  const frameStyle = frameColor ? { borderColor: frameColor } : undefined;
+  return (
+    <span className="inline-flex items-stretch overflow-hidden rounded border" style={frameStyle}>
+      <BaseLabel size={size} value={label} className="rounded-none" style={labelStyle} />
+      <BaseLabel
+        size={size}
+        value={count.toLocaleString(i18n.language)}
+        className="rounded-none"
+        style={countStyle}
+      />
+    </span>
+  );
+}

--- a/src/components/badge/route-count-badge.stories.tsx
+++ b/src/components/badge/route-count-badge.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { busRoute, busRoute2, noColorRoute, subwayRoute, tramRoute } from '../../stories/fixtures';
 import { LANG_COMPARISON_CASES } from '../../stories/lang-comparison';
-import { RouteLabel } from './route-label';
+import { RouteCountBadge } from './route-count-badge';
 
 /**
  * A route with a very long English translation, used to verify layout
@@ -28,8 +28,8 @@ const longNameRoute = {
 } as const;
 
 const meta = {
-  title: 'Label/RouteLabel',
-  component: RouteLabel,
+  title: 'Badge/RouteCountBadge',
+  component: RouteCountBadge,
   args: {
     route: busRoute,
     count: 42,
@@ -41,7 +41,7 @@ const meta = {
     count: { control: 'number' },
     size: { control: 'inline-radio', options: ['xs', 'sm', 'md'] },
   },
-} satisfies Meta<typeof RouteLabel>;
+} satisfies Meta<typeof RouteCountBadge>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -123,21 +123,21 @@ export const CountThousands: Story = {
 export const SizeComparison: Story = {
   render: (args) => (
     <div className="flex items-center gap-2">
-      <RouteLabel
+      <RouteCountBadge
         route={args.route}
         count={args.count}
         dataLang={args.dataLang}
         agencies={args.agencies}
         size="xs"
       />
-      <RouteLabel
+      <RouteCountBadge
         route={args.route}
         count={args.count}
         dataLang={args.dataLang}
         agencies={args.agencies}
         size="sm"
       />
-      <RouteLabel
+      <RouteCountBadge
         route={args.route}
         count={args.count}
         dataLang={args.dataLang}
@@ -156,7 +156,7 @@ export const LangComparison: Story = {
       {LANG_COMPARISON_CASES.map(({ dataLang, label }) => (
         <div key={label} className="flex items-center gap-2">
           <span className="w-20 text-[10px] text-gray-400">{label}</span>
-          <RouteLabel
+          <RouteCountBadge
             route={args.route}
             count={args.count}
             dataLang={dataLang}
@@ -186,7 +186,7 @@ export const KitchenSink: Story = {
         {samples.map(({ label, route, count }) => (
           <div key={label} className="flex items-center gap-2">
             <span className="w-28 text-xs text-gray-500">{label}</span>
-            <RouteLabel
+            <RouteCountBadge
               route={route}
               count={count}
               dataLang={args.dataLang}

--- a/src/components/badge/route-count-badge.tsx
+++ b/src/components/badge/route-count-badge.tsx
@@ -1,10 +1,10 @@
 import { resolveAgencyLang } from '../../config/transit-defaults';
 import { getRouteDisplayNames } from '../../domain/transit/get-route-display-names';
+import type { BaseLabelSize } from '../label/base-label';
 import type { Agency, Route } from '../../types/app/transit';
-import { LabelCountBadge } from '../badge/label-count-badge';
-import type { BaseLabelSize } from './base-label';
+import { LabelCountBadge } from './label-count-badge';
 
-interface RouteLabelProps {
+interface RouteCountBadgeProps {
   route: Route;
   count: number;
   dataLang: readonly string[];
@@ -20,7 +20,13 @@ interface RouteLabelProps {
  * out of the presentation primitive so that `LabelCountBadge` can stay
  * reusable across other domain types (agency, stop, headsign, etc.).
  */
-export function RouteLabel({ route, count, dataLang, agencies, size = 'sm' }: RouteLabelProps) {
+export function RouteCountBadge({
+  route,
+  count,
+  dataLang,
+  agencies,
+  size = 'sm',
+}: RouteCountBadgeProps) {
   const label =
     getRouteDisplayNames(route, dataLang, resolveAgencyLang(agencies, route.agency_id)).resolved
       .name || route.route_id;

--- a/src/components/button/map-toggle-button.tsx
+++ b/src/components/button/map-toggle-button.tsx
@@ -1,6 +1,6 @@
 /** Visual-only Tailwind classes for map overlay buttons (no positioning). */
 const MAP_OVERLAY_BUTTON_STYLE =
-  'flex h-10 w-10 items-center justify-center rounded-lg border-2 border-black/60 bg-white text-lg leading-none cursor-pointer active:bg-[#e0e0e0] disabled:cursor-not-allowed disabled:active:bg-white dark:border-white/40 dark:bg-gray-800 dark:text-white dark:active:bg-gray-700 dark:disabled:active:bg-gray-800';
+  'flex h-10 w-10 items-center justify-center rounded-lg border-2 border-black/60 bg-white text-lg leading-none cursor-pointer select-none [-webkit-touch-callout:none] active:bg-[#e0e0e0] disabled:cursor-not-allowed disabled:active:bg-white dark:border-white/40 dark:bg-gray-800 dark:text-white dark:active:bg-gray-700 dark:disabled:active:bg-gray-800';
 
 interface MapToggleButtonProps {
   active: boolean;

--- a/src/components/button/pill-button.tsx
+++ b/src/components/button/pill-button.tsx
@@ -90,7 +90,7 @@ export function PillButton({
       type="button"
       disabled={disabled}
       className={cn(
-        'inline-flex shrink-0 items-center rounded-full font-medium whitespace-nowrap transition-colors',
+        'inline-flex shrink-0 items-center rounded-full font-medium whitespace-nowrap transition-colors select-none [-webkit-touch-callout:none]',
         sizeVariants[size] ?? sizeVariants.default,
         active
           ? activeBg

--- a/src/components/departure-item.tsx
+++ b/src/components/departure-item.tsx
@@ -1,10 +1,11 @@
 import type { InfoLevel } from '../types/app/settings';
 import { useTranslation } from 'react-i18next';
-import type { Agency } from '../types/app/transit';
+import type { Agency, TimetableEntryAttributes } from '../types/app/transit';
 import type { ContextualTimetableEntry } from '../types/app/transit-composed';
 import { getEffectiveHeadsign } from '../domain/transit/get-effective-headsign';
 import { formatAbsoluteTime } from '../domain/transit/time';
 import { minutesToDate } from '../domain/transit/calendar-utils';
+import { getTimetableEntryAttributes } from '../domain/transit/timetable-entry-attributes';
 import { getDisplayMinutes, hasBoardableDeparture } from '../domain/transit/timetable-utils';
 import { RelativeTime } from './relative-time';
 import { TripInfo } from './trip-info';
@@ -57,6 +58,16 @@ export function DepartureItem({
   const first = displayTimes[0];
   const diffMs = first ? first.getTime() - now.getTime() : 0;
 
+  // Group-level attributes: terminal/origin/dropOffUnavailable come from the
+  // first entry (all entries in a route+headsign group share the same pattern
+  // position), while pickupUnavailable reflects whether the group as a whole
+  // has no boardable entry.
+  const baseAttributes = getTimetableEntryAttributes(firstEntry);
+  const groupAttributes: TimetableEntryAttributes = {
+    ...baseAttributes,
+    isPickupUnavailable: !hasBoardableDeparture(entries),
+  };
+
   return (
     <div className="border-b border-[#e0e0e0] py-1 last:border-b-0 dark:border-gray-700">
       <div>
@@ -66,8 +77,7 @@ export function DepartureItem({
           dataLang={dataLang}
           showRouteTypeIcon={showRouteTypeIcon}
           agency={agency}
-          isTerminal={firstEntry.patternPosition.isTerminal}
-          isPickupUnavailable={!hasBoardableDeparture(entries)}
+          attributes={groupAttributes}
         />
       </div>
       <div className="flex items-center gap-3 pl-1">

--- a/src/components/dialog/stop-search-modal.tsx
+++ b/src/components/dialog/stop-search-modal.tsx
@@ -51,6 +51,16 @@ function StopSearchResultItem({
 }: StopSearchResultItemProps) {
   const info = useInfoLevel(infoLevel);
   // Always show subNames in search results for discoverability.
+  //
+  // We pass DEFAULT_AGENCY_LANG (not the agency-specific lang) on
+  // purpose. `getStopDisplayNames`'s third argument only controls the
+  // sort priority of the alternative names in `subNames`; it does not
+  // affect the resolved primary `name` or the set of names that appear
+  // in `subNames`. Search loads only `Stop[]` via `repo.getAllStops()`
+  // and intentionally never pulls `StopWithMeta` / agencies for every
+  // result, so we cannot call `resolveAgencyLang(agencies, ...)` here.
+  // Doing so would require a parallel batch lookup just to influence
+  // sub-name ordering, which is not worth the cost for a search list.
   const stopNames = getStopDisplayNames(stop, dataLang, DEFAULT_AGENCY_LANG);
 
   return (

--- a/src/components/flat-departure-item.tsx
+++ b/src/components/flat-departure-item.tsx
@@ -3,6 +3,7 @@ import type { Agency } from '../types/app/transit';
 import type { ContextualTimetableEntry } from '../types/app/transit-composed';
 import { formatAbsoluteTime } from '../domain/transit/time';
 import { minutesToDate } from '../domain/transit/calendar-utils';
+import { getTimetableEntryAttributes } from '../domain/transit/timetable-entry-attributes';
 import { getDisplayMinutes } from '../domain/transit/timetable-utils';
 import { RelativeTime } from './relative-time';
 import { TripInfo } from './trip-info';
@@ -44,9 +45,9 @@ export function FlatDepartureItem({
   const showVerbose = infoLevel === 'verbose';
   const { route } = entry.routeDirection;
   const bgColor = route.route_color ? `#${route.route_color}` : undefined;
-  const isTerminal = entry.patternPosition.isTerminal;
+  const attributes = getTimetableEntryAttributes(entry);
+  const isTerminal = attributes.isTerminal;
   const departureTime = minutesToDate(entry.serviceDate, getDisplayMinutes(entry));
-  const isPickupUnavailable = entry.boarding.pickupType === 1;
   const diffMs = departureTime.getTime() - now.getTime();
   const showRelativeTime = isFirst || diffMs <= 60 * 60 * 1000;
 
@@ -78,8 +79,7 @@ export function FlatDepartureItem({
           dataLang={dataLang}
           showRouteTypeIcon={showRouteTypeIcon}
           agency={agency}
-          isTerminal={isTerminal}
-          isPickupUnavailable={isPickupUnavailable}
+          attributes={attributes}
         />
       </div>
       {/* Verbose data */}

--- a/src/components/label/base-label.stories.tsx
+++ b/src/components/label/base-label.stories.tsx
@@ -58,7 +58,7 @@ export const TruncatedNoEllipsis: Story = {
  * Use the `style` prop to pass hex values that are only known at
  * runtime (e.g. GTFS `route_color`). This is the same pattern used
  * by `PillButton` and `RouteBadge` for dynamic GTFS colors, and is
- * the path `RouteLabel` uses internally.
+ * the path `RouteCountBadge` uses internally.
  */
 export const InlineStyle: Story = {
   args: {

--- a/src/components/label/base-label.stories.tsx
+++ b/src/components/label/base-label.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { CSSProperties } from 'react';
 import { BaseLabel, type BaseLabelSize } from './base-label';
 
 const meta = {
@@ -10,6 +11,7 @@ const meta = {
     maxLength: { control: 'number' },
     ellipsis: { control: 'boolean' },
     className: { control: 'text' },
+    style: { control: 'object' },
   },
 } satisfies Meta<typeof BaseLabel>;
 
@@ -50,7 +52,43 @@ export const TruncatedNoEllipsis: Story = {
   },
 };
 
-const sampleStyles = [
+/**
+ * Inline style for runtime-computed colors.
+ *
+ * Use the `style` prop to pass hex values that are only known at
+ * runtime (e.g. GTFS `route_color`). This is the same pattern used
+ * by `PillButton` and `RouteBadge` for dynamic GTFS colors, and is
+ * the path `RouteLabel` uses internally.
+ */
+export const InlineStyle: Story = {
+  args: {
+    value: 'Tokyo Sakura Tram (Arakawa Line)',
+    style: { background: '#ec6fa8', color: '#ffffff' },
+  },
+};
+
+/**
+ * Combined className and style.
+ *
+ * Static layout / typography via `className`, runtime colors via
+ * `style`. Useful when the caller wants consistent padding or
+ * font treatment across instances but still needs per-item colors.
+ */
+export const ClassNameAndStyle: Story = {
+  args: {
+    value: 'Combined',
+    className: 'font-bold',
+    style: { background: '#0067b0', color: '#ffffff' },
+  },
+};
+
+interface SampleStyle {
+  label: string;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const classNameSamples: SampleStyle[] = [
   { label: 'gray solid', className: 'bg-gray-500 text-white' },
   { label: 'blue solid', className: 'bg-blue-500 text-white' },
   { label: 'red solid', className: 'bg-red-500 text-white' },
@@ -62,30 +100,56 @@ const sampleStyles = [
   { label: 'muted', className: 'text-muted-foreground bg-muted' },
 ];
 
-/** All size × style combinations. */
+const styleSamples: SampleStyle[] = [
+  { label: 'Asakusa', style: { background: '#ff535f', color: '#ffffff' } },
+  { label: 'Mita', style: { background: '#0067b0', color: '#ffffff' } },
+  { label: 'Shinjuku', style: { background: '#9fb01c', color: '#ffffff' } },
+  { label: 'Oedo', style: { background: '#cf3366', color: '#ffffff' } },
+];
+
+/**
+ * All size x color combinations, grouped by coloring mechanism.
+ *
+ * The top group uses static Tailwind classes via `className`.
+ * The bottom group uses runtime hex values via `style` (simulating GTFS route_color).
+ * Each label is prefixed with its sample name so it is clear which is which.
+ */
 export const KitchenSink: Story = {
   args: { value: 'Label' },
   render: ({ value = 'Label', maxLength, ellipsis }) => {
     const sizes: BaseLabelSize[] = ['xs', 'sm', 'md'];
-    return (
-      <div className="flex flex-col gap-3">
-        {sizes.map((size) => (
-          <div key={size}>
-            <div className="mb-1 text-xs font-semibold text-gray-500">{size}</div>
-            <div className="flex flex-wrap items-center gap-1">
-              {sampleStyles.map(({ label, className }) => (
-                <BaseLabel
-                  key={label}
-                  value={value}
-                  size={size}
-                  className={className}
-                  maxLength={maxLength}
-                  ellipsis={ellipsis}
-                />
-              ))}
+    const renderGroup = (title: string, samples: SampleStyle[]) => (
+      <div>
+        <div className="mb-2 text-sm font-bold text-gray-700 dark:text-gray-300">{title}</div>
+        <div className="flex flex-col gap-3">
+          {sizes.map((size) => (
+            <div key={size}>
+              <div className="mb-1 text-xs font-semibold text-gray-500">{size}</div>
+              <div className="flex flex-col gap-1">
+                {samples.map(({ label, className, style }) => (
+                  <div key={label} className="flex items-center gap-2">
+                    <span className="w-28 text-xs text-gray-500">{label}</span>
+                    <BaseLabel
+                      value={value}
+                      size={size}
+                      className={className}
+                      style={style}
+                      maxLength={maxLength}
+                      ellipsis={ellipsis}
+                    />
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
+      </div>
+    );
+
+    return (
+      <div className="flex flex-col gap-6">
+        {renderGroup('className-based (static Tailwind)', classNameSamples)}
+        {renderGroup('style-based (runtime hex, e.g. GTFS route_color)', styleSamples)}
       </div>
     );
   },

--- a/src/components/label/base-label.tsx
+++ b/src/components/label/base-label.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import { cn } from '../../lib/utils';
 
 export type BaseLabelSize = 'xs' | 'sm' | 'md';
@@ -10,6 +11,8 @@ interface BaseLabelProps {
   /** Append "…" when truncated. Only effective with maxLength. @default true */
   ellipsis?: boolean;
   className?: string;
+  /** Inline style for runtime-computed values (e.g. GTFS route_color hex). */
+  style?: CSSProperties;
 }
 
 const sizeClasses: Record<BaseLabelSize, string> = {
@@ -18,19 +21,21 @@ const sizeClasses: Record<BaseLabelSize, string> = {
   md: 'px-1.5 py-0.5 text-[10px]',
 };
 
-/** Compact inline text label primitive. Color is controlled via className. */
+/** Compact inline text label primitive. Color is controlled via className or style. */
 export function BaseLabel({
   value,
   size = 'sm',
   maxLength,
   ellipsis = true,
   className,
+  style,
 }: BaseLabelProps) {
   const truncated = maxLength != null && value.length > maxLength;
   const display = truncated ? value.slice(0, maxLength) + (ellipsis ? '\u2026' : '') : value;
   return (
     <span
       className={cn('shrink-0 rounded font-medium', sizeClasses[size], className)}
+      style={style}
       title={truncated ? value : undefined}
     >
       {display}

--- a/src/components/label/route-label.stories.tsx
+++ b/src/components/label/route-label.stories.tsx
@@ -1,0 +1,201 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { busRoute, busRoute2, noColorRoute, subwayRoute, tramRoute } from '../../stories/fixtures';
+import { LANG_COMPARISON_CASES } from '../../stories/lang-comparison';
+import { RouteLabel } from './route-label';
+
+/**
+ * A route with a very long English translation, used to verify layout
+ * when the route_long_name fallback produces wide labels (such as the
+ * Toei Arakawa Line case where route_short_name is empty and the
+ * translated long_name like "Tokyo Sakura Tram (Arakawa Line)" takes
+ * over).
+ */
+const longNameRoute = {
+  ...tramRoute,
+  route_id: 'route-long',
+  route_short_name: '',
+  route_short_names: {},
+  route_long_name: '東京さくらトラム（都電荒川線）',
+  route_long_names: {
+    ja: '東京さくらトラム（都電荒川線）',
+    en: 'Tokyo Sakura Tram (Arakawa Line)',
+    ko: '도쿄 사쿠라 트램 (아라카와선)',
+    'zh-Hans': '东京樱花电车 (荒川线)',
+    'zh-Hant': '東京櫻花電車 (荒川線)',
+  },
+  route_color: 'EC6FA8',
+  route_text_color: 'FFFFFF',
+} as const;
+
+const meta = {
+  title: 'Label/RouteLabel',
+  component: RouteLabel,
+  args: {
+    route: busRoute,
+    count: 42,
+    dataLang: ['ja'],
+    agencies: [],
+    size: 'sm',
+  },
+  argTypes: {
+    count: { control: 'number' },
+    size: { control: 'inline-radio', options: ['xs', 'sm', 'md'] },
+  },
+} satisfies Meta<typeof RouteLabel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// --- Size variants ---
+
+export const SizeXs: Story = {
+  args: { size: 'xs' },
+};
+
+export const SizeSm: Story = {
+  args: { size: 'sm' },
+};
+
+export const SizeMd: Story = {
+  args: { size: 'md' },
+};
+
+// --- Route variants ---
+
+/** Bus route (short name + small count). */
+export const Bus: Story = {
+  args: { route: busRoute, count: 42 },
+};
+
+/** Another bus route with different color. */
+export const Bus2: Story = {
+  args: { route: busRoute2, count: 18 },
+};
+
+/** Tram route. */
+export const Tram: Story = {
+  args: { route: tramRoute, count: 124 },
+};
+
+/** Subway route (short code + English name). */
+export const Subway: Story = {
+  args: { route: subwayRoute, count: 200 },
+};
+
+/**
+ * Route without route_color / route_text_color — falls back to
+ * BaseLabel's default (no background), only the outer frame is
+ * invisible (no borderColor).
+ */
+export const NoColor: Story = {
+  args: { route: noColorRoute, count: 7 },
+};
+
+/**
+ * Long-name route simulating the Toei Arakawa Line case:
+ * route_short_name is empty, so the translated route_long_name
+ * dominates and the label becomes wide.
+ */
+export const LongName: Story = {
+  args: { route: longNameRoute, count: 348, dataLang: ['en'] },
+};
+
+// --- Count variants ---
+
+/** Single-digit count. */
+export const CountSmall: Story = {
+  args: { count: 3 },
+};
+
+/** Three-digit count. */
+export const CountLarge: Story = {
+  args: { count: 348 },
+};
+
+/** Four-digit count (with thousands separator per locale). */
+export const CountThousands: Story = {
+  args: { count: 1234 },
+};
+
+// --- Comparisons ---
+
+/** All sizes side by side. */
+export const SizeComparison: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-2">
+      <RouteLabel
+        route={args.route}
+        count={args.count}
+        dataLang={args.dataLang}
+        agencies={args.agencies}
+        size="xs"
+      />
+      <RouteLabel
+        route={args.route}
+        count={args.count}
+        dataLang={args.dataLang}
+        agencies={args.agencies}
+        size="sm"
+      />
+      <RouteLabel
+        route={args.route}
+        count={args.count}
+        dataLang={args.dataLang}
+        agencies={args.agencies}
+        size="md"
+      />
+    </div>
+  ),
+};
+
+/** All supported languages, one unsupported, and default fallback. */
+export const LangComparison: Story = {
+  args: { route: longNameRoute, count: 348 },
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      {LANG_COMPARISON_CASES.map(({ dataLang, label }) => (
+        <div key={label} className="flex items-center gap-2">
+          <span className="w-20 text-[10px] text-gray-400">{label}</span>
+          <RouteLabel
+            route={args.route}
+            count={args.count}
+            dataLang={dataLang}
+            agencies={args.agencies}
+            size={args.size}
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** All route variants stacked, size md for easier inspection. */
+export const KitchenSink: Story = {
+  args: { size: 'md' },
+  render: (args) => {
+    const samples: Array<{ label: string; route: typeof busRoute; count: number }> = [
+      { label: 'bus (色あり)', route: busRoute, count: 42 },
+      { label: 'bus2 (色あり)', route: busRoute2, count: 18 },
+      { label: 'tram (色あり)', route: tramRoute, count: 124 },
+      { label: 'subway (色あり)', route: subwayRoute, count: 200 },
+      { label: 'no color', route: noColorRoute, count: 7 },
+      { label: 'long name', route: longNameRoute as typeof busRoute, count: 348 },
+    ];
+    return (
+      <div className="flex flex-col gap-2">
+        {samples.map(({ label, route, count }) => (
+          <div key={label} className="flex items-center gap-2">
+            <span className="w-28 text-xs text-gray-500">{label}</span>
+            <RouteLabel
+              route={route}
+              count={count}
+              dataLang={args.dataLang}
+              agencies={args.agencies}
+              size={args.size}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  },
+};

--- a/src/components/label/route-label.tsx
+++ b/src/components/label/route-label.tsx
@@ -1,8 +1,8 @@
-import { useTranslation } from 'react-i18next';
 import { resolveAgencyLang } from '../../config/transit-defaults';
 import { getRouteDisplayNames } from '../../domain/transit/get-route-display-names';
 import type { Agency, Route } from '../../types/app/transit';
-import { BaseLabel, type BaseLabelSize } from './base-label';
+import { LabelCountBadge } from '../badge/label-count-badge';
+import type { BaseLabelSize } from './base-label';
 
 interface RouteLabelProps {
   route: Route;
@@ -13,36 +13,20 @@ interface RouteLabelProps {
 }
 
 /**
- * Display-only label for a route with its entry count.
+ * Domain adapter that resolves a route's display name and colors and
+ * delegates rendering to {@link LabelCountBadge}.
  *
- * Visually composed of two joined segments:
- *  - left: route name with `route_color` / `route_text_color`
- *  - right: count with inverted colors (background = text color of
- *    the left segment, text = background color of the left segment)
- *
- * Uses two {@link BaseLabel} instances inside a flex wrapper with the
- * inner corners flattened so the pair reads as a single pill split
- * into two halves.
+ * Keeps GTFS-specific resolution (translations, agency language chain)
+ * out of the presentation primitive so that `LabelCountBadge` can stay
+ * reusable across other domain types (agency, stop, headsign, etc.).
  */
 export function RouteLabel({ route, count, dataLang, agencies, size = 'sm' }: RouteLabelProps) {
-  const { i18n } = useTranslation();
-  const name =
+  const label =
     getRouteDisplayNames(route, dataLang, resolveAgencyLang(agencies, route.agency_id)).resolved
       .name || route.route_id;
-  const bg = route.route_color ? `#${route.route_color}` : undefined;
-  const fg = route.route_text_color ? `#${route.route_text_color}` : undefined;
-  const nameStyle = bg ? { background: bg, color: fg } : undefined;
-  const countStyle = bg ? { background: fg, color: bg } : undefined;
-  const frameStyle = bg ? { borderColor: bg } : undefined;
+  const labelBg = route.route_color ? `#${route.route_color}` : undefined;
+  const labelFg = route.route_text_color ? `#${route.route_text_color}` : undefined;
   return (
-    <span className="inline-flex items-stretch overflow-hidden rounded border" style={frameStyle}>
-      <BaseLabel size={size} value={name} className="rounded-none" style={nameStyle} />
-      <BaseLabel
-        size={size}
-        value={count.toLocaleString(i18n.language)}
-        className="rounded-none"
-        style={countStyle}
-      />
-    </span>
+    <LabelCountBadge label={label} count={count} size={size} labelBg={labelBg} labelFg={labelFg} />
   );
 }

--- a/src/components/label/route-label.tsx
+++ b/src/components/label/route-label.tsx
@@ -15,20 +15,34 @@ interface RouteLabelProps {
 /**
  * Display-only label for a route with its entry count.
  *
- * Wraps {@link BaseLabel} and applies the route's own `route_color` /
- * `route_text_color` via inline style, so the coloring matches other
- * route-badge surfaces (RouteBadge, PillButton) without needing filter
- * affordances.
+ * Visually composed of two joined segments:
+ *  - left: route name with `route_color` / `route_text_color`
+ *  - right: count with inverted colors (background = text color of
+ *    the left segment, text = background color of the left segment)
+ *
+ * Uses two {@link BaseLabel} instances inside a flex wrapper with the
+ * inner corners flattened so the pair reads as a single pill split
+ * into two halves.
  */
 export function RouteLabel({ route, count, dataLang, agencies, size = 'sm' }: RouteLabelProps) {
   const { i18n } = useTranslation();
   const name =
     getRouteDisplayNames(route, dataLang, resolveAgencyLang(agencies, route.agency_id)).resolved
       .name || route.route_id;
-  const value = `${name}: ${count.toLocaleString(i18n.language)}`;
   const bg = route.route_color ? `#${route.route_color}` : undefined;
   const fg = route.route_text_color ? `#${route.route_text_color}` : undefined;
+  const nameStyle = bg ? { background: bg, color: fg } : undefined;
+  const countStyle = bg ? { background: fg, color: bg } : undefined;
+  const frameStyle = bg ? { borderColor: bg } : undefined;
   return (
-    <BaseLabel size={size} value={value} style={bg ? { background: bg, color: fg } : undefined} />
+    <span className="inline-flex items-stretch overflow-hidden rounded border" style={frameStyle}>
+      <BaseLabel size={size} value={name} className="rounded-none" style={nameStyle} />
+      <BaseLabel
+        size={size}
+        value={count.toLocaleString(i18n.language)}
+        className="rounded-none"
+        style={countStyle}
+      />
+    </span>
   );
 }

--- a/src/components/label/route-label.tsx
+++ b/src/components/label/route-label.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next';
+import { resolveAgencyLang } from '../../config/transit-defaults';
+import { getRouteDisplayNames } from '../../domain/transit/get-route-display-names';
+import type { Agency, Route } from '../../types/app/transit';
+import { BaseLabel, type BaseLabelSize } from './base-label';
+
+interface RouteLabelProps {
+  route: Route;
+  count: number;
+  dataLang: readonly string[];
+  agencies: Agency[];
+  size?: BaseLabelSize;
+}
+
+/**
+ * Display-only label for a route with its entry count.
+ *
+ * Wraps {@link BaseLabel} and applies the route's own `route_color` /
+ * `route_text_color` via inline style, so the coloring matches other
+ * route-badge surfaces (RouteBadge, PillButton) without needing filter
+ * affordances.
+ */
+export function RouteLabel({ route, count, dataLang, agencies, size = 'sm' }: RouteLabelProps) {
+  const { i18n } = useTranslation();
+  const name =
+    getRouteDisplayNames(route, dataLang, resolveAgencyLang(agencies, route.agency_id)).resolved
+      .name || route.route_id;
+  const value = `${name}: ${count.toLocaleString(i18n.language)}`;
+  const bg = route.route_color ? `#${route.route_color}` : undefined;
+  const fg = route.route_text_color ? `#${route.route_text_color}` : undefined;
+  return (
+    <BaseLabel size={size} value={value} style={bg ? { background: bg, color: fg } : undefined} />
+  );
+}

--- a/src/components/label/timetable-entry-attributes-labels.stories.tsx
+++ b/src/components/label/timetable-entry-attributes-labels.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { TimetableEntryLabels } from './timetable-entry-labels';
+import { TimetableEntryAttributesLabels } from './timetable-entry-attributes-labels';
+import { getTimetableEntryAttributes } from '../../domain/transit/timetable-entry-attributes';
 import { createEntry } from '../../stories/fixtures';
 
 const allEnabled = {
@@ -10,15 +11,15 @@ const allEnabled = {
 };
 
 const meta = {
-  title: 'Label/TimetableEntryLabels',
-  component: TimetableEntryLabels,
+  title: 'Label/TimetableEntryAttributesLabels',
+  component: TimetableEntryAttributesLabels,
   argTypes: {
     isDisplayTerminal: { control: 'boolean' },
     isDisplayOrigin: { control: 'boolean' },
     isDisplayPickupUnavailable: { control: 'boolean' },
     isDisplayDropOffUnavailable: { control: 'boolean' },
   },
-} satisfies Meta<typeof TimetableEntryLabels>;
+} satisfies Meta<typeof TimetableEntryAttributesLabels>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -26,7 +27,7 @@ type Story = StoryObj<typeof meta>;
 /** No labels shown — all flags false or entry has no special state. */
 export const Normal: Story = {
   args: {
-    entry: createEntry(),
+    attributes: getTimetableEntryAttributes(createEntry()),
     ...allEnabled,
   },
 };
@@ -34,7 +35,7 @@ export const Normal: Story = {
 /** Terminal stop — gray label. */
 export const Terminal: Story = {
   args: {
-    entry: createEntry({ isTerminal: true }),
+    attributes: getTimetableEntryAttributes(createEntry({ isTerminal: true })),
     ...allEnabled,
   },
 };
@@ -42,7 +43,7 @@ export const Terminal: Story = {
 /** Origin stop — blue label. */
 export const Origin: Story = {
   args: {
-    entry: createEntry({ isOrigin: true }),
+    attributes: getTimetableEntryAttributes(createEntry({ isOrigin: true })),
     ...allEnabled,
   },
 };
@@ -50,7 +51,7 @@ export const Origin: Story = {
 /** Pickup unavailable (pickupType=1) — red label. */
 export const PickupUnavailable: Story = {
   args: {
-    entry: createEntry({ pickupType: 1 }),
+    attributes: getTimetableEntryAttributes(createEntry({ pickupType: 1 })),
     ...allEnabled,
   },
 };
@@ -58,7 +59,7 @@ export const PickupUnavailable: Story = {
 /** Drop-off unavailable (dropOffType=1) — red label. */
 export const DropOffUnavailable: Story = {
   args: {
-    entry: createEntry({ dropOffType: 1 }),
+    attributes: getTimetableEntryAttributes(createEntry({ dropOffType: 1 })),
     ...allEnabled,
   },
 };
@@ -66,15 +67,19 @@ export const DropOffUnavailable: Story = {
 /** Terminal + origin + both boarding constraints. */
 export const AllLabels: Story = {
   args: {
-    entry: createEntry({ isTerminal: true, isOrigin: true, pickupType: 1, dropOffType: 1 }),
+    attributes: getTimetableEntryAttributes(
+      createEntry({ isTerminal: true, isOrigin: true, pickupType: 1, dropOffType: 1 }),
+    ),
     ...allEnabled,
   },
 };
 
-/** Display flags disabled — entry has all states but nothing renders. */
+/** Display flags disabled — attributes has all states but nothing renders. */
 export const AllDisabled: Story = {
   args: {
-    entry: createEntry({ isTerminal: true, isOrigin: true, pickupType: 1, dropOffType: 1 }),
+    attributes: getTimetableEntryAttributes(
+      createEntry({ isTerminal: true, isOrigin: true, pickupType: 1, dropOffType: 1 }),
+    ),
     isDisplayTerminal: false,
     isDisplayOrigin: false,
     isDisplayPickupUnavailable: false,
@@ -85,7 +90,7 @@ export const AllDisabled: Story = {
 /** All combinations side by side. */
 export const KitchenSink: Story = {
   args: {
-    entry: createEntry(),
+    attributes: getTimetableEntryAttributes(createEntry()),
     ...allEnabled,
   },
   render: () => {
@@ -110,7 +115,10 @@ export const KitchenSink: Story = {
         {cases.map(({ label, overrides }) => (
           <div key={label} className="flex items-center gap-2">
             <span className="w-40 text-xs text-gray-500">{label}</span>
-            <TimetableEntryLabels entry={createEntry(overrides)} {...allEnabled} />
+            <TimetableEntryAttributesLabels
+              attributes={getTimetableEntryAttributes(createEntry(overrides))}
+              {...allEnabled}
+            />
             {Object.keys(overrides).length === 0 && (
               <span className="text-xs text-gray-400">(renders nothing)</span>
             )}

--- a/src/components/label/timetable-entry-attributes-labels.tsx
+++ b/src/components/label/timetable-entry-attributes-labels.tsx
@@ -1,9 +1,9 @@
-import type { TimetableEntry } from '../../types/app/transit-composed';
+import type { TimetableEntryAttributes } from '../../types/app/transit';
 import { useTranslation } from 'react-i18next';
 import { BaseLabel, type BaseLabelSize } from './base-label';
 
-interface TimetableEntryLabelsProps {
-  entry: TimetableEntry;
+interface TimetableEntryAttributesLabelsProps {
+  attributes: TimetableEntryAttributes;
   size?: BaseLabelSize;
   isDisplayTerminal: boolean;
   isDisplayOrigin: boolean;
@@ -11,22 +11,27 @@ interface TimetableEntryLabelsProps {
   isDisplayDropOffUnavailable: boolean;
 }
 
-/** Compact labels for terminal, origin, and boarding availability. */
-export function TimetableEntryLabels({
-  entry,
+/**
+ * Compact labels for the four {@link TimetableEntryAttributes} flags
+ * (terminal, origin, pickup unavailable, drop-off unavailable).
+ *
+ * Scope is deliberately limited to those four attributes — anything
+ * beyond them (headsign, route info, etc.) belongs in other components.
+ */
+export function TimetableEntryAttributesLabels({
+  attributes,
   size = 'xs',
   isDisplayTerminal,
   isDisplayOrigin,
   isDisplayPickupUnavailable,
   isDisplayDropOffUnavailable,
-}: TimetableEntryLabelsProps) {
+}: TimetableEntryAttributesLabelsProps) {
   const { t } = useTranslation();
-  const { boarding, patternPosition } = entry;
 
-  const showTerminal = isDisplayTerminal && patternPosition.isTerminal;
-  const showOrigin = isDisplayOrigin && patternPosition.isOrigin;
-  const showPickupUnavailable = isDisplayPickupUnavailable && boarding.pickupType === 1;
-  const showDropOffUnavailable = isDisplayDropOffUnavailable && boarding.dropOffType === 1;
+  const showTerminal = isDisplayTerminal && attributes.isTerminal;
+  const showOrigin = isDisplayOrigin && attributes.isOrigin;
+  const showPickupUnavailable = isDisplayPickupUnavailable && attributes.isPickupUnavailable;
+  const showDropOffUnavailable = isDisplayDropOffUnavailable && attributes.isDropOffUnavailable;
 
   if (!showTerminal && !showOrigin && !showPickupUnavailable && !showDropOffUnavailable) {
     return null;

--- a/src/components/map/map-overlay-panels.tsx
+++ b/src/components/map/map-overlay-panels.tsx
@@ -4,6 +4,7 @@ import type { AnchorEntry } from '../../domain/portal/anchor';
 import type { StopHistoryEntry } from '../../domain/transit/stop-history';
 import type { UserLocation } from '../../types/app/map';
 import type { AppRouteTypeValue, Stop } from '../../types/app/transit';
+import type { StopWithMeta } from '../../types/app/transit-composed';
 import { InfoPanel } from '../panel/info-panel';
 import { MapControlPanel } from '../panel/map-control-panel';
 import { MapLayerPanel } from '../panel/map-layer-panel';
@@ -42,6 +43,13 @@ interface MapOverlayPanelsProps {
   onDeselectStop: () => void;
   onHistorySelect: (stop: Stop, routeTypes: AppRouteTypeValue[]) => void;
   onPortalSelect: (entry: AnchorEntry) => void;
+  /**
+   * Looks up an anchored stop's current `StopWithMeta` from the
+   * repository's full dataset. Forwarded to `Portals` so anchor
+   * display names can be resolved against the latest GTFS data
+   * at render time, regardless of viewport position.
+   */
+  lookupAnchorStopMeta: (stopId: string) => StopWithMeta | null;
   tileIndex: number | null;
 }
 
@@ -72,6 +80,7 @@ export function MapOverlayPanels({
   onDeselectStop,
   onHistorySelect,
   onPortalSelect,
+  lookupAnchorStopMeta,
   tileIndex,
 }: MapOverlayPanelsProps) {
   return (
@@ -120,7 +129,13 @@ export function MapOverlayPanels({
           dataLang={dataLang}
           onSelect={onHistorySelect}
         />
-        <Portals anchors={anchors} infoLevel={infoLevel} onSelect={onPortalSelect} />
+        <Portals
+          anchors={anchors}
+          infoLevel={infoLevel}
+          dataLang={dataLang}
+          lookupAnchorStopMeta={lookupAnchorStopMeta}
+          onSelect={onPortalSelect}
+        />
       </div>
     </>
   );

--- a/src/components/map/map-overlay-panels.tsx
+++ b/src/components/map/map-overlay-panels.tsx
@@ -117,6 +117,7 @@ export function MapOverlayPanels({
           history={stopHistory}
           selectedStopId={selectedStopId}
           infoLevel={infoLevel}
+          dataLang={dataLang}
           onSelect={onHistorySelect}
         />
         <Portals anchors={anchors} infoLevel={infoLevel} onSelect={onPortalSelect} />

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -251,6 +251,13 @@ interface MapViewProps {
   anchors: AnchorEntry[];
   /** Called when an anchor is chosen from the Portal dropdown. */
   onPortalSelect: (entry: AnchorEntry) => void;
+  /**
+   * Looks up an anchored stop's current `StopWithMeta` from the
+   * repository's full dataset. Forwarded to the Portal dropdown so
+   * anchor display names can be resolved against the latest GTFS
+   * data at render time, regardless of viewport position.
+   */
+  lookupAnchorStopMeta: (stopId: string) => StopWithMeta | null;
 }
 
 export function MapView({
@@ -291,6 +298,7 @@ export function MapView({
   onSearchClick,
   onInfoClick,
   stopHistory,
+  lookupAnchorStopMeta,
   onHistorySelect,
   anchors,
   onPortalSelect,
@@ -501,6 +509,7 @@ export function MapView({
         onDeselectStop={onDeselectStop}
         onHistorySelect={onHistorySelect}
         onPortalSelect={onPortalSelect}
+        lookupAnchorStopMeta={lookupAnchorStopMeta}
       />
       {mapInstance && (
         <EdgeMarkersSwitch

--- a/src/components/marker/stop-summary.tsx
+++ b/src/components/marker/stop-summary.tsx
@@ -5,6 +5,7 @@ import { resolveAgencyLang } from '../../config/transit-defaults';
 import { createInfoLevel } from '../../utils/create-info-level';
 import { getStopDisplayNames } from '../../domain/transit/get-stop-display-names';
 import { minutesToDate } from '../../domain/transit/calendar-utils';
+import { getTimetableEntryAttributes } from '../../domain/transit/timetable-entry-attributes';
 import { getDisplayMinutes } from '../../domain/transit/timetable-utils';
 import { AgencyBadge } from '../badge/agency-badge';
 import { routeTypesEmoji } from '../../utils/route-type-emoji';
@@ -87,8 +88,7 @@ export function StopSummary({
               infoLevel={infoLevel === 'verbose' ? infoLevel : 'simple'}
               dataLang={dataLang}
               showRouteTypeIcon={false}
-              isTerminal={entry.patternPosition.isTerminal}
-              isPickupUnavailable={entry.boarding.pickupType === 1}
+              attributes={getTimetableEntryAttributes(entry)}
               ellipsisHeadsign={true}
             />
 

--- a/src/components/portals.tsx
+++ b/src/components/portals.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import type { InfoLevel } from '../types/app/settings';
 import type { AnchorEntry } from '../domain/portal/anchor';
+import type { StopWithMeta } from '../types/app/transit-composed';
+import { resolveAgencyLang } from '../config/transit-defaults';
+import { getStopDisplayNames } from '../domain/transit/get-stop-display-names';
 import { useInfoLevel } from '../hooks/use-info-level';
 import { routeTypesEmoji } from '../utils/route-type-emoji';
 import { DoorOpen } from 'lucide-react';
@@ -13,6 +16,17 @@ const logger = createLogger('Portals');
 interface PortalsProps {
   anchors: AnchorEntry[];
   infoLevel: InfoLevel;
+  /** Display language chain for translated GTFS/ODPT data names. */
+  dataLang: readonly string[];
+  /**
+   * Looks up an anchored stop's current `StopWithMeta` from the
+   * repository's full dataset (not just the visible viewport).
+   * Used to resolve the anchor's display name in the user's current
+   * language from the latest GTFS data at render time, so newly
+   * added translations flow through without needing to rewrite the
+   * stored anchor entry.
+   */
+  lookupAnchorStopMeta: (stopId: string) => StopWithMeta | null;
   onSelect: (entry: AnchorEntry) => void;
 }
 
@@ -27,7 +41,13 @@ interface PortalsProps {
  * @param infoLevel - Controls display detail.
  * @param onSelect - Called when an anchor entry is chosen.
  */
-export function Portals({ anchors, infoLevel, onSelect }: PortalsProps) {
+export function Portals({
+  anchors,
+  infoLevel,
+  dataLang,
+  lookupAnchorStopMeta,
+  onSelect,
+}: PortalsProps) {
   const il = useInfoLevel(infoLevel);
   const [open, setOpen] = useState(false);
 
@@ -63,21 +83,31 @@ export function Portals({ anchors, infoLevel, onSelect }: PortalsProps) {
           position="popper"
           className="z-1002 max-h-[40dvh] min-w-48 border-none bg-white/80 text-black backdrop-blur-sm dark:bg-black/80 dark:text-white"
         >
-          {anchors.map((entry) => (
-            <SelectItem
-              key={entry.stopId}
-              value={entry.stopId}
-              className="overflow-hidden focus:bg-black/10 focus:text-black dark:focus:bg-white/20 dark:focus:text-white"
-            >
-              <span className="shrink-0 text-base">{routeTypesEmoji(entry.routeTypes)}</span>
-              <span className="max-w-[60dvw] truncate">{entry.stopName}</span>
-              {il.isVerboseEnabled && (
-                <Badge variant="secondary" className="ml-1 text-[10px]">
-                  {entry.stopId}
-                </Badge>
-              )}
-            </SelectItem>
-          ))}
+          {anchors.map((entry) => {
+            const meta = lookupAnchorStopMeta(entry.stopId);
+            const displayName = meta
+              ? getStopDisplayNames(
+                  meta.stop,
+                  dataLang,
+                  resolveAgencyLang(meta.agencies, meta.stop.agency_id),
+                ).name || entry.stopName
+              : entry.stopName;
+            return (
+              <SelectItem
+                key={entry.stopId}
+                value={entry.stopId}
+                className="overflow-hidden focus:bg-black/10 focus:text-black dark:focus:bg-white/20 dark:focus:text-white"
+              >
+                <span className="shrink-0 text-base">{routeTypesEmoji(entry.routeTypes)}</span>
+                <span className="max-w-[60dvw] truncate">{displayName}</span>
+                {il.isVerboseEnabled && (
+                  <Badge variant="secondary" className="ml-1 text-[10px]">
+                    {entry.stopId}
+                  </Badge>
+                )}
+              </SelectItem>
+            );
+          })}
         </SelectContent>
       </Select>
     </div>

--- a/src/components/stop-history.tsx
+++ b/src/components/stop-history.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next';
 import type { InfoLevel } from '../types/app/settings';
 import type { Stop } from '../types/app/transit';
 import type { StopHistoryEntry } from '../domain/transit/stop-history';
+import { resolveAgencyLang } from '../config/transit-defaults';
+import { getStopDisplayNames } from '../domain/transit/get-stop-display-names';
 import { useInfoLevel } from '../hooks/use-info-level';
 import { routeTypesEmoji } from '../utils/route-type-emoji';
 import { History } from 'lucide-react';
@@ -16,6 +18,8 @@ interface StopHistoryProps {
   history: StopHistoryEntry[];
   selectedStopId: string | null;
   infoLevel: InfoLevel;
+  /** Display language chain for translated GTFS/ODPT data names. */
+  dataLang: readonly string[];
   onSelect: (stop: Stop, routeTypes: StopHistoryEntry['routeTypes']) => void;
 }
 
@@ -36,7 +40,13 @@ interface StopHistoryProps {
  * @param infoLevel - Controls display detail.
  * @param onSelect - Called when a history entry is chosen.
  */
-export function StopHistory({ history, selectedStopId, infoLevel, onSelect }: StopHistoryProps) {
+export function StopHistory({
+  history,
+  selectedStopId,
+  infoLevel,
+  dataLang,
+  onSelect,
+}: StopHistoryProps) {
   const { t } = useTranslation();
   const il = useInfoLevel(infoLevel);
   const [open, setOpen] = useState(false);
@@ -85,7 +95,16 @@ export function StopHistory({ history, selectedStopId, infoLevel, onSelect }: St
             {selectedEntry ? (
               <>
                 <span className="text-base">{routeTypesEmoji(selectedEntry.routeTypes)}</span>
-                <span className="truncate">{selectedEntry.stopWithMeta.stop.stop_name}</span>
+                <span className="truncate">
+                  {getStopDisplayNames(
+                    selectedEntry.stopWithMeta.stop,
+                    dataLang,
+                    resolveAgencyLang(
+                      selectedEntry.stopWithMeta.agencies,
+                      selectedEntry.stopWithMeta.stop.agency_id,
+                    ),
+                  ).name || selectedEntry.stopWithMeta.stop.stop_name}
+                </span>
               </>
             ) : (
               <History size={14} strokeWidth={3} className="inline text-sky-400" />
@@ -97,7 +116,10 @@ export function StopHistory({ history, selectedStopId, infoLevel, onSelect }: St
           className="z-1002 max-h-[40dvh] min-w-48 border-none bg-white/80 text-black backdrop-blur-sm dark:bg-black/80 dark:text-white"
         >
           {history.map((entry) => {
-            const { stop } = entry.stopWithMeta;
+            const { stop, agencies } = entry.stopWithMeta;
+            const displayName =
+              getStopDisplayNames(stop, dataLang, resolveAgencyLang(agencies, stop.agency_id))
+                .name || stop.stop_name;
             return (
               <SelectItem
                 key={stop.stop_id}
@@ -105,7 +127,7 @@ export function StopHistory({ history, selectedStopId, infoLevel, onSelect }: St
                 className="overflow-hidden focus:bg-black/10 focus:text-black dark:focus:bg-white/20 dark:focus:text-white"
               >
                 <span className="shrink-0 text-base">{routeTypesEmoji(entry.routeTypes)}</span>
-                <span className="max-w-[60dvw] truncate">{stop.stop_name}</span>
+                <span className="max-w-[60dvw] truncate">{displayName}</span>
                 {il.isVerboseEnabled && (
                   <Badge variant="secondary" className="ml-1 text-[10px]">
                     {stop.stop_id}

--- a/src/components/timetable/timetable-grid-entry.tsx
+++ b/src/components/timetable/timetable-grid-entry.tsx
@@ -1,9 +1,10 @@
 import type { InfoLevel } from '../../types/app/settings';
 import type { TimetableEntry } from '../../types/app/transit-composed';
 import { getDisplayMinutes } from '../../domain/transit/timetable-utils';
+import { getTimetableEntryAttributes } from '../../domain/transit/timetable-entry-attributes';
 import { HeadsignBadge } from '../badge/headsign-badge';
 import { VerboseTimetableGridEntry as VerboseGridEntry } from '../verbose/verbose-timetable-grid-entry';
-import { TimetableEntryLabels } from '../label/timetable-entry-labels';
+import { TimetableEntryAttributesLabels } from '../label/timetable-entry-attributes-labels';
 
 interface TimetableGridEntryProps {
   entry: TimetableEntry;
@@ -69,8 +70,9 @@ export function TimetableGridEntry({
           disableVerbose={disableVerbose}
         />
       )}
-      <TimetableEntryLabels
-        entry={entry}
+      <TimetableEntryAttributesLabels
+        attributes={getTimetableEntryAttributes(entry)}
+        size={'xs'}
         isDisplayTerminal={isDisplayTerminal}
         isDisplayOrigin={isDisplayOrigin}
         isDisplayPickupUnavailable={isDisplayPickupUnavailable}

--- a/src/components/timetable/timetable-metadata.tsx
+++ b/src/components/timetable/timetable-metadata.tsx
@@ -1,11 +1,8 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { resolveAgencyLang } from '@/config/transit-defaults';
-import { getRouteDisplayNames } from '@/domain/transit/get-route-display-names';
 import { getDisplayMinutes } from '@/domain/transit/timetable-utils';
 import type { Agency, Route } from '@/types/app/transit';
 import type { TimetableEntry } from '@/types/app/transit-composed';
-import { PillButton } from '../button/pill-button';
 import { RouteLabel } from '../label/route-label';
 
 interface TimetableMetadataProps {
@@ -85,46 +82,20 @@ export function TimetableMetadata({
           </span>
         )}
       </p>
-      {routeBreakdown.length > 1 && (
-        <div className="flex flex-wrap gap-1">
-          {routeBreakdown.map((item) => {
-            const bg = item.route.route_color ? `#${item.route.route_color}` : undefined;
-            const fg = item.route.route_text_color ? `#${item.route.route_text_color}` : undefined;
-            const label = getRouteDisplayNames(
-              item.route,
-              dataLang,
-              resolveAgencyLang(agencies, item.route.agency_id),
-            ).resolved.name;
 
-            return (
-              <PillButton
-                key={item.route.route_id}
-                size="sm"
-                active={true}
-                activeBg={bg}
-                activeFg={fg}
-                count={item.count}
-              >
-                {label}
-              </PillButton>
-            );
-          })}
-        </div>
-      )}
-      {
-        <div className="flex flex-wrap gap-1">
-          {routeBreakdown.map((item) => (
-            <RouteLabel
-              key={item.route.route_id}
-              route={item.route}
-              count={item.count}
-              dataLang={dataLang}
-              agencies={agencies}
-              size="sm"
-            />
-          ))}
-        </div>
-      }
+      {/* Routes with their counts */}
+      <div className="flex flex-wrap gap-1">
+        {routeBreakdown.map((item) => (
+          <RouteLabel
+            key={item.route.route_id}
+            route={item.route}
+            count={item.count}
+            dataLang={dataLang}
+            agencies={agencies}
+            size="sm"
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/timetable/timetable-metadata.tsx
+++ b/src/components/timetable/timetable-metadata.tsx
@@ -83,7 +83,16 @@ export function TimetableMetadata({
         )}
       </p>
 
-      {/* Routes with their counts */}
+      {/* Routes with their counts.
+       *
+       * Intentionally rendered for every stop, including single-route
+       * stops, even though the previous PillButton row was gated on
+       * `routeBreakdown.length > 1`. RouteCountBadge is read-only and
+       * visually distinct from a filter pill, so the duplication with
+       * the trip count line is acceptable, and consistently surfacing
+       * the route-color chip helps users associate route × count even
+       * when there is only one route at this stop.
+       */}
       <div className="flex flex-wrap gap-1">
         {routeBreakdown.map((item) => (
           <RouteCountBadge

--- a/src/components/timetable/timetable-metadata.tsx
+++ b/src/components/timetable/timetable-metadata.tsx
@@ -6,6 +6,7 @@ import { getDisplayMinutes } from '@/domain/transit/timetable-utils';
 import type { Agency, Route } from '@/types/app/transit';
 import type { TimetableEntry } from '@/types/app/transit-composed';
 import { PillButton } from '../button/pill-button';
+import { RouteLabel } from '../label/route-label';
 
 interface TimetableMetadataProps {
   timetableEntries: TimetableEntry[];
@@ -110,6 +111,20 @@ export function TimetableMetadata({
           })}
         </div>
       )}
+      {
+        <div className="flex flex-wrap gap-1">
+          {routeBreakdown.map((item) => (
+            <RouteLabel
+              key={item.route.route_id}
+              route={item.route}
+              count={item.count}
+              dataLang={dataLang}
+              agencies={agencies}
+              size="sm"
+            />
+          ))}
+        </div>
+      }
     </div>
   );
 }

--- a/src/components/timetable/timetable-metadata.tsx
+++ b/src/components/timetable/timetable-metadata.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { getDisplayMinutes } from '@/domain/transit/timetable-utils';
 import type { Agency, Route } from '@/types/app/transit';
 import type { TimetableEntry } from '@/types/app/transit-composed';
-import { RouteLabel } from '../label/route-label';
+import { RouteCountBadge } from '../badge/route-count-badge';
 
 interface TimetableMetadataProps {
   timetableEntries: TimetableEntry[];
@@ -86,7 +86,7 @@ export function TimetableMetadata({
       {/* Routes with their counts */}
       <div className="flex flex-wrap gap-1">
         {routeBreakdown.map((item) => (
-          <RouteLabel
+          <RouteCountBadge
             key={item.route.route_id}
             route={item.route}
             count={item.count}

--- a/src/components/trip-info.stories.tsx
+++ b/src/components/trip-info.stories.tsx
@@ -237,8 +237,14 @@ export const TimetableEntryAttributesComparison: Story = {
 
 /**
  * Size comparison — `sm` (compact, used in StopSummary popovers) vs
- * `default` (used in DepartureItem / FlatDepartureItem). Labels scale
- * correspondingly via BaseLabelSize.
+ * `default` (used in DepartureItem / FlatDepartureItem).
+ *
+ * The route badge / headsign / agency badge scale with the parent
+ * `size` prop. The `TimetableEntryAttributesLabels` row uses a
+ * fixed `BaseLabelSize='sm'` regardless of the parent variant by
+ * design — these flags are visually subordinate to the main route /
+ * headsign info and should not compete for attention by scaling up.
+ * See the inline comment in `trip-info.tsx` for context.
  */
 export const SizeComparison: Story = {
   args: {

--- a/src/components/trip-info.stories.tsx
+++ b/src/components/trip-info.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { Agency, Route } from '../types/app/transit';
+import type { Agency, Route, TimetableEntryAttributes } from '../types/app/transit';
 import {
   createRouteDirection,
   emptyHeadsign,
@@ -103,6 +103,13 @@ const stopOverridesTripRd = createRouteDirection({
   stopHeadsign: stopHeadsignDemachiyanagi,
 });
 
+const emptyAttributes: TimetableEntryAttributes = {
+  isTerminal: false,
+  isOrigin: false,
+  isPickupUnavailable: false,
+  isDropOffUnavailable: false,
+};
+
 const meta = {
   title: 'Departure/TripInfo',
   component: TripInfo,
@@ -112,12 +119,14 @@ const meta = {
     dataLang: ['ja'],
     showRouteTypeIcon: true,
     agency,
+    attributes: emptyAttributes,
+    size: 'default',
   },
   argTypes: {
     infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
     showRouteTypeIcon: { control: 'boolean' },
-    isTerminal: { control: 'boolean' },
-    isPickupUnavailable: { control: 'boolean' },
+    size: { control: 'inline-radio', options: ['sm', 'default'] },
+    attributes: { control: 'object' },
   },
   decorators: [
     (Story) => (
@@ -143,12 +152,121 @@ export const KyotoBusRoute: Story = {
   args: { routeDirection: kyotoBusRd, agency: kyotoAgency },
 };
 
+// --- Attributes ---
+
+/** Terminal stop — gray label ("終点"). */
 export const Terminal: Story = {
-  args: { isTerminal: true },
+  args: { attributes: { ...emptyAttributes, isTerminal: true } },
 };
 
+/** Origin stop — blue label ("始発"). */
+export const Origin: Story = {
+  args: { attributes: { ...emptyAttributes, isOrigin: true } },
+};
+
+/** Pickup unavailable — red "乗×" label. */
 export const PickupUnavailable: Story = {
-  args: { isPickupUnavailable: true },
+  args: { attributes: { ...emptyAttributes, isPickupUnavailable: true } },
+};
+
+/** Drop-off unavailable — red "降×" label. */
+export const DropOffUnavailable: Story = {
+  args: { attributes: { ...emptyAttributes, isDropOffUnavailable: true } },
+};
+
+/** All four attributes set — every label renders. */
+export const AllAttributes: Story = {
+  args: {
+    attributes: {
+      isTerminal: true,
+      isOrigin: true,
+      isPickupUnavailable: true,
+      isDropOffUnavailable: true,
+    },
+  },
+};
+
+/**
+ * Side-by-side comparison of each `TimetableEntryAttributes` state
+ * against the baseline (no attributes), using the default size.
+ */
+export const TimetableEntryAttributesComparison: Story = {
+  render: (args) => {
+    const cases: Array<{ label: string; attributes: TimetableEntryAttributes }> = [
+      { label: 'none', attributes: emptyAttributes },
+      { label: 'terminal', attributes: { ...emptyAttributes, isTerminal: true } },
+      { label: 'origin', attributes: { ...emptyAttributes, isOrigin: true } },
+      {
+        label: 'pickup unavailable',
+        attributes: { ...emptyAttributes, isPickupUnavailable: true },
+      },
+      {
+        label: 'drop-off unavailable',
+        attributes: { ...emptyAttributes, isDropOffUnavailable: true },
+      },
+      {
+        label: 'all four',
+        attributes: {
+          isTerminal: true,
+          isOrigin: true,
+          isPickupUnavailable: true,
+          isDropOffUnavailable: true,
+        },
+      },
+    ];
+    return (
+      <div className="flex flex-col gap-3">
+        {cases.map(({ label, attributes }) => (
+          <div key={label}>
+            <span className="mb-0.5 block text-[10px] text-gray-400">{label}</span>
+            <TripInfo
+              routeDirection={args.routeDirection}
+              infoLevel={args.infoLevel}
+              dataLang={args.dataLang}
+              showRouteTypeIcon={args.showRouteTypeIcon}
+              agency={args.agency}
+              attributes={attributes}
+              size={args.size}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  },
+};
+
+/**
+ * Size comparison — `sm` (compact, used in StopSummary popovers) vs
+ * `default` (used in DepartureItem / FlatDepartureItem). Labels scale
+ * correspondingly via BaseLabelSize.
+ */
+export const SizeComparison: Story = {
+  args: {
+    attributes: {
+      isTerminal: true,
+      isOrigin: false,
+      isPickupUnavailable: true,
+      isDropOffUnavailable: false,
+    },
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-3">
+      {(['sm', 'default'] as const).map((size) => (
+        <div key={size}>
+          <span className="mb-0.5 block text-[10px] text-gray-400">size: {size}</span>
+          <TripInfo
+            routeDirection={args.routeDirection}
+            infoLevel={args.infoLevel}
+            dataLang={args.dataLang}
+            showRouteTypeIcon={args.showRouteTypeIcon}
+            agency={args.agency}
+            attributes={args.attributes}
+            size={size}
+          />
+        </div>
+      ))}
+    </div>
+  ),
 };
 
 export const EmptyHeadsign: Story = {
@@ -198,6 +316,28 @@ export const LangComparison: Story = {
   ),
 };
 
+/**
+ * KitchenSink — maximum-information composition for visual regression.
+ *
+ * - `stopOverridesTripRd` for rich multi-language route names and
+ *   both trip/stop headsigns (verbose mode renders both).
+ * - `kyotoAgency` matches `kyotoBusRoute.agency_id` so the agency
+ *   badge resolves correctly.
+ * - All four `TimetableEntryAttributes` flags enabled so every
+ *   per-entry label (Terminal / Origin / PickupUnavailable /
+ *   DropOffUnavailable) renders.
+ * - `infoLevel: 'verbose'` to surface all available verbose data.
+ */
 export const KitchenSink: Story = {
-  args: { routeDirection: tramRd, agency: kyotoAgency, infoLevel: 'verbose', isTerminal: true },
+  args: {
+    routeDirection: stopOverridesTripRd,
+    agency: kyotoAgency,
+    infoLevel: 'verbose',
+    attributes: {
+      isTerminal: true,
+      isOrigin: true,
+      isPickupUnavailable: true,
+      isDropOffUnavailable: true,
+    },
+  },
 };

--- a/src/components/trip-info.tsx
+++ b/src/components/trip-info.tsx
@@ -181,10 +181,8 @@ export function TripInfo({
       {attributes && (
         <TimetableEntryAttributesLabels
           attributes={attributes}
-          // size={labelSize}
-          // size={'md'}
+          // size: fixed for design reasons — these labels are visually subordinate to the main route/headsign info and should not compete for attention by scaling up to the same size as the route badge.
           size={'sm'}
-          // size={'xs'}
           isDisplayTerminal={true}
           isDisplayOrigin={true}
           isDisplayPickupUnavailable={true}

--- a/src/components/trip-info.tsx
+++ b/src/components/trip-info.tsx
@@ -1,9 +1,8 @@
 import type { InfoLevel } from '../types/app/settings';
-import type { Agency } from '../types/app/transit';
+import type { Agency, TimetableEntryAttributes } from '../types/app/transit';
 import type { RouteDirection } from '../types/app/transit-composed';
 import { type ResolvedDisplayNames, hasDisplayContent } from '../domain/transit/get-display-names';
 import type { InfoLevelFlags } from '../utils/create-info-level';
-import { useTranslation } from 'react-i18next';
 import { DEFAULT_AGENCY_LANG } from '../config/transit-defaults';
 import { cn } from '../lib/utils';
 import { useInfoLevel } from '../hooks/use-info-level';
@@ -11,6 +10,7 @@ import { routeTypeEmoji } from '../utils/route-type-emoji';
 import { getHeadsignDisplayNames } from '../domain/transit/get-headsign-display-names';
 import { AgencyBadge } from './badge/agency-badge';
 import { RouteBadge } from './badge/route-badge';
+import { TimetableEntryAttributesLabels } from './label/timetable-entry-attributes-labels';
 import { headsignSourceEmoji } from '../domain/transit/headsign-source-emoji';
 
 const sizeVariants = {
@@ -71,10 +71,13 @@ interface TripInfoProps {
   showRouteTypeIcon?: boolean;
   /** Agency operating this trip. Shown at detailed+ info level. */
   agency?: Agency;
-  /** Whether this stop is the terminal (last stop) of the trip. */
-  isTerminal?: boolean;
-  /** Whether pickup is unavailable at this stop. */
-  isPickupUnavailable?: boolean;
+  /**
+   * Per-entry boolean attributes (terminal / origin / pickup-unavailable /
+   * drop-off-unavailable). When provided, rendered via the shared
+   * `TimetableEntryAttributesLabels` primitive so the style matches the
+   * timetable grid.
+   */
+  attributes?: TimetableEntryAttributes;
   /** Size variant. @default 'default' */
   size?: keyof typeof sizeVariants;
   /** Apply CSS text-overflow ellipsis to headsign name and sub-names. */
@@ -94,13 +97,11 @@ export function TripInfo({
   dataLang,
   showRouteTypeIcon = false,
   agency,
-  isTerminal = false,
-  isPickupUnavailable = false,
+  attributes,
   size = 'default',
   ellipsisHeadsign = false,
 }: TripInfoProps) {
   const { route } = routeDirection;
-  const { t } = useTranslation();
   const info = useInfoLevel(infoLevel);
   const v = sizeVariants[size];
   const agencyLang = agency?.agency_lang ? [agency.agency_lang] : DEFAULT_AGENCY_LANG;
@@ -177,19 +178,18 @@ export function TripInfo({
       {/* Headsign */}
       {headSignInfos}
 
-      {isTerminal && (
-        <span
-          className={`shrink-0 rounded bg-gray-100 px-1 ${v.label} font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300`}
-        >
-          {t('departure.terminal')}
-        </span>
-      )}
-      {isPickupUnavailable && (
-        <span
-          className={`shrink-0 rounded bg-red-100 px-1 ${v.label} font-medium text-red-700 dark:bg-red-900 dark:text-red-300`}
-        >
-          {t('departure.noBoarding')}
-        </span>
+      {attributes && (
+        <TimetableEntryAttributesLabels
+          attributes={attributes}
+          // size={labelSize}
+          // size={'md'}
+          size={'sm'}
+          // size={'xs'}
+          isDisplayTerminal={true}
+          isDisplayOrigin={true}
+          isDisplayPickupUnavailable={true}
+          isDisplayDropOffUnavailable={true}
+        />
       )}
     </div>
   );

--- a/src/domain/transit/__tests__/timetable-entry-attributes.test.ts
+++ b/src/domain/transit/__tests__/timetable-entry-attributes.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import type { StopServiceType } from '../../../types/app/transit-composed';
+import type { TimetableEntry } from '../../../types/app/transit-composed';
+import { getTimetableEntryAttributes } from '../timetable-entry-attributes';
+
+/**
+ * Build a minimal TimetableEntry with only the fields that
+ * getTimetableEntryAttributes reads. Other fields get plausible
+ * defaults so the type-check passes.
+ */
+function makeEntry(overrides: {
+  isTerminal?: boolean;
+  isOrigin?: boolean;
+  pickupType?: StopServiceType;
+  dropOffType?: StopServiceType;
+}): TimetableEntry {
+  return {
+    schedule: { departureMinutes: 480, arrivalMinutes: 480 },
+    routeDirection: {
+      route: {
+        route_id: 'r1',
+        route_short_name: '',
+        route_short_names: {},
+        route_long_name: '',
+        route_long_names: {},
+        route_type: 3,
+        route_color: '',
+        route_text_color: '',
+        agency_id: 'a1',
+      },
+      tripHeadsign: { name: 'Dest', names: {} },
+    },
+    boarding: {
+      pickupType: overrides.pickupType ?? 0,
+      dropOffType: overrides.dropOffType ?? 0,
+    },
+    patternPosition: {
+      stopIndex: 5,
+      totalStops: 10,
+      isTerminal: overrides.isTerminal ?? false,
+      isOrigin: overrides.isOrigin ?? false,
+    },
+  };
+}
+
+describe('getTimetableEntryAttributes', () => {
+  it('derives all four flags as false by default', () => {
+    const attributes = getTimetableEntryAttributes(makeEntry({}));
+    expect(attributes).toEqual({
+      isTerminal: false,
+      isOrigin: false,
+      isPickupUnavailable: false,
+      isDropOffUnavailable: false,
+    });
+  });
+
+  it('reflects isTerminal from patternPosition.isTerminal', () => {
+    expect(getTimetableEntryAttributes(makeEntry({ isTerminal: true })).isTerminal).toBe(true);
+    expect(getTimetableEntryAttributes(makeEntry({ isTerminal: false })).isTerminal).toBe(false);
+  });
+
+  it('reflects isOrigin from patternPosition.isOrigin', () => {
+    expect(getTimetableEntryAttributes(makeEntry({ isOrigin: true })).isOrigin).toBe(true);
+    expect(getTimetableEntryAttributes(makeEntry({ isOrigin: false })).isOrigin).toBe(false);
+  });
+
+  it('sets isPickupUnavailable when pickupType is 1', () => {
+    expect(getTimetableEntryAttributes(makeEntry({ pickupType: 1 })).isPickupUnavailable).toBe(
+      true,
+    );
+  });
+
+  it('leaves isPickupUnavailable false for pickupType 0 (boardable)', () => {
+    expect(getTimetableEntryAttributes(makeEntry({ pickupType: 0 })).isPickupUnavailable).toBe(
+      false,
+    );
+  });
+
+  it('leaves isPickupUnavailable false for pickupType 2 (must phone)', () => {
+    expect(getTimetableEntryAttributes(makeEntry({ pickupType: 2 })).isPickupUnavailable).toBe(
+      false,
+    );
+  });
+
+  it('leaves isPickupUnavailable false for pickupType 3 (coordinate with driver)', () => {
+    expect(getTimetableEntryAttributes(makeEntry({ pickupType: 3 })).isPickupUnavailable).toBe(
+      false,
+    );
+  });
+
+  it('sets isDropOffUnavailable when dropOffType is 1', () => {
+    expect(getTimetableEntryAttributes(makeEntry({ dropOffType: 1 })).isDropOffUnavailable).toBe(
+      true,
+    );
+  });
+
+  it('leaves isDropOffUnavailable false for dropOffType 0 (alightable)', () => {
+    expect(getTimetableEntryAttributes(makeEntry({ dropOffType: 0 })).isDropOffUnavailable).toBe(
+      false,
+    );
+  });
+
+  it('leaves isDropOffUnavailable false for dropOffType 2 (must phone)', () => {
+    expect(getTimetableEntryAttributes(makeEntry({ dropOffType: 2 })).isDropOffUnavailable).toBe(
+      false,
+    );
+  });
+
+  it('handles an entry with multiple flags set simultaneously', () => {
+    const attributes = getTimetableEntryAttributes(
+      makeEntry({ isTerminal: true, pickupType: 1, dropOffType: 1 }),
+    );
+    expect(attributes).toEqual({
+      isTerminal: true,
+      isOrigin: false,
+      isPickupUnavailable: true,
+      isDropOffUnavailable: true,
+    });
+  });
+
+  it('never crashes on origin + terminal together (edge case)', () => {
+    const attributes = getTimetableEntryAttributes(makeEntry({ isOrigin: true, isTerminal: true }));
+    expect(attributes.isOrigin).toBe(true);
+    expect(attributes.isTerminal).toBe(true);
+  });
+});

--- a/src/domain/transit/timetable-entry-attributes.ts
+++ b/src/domain/transit/timetable-entry-attributes.ts
@@ -1,0 +1,19 @@
+import type { TimetableEntryAttributes } from '../../types/app/transit';
+import type { TimetableEntry } from '../../types/app/transit-composed';
+
+/**
+ * Derive flat display attributes from a {@link TimetableEntry}.
+ *
+ * Maps `patternPosition` and `boarding` fields into the shape expected
+ * by display components. All four flags are determined purely from the
+ * entry itself — no external context (trip pattern, route, agency) is
+ * required.
+ */
+export function getTimetableEntryAttributes(entry: TimetableEntry): TimetableEntryAttributes {
+  return {
+    isTerminal: entry.patternPosition.isTerminal,
+    isOrigin: entry.patternPosition.isOrigin,
+    isPickupUnavailable: entry.boarding.pickupType === 1,
+    isDropOffUnavailable: entry.boarding.dropOffType === 1,
+  };
+}

--- a/src/hooks/use-route-stops.ts
+++ b/src/hooks/use-route-stops.ts
@@ -11,6 +11,15 @@ const logger = createLogger('RouteStops');
  * Used to display stop markers on selected routes when a stop is selected.
  * Recomputes when `routeIds` changes (referential equality).
  *
+ * Uses `repo.getStopMetaByIds` (full-dataset scan) — **not** the
+ * viewport-limited `findStopWithMeta` callback in `app.tsx` — because
+ * a route's stops can extend far outside the current map viewport.
+ * Reaching for a viewport-limited helper here previously caused stops
+ * on long routes to silently disappear from the marker layer; that
+ * regression is what motivated adding `getStopMetaByIds` to the
+ * repository interface in the first place. See
+ * `DEVELOPMENT.md > Stop ID lookup の選び方` for the general rule.
+ *
  * @param routeIds - Set of route IDs from selectionInfo, or null if nothing is selected.
  * @param repo - Transit data repository.
  * @returns Array of StopWithMeta for all stops on the specified routes.

--- a/src/repositories/mock-repository.ts
+++ b/src/repositories/mock-repository.ts
@@ -108,7 +108,14 @@ for (const agency of [AGENCY, AGENCY_SORA]) {
 const AGENCY_MAP = new Map<string, Agency>([AGENCY, AGENCY_SORA].map((a) => [a.agency_id, a]));
 
 const STOP_NAME_TRANSLATIONS: Record<string, Record<string, string>> = {
-  sta_central: { ko: '아오바중앙역', 'zh-Hans': '青叶中央站', 'zh-Hant': '青葉中央站' },
+  sta_central: {
+    ko: '아오바중앙역',
+    'zh-Hans': '青叶中央站',
+    'zh-Hant': '青葉中央站',
+    de: 'Aoba-Chūō Bahnhof',
+    es: 'Estación Aoba-Chūō',
+    fr: "Gare d'Aoba-Chūō",
+  },
   sta_central_s: {
     ko: '아오바중앙역 남쪽 출구',
     'zh-Hans': '青叶中央站南口',

--- a/src/repositories/transit-repository.ts
+++ b/src/repositories/transit-repository.ts
@@ -213,11 +213,23 @@ export interface TransitRepository {
   getFullDayTimetableEntries(stopId: string, dateTime: Date): Promise<TimetableResult>;
 
   /**
-   * Returns a single stop with metadata by its GTFS stop_id.
+   * Returns a single stop with metadata by its GTFS stop_id, scanning
+   * the **entire loaded dataset** (not just the current viewport).
    *
-   * Used for URL-based stop selection (`?stop=<id>`) where only
-   * the stop ID is known and the full stop with agencies/routes
-   * metadata is needed.
+   * Async single-id variant of {@link getStopMetaByIds}. Use this for
+   * one-off lookups where the stop_id is known but the stop may be
+   * anywhere in the dataset — typically URL-based stop selection
+   * (`?stop=<id>`) where the user can paste in a stop_id from any
+   * source.
+   *
+   * For batched lookups (anchor refresh, route stops, etc.) use
+   * {@link getStopMetaByIds} instead — it is synchronous and avoids
+   * one Promise per id.
+   *
+   * Do **not** substitute the viewport-limited `findStopWithMeta`
+   * callback in `app.tsx` for this kind of persistent / arbitrary id
+   * lookup. See `DEVELOPMENT.md > Stop ID lookup の選び方` for the
+   * full rule.
    *
    * ### Error conditions
    * - Unknown stop_id:
@@ -229,13 +241,45 @@ export interface TransitRepository {
   getStopMetaById(stopId: string): Promise<Result<StopWithMeta>>;
 
   /**
-   * Returns StopWithMeta for each of the given stop IDs.
+   * Returns StopWithMeta for each of the given stop IDs by scanning
+   * the **entire loaded dataset**, not just the current viewport.
    *
-   * Unknown stop IDs are silently skipped. The returned array preserves
-   * no particular order.
+   * ### When to use this method (vs. local viewport helpers)
    *
-   * @param stopIds - Set of stop IDs to look up.
-   * @returns Array of StopWithMeta for found stops.
+   * Use this method whenever the caller holds a set of stable stop IDs
+   * that may refer to stops anywhere in the dataset — including stops
+   * outside the current map viewport, outside the nearby radius, or
+   * loaded from another data source. Typical cases:
+   *
+   * - Anchor (bookmark) refresh on startup
+   * - Anchor display name resolution for the Portal dropdown
+   * - Stops belonging to a selected route (the route may extend far
+   *   beyond the current view)
+   * - Any feature that operates on persisted IDs from localStorage,
+   *   URL params, or other long-lived storage
+   *
+   * Do **not** substitute a viewport-limited helper like the
+   * `findStopWithMeta` callback in `app.tsx` for these cases — that
+   * callback only searches `radiusStops` / `inBoundStops` and will
+   * silently return null for anything outside the current view,
+   * causing display fallbacks and translation regressions. (This was
+   * the original motivation for adding this method in the first
+   * place; if you find yourself reaching for `findStopWithMeta` to
+   * resolve a stop ID that the user could have stored long ago,
+   * use `getStopMetaByIds` instead.)
+   *
+   * ### Behavior
+   *
+   * - Synchronous (the in-memory v2 repository keeps all stops
+   *   indexed by ID, so lookup is O(N) where N = `stopIds.size`).
+   * - Unknown stop IDs are silently skipped — the result length may
+   *   be smaller than `stopIds.size`.
+   * - The returned array preserves no particular order; callers that
+   *   need a lookup map should `new Map(metas.map((m) => [m.stop.stop_id, m]))`.
+   *
+   * @param stopIds - Set of stop IDs to look up. Can include IDs
+   *                  from any data source loaded into the repository.
+   * @returns Array of StopWithMeta for found stops, in unspecified order.
    */
   getStopMetaByIds(stopIds: Set<string>): StopWithMeta[];
 

--- a/src/repositories/transit-repository.ts
+++ b/src/repositories/transit-repository.ts
@@ -213,14 +213,16 @@ export interface TransitRepository {
   getFullDayTimetableEntries(stopId: string, dateTime: Date): Promise<TimetableResult>;
 
   /**
-   * Returns a single stop with metadata by its GTFS stop_id, scanning
-   * the **entire loaded dataset** (not just the current viewport).
+   * Returns a single stop with metadata by its GTFS stop_id, against
+   * the **full loaded dataset** (not just the current viewport).
    *
-   * Async single-id variant of {@link getStopMetaByIds}. Use this for
-   * one-off lookups where the stop_id is known but the stop may be
-   * anywhere in the dataset — typically URL-based stop selection
-   * (`?stop=<id>`) where the user can paste in a stop_id from any
-   * source.
+   * Async single-id variant of {@link getStopMetaByIds}. Implemented
+   * as an O(1) indexed lookup over a pre-built id → StopWithMeta
+   * map; "full dataset" describes the search scope, not a per-call
+   * scan cost. Use this for one-off lookups where the stop_id is
+   * known but the stop may be anywhere in the dataset — typically
+   * URL-based stop selection (`?stop=<id>`) where the user can paste
+   * in a stop_id from any source.
    *
    * For batched lookups (anchor refresh, route stops, etc.) use
    * {@link getStopMetaByIds} instead — it is synchronous and avoids
@@ -241,8 +243,15 @@ export interface TransitRepository {
   getStopMetaById(stopId: string): Promise<Result<StopWithMeta>>;
 
   /**
-   * Returns StopWithMeta for each of the given stop IDs by scanning
-   * the **entire loaded dataset**, not just the current viewport.
+   * Returns StopWithMeta for each of the given stop IDs against the
+   * **full loaded dataset**, not just the current viewport.
+   *
+   * "Full dataset" describes the search scope (any stop loaded into
+   * the repository, regardless of where it sits geographically), not
+   * a per-call scan cost. The v2 in-memory repository implements
+   * this as a series of indexed lookups against a pre-built
+   * `stop_id → StopWithMeta` map, so the actual cost is
+   * O(`stopIds.size`) — independent of how many stops are loaded.
    *
    * ### When to use this method (vs. local viewport helpers)
    *
@@ -271,7 +280,8 @@ export interface TransitRepository {
    * ### Behavior
    *
    * - Synchronous (the in-memory v2 repository keeps all stops
-   *   indexed by ID, so lookup is O(N) where N = `stopIds.size`).
+   *   indexed by ID, so each lookup is O(1) and the whole call is
+   *   O(`stopIds.size`)).
    * - Unknown stop IDs are silently skipped — the result length may
    *   be smaller than `stopIds.size`.
    * - The returned array preserves no particular order; callers that

--- a/src/types/app/transit.ts
+++ b/src/types/app/transit.ts
@@ -89,6 +89,31 @@ export type FilteredTimetableEntriesState =
   | 'filter-hidden';
 
 /**
+ * Display-relevant boolean attributes of a single timetable entry at
+ * a specific stop, extracted into a flat structure so display
+ * components can consume them without depending on the full
+ * `TimetableEntry` shape (defined in `transit-composed.ts`).
+ *
+ * All four flags are derivable from a single `TimetableEntry` via
+ * `getTimetableEntryAttributes()`; no external context (trip pattern,
+ * route, agency) is required.
+ *
+ * Used by the shared `TimetableEntryAttributesLabels` primitive so
+ * that both the timetable grid and the NearbyStop departure rows can
+ * render the same per-entry labels with the same styling.
+ */
+export interface TimetableEntryAttributes {
+  /** This stop is the last stop of the trip pattern. */
+  isTerminal: boolean;
+  /** This stop is the first stop of the trip pattern. */
+  isOrigin: boolean;
+  /** Boarding (pickup) is not available at this stop for this entry. */
+  isPickupUnavailable: boolean;
+  /** Alighting (drop-off) is not available at this stop for this entry. */
+  isDropOffUnavailable: boolean;
+}
+
+/**
  * Input signals used to derive a {@link StopServiceState}.
  *
  * Deliberately a narrow structural type (not the full `TimetableQueryMeta`)


### PR DESCRIPTION
## Summary

Batch of small UI fixes and refactors collected during the day.

### Text selection guard on overlay buttons

- `MapToggleButton` (zoom / layer / lang / etc.): apply `select-none` and `[-webkit-touch-callout:none]` so iPhone long-press no longer turns the icon/text into a selection.
- `PillButton` (BottomSheet view + filter pills, stop timetable filter, route breakdown): same treatment.

### Per-entry timetable label unification (Terminal / Origin / NoPickup / NoDropOff)

- New `TimetableEntryAttributes` interface (`src/types/app/transit.ts`) + `getTimetableEntryAttributes(entry)` derivation in `src/domain/transit/`.
- Rename `TimetableEntryLabels` -> `TimetableEntryAttributesLabels` so the component name reflects what it actually renders.
- `TripInfo` drops its inline pastel `<span>` markup and the `isTerminal` / `isPickupUnavailable` props in favor of an optional `attributes` prop. NearbyStop departure rows now share the same solid-palette label primitive as the timetable grid, fixing the inconsistency where \`終点\` was easy to miss in departure lists.
- `FlatDepartureItem` / `DepartureItem` / `StopSummary` updated to construct attributes at the call site (`DepartureItem` keeps its group-level \`!hasBoardableDeparture(entries)\` semantics for \`isPickupUnavailable\`).

### LabelCountBadge / RouteCountBadge introduction

- New `LabelCountBadge` presentation primitive (`src/components/badge/label-count-badge.tsx`): two-half framed capsule with explicit `labelBg` / `labelFg` / `countBg` / `countFg` / `frameColor` props, defaulting to inverted count colors and a route-color frame. Intentionally non-pill so it does not look like a filter.
- `BaseLabel` gains an optional `style` prop for runtime hex colors (matches the existing `PillButton` / `RouteBadge` pattern), used internally by `LabelCountBadge`.
- `RouteCountBadge` (was `RouteLabel`, now under `src/components/badge/`) is reduced to a thin domain adapter that resolves the route's display name and colors via `getRouteDisplayNames` then delegates to `LabelCountBadge`.
- `TimetableMetadata` route breakdown row drops `PillButton` (which read as an interactive filter) and uses `RouteCountBadge` instead.

### Stop name i18n: StopHistory and Portal dropdowns

- **StopHistory dropdown** previously read `stopWithMeta.stop.stop_name` (feed_lang primary) directly. Now resolves via `getStopDisplayNames(stop, dataLang, resolveAgencyLang(agencies, stop.agency_id))`. History snapshots already include the full \`stop_names\` translation map, so this is a display-layer-only fix.
- **Portal (anchor) dropdown** was reading the snapshot \`entry.stopName\` saved at anchor add time, which never followed language switches and could not benefit from translations added to GTFS later. Anchors are long-lived (up to 100 entries, persisted across sessions), so this drift mattered.
  - Pre-resolve the anchor stops to a `Map<stopId, StopWithMeta>` once per `anchors` change via \`repo.getStopMetaByIds(stopIds)\` (full-dataset scan, synchronous).
  - Forward as \`lookupAnchorStopMeta\` through MapView -> MapOverlayPanels -> Portals.
  - Portals resolves each entry's display name with `getStopDisplayNames`, falling back to the stored snapshot only when the stop is no longer in the active dataset (cross-source anchor in mock mode, or stop deleted from GTFS).
  - The same resolution is applied to the anchor add/remove toast description.
  - `AnchorEntry` schema is unchanged. New GTFS translations flow through automatically without any write-side migration.

The previous code was reaching for the local \`findStopWithMeta\` callback (which only searches \`radiusStops\` + \`inBoundStops\`); switching to \`getStopMetaByIds\` is what makes anchors located far from the current map view translate correctly. This is the **same regression pattern that previously hit the route stops feature** and prompted adding \`getStopMetaByIds\` to the repository interface in the first place — so this PR also adds the documentation needed to prevent a third repeat:

- `DEVELOPMENT.md`: new "Stop ID lookup の選び方" section explaining when to use \`repo.getStopMetaByIds\` vs. the viewport-limited \`findStopWithMeta\`, plus the regression history.
- `TransitRepository.getStopMetaByIds` / `getStopMetaById` TSDoc: spell out full-dataset semantics, the canonical use cases (anchor refresh / Portal display / route stops / `?stop=` / persisted IDs), and the explicit warning against `findStopWithMeta` for persistent IDs.
- `app.tsx` `findStopWithMeta` definition: long warning comment with a pointer at the correct alternative + DEVELOPMENT.md.
- `useRouteStops` hook: inline comment recording why it uses `getStopMetaByIds`, so the canonical correct example is grep-able.

### Mock data extension for testing

- MockRepository \`sta_central\` translations cover all nine \`SUPPORTED_LANGS\` (added de / es / fr) so anchor i18n can be exercised on \`?repo=mock\` across every supported display language.

### Stories

- `BaseLabel.stories`: cover the new `style` prop, split KitchenSink into clearly labelled className-vs-style groups, add `InlineStyle` and `ClassNameAndStyle` stories.
- `RouteCountBadge.stories`: size / route variants, count variants, KitchenSink with a `LongName` fixture simulating the Toei Arakawa Line case (empty `route_short_name`, long translated `route_long_name`).
- `LabelCountBadge.stories`: size / color behavior / label / count / `FrameColorComparison` / `KitchenSink`.
- `TripInfo.stories`: replace the removed `isTerminal` / `isPickupUnavailable` controls with `attributes` stories (`Terminal` / `Origin` / `PickupUnavailable` / `DropOffUnavailable` / `AllAttributes`), add `TimetableEntryAttributesComparison` and `SizeComparison` renders, beef up `KitchenSink` to use the rich `stopOverridesTripRd` + `kyotoAgency` fixture with all four flags set.
- `TimetableEntryAttributesLabels.stories`: route existing entry-based fixtures through `getTimetableEntryAttributes` to match the new API.

## Test plan

- [x] `npx tsc --noEmit --project tsconfig.app.json`
- [x] `npm run lint`
- [x] `npx prettier --check src CHANGELOG.md DEVELOPMENT.md`
- [x] `npm run test` (158 files, 2393 tests pass)
- [x] `npm run build`
- [x] Manual: text selection guard checked on the overlay buttons via Chrome DevTools (computed `user-select: none`; \`-webkit-touch-callout: none\` present in compiled CSS).
- [x] Manual: TimetableMetadata route breakdown row reviewed visually — RouteCountBadge replaces the filter-looking PillButton and reads as display.
- [x] Manual: StopHistory dropdown verified across multiple display languages, all entries show the translated name.
- [x] Manual: Portal dropdown verified in the real repo across multiple anchors located outside the current viewport (Tokyo / Kyoto / Nagoya / Matsuyama / Venice / Freiburg) with `lang=ja`, `lang=en`, `lang=ko`, and `lang=unknown` (falls back to default ja). All in-repo anchors translate; cross-source anchors fall back to the snapshot as designed.
- [x] Manual: anchor add/remove toast follows the current display language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)