### PR TITLE
fix(pipeline): preserve route_short_name translations from GTFS (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,18 @@ and this project adheres to [CalVer](https://calver.org/).
 - StopHistory ドロップダウンが `stopWithMeta.stop.stop_name` (feed_lang 由来) を直接表示していた問題を修正。`getStopDisplayNames(stop, dataLang, resolveAgencyLang(agencies, stop.agency_id))` で現在表示言語に従って解決。履歴のスナップショットには既に `stop_names` 翻訳マップが含まれているため、表示層のみの修正。
 - Portal (アンカー) ドロップダウンの表示が常に保存時の `stopName` snapshot を使っていた問題を修正。`repo.getStopMetaByIds` で全データセットから fresh な `StopWithMeta` を取得し、`getStopDisplayNames` で現在表示言語に解決。viewport 外のアンカーも翻訳されるようになり、新たに追加された GTFS 翻訳にも自動追従する (anchor refresh 不要)。`AnchorEntry` のスキーマ変更なし。
 - アンカー追加/削除時の toast メッセージ (`anchor.added` / `anchor.removed`) も翻訳解決に切り替え。表示言語に応じた stop 名を表示。
+- pipeline (v2) が GTFS の `routes.route_short_name` 翻訳を抽出していなかった問題を修正 (#103)。`extract-translations.ts` に `route_short_name` 抽出ブロックを追加 (GTFS-JP の `record_id` 経由と標準 GTFS の `field_value` 経由の両方をサポート)。kyoto-city-bus (139 件) / keio-bus (31 件) などのフィードに含まれる短縮名翻訳が `data.json` の `translations.route_short_names` まで届き、`Route.route_short_names` を経由して `getRouteDisplayNames` が言語切替に追従するようになる (例: `市バス１` → `1 City Bus` を `lang=en` で表示)。
 
 ### Changed
 
 - `MapToggleButton` (地図上の全コントロールボタン) でテキスト選択不可に。`user-select: none` と `-webkit-touch-callout: none` を適用し、iPhone などタッチデバイスでボタン上の文字列が選択状態になる問題を抑止。
 - `PillButton` (BottomSheet の View/Operating/Route type/Agency フィルタ、stop 詳細の timetable フィルタ、route 内訳表示) でもテキスト選択不可に。同じく `user-select: none` と `-webkit-touch-callout: none` を適用。
 - `TransitRepository.getStopMetaByIds` / `getStopMetaById` の TSDoc を強化し、「いつ使うべきか」「viewport 制限のある `findStopWithMeta` との違い」「過去の regression の経緯」を明記。`use-route-stops.ts` と `app.tsx` の `findStopWithMeta` 定義箇所にも対応するコメントと DEVELOPMENT.md への参照を追加。
+- `TranslationsJson` (`src/types/data/transit-json.ts`) のスキーマをリネーム + 拡張し、各フィールドに TSDoc を追加 (#103):
+    - `route_names` → `route_long_names` (long であることを名前に明示)
+    - 新フィールド `route_short_names` を追加 (`route_short_name` / `route_long_name` を first-class な対等フィールドとして扱う)
+    - `headsigns` → `trip_headsigns` (`stop_headsigns` と対称にし、何の翻訳か曖昧な命名を解消)
+    - `public/data-v2/*/data.json` の再生成は別途データ更新フローで実施 (本 PR のスコープ外)
 
 ## [2026.04.12]
 

--- a/pipeline/docs/V2_APP_DATA.md
+++ b/pipeline/docs/V2_APP_DATA.md
@@ -122,7 +122,7 @@ interface TripPatternJson {
 
 消費側 (WebApp) が effective headsign を決定する想定: `effectiveHeadsign = stops[i].sh ?? h`
 
-翻訳参照の想定: `sh` が存在する場合は `translations.stop_headsigns[sh]`、存在しない場合は `translations.headsigns[h]` を使用する。
+翻訳参照の想定: `sh` が存在する場合は `translations.stop_headsigns[sh]`、存在しない場合は `translations.trip_headsigns[h]` を使用する。
 
 > **Note**: 消費側の headsign 解決ロジックは未実装。現時点では Pipeline がデータを出力するのみ。
 

--- a/pipeline/scripts/dev/README.md
+++ b/pipeline/scripts/dev/README.md
@@ -25,7 +25,7 @@
 主な調査対象:
 
 - V2 primary field: `routes.s`, `routes.l`, `agency.n`, `agency.sn`, `tripPatterns.h`, `stops.n`
-- V2 translations: `translations.agency_names`, `translations.agency_short_names`, `translations.headsigns`, `translations.stop_headsigns`, `translations.stop_names`, `translations.route_names`
+- V2 translations: `translations.agency_names`, `translations.route_long_names`, `translations.route_short_names`, `translations.stop_names`, `translations.trip_headsigns`, `translations.stop_headsigns`
 - V2 未出力の監査対象: `trips.trip_short_name`, `stops.tts_stop_name`, `agency_jp.agency_official_name`, `trips.jp_trip_desc`, `trips.jp_trip_desc_symbol`
 
 > **Note**: `stop_times.stop_headsign` は `tripPatterns.stops[].sh` として出力されるようになったため、未出力リストから除外した。

--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-name-fields-analysis.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-name-fields-analysis.test.ts
@@ -82,11 +82,12 @@ function createTestBundle(overrides?: Partial<DataBundle>): DataBundle {
     translations: {
       v: 1,
       data: {
-        headsigns: { 'To A': { en: 'To A' }, Empty: { en: '' } },
-        stop_headsigns: { 'Stop A': { en: 'Stop A' } },
-        stop_names: { 'stop:a': { en: 'Stop A' }, 'stop:b': { en: '' } },
-        route_names: { 'route:1': { en: 'Route 1' } },
         agency_names: { 'agency:1': { en: 'Agency One' } },
+        route_long_names: { 'route:1': { en: 'Route 1' } },
+        route_short_names: {},
+        stop_names: { 'stop:a': { en: 'Stop A' }, 'stop:b': { en: '' } },
+        trip_headsigns: { 'To A': { en: 'To A' }, Empty: { en: '' } },
+        stop_headsigns: { 'Stop A': { en: 'Stop A' } },
       },
     },
     lookup: { v: 2, data: { routeUrls: {}, stopDescs: {}, routeDescs: {} } },
@@ -102,9 +103,19 @@ describe('analyzeFieldCounts', () => {
     expect(counts).toContainEqual({ field: 'routes.l', nonEmpty: 2, empty: 0 });
     expect(counts).toContainEqual({ field: 'tripPatterns.h', nonEmpty: 1, empty: 1 });
     expect(counts).toContainEqual({
-      field: 'translations.headsigns',
+      field: 'translations.trip_headsigns',
       nonEmpty: 1,
       empty: 1,
+    });
+    expect(counts).toContainEqual({
+      field: 'translations.route_long_names',
+      nonEmpty: 1,
+      empty: 0,
+    });
+    expect(counts).toContainEqual({
+      field: 'translations.route_short_names',
+      nonEmpty: 0,
+      empty: 0,
     });
     expect(counts).toContainEqual({ field: 'trips.trip_short_name', nonEmpty: 0, empty: 0 });
     expect(counts).toContainEqual({ field: 'stops.tts_stop_name', nonEmpty: 0, empty: 0 });
@@ -185,7 +196,8 @@ describe('formatSourceAnalysis', () => {
 
     expect(output).toContain('=== test ===');
     expect(output).toContain('routes.s: nonEmpty=1, empty=1');
-    expect(output).toContain('translations.route_names: nonEmpty=1, empty=0');
+    expect(output).toContain('translations.route_long_names: nonEmpty=1, empty=0');
+    expect(output).toContain('translations.route_short_names: nonEmpty=0, empty=0');
     expect(output).toContain('trips.jp_trip_desc_symbol: nonEmpty=0, empty=0');
   });
 });

--- a/pipeline/scripts/dev/dev-lib/v2-name-fields-analysis.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-name-fields-analysis.ts
@@ -74,9 +74,9 @@ const FIELD_TARGETS: FieldTarget[] = [
       ),
   },
   {
-    field: 'translations.headsigns',
+    field: 'translations.trip_headsigns',
     count: (bundle) =>
-      countTranslationMap('translations.headsigns', bundle.translations.data.headsigns),
+      countTranslationMap('translations.trip_headsigns', bundle.translations.data.trip_headsigns),
   },
   {
     field: 'translations.stop_headsigns',
@@ -93,9 +93,20 @@ const FIELD_TARGETS: FieldTarget[] = [
       countTranslationMap('translations.stop_names', bundle.translations.data.stop_names),
   },
   {
-    field: 'translations.route_names',
+    field: 'translations.route_long_names',
     count: (bundle) =>
-      countTranslationMap('translations.route_names', bundle.translations.data.route_names),
+      countTranslationMap(
+        'translations.route_long_names',
+        bundle.translations.data.route_long_names,
+      ),
+  },
+  {
+    field: 'translations.route_short_names',
+    count: (bundle) =>
+      countTranslationMap(
+        'translations.route_short_names',
+        bundle.translations.data.route_short_names,
+      ),
   },
   {
     field: 'trips.trip_short_name',

--- a/pipeline/scripts/pipeline/app-data-v2/__tests__/build-from-odpt-train.test.ts
+++ b/pipeline/scripts/pipeline/app-data-v2/__tests__/build-from-odpt-train.test.ts
@@ -169,7 +169,7 @@ describe('ODPT DataBundle assembly', () => {
     expect(calendar.services).toHaveLength(1);
     expect(Object.keys(tripPatterns).length).toBeGreaterThanOrEqual(2);
     expect(Object.keys(timetable).length).toBeGreaterThanOrEqual(1);
-    expect(Object.keys(translations.headsigns).length).toBeGreaterThanOrEqual(1);
+    expect(Object.keys(translations.trip_headsigns).length).toBeGreaterThanOrEqual(1);
 
     // ODPT: lookup is empty, pt/dt are absent
     expect(bundle.lookup.data).toEqual({});

--- a/pipeline/scripts/pipeline/app-data-v2/__tests__/build-global-insights.test.ts
+++ b/pipeline/scripts/pipeline/app-data-v2/__tests__/build-global-insights.test.ts
@@ -109,11 +109,12 @@ function makeDataBundle(opts: {
     translations: {
       v: 1,
       data: {
-        headsigns: {},
-        stop_headsigns: {},
-        stop_names: {},
-        route_names: {},
         agency_names: {},
+        route_long_names: {},
+        route_short_names: {},
+        stop_names: {},
+        trip_headsigns: {},
+        stop_headsigns: {},
       },
     },
     lookup: { v: 2, data: {} },

--- a/pipeline/scripts/pipeline/app-data-v2/__tests__/build-insights.test.ts
+++ b/pipeline/scripts/pipeline/app-data-v2/__tests__/build-insights.test.ts
@@ -53,11 +53,12 @@ function makeDataBundle(services: { id: string; d: number[] }[]): DataBundle {
     translations: {
       v: 1,
       data: {
-        headsigns: {},
-        stop_headsigns: {},
-        stop_names: {},
-        route_names: {},
         agency_names: {},
+        route_long_names: {},
+        route_short_names: {},
+        stop_names: {},
+        trip_headsigns: {},
+        stop_headsigns: {},
       },
     },
     lookup: { v: 2, data: {} },

--- a/pipeline/scripts/pipeline/app-data-v2/build-from-odpt-train.ts
+++ b/pipeline/scripts/pipeline/app-data-v2/build-from-odpt-train.ts
@@ -113,7 +113,7 @@ function buildSourceDataBundle(source: OdptTrainSource): void {
   console.log(`  feed-info: ${feedInfo.pn} (v${feedInfo.v})`);
 
   const translations = buildTranslationsV2(prefix, timetables, railways, stations);
-  console.log(`  ${Object.keys(translations.headsigns).length} headsign translations`);
+  console.log(`  ${Object.keys(translations.trip_headsigns).length} trip headsign translations`);
 
   const { tripPatterns, timetable } = buildTripPatternsAndTimetableFromOdpt(
     prefix,

--- a/pipeline/src/lib/pipeline/app-data-v2/__tests__/build-global-stop-entries.test.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/__tests__/build-global-stop-entries.test.ts
@@ -84,11 +84,12 @@ function makeDataBundle(opts: {
     translations: {
       v: 1,
       data: {
-        headsigns: {},
-        stop_headsigns: {},
-        stop_names: {},
-        route_names: {},
         agency_names: {},
+        route_long_names: {},
+        route_short_names: {},
+        stop_names: {},
+        trip_headsigns: {},
+        stop_headsigns: {},
       },
     },
     lookup: { v: 2, data: {} },

--- a/pipeline/src/lib/pipeline/app-data-v2/__tests__/bundle-writer.test.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/__tests__/bundle-writer.test.ts
@@ -32,11 +32,12 @@ function makeBundle(): DataBundle {
     translations: {
       v: 1,
       data: {
-        headsigns: {},
-        stop_headsigns: {},
-        stop_names: {},
-        route_names: {},
         agency_names: {},
+        route_long_names: {},
+        route_short_names: {},
+        stop_names: {},
+        trip_headsigns: {},
+        stop_headsigns: {},
       },
     },
     lookup: { v: 2, data: {} },

--- a/pipeline/src/lib/pipeline/app-data-v2/__tests__/validate-data.test.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/__tests__/validate-data.test.ts
@@ -110,11 +110,12 @@ function makeValidBundle(overrides?: Partial<DataBundle>): DataBundle {
     translations: {
       v: 1,
       data: {
-        headsigns: {},
-        stop_headsigns: {},
-        stop_names: {},
-        route_names: {},
         agency_names: {},
+        route_long_names: {},
+        route_short_names: {},
+        stop_names: {},
+        trip_headsigns: {},
+        stop_headsigns: {},
       },
     },
     lookup: { v: 2, data: {} },

--- a/pipeline/src/lib/pipeline/app-data-v2/gtfs/__tests__/extract-translations.test.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/gtfs/__tests__/extract-translations.test.ts
@@ -55,11 +55,12 @@ describe('extractTranslationsV2', () => {
   it('returns empty maps when no translations exist', () => {
     const result = extractTranslationsV2(db, 'test');
     expect(result).toEqual({
-      headsigns: {},
-      stop_headsigns: {},
-      stop_names: {},
-      route_names: {},
       agency_names: {},
+      route_long_names: {},
+      route_short_names: {},
+      stop_names: {},
+      trip_headsigns: {},
+      stop_headsigns: {},
     });
   });
 
@@ -72,7 +73,7 @@ describe('extractTranslationsV2', () => {
     `);
 
     const result = extractTranslationsV2(db, 'test');
-    expect(result.headsigns['新橋駅前']).toEqual({ en: 'Shimbashi Sta.' });
+    expect(result.trip_headsigns['新橋駅前']).toEqual({ en: 'Shimbashi Sta.' });
   });
 
   it('extracts stop_name translations for all location_types (v2)', () => {
@@ -120,7 +121,7 @@ describe('extractTranslationsV2', () => {
     `);
 
     const result = extractTranslationsV2(db, 'test');
-    expect(result.headsigns['東京駅']).toEqual({ en: 'Tokyo Station' });
+    expect(result.trip_headsigns['東京駅']).toEqual({ en: 'Tokyo Station' });
   });
 
   it('extracts stop_headsign translations', () => {
@@ -146,7 +147,67 @@ describe('extractTranslationsV2', () => {
     `);
 
     const result = extractTranslationsV2(db, 'test');
-    expect(result.route_names['test:R001']).toEqual({ en: 'Yamanote Line' });
+    expect(result.route_long_names['test:R001']).toEqual({ en: 'Yamanote Line' });
+    expect(result.route_short_names['test:R001']).toBeUndefined();
+  });
+
+  it('extracts route_short_name translations via record_id (GTFS-JP)', () => {
+    db.exec(`
+      INSERT INTO agency (agency_id, agency_name) VALUES ('A001', 'Test Agency');
+      INSERT INTO routes (route_id, agency_id, route_short_name, route_long_name, route_type)
+      VALUES ('R100', 'A001', '市バス1', '', 3);
+      INSERT INTO translations (table_name, field_name, language, translation, record_id)
+      VALUES ('routes', 'route_short_name', 'en', '1 City Bus', 'R100');
+    `);
+
+    const result = extractTranslationsV2(db, 'test');
+    expect(result.route_short_names['test:R100']).toEqual({ en: '1 City Bus' });
+    expect(result.route_long_names['test:R100']).toBeUndefined();
+  });
+
+  it('extracts route_short_name translations via field_value (standard GTFS)', () => {
+    db.exec(`
+      INSERT INTO routes (route_id, route_short_name, route_long_name, route_type)
+      VALUES ('R101', '1', '', 3);
+      INSERT INTO translations (table_name, field_name, language, translation, field_value)
+      VALUES ('routes', 'route_short_name', 'en', 'One', '1');
+    `);
+
+    const result = extractTranslationsV2(db, 'test');
+    expect(result.route_short_names['test:R101']).toEqual({ en: 'One' });
+  });
+
+  it('extracts both route_short_name and route_long_name translations independently', () => {
+    db.exec(`
+      INSERT INTO agency (agency_id, agency_name) VALUES ('A001', 'Test Agency');
+      INSERT INTO routes (route_id, agency_id, route_short_name, route_long_name, route_type)
+      VALUES ('R200', 'A001', '市バス2', '京都市バス2号系統', 3);
+      INSERT INTO translations (table_name, field_name, language, translation, record_id)
+      VALUES ('routes', 'route_short_name', 'en', '2 City Bus', 'R200'),
+             ('routes', 'route_long_name', 'en', 'Kyoto City Bus Route 2', 'R200');
+    `);
+
+    const result = extractTranslationsV2(db, 'test');
+    expect(result.route_short_names['test:R200']).toEqual({ en: '2 City Bus' });
+    expect(result.route_long_names['test:R200']).toEqual({ en: 'Kyoto City Bus Route 2' });
+  });
+
+  it('extracts multiple languages for a route_short_name', () => {
+    db.exec(`
+      INSERT INTO routes (route_id, route_short_name, route_long_name, route_type)
+      VALUES ('R300', '市バス3', '', 3);
+      INSERT INTO translations (table_name, field_name, language, translation, record_id)
+      VALUES ('routes', 'route_short_name', 'en', '3 City Bus', 'R300'),
+             ('routes', 'route_short_name', 'ko', '3번 시영버스', 'R300'),
+             ('routes', 'route_short_name', 'zh-Hans', '3路市营巴士', 'R300');
+    `);
+
+    const result = extractTranslationsV2(db, 'test');
+    expect(result.route_short_names['test:R300']).toEqual({
+      en: '3 City Bus',
+      ko: '3번 시영버스',
+      'zh-Hans': '3路市营巴士',
+    });
   });
 
   it('deduplicates headsign translations when multiple trips share the same headsign', () => {
@@ -161,8 +222,8 @@ describe('extractTranslationsV2', () => {
     `);
 
     const result = extractTranslationsV2(db, 'test');
-    expect(result.headsigns['新宿駅']).toEqual({ en: 'Shinjuku Sta.' });
-    expect(Object.keys(result.headsigns)).toHaveLength(1);
+    expect(result.trip_headsigns['新宿駅']).toEqual({ en: 'Shinjuku Sta.' });
+    expect(Object.keys(result.trip_headsigns)).toHaveLength(1);
   });
 
   it('extracts multiple languages for the same stop', () => {
@@ -204,7 +265,7 @@ describe('extractTranslationsV2', () => {
     `);
 
     const result = extractTranslationsV2(db, 'test');
-    expect(result.route_names['test:R001']).toEqual({ en: 'Yamanote Line' });
+    expect(result.route_long_names['test:R001']).toEqual({ en: 'Yamanote Line' });
   });
 
   it('handles multiple agencies with translations', () => {

--- a/pipeline/src/lib/pipeline/app-data-v2/gtfs/extract-translations.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/gtfs/extract-translations.ts
@@ -64,7 +64,7 @@ function buildTranslationMap(
  */
 export function extractTranslationsV2(db: Database.Database, prefix: string): TranslationsJson {
   // trip_headsign translations
-  const headsignRows = db
+  const tripHeadsignRows = db
     .prepare(
       `SELECT DISTINCT COALESCE(tr.trip_headsign, t.field_value) as headsign_text,
         t.language, t.translation
@@ -75,7 +75,7 @@ export function extractTranslationsV2(db: Database.Database, prefix: string): Tr
     )
     .all() as Array<{ headsign_text: string; language: string; translation: string }>;
 
-  const headsigns = buildTranslationMap(headsignRows);
+  const tripHeadsigns = buildTranslationMap(tripHeadsignRows);
 
   // stop_headsign translations
   const stopHeadsignRows = db
@@ -117,7 +117,7 @@ export function extractTranslationsV2(db: Database.Database, prefix: string): Tr
   }
 
   // route_long_name translations (keyed by prefixed route_id)
-  const routeNameRows = db
+  const routeLongNameRows = db
     .prepare(
       `SELECT r.route_id, t.language, t.translation
        FROM translations t
@@ -127,16 +127,39 @@ export function extractTranslationsV2(db: Database.Database, prefix: string): Tr
     )
     .all() as Array<{ route_id: string; language: string; translation: string }>;
 
-  const routeNamesMap = buildNamesMap(
-    routeNameRows.map((r) => ({
+  const routeLongNamesMap = buildNamesMap(
+    routeLongNameRows.map((r) => ({
       key: r.route_id,
       language: r.language,
       translation: r.translation,
     })),
   );
-  const routeNames: Record<string, Record<string, string>> = {};
-  for (const [routeId, names] of routeNamesMap) {
-    routeNames[`${prefix}:${routeId}`] = names;
+  const routeLongNames: Record<string, Record<string, string>> = {};
+  for (const [routeId, names] of routeLongNamesMap) {
+    routeLongNames[`${prefix}:${routeId}`] = names;
+  }
+
+  // route_short_name translations (keyed by prefixed route_id)
+  const routeShortNameRows = db
+    .prepare(
+      `SELECT r.route_id, t.language, t.translation
+       FROM translations t
+       JOIN routes r ON (r.route_id = t.record_id
+         OR (t.record_id IS NULL AND r.route_short_name = t.field_value))
+       WHERE t.table_name = 'routes' AND t.field_name = 'route_short_name'`,
+    )
+    .all() as Array<{ route_id: string; language: string; translation: string }>;
+
+  const routeShortNamesMap = buildNamesMap(
+    routeShortNameRows.map((r) => ({
+      key: r.route_id,
+      language: r.language,
+      translation: r.translation,
+    })),
+  );
+  const routeShortNames: Record<string, Record<string, string>> = {};
+  for (const [routeId, names] of routeShortNamesMap) {
+    routeShortNames[`${prefix}:${routeId}`] = names;
   }
 
   // agency_name translations (keyed by prefixed agency_id)
@@ -163,20 +186,22 @@ export function extractTranslationsV2(db: Database.Database, prefix: string): Tr
     agencyNames[`${prefix}:${agencyId}`] = { ...names };
   }
 
-  const headsignCount = Object.keys(headsigns).length;
+  const tripHeadsignCount = Object.keys(tripHeadsigns).length;
   const stopHeadsignCount = Object.keys(stopHeadsigns).length;
   const stopNameCount = Object.keys(stopNames).length;
-  const routeNameCount = Object.keys(routeNames).length;
+  const routeLongNameCount = Object.keys(routeLongNames).length;
+  const routeShortNameCount = Object.keys(routeShortNames).length;
   const agencyNameCount = Object.keys(agencyNames).length;
   console.log(
-    `  [${prefix}] translations: ${headsignCount} headsigns, ${stopHeadsignCount} stop_headsigns, ${stopNameCount} stop_names, ${routeNameCount} route_names, ${agencyNameCount} agency_names`,
+    `  [${prefix}] translations: ${tripHeadsignCount} trip_headsigns, ${stopHeadsignCount} stop_headsigns, ${stopNameCount} stop_names, ${routeLongNameCount} route_long_names, ${routeShortNameCount} route_short_names, ${agencyNameCount} agency_names`,
   );
 
   return {
-    headsigns,
-    stop_headsigns: stopHeadsigns,
-    stop_names: stopNames,
-    route_names: routeNames,
     agency_names: agencyNames,
+    route_long_names: routeLongNames,
+    route_short_names: routeShortNames,
+    stop_names: stopNames,
+    trip_headsigns: tripHeadsigns,
+    stop_headsigns: stopHeadsigns,
   };
 }

--- a/pipeline/src/lib/pipeline/app-data-v2/odpt/__tests__/build-odpt-translations.test.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/odpt/__tests__/build-odpt-translations.test.ts
@@ -40,7 +40,7 @@ function makeRailway(
 }
 
 describe('buildTranslationsV2', () => {
-  it('generates headsign, stop_names, route_names, agency translations', () => {
+  it('generates headsign, stop_names, route_long_names, agency translations', () => {
     const orders: OdptStationOrder[] = [
       makeOrder(1, 'odpt.Station:Test.A', 'A駅', 'Station A'),
       makeOrder(2, 'odpt.Station:Test.B', 'B駅', 'Station B'),
@@ -75,11 +75,13 @@ describe('buildTranslationsV2', () => {
     const result = buildTranslationsV2('test', timetables, [railway], stations);
 
     // Headsign: derived from destinationStation
-    expect(result.headsigns['B駅']).toEqual({ ja: 'B駅', en: 'Station B' });
+    expect(result.trip_headsigns['B駅']).toEqual({ ja: 'B駅', en: 'Station B' });
     // Stop names
     expect(result.stop_names['test:A']).toEqual({ ja: 'A駅', en: 'Station A' });
-    // Route names
-    expect(result.route_names['test:U']).toEqual({ ja: 'テスト線', en: 'Test Line' });
+    // Route long names
+    expect(result.route_long_names['test:U']).toEqual({ ja: 'テスト線', en: 'Test Line' });
+    // Route short names: ODPT does not provide short_name translations.
+    expect(result.route_short_names).toEqual({});
     // Agency names: ODPT has no agency translations (managed on App side).
     expect(result.agency_names).toEqual({});
   });
@@ -122,7 +124,7 @@ describe('buildTranslationsV2', () => {
     ];
 
     const result = buildTranslationsV2('test', [], [railway], stations);
-    expect(result.headsigns).toEqual({});
+    expect(result.trip_headsigns).toEqual({});
   });
 
   it('produces multiple headsigns from multiple destinations', () => {
@@ -154,9 +156,9 @@ describe('buildTranslationsV2', () => {
     ];
 
     const result = buildTranslationsV2('test', timetables, [railway], stations);
-    expect(result.headsigns['B駅']).toEqual({ ja: 'B駅', en: 'Station B' });
-    expect(result.headsigns['C駅']).toEqual({ ja: 'C駅', en: 'Station C' });
-    expect(Object.keys(result.headsigns)).toHaveLength(2);
+    expect(result.trip_headsigns['B駅']).toEqual({ ja: 'B駅', en: 'Station B' });
+    expect(result.trip_headsigns['C駅']).toEqual({ ja: 'C駅', en: 'Station C' });
+    expect(Object.keys(result.trip_headsigns)).toHaveLength(2);
   });
 
   it('stop_headsigns is always empty for ODPT', () => {
@@ -220,7 +222,7 @@ describe('buildTranslationsV2', () => {
     ];
 
     const result = buildTranslationsV2('test', timetables, [railway], []);
-    expect(Object.keys(result.headsigns)).toHaveLength(1);
-    expect(result.headsigns['B駅']).toEqual({ ja: 'B駅', en: 'Station B' });
+    expect(Object.keys(result.trip_headsigns)).toHaveLength(1);
+    expect(result.trip_headsigns['B駅']).toEqual({ ja: 'B駅', en: 'Station B' });
   });
 });

--- a/pipeline/src/lib/pipeline/app-data-v2/odpt/build-translations.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/odpt/build-translations.ts
@@ -27,7 +27,7 @@ export function buildTranslationsV2(
   railways: OdptRailway[],
   stations: OdptStation[],
 ): TranslationsJson {
-  const headsigns: Record<string, Record<string, string>> = {};
+  const tripHeadsigns: Record<string, Record<string, string>> = {};
 
   // Build station -> railway lookup.
   // A station shared by multiple railways maps to all of them (1:N).
@@ -67,7 +67,7 @@ export function buildTranslationsV2(
         tt['odpt:railDirection'],
         rw.stationOrder,
       );
-      if (headsigns[headsignJa]) {
+      if (tripHeadsigns[headsignJa]) {
         continue;
       }
       // Find title for the destination station
@@ -87,7 +87,7 @@ export function buildTranslationsV2(
       if (title['zh-Hans']) {
         names['zh-Hans'] = title['zh-Hans'];
       }
-      headsigns[headsignJa] = names;
+      tripHeadsigns[headsignJa] = names;
     }
   }
 
@@ -106,20 +106,27 @@ export function buildTranslationsV2(
     stopNames[`${prefix}:${shortId}`] = names;
   }
 
-  // route_names: railway translations keyed by prefixed route_id
-  const routeNames: Record<string, Record<string, string>> = {};
+  // route_long_names: railway translations keyed by prefixed route_id.
+  // ODPT railway titles are conceptually long names — they describe the
+  // line (e.g. "Yurikamome", "Tsukuba Express"), not a short identifier.
+  const routeLongNames: Record<string, Record<string, string>> = {};
   for (const rw of railways) {
     const title = rw['odpt:railwayTitle'];
-    routeNames[`${prefix}:${rw['odpt:lineCode']}`] = { ja: title.ja, en: title.en };
+    routeLongNames[`${prefix}:${rw['odpt:lineCode']}`] = { ja: title.ja, en: title.en };
   }
+
+  // route_short_names: ODPT does not provide a separate short_name
+  // translation; emit empty so the schema is satisfied.
+  const routeShortNames: Record<string, Record<string, string>> = {};
 
   // agency_names: ODPT has no agency name translations — managed on
   // the App side via agency-attributes.ts.
   return {
-    headsigns,
-    stop_headsigns: {},
-    stop_names: stopNames,
-    route_names: routeNames,
     agency_names: {},
+    route_long_names: routeLongNames,
+    route_short_names: routeShortNames,
+    stop_names: stopNames,
+    trip_headsigns: tripHeadsigns,
+    stop_headsigns: {},
   };
 }

--- a/src/components/badge/route-badge.tsx
+++ b/src/components/badge/route-badge.tsx
@@ -59,7 +59,7 @@ export function RouteBadge({
   disableVerbose = false,
   className,
 }: RouteBadgeProps) {
-  const routeNames = getRouteDisplayNames(route, dataLang, agencyLangs);
+  const routeNames = getRouteDisplayNames(route, dataLang, agencyLangs, 'short');
   const bg = route.route_color ? `#${route.route_color}` : undefined;
   const fg = route.route_text_color ? `#${route.route_text_color}` : undefined;
   const showVerbose = infoLevel === 'verbose' && !disableVerbose;

--- a/src/components/badge/route-count-badge.tsx
+++ b/src/components/badge/route-count-badge.tsx
@@ -27,9 +27,13 @@ export function RouteCountBadge({
   agencies,
   size = 'sm',
 }: RouteCountBadgeProps) {
-  const label =
-    getRouteDisplayNames(route, dataLang, resolveAgencyLang(agencies, route.agency_id), 'short')
-      .resolved.name || route.route_id;
+  const routeNames = getRouteDisplayNames(
+    route,
+    dataLang,
+    resolveAgencyLang(agencies, route.agency_id),
+    'short',
+  );
+  const label = routeNames.resolved.name || route.route_id;
   const labelBg = route.route_color ? `#${route.route_color}` : undefined;
   const labelFg = route.route_text_color ? `#${route.route_text_color}` : undefined;
   return (

--- a/src/components/badge/route-count-badge.tsx
+++ b/src/components/badge/route-count-badge.tsx
@@ -28,8 +28,8 @@ export function RouteCountBadge({
   size = 'sm',
 }: RouteCountBadgeProps) {
   const label =
-    getRouteDisplayNames(route, dataLang, resolveAgencyLang(agencies, route.agency_id)).resolved
-      .name || route.route_id;
+    getRouteDisplayNames(route, dataLang, resolveAgencyLang(agencies, route.agency_id), 'short')
+      .resolved.name || route.route_id;
   const labelBg = route.route_color ? `#${route.route_color}` : undefined;
   const labelFg = route.route_text_color ? `#${route.route_text_color}` : undefined;
   return (

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -144,8 +144,12 @@ export function TimetableModal({ data, time, infoLevel, dataLang, onClose }: Tim
   if (data.type === 'route-headsign') {
     const route = data.routes[0];
     const descriptionRouteName = route
-      ? getRouteDisplayNames(route, dataLang, resolveAgencyLang(data.agencies, route.agency_id))
-          .resolved.name
+      ? getRouteDisplayNames(
+          route,
+          dataLang,
+          resolveAgencyLang(data.agencies, route.agency_id),
+          'short',
+        ).resolved.name
       : '';
 
     timetableDescription = t(

--- a/src/components/map/selection-indicator.tsx
+++ b/src/components/map/selection-indicator.tsx
@@ -64,7 +64,7 @@ export function SelectionIndicator({
 
   logger.debug('Rendering route selection indicator for route', info.route);
 
-  const routeNames = getRouteDisplayNames(info.route, dataLang, DEFAULT_AGENCY_LANG);
+  const routeNames = getRouteDisplayNames(info.route, dataLang, DEFAULT_AGENCY_LANG, 'short');
 
   return (
     <div className="pointer-events-auto absolute bottom-8 left-1/2 z-1001 flex max-w-[70%] -translate-x-1/2 cursor-default flex-col items-center gap-0.5 overflow-hidden rounded-2xl border-none bg-black/75 px-3.5 py-1.5 text-sm font-semibold text-ellipsis whitespace-nowrap text-white">

--- a/src/datasources/__tests__/fetch-data-source-v2.test.ts
+++ b/src/datasources/__tests__/fetch-data-source-v2.test.ts
@@ -23,12 +23,12 @@ function makeDataBundle() {
     translations: {
       v: 1,
       data: {
-        headsigns: {},
-        stop_headsigns: {},
-        stop_names: {},
-        route_names: {},
         agency_names: {},
-        agency_short_names: {},
+        route_long_names: {},
+        route_short_names: {},
+        stop_names: {},
+        trip_headsigns: {},
+        stop_headsigns: {},
       },
     },
     lookup: { v: 2, data: {} },

--- a/src/repositories/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/__tests__/athenai-repository-v2.test.ts
@@ -259,19 +259,20 @@ describe('mergeSourcesV2', () => {
           translations: {
             v: 1,
             data: {
-              headsigns: {
-                'Stazione Centrale': { en: 'Central Station' },
-              },
-              stop_headsigns: {},
-              stop_names: {
-                'itfeed:s1': { en: 'Central Station' },
-              },
-              route_names: {
-                'itfeed:r1': { en: 'Line 1' },
-              },
               agency_names: {
                 'itfeed:ag1': { en: 'English Transit Co.' },
               },
+              route_long_names: {
+                'itfeed:r1': { en: 'Line 1' },
+              },
+              route_short_names: {},
+              stop_names: {
+                'itfeed:s1': { en: 'Central Station' },
+              },
+              trip_headsigns: {
+                'Stazione Centrale': { en: 'Central Station' },
+              },
+              stop_headsigns: {},
             },
           },
           lookup: { v: 2, data: {} },
@@ -283,7 +284,7 @@ describe('mergeSourcesV2', () => {
       const merged = mergeSourcesV2([createFeedLangFixture()]);
       const translations = merged.headsignTranslations.get('itfeed');
       // feed_lang="it", so "Stazione Centrale" should be injected as "it" candidate
-      expect(translations!.headsigns['Stazione Centrale']).toEqual({
+      expect(translations!.trip_headsigns['Stazione Centrale']).toEqual({
         it: 'Stazione Centrale',
         en: 'Central Station',
       });
@@ -312,6 +313,26 @@ describe('mergeSourcesV2', () => {
       const merged = mergeSourcesV2([createFeedLangFixture()]);
       const route = merged.routeMap.get('itfeed:r1');
       expect(route!.route_short_names).toEqual({ it: 'L1' });
+    });
+
+    it('merges route_short_names translations from pipeline into Route', () => {
+      // Simulate a pipeline-emitted route_short_name translation
+      // (e.g. kyoto-city-bus `市バス1` → `1 City Bus`).
+      const source = createFeedLangFixture();
+      source.data.translations.data.route_short_names = {
+        'itfeed:r1': { en: 'L1 Express' },
+      };
+      const merged = mergeSourcesV2([source]);
+      const route = merged.routeMap.get('itfeed:r1');
+      expect(route!.route_short_names).toEqual({
+        it: 'L1',
+        en: 'L1 Express',
+      });
+      // route_long_names is unaffected by the short_names translation
+      expect(route!.route_long_names).toEqual({
+        it: 'Linea 1',
+        en: 'Line 1',
+      });
     });
 
     it('injects agency_names base value under feed_lang, not agency_lang', () => {

--- a/src/repositories/__tests__/fixtures/test-data-source-v2.ts
+++ b/src/repositories/__tests__/fixtures/test-data-source-v2.ts
@@ -441,14 +441,12 @@ export function createFixtureV2(): SourceDataV2 {
     translations: {
       v: 1,
       data: {
-        headsigns: {
-          'Oji-eki via All Stops': { en: 'Oji Station via All Stops' },
+        agency_names: {
+          'test:agency': { ja: 'テスト事業者', en: 'Test Agency' },
+          'test:partner': { ja: '共同バス', en: 'Partner Bus' },
         },
-        stop_headsigns: {
-          'Oji-eki via Park': { en: 'Oji Station via Park' },
-          'Oji-eki': { en: 'Oji Station' },
-          'Oji-eki via All Stops': { en: 'Oji Station via All Stops' },
-        },
+        route_long_names: {},
+        route_short_names: {},
         stop_names: {
           sub_01: { ja: '西巣鴨', en: 'Nishi-sugamo' },
           sub_02: { ja: '巣鴨新田', en: 'Sugamo-shinden' },
@@ -465,10 +463,13 @@ export function createFixtureV2(): SourceDataV2 {
           stop_closed: { ja: '休止停留所', en: 'Closed Stop' },
           sta_parent: { ja: 'テスト駅', en: 'Test Station' },
         },
-        route_names: {},
-        agency_names: {
-          'test:agency': { ja: 'テスト事業者', en: 'Test Agency' },
-          'test:partner': { ja: '共同バス', en: 'Partner Bus' },
+        trip_headsigns: {
+          'Oji-eki via All Stops': { en: 'Oji Station via All Stops' },
+        },
+        stop_headsigns: {
+          'Oji-eki via Park': { en: 'Oji Station via Park' },
+          'Oji-eki': { en: 'Oji Station' },
+          'Oji-eki via All Stops': { en: 'Oji Station via All Stops' },
         },
       },
     },

--- a/src/repositories/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository-v2.ts
@@ -101,7 +101,7 @@ interface ResolvedPattern {
 type HeadsignTranslationsByPrefix = Map<
   string,
   {
-    headsigns: Record<string, Record<string, string>>;
+    trip_headsigns: Record<string, Record<string, string>>;
     stop_headsigns: Record<string, Record<string, string>>;
   }
 >;
@@ -205,40 +205,49 @@ export function mergeSourcesV2(sources: SourceDataV2[]): MergedDataV2 {
   }
 
   // --- Translations ---
-  // headsigns/stop_headsigns are kept per-source to preserve agency-specific
-  // translations. Other maps use prefixed IDs and don't collide.
+  // trip_headsigns/stop_headsigns are kept per-source to preserve
+  // agency-specific translations. Other maps use prefixed IDs and
+  // don't collide.
   const translationsMap: TranslationsJson = {
-    headsigns: {},
-    stop_headsigns: {},
-    stop_names: {},
-    route_names: {},
     agency_names: {},
+    route_long_names: {},
+    route_short_names: {},
+    stop_names: {},
+    trip_headsigns: {},
+    stop_headsigns: {},
   };
   const headsignTranslations: HeadsignTranslationsByPrefix = new Map();
   for (const source of sources) {
     const t = source.data.translations.data;
     const feedLang = feedLangByPrefix.get(source.prefix);
 
-    // Normalize headsign/stop_headsign translations: inject base value
+    // Normalize trip/stop headsign translations: inject base value
     // (the headsign text itself) under feed_lang when not already present.
-    const headsigns: Record<string, Record<string, string>> = {};
-    for (const [text, langMap] of Object.entries(t.headsigns)) {
-      headsigns[text] = injectOriginLang(langMap, text, feedLang);
+    const tripHeadsigns: Record<string, Record<string, string>> = {};
+    if (t.trip_headsigns) {
+      for (const [text, langMap] of Object.entries(t.trip_headsigns)) {
+        tripHeadsigns[text] = injectOriginLang(langMap, text, feedLang);
+      }
     }
     const stopHeadsigns: Record<string, Record<string, string>> = {};
-    for (const [text, langMap] of Object.entries(t.stop_headsigns)) {
-      stopHeadsigns[text] = injectOriginLang(langMap, text, feedLang);
+    if (t.stop_headsigns) {
+      for (const [text, langMap] of Object.entries(t.stop_headsigns)) {
+        stopHeadsigns[text] = injectOriginLang(langMap, text, feedLang);
+      }
     }
     headsignTranslations.set(source.prefix, {
-      headsigns,
+      trip_headsigns: tripHeadsigns,
       stop_headsigns: stopHeadsigns,
     });
 
     if (t.stop_names) {
       Object.assign(translationsMap.stop_names, t.stop_names);
     }
-    if (t.route_names) {
-      Object.assign(translationsMap.route_names, t.route_names);
+    if (t.route_long_names) {
+      Object.assign(translationsMap.route_long_names, t.route_long_names);
+    }
+    if (t.route_short_names) {
+      Object.assign(translationsMap.route_short_names, t.route_short_names);
     }
     if (t.agency_names) {
       Object.assign(translationsMap.agency_names, t.agency_names);
@@ -315,9 +324,17 @@ export function mergeSourcesV2(sources: SourceDataV2[]): MergedDataV2 {
       routeMap.set(r.i, {
         route_id: r.i,
         route_short_name: r.s,
-        route_short_names: injectOriginLang({}, r.s, feedLang),
+        route_short_names: injectOriginLang(
+          translationsMap.route_short_names[r.i] ?? {},
+          r.s,
+          feedLang,
+        ),
         route_long_name: r.l,
-        route_long_names: injectOriginLang(translationsMap.route_names[r.i] ?? {}, r.l, feedLang),
+        route_long_names: injectOriginLang(
+          translationsMap.route_long_names[r.i] ?? {},
+          r.l,
+          feedLang,
+        ),
         route_type: (VALID_ROUTE_TYPE_VALUES.has(r.t) ? r.t : -1) as AppRouteTypeValue,
         route_color: r.c,
         route_text_color: r.tc,
@@ -1393,7 +1410,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       route: resolved.route,
       tripHeadsign: {
         name: resolved.headsign,
-        names: src?.headsigns[resolved.headsign] ?? {},
+        names: src?.trip_headsigns[resolved.headsign] ?? {},
       },
       stopHeadsign:
         stop.headsign != null

--- a/src/types/data/transit-json.ts
+++ b/src/types/data/transit-json.ts
@@ -57,18 +57,95 @@ export interface FeedInfoJson {
   v: string; // feed_version
 }
 
-/** translations.json */
+/**
+ * translations.json — per-source translations extracted from
+ * `translations.txt` (GTFS) or the equivalent ODPT dictionaries.
+ *
+ * Each field is a Map from a primary key to a per-language translation
+ * record. The primary key shape depends on the field — see individual
+ * field comments. Languages use BCP 47 codes as they appear in the
+ * upstream `translations.txt` (e.g. `ja`, `en`, `ja-Hrkt`, `zh-Hans`).
+ *
+ * All fields are required. Sources without translations for a given
+ * field emit an empty object (`{}`) rather than omitting the field,
+ * so consumers do not need optional-chaining for the field itself.
+ */
 export interface TranslationsJson {
-  /** trip_headsign -> { language -> translation } */
-  headsigns: Record<string, Record<string, string>>;
-  /** stop_headsign -> { language -> translation } */
-  stop_headsigns: Record<string, Record<string, string>>;
-  /** stop_id -> { language -> translation } */
-  stop_names: Record<string, Record<string, string>>;
-  /** route_id -> { language -> translation } */
-  route_names: Record<string, Record<string, string>>;
-  /** agency_id -> { language -> translation of agency_name } */
+  /**
+   * agency_id -> { language -> translation of `agency_name` }.
+   *
+   * Key is the **prefixed** agency_id (e.g. `kcbus:2000020261009`),
+   * matching `AgencyV2Json.i`. Built from rows where
+   * `translations.table_name = 'agency'` and
+   * `translations.field_name = 'agency_name'`.
+   */
   agency_names: Record<string, Record<string, string>>;
+
+  /**
+   * route_id -> { language -> translation of `route_long_name` }.
+   *
+   * Key is the **prefixed** route_id (e.g. `toaran:6`), matching
+   * `RouteV2Json.i`. Built from rows where
+   * `translations.table_name = 'routes'` and
+   * `translations.field_name = 'route_long_name'`.
+   *
+   * Per GTFS spec `route_short_name` and `route_long_name` are both
+   * first-class fields (one is required when the other is empty),
+   * so this lives alongside {@link route_short_names} as an equal
+   * peer rather than under a generic `route_names` umbrella.
+   */
+  route_long_names: Record<string, Record<string, string>>;
+
+  /**
+   * route_id -> { language -> translation of `route_short_name` }.
+   *
+   * Key is the **prefixed** route_id, same shape as
+   * {@link route_long_names}. Built from rows where
+   * `translations.table_name = 'routes'` and
+   * `translations.field_name = 'route_short_name'`.
+   *
+   * Some feeds (e.g. kyoto-city-bus, keio-bus) translate the short
+   * name (`市バス1` → `1 City Bus`) but not the long name; this
+   * field captures that.
+   */
+  route_short_names: Record<string, Record<string, string>>;
+
+  /**
+   * stop_id -> { language -> translation of `stop_name` }.
+   *
+   * Key is the **prefixed** stop_id (e.g. `minkuru:0241-01`),
+   * matching `StopV2Json.i`. Built from rows where
+   * `translations.table_name = 'stops'` and
+   * `translations.field_name = 'stop_name'`. Includes all
+   * `location_type` values (the v2 pipeline does not filter to
+   * platforms only).
+   */
+  stop_names: Record<string, Record<string, string>>;
+
+  /**
+   * trip_headsign text -> { language -> translation }.
+   *
+   * Keyed by the **headsign text itself** (not by trip_id), so
+   * every trip that uses the same headsign string shares one entry.
+   * Built from rows where `translations.table_name = 'trips'` and
+   * `translations.field_name = 'trip_headsign'`, joined back to
+   * `trips` to recover the headsign text when the row only
+   * references `record_id`.
+   *
+   * Naming: this is the trip_headsign translations map; paired with
+   * {@link stop_headsigns} for the stop_headsign override.
+   */
+  trip_headsigns: Record<string, Record<string, string>>;
+
+  /**
+   * stop_headsign text -> { language -> translation }.
+   *
+   * Keyed by the headsign text. `stop_headsign` is a per-stop_time
+   * override of the trip-level headsign (used when a trip changes
+   * destination mid-route, etc.) — this captures the translations
+   * for those override strings.
+   */
+  stop_headsigns: Record<string, Record<string, string>>;
 }
 
 /** calendar.json */

--- a/src/types/data/transit-v2-json.ts
+++ b/src/types/data/transit-v2-json.ts
@@ -380,7 +380,7 @@ export interface TripPatternJson {
      *
      * For translation lookup, when `sh` is present use
      * `translations.stop_headsigns[sh]`; otherwise use
-     * `translations.headsigns[h]`.
+     * `translations.trip_headsigns[h]`.
      *
      * Omitted when the source does not provide `stop_headsign`
      * or when the value is NULL.


### PR DESCRIPTION
Fixes #103.

## Summary

Some GTFS feeds declare translations for `routes.route_short_name` in `translations.txt`, but the v2 pipeline was only extracting `route_long_name` translations, so those short-name translations never reached `data.json` and the app could not follow language switches for affected routes. This PR adds `route_short_name` extraction, cleans up the translation schema naming, and adds TSDoc for every field in `TranslationsJson`.

## User-visible impact

The dominant affected feed is **Kyoto City Bus**. Its `translations.txt` declares 139 route-level `en` short-name translations like `市バス１` → `1 City Bus`, `市バス２０６` → `206 City Bus`, etc. Before this PR, switching the display language to English left those routes displayed as `市バス５` / `市バス２０６` / … — unusable for English-speaking tourists picking a bus at e.g. Kyoto Station. After this PR (once `public/data-v2/kcbus/data.json` is regenerated), route badges resolve to `5 City Bus` / `206 City Bus` / etc. following the user's current display language.

Coverage summary across currently loaded GTFS sources:

| Source | short_en | long_en | Note |
|---|---:|---:|---|
| kyoto-city-bus | **139** | 0 | short-only, this is the main target |
| keio-bus | **31** | 0 | short-only; source quality is low (en values are Japanese-script short forms), but the plumbing is now in place |
| iyotetsu-bus | 0 | 78 | long-only, already extracted (rename-only) |
| kanto-bus | 0 | 394 | long-only, already extracted (rename-only) |
| miyake-bus | 0 | 18 | long-only, already extracted (rename-only) |
| nagoya-srt | 0 | 1 | long-only, already extracted (rename-only) |
| oshima-bus | 0 | 26 | long-only, already extracted (rename-only) |

No source currently has both short_en and long_en, so there is no fixture today that exercises both simultaneously — but the schema and pipeline already support that case.

## Schema changes

`src/types/data/transit-json.ts` — `TranslationsJson`:

- Renamed `route_names` → `route_long_names` so the field name reflects that it only carries long-name translations.
- Added `route_short_names` as a first-class peer of `route_long_names`. Per GTFS spec, \`route_short_name\` and \`route_long_name\` are both first-class fields (one is required when the other is empty), so the schema now treats them symmetrically.
- Renamed `headsigns` → `trip_headsigns` so it is symmetric with `stop_headsigns` and the field name states which upstream GTFS source it was built from.
- Every field now carries a dedicated TSDoc block describing its key shape, the upstream GTFS table/column it is built from, and the relationship with neighbouring fields.

## Pipeline changes

- `pipeline/src/lib/pipeline/app-data-v2/gtfs/extract-translations.ts`: rename local vars / output keys to match the new schema, and add a new query block for \`routes.route_short_name\` that supports both GTFS-JP (record_id-based) and standard GTFS (field_value-based) translation row shapes. Same pattern as the existing route_long_name extraction. Summary log line now reports trip_headsigns / route_long_names / route_short_names counts.
- `pipeline/src/lib/pipeline/app-data-v2/odpt/build-translations.ts`: rename the in-memory map and return keys to the new schema. ODPT does not expose a separate short_name translation, so `route_short_names` is emitted as an empty map (sufficient to satisfy the schema).
- `pipeline/scripts/dev/dev-lib/v2-name-fields-analysis.ts` analyzer: read from and report `translations.trip_headsigns`, `translations.route_long_names`, `translations.route_short_names` individually in the field-count inventory.

## Pipeline tests

- `extract-translations.test.ts`:
  - Update the "empty maps" assertion and all existing `headsigns` / `route_names` references to the new keys.
  - Add five new cases covering `route_short_name` extraction: GTFS-JP record_id path, standard GTFS field_value path, long and short coexisting independently, multi-language short-name, and the short/long interaction on a single route.
- `build-odpt-translations.test.ts`: update existing assertions for the renamed keys and verify `route_short_names` is empty for ODPT.
- All other pipeline fixtures with inline TranslationsJson literals (`validate-data.test.ts`, `bundle-writer.test.ts`, `build-global-stop-entries.test.ts`, `build-insights.test.ts`, `build-global-insights.test.ts`, `v2-name-fields-analysis.test.ts`, `build-from-odpt-train.test.ts`) updated to emit the new shape.

## Webapp loader changes

`src/repositories/athenai-repository-v2.ts`:

- Initialize the merged `translationsMap` with the new schema.
- Read `t.trip_headsigns` / `t.route_long_names` / `t.route_short_names` during the per-source merge, keeping the existing defensive `if (t.field)` checks so existing committed \`public/data-v2/*/data.json\` files still load without crashing while the data refresh is pending (the old `route_names` / `headsigns` keys will simply be ignored; translations appear empty for the affected fields until the data is regenerated).
- Rename the internal `HeadsignTranslationsByPrefix` map entry key from `headsigns` to `trip_headsigns` and update the single consumer in `resolveRouteDirection` accordingly.
- Build `Route.route_short_names` from `translationsMap.route_short_names[r.i]` (previously always empty; now populated when the pipeline emits short-name translations).

## Display-layer consumers

`src/components/badge/route-badge.tsx`, `route-count-badge.tsx`, `src/components/dialog/timetable-modal.tsx`, and `src/components/map/selection-indicator.tsx` now pass the explicit \`'short'\` prefer argument to `getRouteDisplayNames` at the four surfaces that display the short route identifier. \`'short'\` is already the default, so this is a no-op behaviour change — it locks intent at the call site and is resilient against a future default change.

## Webapp regression test

`src/repositories/__tests__/athenai-repository-v2.test.ts` gets a new case that mirrors the existing `injects … under feed_lang` coverage: verifies that pipeline-emitted `route_short_names` flow into `Route.route_short_names` in parallel with `route_long_names`, and that the short-name translation does not disturb the long-name resolution.

## Test fixtures

Every direct `TranslationsJson` construction in test fixtures is updated to the new shape, including the new `route_short_names` field. Removed a stale `agency_short_names: {}` field from the `fetch-data-source-v2` test fixture that was never part of the type.

## Out of scope

- **`public/data-v2/*/data.json` regeneration**: intentionally not included in this PR. The webapp loader is defensive against missing fields, so existing `data.json` files continue to load (with the affected translation fields temporarily empty) until the data is refreshed via the existing data update flow. Once regenerated, kyoto-city-bus English short names will surface in the UI automatically — no additional webapp change needed.
- **keio-bus en data quality**: keio-bus's source `translations.txt` declares Japanese-script strings for \`en\` short-name (`すぎ丸 けやき路線` → `けやき路線`). This is a source-side data issue, not a pipeline bug. The plumbing is in place; fixing the actual translations is separate.

## Test plan

- [x] `npx tsc --noEmit --project tsconfig.app.json`
- [x] `cd pipeline && npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npx prettier --check src pipeline CHANGELOG.md`
- [x] `npm run test` (158 files, 2398 tests pass)
- [x] `npm run build`
- [x] Manual pipeline re-run against a local workspace (`npm run pipeline:build:v2-data`) and inspection of the regenerated `data-v2/kcbus/data.json`: `translations.data.route_short_names` contains 139 entries like `{ ja: "市バス１", en: "1 City Bus" }`. Same check on `data-v2/kobus/data.json` showed 31 entries.
- [x] Manual dev-server check (after pointing `public/data-v2/` at the locally regenerated bundle): `?stop=kcbus:061001&lang=en` renders route badges as `6 City Bus`, `50 City Bus`, `9 City Bus`, `16 City Bus`, `19 City Bus`, `28 City Bus`, `33 City Bus`, `快速Rapid 9 City Bus`, etc. across the whole stop's route list. Switching to `lang=ja` restores `市バス６`, `市バス５０`, `市バス快速９`, etc. The local `public/data-v2/` tree was reverted before committing (out of scope above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)