### PR TITLE
feat(ui): JourneyTimeBar, showAgency gate, layout polish + dev analyzers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `computeJourneyTime` 純粋関数 (`src/domain/transit/journey-time.ts`): trip の remaining / total minutes から bar 描画用の値 (sanitized minutes、progress ratio、display 用の rounded values) を計算する domain helper。Result-type API (`{ ok: true, value } | { ok: false, reason }`) で `no-total` / `invalid-total` の失敗を呼び出し側が単一 gate で扱える。sub-minute total の degenerate 表示 (`0 / 0`) を回避するため `displayTotalMinutes = Math.max(1, Math.round(...))` で clamp。pipeline 由来の小数 minutes に対する 100% fill 時のラベル整合性も担保。エッジケース 40 tests 追加。
+- `JourneyTimeBar` 新規コンポーネント (`src/components/journey-time-bar.tsx`): trip の remaining / total minutes を視覚化する progress bar。`size` (sm/md/lg/xl)、`color` (route_color hex)、`border`、`fillDirection` (ltr/rtl)、`minsPosition` (left/right/top/bottom)、`showRMins` / `showTMins`、`rTimeLabel` / `tMinsLabel` の柔軟な props。`maxMinutes` (default 120) で長距離 trip の bar 幅を clamp。`showEmoji` (⏳) prop 追加 — verbose info level での at-a-glance 識別用。`shadcn/ui` の `Progress` primitive を採用。Storybook stories に 12+ ケース (Sizes / Colors / Borders / FillDirections / LabelCombinations / KitchenSink 等)。
+- `FlatDepartureItem` の `infoLevel >= detailed` で `JourneyTimeBar` を表示。verbose 時は分数ラベル (現在 / 合計 mins) も併記し、route の bgColor を bar fill にも引き継ぐ。
+- `TripInfo` に `showAgency?: boolean` prop (default `false`) を追加。agency badge は `info.isDetailedEnabled && agency && showAgency` でレンダリング。`FlatDepartureItem` / `DepartureItem` にも同名 pass-through prop を追加し、`nearby-stop.tsx` で `showAgency = info.isVerboseEnabled || agencies.length > 1` を計算して渡す。current dataset では multi-operator stop が稀なため、single-operator stop (大半) では agency badge は冗長 noise として非表示になる。
+- `TripPositionIndicator` の verbose 時に 🚏 emoji prefix を追加 (at-a-glance 識別用)。
+- 論理的 (place-name-independent) な long/short fixtures を `src/stories/fixtures.ts` に追加: `routeLong` / `tripHeadsignLong` / `tripHeadsignShort` / `stopHeadsignLong` 等、9 言語の翻訳を持つ抽象 placeholder データ (Alpha Park / Bravo Station 等)。実在地名に依存せず wrap / truncation / multi-lang fallback の構造的検証を行うため。
+- `LogicalLongInfoLevelComparison` story を全主要コンポーネントに標準化追加 (DepartureItem / FlatDepartureItem / TripInfo / HeadsignBadge / RouteBadge / StopSummary / StopMarkersDom)。4 つの `infoLevel` (simple/normal/detailed/verbose) を縦並びで一覧表示し、論理的 long-form fixtures を使って full-data 状態での rendering を視覚的に確認できる。
+- `DepartureItem.LogicalLongInfoLevelComparison` を per-departure attribute label catalog として拡張: 5 entries で `TimetableEntryAttributesLabels` の全フラグ (plain / terminal / origin / pickup× / dropoff×) を網羅。
+- `StopMarkersDom.LangComparison` 新規追加 (9 言語の地図インスタンスを stack)。
+- `TripInfo.MultiAgenciesStop` story 追加 (`showAgency=true` 時の rendering 確認)。
+- pipeline dev tools 2 件を追加: `pipeline/scripts/dev/analyze-v2-insights.ts` (per-source `InsightsBundle` 解析: `tripPatternStats` / `serviceGroups` / `tripPatternGeo` / `stopStats` の overview + distribution)、`pipeline/scripts/dev/analyze-v2-global-insights.ts` (`GlobalInsightsBundle` の `stopGeo` 解析: nr / wp / cn 分布、isolation buckets、hub counts、Top-N leaderboards)。dev-lib pattern (pure analysis + formatter + thin CLI wrapper) に従い、`dev-tools.ts` / `README.md` も更新。smoke test 追加。
+
+### Changed
+
+- `DepartureItem` の絶対時刻 row を `flex-wrap` 対応に変更。`RelativeTime` は単一 unit として非折り返しのまま、n 個の絶対時刻 entry 群を新規 `<div>` でラップして内側で wrap 可能に (`min-w-0 flex-1 flex-wrap`)。各時刻 span は `whitespace-nowrap` で「時刻 + attribute label」が分離しない。狭幅で時刻が右側に overflow して clip されていた問題を解消。
+- `DepartureItem` の各時刻 span を `items-baseline` から `items-center` に変更。attribute label pill が時刻テキストに対してベースラインではなく縦中央で揃うように調整。
+- `TimetableEntryAttributesLabels` の表示順を入れ替え: origin (始発) を terminal (終点) より先にレンダリング。両フラグが立つ場合に始発状態を先に読める自然な順序に。
+- `JourneyTimeBar` 内部の horizontal / vertical layout 分岐を統一 (`isHorizontal` フラグでクラス選択)。重複していた wrapper ロジックを 1 か所に集約。
+
+### Fixed
+
+- `FlatDepartureItem` の verbose stop 位置ラベル (`stopIndex / totalStops`) のレイアウトを微調整。`TripPositionIndicator` の右隣に inline 配置するように変更し、専用 row を廃止。
+
 ## [2026.04.14]
 
 ### Changed

--- a/pipeline/scripts/dev/README.md
+++ b/pipeline/scripts/dev/README.md
@@ -4,13 +4,15 @@
 
 ## スクリプト一覧
 
-| スクリプト                          | 対象データ                                       | 概要                                                                                                                   |
-| ----------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| `describe-resources.ts`             | `pipeline/config/resources/` (リソース定義)      | リソース定義の一覧表示 (`npm run pipeline:describe`)                                                                   |
-| `find-joint-routes.ts`              | `public/data/` (生成済み JSON)                   | 共同運行路線の検出。ソース間で route_short_name が一致する路線を検出し、停留所名の突き合わせと座標による近接分析を行う |
-| `analyze-gtfs-stop-times.ts`        | `pipeline/workspace/_build/db/` (SQLite DB)      | GTFS stop_times パターン分析 (terminal-only stops, circular routes, pickup/drop-off types 等)                          |
-| `analyze-odpt-station-timetable.ts` | `pipeline/workspace/data/odpt-json/` (ODPT JSON) | ODPT StationTimetable データパターン分析 (time field availability, station/direction/calendar coverage 等)             |
-| `analyze-v2-name-fields.ts`         | `public/data-v2/` (生成済み V2 DataBundle)       | 定義済みの名称系調査対象について、V2 JSON 上の `nonEmpty` / `empty` 件数を source ごとに集計する                       |
+| スクリプト                          | 対象データ                                                   | 概要                                                                                                                   |
+| ----------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `describe-resources.ts`             | `pipeline/config/resources/` (リソース定義)                  | リソース定義の一覧表示 (`npm run pipeline:describe`)                                                                   |
+| `find-joint-routes.ts`              | `public/data/` (生成済み JSON)                               | 共同運行路線の検出。ソース間で route_short_name が一致する路線を検出し、停留所名の突き合わせと座標による近接分析を行う |
+| `analyze-gtfs-stop-times.ts`        | `pipeline/workspace/_build/db/` (SQLite DB)                  | GTFS stop_times パターン分析 (terminal-only stops, circular routes, pickup/drop-off types 等)                          |
+| `analyze-odpt-station-timetable.ts` | `pipeline/workspace/data/odpt-json/` (ODPT JSON)             | ODPT StationTimetable データパターン分析 (time field availability, station/direction/calendar coverage 等)             |
+| `analyze-v2-name-fields.ts`         | `public/data-v2/` (生成済み V2 DataBundle)                   | 定義済みの名称系調査対象について、V2 JSON 上の `nonEmpty` / `empty` 件数を source ごとに集計する                       |
+| `analyze-v2-insights.ts`            | `public/data-v2/<source>/insights.json` (InsightsBundle)     | InsightsBundle の 4 セクション (serviceGroups / tripPatternStats / tripPatternGeo / stopStats) を source 別に集計する  |
+| `analyze-v2-global-insights.ts`     | `public/data-v2/global/insights.json` (GlobalInsightsBundle) | GlobalInsightsBundle の `stopGeo` を source 別に集計する (stop 件数、`wp`/`cn` カバレッジ、`nr` 分布)                  |
 
 ## `analyze-v2-name-fields.ts`
 
@@ -42,4 +44,6 @@ npx tsx pipeline/scripts/dev/find-joint-routes.ts
 npx tsx pipeline/scripts/dev/analyze-gtfs-stop-times.ts
 npx tsx pipeline/scripts/dev/analyze-odpt-station-timetable.ts
 npx tsx pipeline/scripts/dev/analyze-v2-name-fields.ts
+npx tsx pipeline/scripts/dev/analyze-v2-insights.ts
+npx tsx pipeline/scripts/dev/analyze-v2-global-insights.ts
 ```

--- a/pipeline/scripts/dev/analyze-v2-global-insights.ts
+++ b/pipeline/scripts/dev/analyze-v2-global-insights.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env -S npx tsx
+
+/**
+ * Analyze the v2 GlobalInsightsBundle (`public/data-v2/global/insights.json`).
+ *
+ * Prints a per-source breakdown of the `stopGeo` section with basic
+ * coverage of optional fields (`wp`, `cn`) and a distribution of the
+ * `nr` (nearest different-route distance) metric.
+ *
+ * Usage:
+ *   npx tsx pipeline/scripts/dev/analyze-v2-global-insights.ts
+ *   npx tsx pipeline/scripts/dev/analyze-v2-global-insights.ts --help
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { GlobalInsightsBundle } from '../../../src/types/data/transit-v2-json';
+import {
+  analyzeGlobalInsightsBundle,
+  formatGlobalInsightsAnalysis,
+} from './dev-lib/v2-global-insights-analysis';
+import { PIPELINE_ROOT } from '../../src/lib/paths';
+import { runMain } from '../../src/lib/pipeline/pipeline-utils';
+
+const PUBLIC_V2_DIR = join(PIPELINE_ROOT, '..', 'public', 'data-v2');
+const GLOBAL_INSIGHTS_PATH = join(PUBLIC_V2_DIR, 'global', 'insights.json');
+
+type CliMode = { kind: 'help' } | { kind: 'run' };
+
+function parseArgs(args: string[]): CliMode {
+  if (args.length === 0) {
+    return { kind: 'run' };
+  }
+  if (args.length === 1 && (args[0] === '--help' || args[0] === '-h')) {
+    return { kind: 'help' };
+  }
+  return { kind: 'help' };
+}
+
+function printHelp(): void {
+  console.log('Usage: analyze-v2-global-insights.ts');
+  console.log('  No args    Analyze public/data-v2/global/insights.json');
+  console.log('  --help     Show this help');
+}
+
+function main(): void {
+  const mode = parseArgs(process.argv.slice(2));
+
+  if (mode.kind === 'help') {
+    printHelp();
+    return;
+  }
+
+  if (!existsSync(GLOBAL_INSIGHTS_PATH)) {
+    console.error(`Global insights bundle not found: ${GLOBAL_INSIGHTS_PATH}`);
+    console.error('Run the pipeline to build it first.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const bundle = JSON.parse(readFileSync(GLOBAL_INSIGHTS_PATH, 'utf-8')) as GlobalInsightsBundle;
+  if (bundle.kind !== 'global-insights') {
+    console.error(`Unexpected bundle kind: ${String(bundle.kind)}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const stats = analyzeGlobalInsightsBundle(bundle);
+  console.log(formatGlobalInsightsAnalysis(stats));
+}
+
+runMain(main);

--- a/pipeline/scripts/dev/analyze-v2-insights.ts
+++ b/pipeline/scripts/dev/analyze-v2-insights.ts
@@ -59,7 +59,16 @@ function listSourcePrefixes(): string[] {
 
 function readInsights(source: string): InsightsBundle {
   const bundlePath = join(PUBLIC_V2_DIR, source, 'insights.json');
-  return JSON.parse(readFileSync(bundlePath, 'utf-8')) as InsightsBundle;
+  const bundle = JSON.parse(readFileSync(bundlePath, 'utf-8')) as InsightsBundle;
+  // Defensive: catch corrupted or mis-named bundles early so the
+  // analyser never tries to interpret e.g. a global-insights bundle
+  // through the per-source code path.
+  if (bundle.kind !== 'insights') {
+    throw new Error(
+      `Expected insights bundle at ${bundlePath} but got kind=${String(bundle.kind)}`,
+    );
+  }
+  return bundle;
 }
 
 /**

--- a/pipeline/scripts/dev/analyze-v2-insights.ts
+++ b/pipeline/scripts/dev/analyze-v2-insights.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env -S npx tsx
+
+/**
+ * Analyze per-source v2 InsightsBundle files.
+ *
+ * Reads `public/data-v2/<source>/insights.json` and prints duration
+ * statistics (mean, median, p90, std, min, max, pct trips > 60 min) for
+ * each source, in both per-pattern and per-trip (freq-weighted) views.
+ *
+ * Usage:
+ *   npx tsx pipeline/scripts/dev/analyze-v2-insights.ts              # all sources
+ *   npx tsx pipeline/scripts/dev/analyze-v2-insights.ts <source>     # single source
+ *   npx tsx pipeline/scripts/dev/analyze-v2-insights.ts --list       # list sources
+ *   npx tsx pipeline/scripts/dev/analyze-v2-insights.ts --help       # show usage
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { InsightsBundle } from '../../../src/types/data/transit-v2-json';
+import {
+  analyzeInsightsBundle,
+  formatInsightsAnalysis,
+  type InsightsSourceStats,
+} from './dev-lib/v2-insights-analysis';
+import {
+  listGtfsSourceNames,
+  loadAllGtfsSources,
+  loadGtfsSource,
+} from '../../src/lib/resources/load-gtfs-sources';
+import {
+  listOdptJsonSourceNames,
+  loadAllOdptJsonSources,
+  loadOdptJsonSource,
+} from '../../src/lib/resources/load-odpt-json-sources';
+import { PIPELINE_ROOT } from '../../src/lib/paths';
+import { runMain } from '../../src/lib/pipeline/pipeline-utils';
+
+const PUBLIC_V2_DIR = join(PIPELINE_ROOT, '..', 'public', 'data-v2');
+
+type CliMode =
+  | { kind: 'help' }
+  | { kind: 'list' }
+  | { kind: 'all' }
+  | { kind: 'source'; name: string };
+
+interface SourceName {
+  nameEn: string;
+}
+
+/** List source prefixes under public/data-v2 that have an insights.json. */
+function listSourcePrefixes(): string[] {
+  return readdirSync(PUBLIC_V2_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== 'global')
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(join(PUBLIC_V2_DIR, name, 'insights.json')))
+    .sort();
+}
+
+function readInsights(source: string): InsightsBundle {
+  const bundlePath = join(PUBLIC_V2_DIR, source, 'insights.json');
+  return JSON.parse(readFileSync(bundlePath, 'utf-8')) as InsightsBundle;
+}
+
+/**
+ * Build a prefix → nameEn map by loading every resource definition. Used
+ * for full-run mode.
+ */
+async function buildNameMapAll(): Promise<Map<string, SourceName>> {
+  const map = new Map<string, SourceName>();
+  const [gtfs, odpt] = await Promise.all([loadAllGtfsSources(), loadAllOdptJsonSources()]);
+  for (const def of gtfs) {
+    map.set(def.pipeline.prefix, { nameEn: def.resource.nameEn });
+  }
+  for (const def of odpt) {
+    map.set(def.pipeline.prefix, { nameEn: def.resource.nameEn });
+  }
+  return map;
+}
+
+/**
+ * Load resource definitions lazily until one with matching prefix is found.
+ * Used for --source mode to avoid loading every definition when the caller
+ * only cares about one entry.
+ */
+async function resolveNameForPrefix(prefix: string): Promise<SourceName | null> {
+  for (const name of listGtfsSourceNames()) {
+    const def = await loadGtfsSource(name);
+    if (def.pipeline.prefix === prefix) {
+      return { nameEn: def.resource.nameEn };
+    }
+  }
+  for (const name of listOdptJsonSourceNames()) {
+    const def = await loadOdptJsonSource(name);
+    if (def.pipeline.prefix === prefix) {
+      return { nameEn: def.resource.nameEn };
+    }
+  }
+  return null;
+}
+
+function parseArgs(args: string[]): CliMode {
+  if (args.length === 0) {
+    return { kind: 'all' };
+  }
+  if (args.length === 1) {
+    const [a] = args;
+    if (a === '--help' || a === '-h') {
+      return { kind: 'help' };
+    }
+    if (a === '--list') {
+      return { kind: 'list' };
+    }
+    if (!a.startsWith('-')) {
+      return { kind: 'source', name: a };
+    }
+  }
+  return { kind: 'help' };
+}
+
+function printHelp(): void {
+  console.log('Usage: analyze-v2-insights.ts [source-name]');
+  console.log('  No args    Analyze all public/data-v2 sources (excluding global/)');
+  console.log('  <source>   Analyze a single source (by prefix)');
+  console.log('  --list     List available sources');
+  console.log('  --help     Show this help');
+}
+
+async function main(): Promise<void> {
+  const mode = parseArgs(process.argv.slice(2));
+
+  if (mode.kind === 'help') {
+    printHelp();
+    return;
+  }
+
+  const prefixes = listSourcePrefixes();
+
+  if (mode.kind === 'list') {
+    for (const p of prefixes) {
+      console.log(p);
+    }
+    return;
+  }
+
+  if (mode.kind === 'source') {
+    if (!prefixes.includes(mode.name)) {
+      console.error(`Source not found: ${mode.name}`);
+      console.error('Run with --list to see available sources.');
+      process.exitCode = 1;
+      return;
+    }
+    const name = await resolveNameForPrefix(mode.name);
+    if (name === null) {
+      console.warn(`Could not resolve resource name for source: ${mode.name}`);
+    }
+    const nameEn = name?.nameEn ?? mode.name;
+    const bundle = readInsights(mode.name);
+    const row = analyzeInsightsBundle(mode.name, nameEn, bundle);
+    if (row === null) {
+      console.error(`No tripPatternStats data for source: ${mode.name}`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(formatInsightsAnalysis([row]));
+    return;
+  }
+
+  // All-sources mode
+  const nameMap = await buildNameMapAll();
+  const rows: InsightsSourceStats[] = [];
+  for (const prefix of prefixes) {
+    const bundle = readInsights(prefix);
+    const nameEn = nameMap.get(prefix)?.nameEn ?? prefix;
+    const row = analyzeInsightsBundle(prefix, nameEn, bundle);
+    if (row === null) {
+      console.warn(`Skipping ${prefix}: no tripPatternStats data`);
+      continue;
+    }
+    rows.push(row);
+  }
+  console.log(formatInsightsAnalysis(rows));
+}
+
+runMain(main);

--- a/pipeline/scripts/dev/analyze-v2-insights.ts
+++ b/pipeline/scripts/dev/analyze-v2-insights.ts
@@ -74,13 +74,22 @@ function readInsights(source: string): InsightsBundle {
 /**
  * Build a prefix → nameEn map by loading every resource definition. Used
  * for full-run mode.
+ *
+ * The two `loadAll*` calls are awaited sequentially (not via
+ * `Promise.all`) to follow the established convention for loading
+ * local TypeScript resource definitions in this repo. Dynamic
+ * `import()` of local files is effectively instantaneous, so
+ * parallelisation provides no measurable benefit and the sequential
+ * form keeps the call sites uniform with `describe-resources.ts` /
+ * `extract-shapes-from-ksj.ts`.
  */
 async function buildNameMapAll(): Promise<Map<string, SourceName>> {
   const map = new Map<string, SourceName>();
-  const [gtfs, odpt] = await Promise.all([loadAllGtfsSources(), loadAllOdptJsonSources()]);
+  const gtfs = await loadAllGtfsSources();
   for (const def of gtfs) {
     map.set(def.pipeline.prefix, { nameEn: def.resource.nameEn });
   }
+  const odpt = await loadAllOdptJsonSources();
   for (const def of odpt) {
     map.set(def.pipeline.prefix, { nameEn: def.resource.nameEn });
   }

--- a/pipeline/scripts/dev/dev-lib/__tests__/stats-utils.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/stats-utils.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { sortedMedian, sortedPercentile } from '../stats-utils';
+
+describe('sortedMedian', () => {
+  it('returns 0 for an empty array', () => {
+    expect(sortedMedian([])).toBe(0);
+  });
+
+  it('returns the only element for a 1-element array', () => {
+    expect(sortedMedian([42])).toBe(42);
+  });
+
+  it('returns the middle element for an odd-length array', () => {
+    expect(sortedMedian([1, 2, 3])).toBe(2);
+    expect(sortedMedian([1, 2, 3, 4, 5])).toBe(3);
+    expect(sortedMedian([10, 20, 30, 40, 50, 60, 70])).toBe(40);
+  });
+
+  it('returns the average of the two middle elements for even-length arrays', () => {
+    // Standard mathematical median: (20 + 30) / 2 = 25 (NOT 30).
+    // The earlier `Math.floor(n / 2)` impl returned the upper-middle (30),
+    // which biased medians upward. This test pins the corrected behavior.
+    expect(sortedMedian([10, 20, 30, 40])).toBe(25);
+    expect(sortedMedian([1, 2])).toBe(1.5);
+    expect(sortedMedian([1, 2, 3, 4, 5, 6])).toBe(3.5);
+  });
+
+  it('handles arrays with negative values', () => {
+    expect(sortedMedian([-3, -1, 1, 3])).toBe(0);
+    expect(sortedMedian([-5, -3, -1])).toBe(-3);
+  });
+
+  it('handles arrays with floating-point values', () => {
+    expect(sortedMedian([1.5, 2.5, 3.5])).toBe(2.5);
+    expect(sortedMedian([1.0, 2.0, 3.0, 4.0])).toBe(2.5);
+  });
+
+  it('handles all-equal values', () => {
+    expect(sortedMedian([5, 5, 5, 5])).toBe(5);
+    expect(sortedMedian([7, 7, 7])).toBe(7);
+  });
+
+  it('handles large arrays', () => {
+    const values = Array.from({ length: 1000 }, (_, i) => i + 1); // 1..1000
+    // 1000 elements: average of 500th and 501st = (500 + 501) / 2 = 500.5
+    expect(sortedMedian(values)).toBe(500.5);
+  });
+});
+
+describe('sortedPercentile', () => {
+  it('returns 0 for an empty array', () => {
+    expect(sortedPercentile([], 0.5)).toBe(0);
+    expect(sortedPercentile([], 0.9)).toBe(0);
+    expect(sortedPercentile([], 0)).toBe(0);
+    expect(sortedPercentile([], 1)).toBe(0);
+  });
+
+  it('returns the only element for a 1-element array regardless of q', () => {
+    expect(sortedPercentile([42], 0)).toBe(42);
+    expect(sortedPercentile([42], 0.5)).toBe(42);
+    expect(sortedPercentile([42], 0.9)).toBe(42);
+    expect(sortedPercentile([42], 1)).toBe(42);
+  });
+
+  it('returns the minimum for q = 0', () => {
+    expect(sortedPercentile([1, 2, 3, 4, 5], 0)).toBe(1);
+    expect(sortedPercentile([10, 20, 30], 0)).toBe(10);
+  });
+
+  it('returns the maximum for q = 1', () => {
+    expect(sortedPercentile([1, 2, 3, 4, 5], 1)).toBe(5);
+    expect(sortedPercentile([10, 20, 30], 1)).toBe(30);
+  });
+
+  it('computes p90 correctly via nearest-rank (ceil method)', () => {
+    // n=10: ceil(0.9 * 10) = 9, 0-indexed = 8 → values[8] = 9
+    // (The previous floor-based impl returned values[9] = 10, biased high.)
+    expect(sortedPercentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0.9)).toBe(9);
+
+    // n=100: ceil(0.9 * 100) = 90, 0-indexed = 89 → values[89] = 90
+    const hundred = Array.from({ length: 100 }, (_, i) => i + 1);
+    expect(sortedPercentile(hundred, 0.9)).toBe(90);
+
+    // n=20: ceil(0.9 * 20) = 18, 0-indexed = 17 → values[17] = 18
+    expect(
+      sortedPercentile(
+        Array.from({ length: 20 }, (_, i) => i + 1),
+        0.9,
+      ),
+    ).toBe(18);
+  });
+
+  it('computes p50 correctly (matches nearest-rank median, not arithmetic median)', () => {
+    // sortedPercentile(_, 0.5) uses nearest-rank, not the average-of-middle
+    // definition, so it differs from sortedMedian for even-length arrays.
+    // n=4: ceil(0.5 * 4) = 2, 0-indexed = 1 → values[1] = 20
+    expect(sortedPercentile([10, 20, 30, 40], 0.5)).toBe(20);
+    // n=5: ceil(0.5 * 5) = 3, 0-indexed = 2 → values[2] = 30
+    expect(sortedPercentile([10, 20, 30, 40, 50], 0.5)).toBe(30);
+  });
+
+  it('clamps the index to the array bounds', () => {
+    // Defensive: q outside [0, 1] should still produce a valid index.
+    expect(sortedPercentile([1, 2, 3], -0.5)).toBe(1); // clamped to 0
+    expect(sortedPercentile([1, 2, 3], 1.5)).toBe(3); // clamped to n-1
+  });
+
+  it('handles small arrays correctly', () => {
+    // n=3, q=0.9: ceil(2.7) = 3, 0-indexed = 2 → values[2] = 30
+    expect(sortedPercentile([10, 20, 30], 0.9)).toBe(30);
+    // n=2, q=0.5: ceil(1) = 1, 0-indexed = 0 → values[0] = 10
+    expect(sortedPercentile([10, 20], 0.5)).toBe(10);
+    // n=2, q=0.9: ceil(1.8) = 2, 0-indexed = 1 → values[1] = 20
+    expect(sortedPercentile([10, 20], 0.9)).toBe(20);
+  });
+
+  it('handles arrays with floating-point values', () => {
+    expect(sortedPercentile([1.5, 2.5, 3.5, 4.5, 5.5], 0.5)).toBe(3.5);
+    expect(sortedPercentile([0.1, 0.2, 0.3, 0.4, 0.5], 0.9)).toBe(0.5);
+  });
+
+  it('handles all-equal values', () => {
+    expect(sortedPercentile([7, 7, 7, 7, 7], 0.9)).toBe(7);
+    expect(sortedPercentile([7, 7, 7, 7, 7], 0.5)).toBe(7);
+  });
+});

--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-global-insights-analysis.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-global-insights-analysis.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  analyzeGlobalInsightsBundle,
+  formatGlobalInsightsAnalysis,
+} from '../v2-global-insights-analysis';
+import type { GlobalInsightsBundle } from '../../../../../src/types/data/transit-v2-json';
+
+/**
+ * Smoke tests only. See the TSDoc at the top of the source module for
+ * the testing philosophy — these assertions guard against type and
+ * contract regressions, not algorithm correctness.
+ */
+
+function createMinimalBundle(overrides?: Partial<GlobalInsightsBundle>): GlobalInsightsBundle {
+  return {
+    bundle_version: 3,
+    kind: 'global-insights',
+    stopGeo: {
+      v: 1,
+      data: {
+        'src:001': {
+          nr: 0.3,
+          wp: 0.1,
+          cn: { ho: { rc: 4, freq: 50, sc: 3 } },
+        },
+        'src:002': {
+          nr: 0.05,
+          cn: { ho: { rc: 1, freq: 10, sc: 1 } },
+        },
+        'src:003': {
+          nr: 2.5,
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('analyzeGlobalInsightsBundle', () => {
+  it('returns a stats object for a minimal valid bundle', () => {
+    const result = analyzeGlobalInsightsBundle(createMinimalBundle());
+    expect(result).not.toBeNull();
+    expect(result?.totalStops).toBe(3);
+    expect(result?.totalSources).toBe(1);
+    expect(result?.perSource[0].source).toBe('src');
+    expect(result?.perSource[0].stops).toBe(3);
+    expect(result?.perSource[0].connectivity).not.toBeNull();
+    expect(result?.perSource[0].walkablePortal).not.toBeNull();
+  });
+
+  it('returns null when stopGeo is missing', () => {
+    const bundle = createMinimalBundle({ stopGeo: undefined });
+    const result = analyzeGlobalInsightsBundle(bundle);
+    expect(result).toBeNull();
+  });
+
+  it('populates leaderboards when cn data is present', () => {
+    const result = analyzeGlobalInsightsBundle(createMinimalBundle());
+    expect(result?.leaderboards.mostIsolated.length).toBeGreaterThan(0);
+    expect(result?.leaderboards.mostConnected.length).toBeGreaterThan(0);
+    expect(result?.leaderboards.busiestNeighborhood.length).toBeGreaterThan(0);
+  });
+});
+
+describe('formatGlobalInsightsAnalysis', () => {
+  it('emits the expected section headers for a valid input', () => {
+    const stats = analyzeGlobalInsightsBundle(createMinimalBundle());
+    const output = formatGlobalInsightsAnalysis(stats, {
+      analyzedAt: new Date('2026-01-01T00:00:00Z'),
+    });
+    expect(output).toContain('# Athenai Transit — V2 GlobalInsightsBundle analysis');
+    expect(output).toContain('# stopGeo');
+    expect(output).toContain('## Summary');
+    expect(output).toContain('## Distribution of nr (km)');
+    expect(output).toContain('## Isolation buckets');
+    expect(output).toContain('## Connectivity within 300m');
+    expect(output).toContain('## Top 10 most isolated stops');
+  });
+
+  it('returns a message when stats is null', () => {
+    const output = formatGlobalInsightsAnalysis(null, {
+      analyzedAt: new Date('2026-01-01T00:00:00Z'),
+    });
+    expect(output).toContain('No stopGeo data found');
+  });
+});

--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-insights-analysis.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-insights-analysis.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { analyzeInsightsBundle, formatInsightsAnalysis } from '../v2-insights-analysis';
+import type { InsightsBundle } from '../../../../../src/types/data/transit-v2-json';
+
+/**
+ * Smoke tests only. Statistical correctness of the numeric output is
+ * not asserted here (see TSDoc at the top of the source module for the
+ * rationale). These tests guard against type regressions, missing-data
+ * contract breakage, and formatter crashes — not algorithmic bugs.
+ */
+
+function createMinimalBundle(overrides?: Partial<InsightsBundle>): InsightsBundle {
+  return {
+    bundle_version: 3,
+    kind: 'insights',
+    serviceGroups: {
+      v: 1,
+      data: [{ key: 'wd', serviceIds: ['svc:1'] }],
+    },
+    tripPatternStats: {
+      v: 1,
+      data: {
+        wd: {
+          'src:p1': { freq: 2, rd: [30, 15, 0] },
+          'src:p2': { freq: 1, rd: [45, 20, 0] },
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('analyzeInsightsBundle', () => {
+  it('returns a stats object for a minimal valid bundle', () => {
+    const result = analyzeInsightsBundle('src', 'Src Transit', createMinimalBundle());
+    expect(result).not.toBeNull();
+    expect(result?.source).toBe('src');
+    expect(result?.nameEn).toBe('Src Transit');
+    expect(result?.byPattern.count).toBe(2);
+    expect(result?.byTrip.count).toBe(3);
+    expect(result?.serviceGroups.groupCount).toBe(1);
+  });
+
+  it('returns null when tripPatternStats is missing', () => {
+    const bundle = createMinimalBundle({ tripPatternStats: undefined });
+    const result = analyzeInsightsBundle('src', 'Src', bundle);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no patterns are valid', () => {
+    const bundle = createMinimalBundle({
+      tripPatternStats: {
+        v: 1,
+        data: { wd: { 'src:bad': { freq: 1, rd: [0] } } },
+      },
+    });
+    const result = analyzeInsightsBundle('src', 'Src', bundle);
+    expect(result).toBeNull();
+  });
+});
+
+describe('formatInsightsAnalysis', () => {
+  it('emits the expected section headers for a valid input', () => {
+    const row = analyzeInsightsBundle('src', 'Src', createMinimalBundle());
+    expect(row).not.toBeNull();
+    const output = formatInsightsAnalysis(row === null ? [] : [row], {
+      analyzedAt: new Date('2026-01-01T00:00:00Z'),
+    });
+    expect(output).toContain('# Athenai Transit — V2 InsightsBundle analysis');
+    expect(output).toContain('# serviceGroups');
+    expect(output).toContain('# tripPatternStats');
+    expect(output).toContain('# tripPatternGeo');
+    expect(output).toContain('# stopStats');
+    expect(output).toContain('## Overview');
+    expect(output).toContain('## Distribution of trip duration (minutes)');
+  });
+
+  it('returns a non-empty string for an empty rows array', () => {
+    const output = formatInsightsAnalysis([], {
+      analyzedAt: new Date('2026-01-01T00:00:00Z'),
+    });
+    expect(output.length).toBeGreaterThan(0);
+  });
+});

--- a/pipeline/scripts/dev/dev-lib/render-utils.ts
+++ b/pipeline/scripts/dev/dev-lib/render-utils.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared rendering helpers for dev-lib analysers.
+ *
+ * Currently provides a single text-table formatter used by the v2
+ * insights / global-insights analysers. Kept separate from
+ * `stats-utils.ts` because table rendering is presentation, not
+ * statistics — the two responsibilities are evolved independently.
+ */
+
+/**
+ * Render a fixed-width text table from a header row and body rows.
+ *
+ * Columns auto-size to the longest cell (header included). Cells in
+ * the first `leftAlignCount` columns are left-padded with spaces;
+ * remaining columns are right-padded so numeric values line up to
+ * the right.
+ *
+ * Output format:
+ * ```text
+ * col0      col1   col2
+ * --------  -----  -----
+ * value0    val1     123
+ * value0b   val1b   1234
+ * ```
+ *
+ * Empty body rows produce a header + separator only.
+ *
+ * @param header - Column header labels.
+ * @param body - Each inner array is one row; lengths must match `header`.
+ * @param leftAlignCount - How many leading columns to left-align.
+ *   Defaults to `1` (just the first column). Pass `2` for tables
+ *   whose first two columns are both label-like (e.g. source id +
+ *   English name).
+ *
+ * @example
+ * ```ts
+ * renderTable(
+ *   ['source', 'name', 'count', 'pct'],
+ *   [
+ *     ['nsrt', 'Nagoya SRT', '7', '0.5'],
+ *     ['kobus', 'Keio Bus', '1234', '88.2'],
+ *   ],
+ *   2,
+ * );
+ * ```
+ */
+export function renderTable(
+  header: string[],
+  body: string[][],
+  leftAlignCount: number = 1,
+): string {
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...body.map((row) => row[i]?.length ?? 0)),
+  );
+  const pad = (row: string[]): string =>
+    row
+      .map((cell, i) => (i < leftAlignCount ? cell.padEnd(widths[i]) : cell.padStart(widths[i])))
+      .join('  ');
+  const sep = widths.map((w) => '-'.repeat(w)).join('  ');
+  return [pad(header), sep, ...body.map(pad)].join('\n');
+}

--- a/pipeline/scripts/dev/dev-lib/stats-utils.ts
+++ b/pipeline/scripts/dev/dev-lib/stats-utils.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared statistical helpers for dev-lib analysers.
+ *
+ * Used by `v2-insights-analysis.ts` / `v2-global-insights-analysis.ts`
+ * (and any future analyser that needs simple summary statistics over a
+ * pre-collected numeric array).
+ *
+ * All helpers operate on **pre-sorted ascending arrays**. Sorting is the
+ * caller's responsibility so a single sort can be reused across multiple
+ * percentile / median queries on the same input.
+ *
+ * Empty-array inputs return `0` rather than `NaN` so analyser output
+ * stays numeric without forcing every call site to handle the empty
+ * case explicitly. Call sites that need to distinguish "no data" from
+ * "data but median = 0" must check `array.length` before calling.
+ */
+
+/**
+ * Median of a pre-sorted ascending numeric array.
+ *
+ * Uses the standard mathematical definition:
+ * - odd-length: the single middle element
+ * - even-length: average of the two middle elements
+ *
+ * Returns `0` for an empty array.
+ *
+ * @example
+ * ```ts
+ * sortedMedian([1, 2, 3]);      // 2
+ * sortedMedian([1, 2, 3, 4]);   // 2.5
+ * sortedMedian([10, 20, 30, 40]); // 25
+ * sortedMedian([]);             // 0
+ * ```
+ */
+export function sortedMedian(sorted: readonly number[]): number {
+  const n = sorted.length;
+  if (n === 0) {
+    return 0;
+  }
+  const mid = Math.floor(n / 2);
+  if (n % 2 === 1) {
+    return sorted[mid];
+  }
+  return (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * Nearest-rank percentile of a pre-sorted ascending numeric array.
+ *
+ * Implements the standard nearest-rank method (NIST / ISO definition):
+ * `rank = ceil(q * n)` (1-indexed), then convert to 0-indexed via
+ * `index = rank - 1`. Clamps the index to `[0, n - 1]` so:
+ * - `q = 0` returns the minimum
+ * - `q = 1` returns the maximum
+ *
+ * Returns `0` for an empty array.
+ *
+ * @param sorted - Pre-sorted ascending numeric values.
+ * @param q - Quantile in `[0, 1]` (e.g. `0.5` for median, `0.9` for p90).
+ *
+ * @example
+ * ```ts
+ * sortedPercentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0.9); // 9 (90th value)
+ * sortedPercentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0.5); // 5
+ * sortedPercentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0);   // 1
+ * sortedPercentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1);   // 10
+ * sortedPercentile([], 0.9);                              // 0
+ * ```
+ */
+export function sortedPercentile(sorted: readonly number[], q: number): number {
+  const n = sorted.length;
+  if (n === 0) {
+    return 0;
+  }
+  const rank = Math.ceil(q * n);
+  const index = Math.min(n - 1, Math.max(0, rank - 1));
+  return sorted[index];
+}

--- a/pipeline/scripts/dev/dev-lib/v2-global-insights-analysis.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-global-insights-analysis.ts
@@ -27,6 +27,7 @@
  */
 
 import type { GlobalInsightsBundle } from '../../../../src/types/data/transit-v2-json';
+import { sortedMedian, sortedPercentile } from './stats-utils';
 
 /** Distribution summary for a numeric value array (unit-agnostic). */
 export interface DistributionStats {
@@ -395,8 +396,8 @@ function computeDistribution(values: number[]): DistributionStats {
   const sorted = [...values].sort((a, b) => a - b);
   const sum = sorted.reduce((acc, v) => acc + v, 0);
   const mean = sum / count;
-  const median = sorted[Math.floor(count / 2)];
-  const p90 = sorted[Math.floor(count * 0.9)];
+  const median = sortedMedian(sorted);
+  const p90 = sortedPercentile(sorted, 0.9);
   const variance = sorted.reduce((acc, v) => acc + (v - mean) ** 2, 0) / count;
   const std = Math.sqrt(variance);
   return { count, mean, median, p90, std };

--- a/pipeline/scripts/dev/dev-lib/v2-global-insights-analysis.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-global-insights-analysis.ts
@@ -5,12 +5,25 @@
  * and summarizes its single section `stopGeo` — cross-source spatial
  * metrics keyed by stopId.
  *
- * Initial stub implementation: counts + `nr` distribution + coverage of
- * optional fields (`wp`, `cn`). Per-source breakdown (by stopId prefix)
- * is provided alongside the global total so sources contributing many
- * stops do not hide smaller ones.
+ * Per-source breakdown (by stopId prefix) is provided alongside the
+ * global total so sources contributing many stops do not hide smaller
+ * ones. Additional sub-sections cover the `nr` / `wp` distributions,
+ * isolation distance bands, hub/monomorphic counts, connectivity
+ * (`cn.ho`) stats, and Top-N leaderboards.
  *
  * No I/O. Formatter functions return strings.
+ *
+ * ## Testing philosophy
+ *
+ * Statistical correctness of the aggregation output is intentionally
+ * not unit-tested. The numbers here are reductions over real pipeline
+ * data whose "ground truth" is that same data, so the practical
+ * validation path is manual review of the printed output. The
+ * companion test file (`__tests__/v2-global-insights-analysis.test.ts`)
+ * contains smoke tests only — verifying that functions return the
+ * expected shape, handle missing sections gracefully, and format
+ * without throwing. Those guard against type regressions and trivial
+ * breakage during refactor, not against algorithm bugs.
  */
 
 import type { GlobalInsightsBundle } from '../../../../src/types/data/transit-v2-json';

--- a/pipeline/scripts/dev/dev-lib/v2-global-insights-analysis.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-global-insights-analysis.ts
@@ -1,0 +1,799 @@
+/**
+ * Pure analysis of the v2 GlobalInsightsBundle.
+ *
+ * Reads `public/data-v2/global/insights.json` (kind = `global-insights`)
+ * and summarizes its single section `stopGeo` — cross-source spatial
+ * metrics keyed by stopId.
+ *
+ * Initial stub implementation: counts + `nr` distribution + coverage of
+ * optional fields (`wp`, `cn`). Per-source breakdown (by stopId prefix)
+ * is provided alongside the global total so sources contributing many
+ * stops do not hide smaller ones.
+ *
+ * No I/O. Formatter functions return strings.
+ */
+
+import type { GlobalInsightsBundle } from '../../../../src/types/data/transit-v2-json';
+
+/** Distribution summary for a numeric value array (unit-agnostic). */
+export interface DistributionStats {
+  count: number;
+  mean: number;
+  median: number;
+  p90: number;
+  std: number;
+}
+
+/** Count of stops that fall in each `nr` distance band (km-based). */
+export interface IsolationBuckets {
+  /** nr == 0 (colocated alternative, or single-route dataset). */
+  zero: number;
+  /** 0 < nr <= 0.1 km (100m). */
+  under100m: number;
+  /** 0.1 < nr <= 0.5 km. */
+  under500m: number;
+  /** 0.5 < nr <= 1.0 km. */
+  under1km: number;
+  /** 1.0 < nr <= 5.0 km. */
+  under5km: number;
+  /** nr > 5.0 km. */
+  over5km: number;
+}
+
+/** Connectivity (`cn.ho`) stats aggregated over stops that have `cn`. */
+export interface ConnectivityStats {
+  /** Count of stops with cn.ho present. */
+  count: number;
+  /** Routes within 300m (cn.ho.rc). */
+  rc: DistributionStats;
+  /** Max routes within 300m at any single stop. */
+  rcMax: number;
+  /** Departures within 300m (cn.ho.freq). */
+  freq: DistributionStats;
+  /** Max departures within 300m at any single stop. */
+  freqMax: number;
+  /** Stops within 300m (cn.ho.sc). */
+  sc: DistributionStats;
+  /** Max stops within 300m at any single stop. */
+  scMax: number;
+  /**
+   * Ratio `freq.mean / sc.mean`: average departures per colocated stop.
+   * High values indicate "few stops but high frequency" (urban trunks),
+   * low values indicate "many stops sharing few trips" (residential).
+   */
+  freqPerSc: number;
+}
+
+/** Hub / monomorphic stop counts derived from cn.ho.rc. */
+export interface HubCounts {
+  /** Stops with rc >= 5 (hub indicator). */
+  hub5: number;
+  /** Stops with rc >= 10. */
+  hub10: number;
+  /** Stops with rc >= 20. */
+  hub20: number;
+  /** Stops with rc == 1 (only the stop's own route nearby). */
+  mono: number;
+}
+
+/** Walkable portal (`wp`) summary for sources with parent_station data. */
+export interface WalkablePortalStats {
+  /** Count of stops with a valid wp value. */
+  count: number;
+  /** Distribution of wp (km) across stops with wp present. */
+  distribution: DistributionStats;
+  /** Min wp (km). */
+  minKm: number;
+  /** Max wp (km). */
+  maxKm: number;
+  /** Count of stops with wp <= 0.2 km (200m — "hidden walking shortcut"). */
+  under200m: number;
+}
+
+/** Single-stop leaderboard entry. */
+export interface LeaderboardEntry {
+  source: string;
+  stopId: string;
+  nr?: number;
+  cnRc?: number;
+  cnFreq?: number;
+  cnSc?: number;
+}
+
+/** Per-prefix summary of stopGeo entries. */
+export interface StopGeoSourceStats {
+  /** Source prefix extracted from stopId (`<prefix>:<rest>`). */
+  source: string;
+  /** Total stopGeo entries for this source. */
+  stops: number;
+  /** Entries with `wp` present (walkable-portal metric available). */
+  withWp: number;
+  /** Entries with `cn` present (connectivity metric available). */
+  withCn: number;
+  /** Min nr (km), excluding 0 (0 means "not meaningfully isolated"). */
+  nrMinKm: number | null;
+  /** Max nr (km). */
+  nrMaxKm: number | null;
+  /** Distribution of nr (km) across stops with nr > 0. */
+  nrDistribution: DistributionStats;
+  /** nr distance-band bucket counts. */
+  isolationBuckets: IsolationBuckets;
+  /** Connectivity (cn.ho) stats, or null when no stops have `cn`. */
+  connectivity: ConnectivityStats | null;
+  /** Hub and monomorphic counts derived from cn.ho.rc. */
+  hubCounts: HubCounts;
+  /** Walkable portal (wp) stats, or null when no stops have `wp`. */
+  walkablePortal: WalkablePortalStats | null;
+}
+
+/** Overall summary including per-source breakdown and totals. */
+export interface GlobalInsightsStats {
+  /** Total stopGeo entries across all sources. */
+  totalStops: number;
+  /** Number of source prefixes observed. */
+  totalSources: number;
+  /** Per-source breakdown, sorted by stops descending. */
+  perSource: StopGeoSourceStats[];
+  /** Top-N leaderboards computed across all sources. */
+  leaderboards: {
+    /** Most isolated stops (highest nr). */
+    mostIsolated: LeaderboardEntry[];
+    /** Most connected stops (highest cn.ho.rc, ties broken by cn.ho.freq). */
+    mostConnected: LeaderboardEntry[];
+    /** Busiest neighborhoods (highest cn.ho.freq). */
+    busiestNeighborhood: LeaderboardEntry[];
+  };
+}
+
+/** Top-N size for the leaderboards. */
+const TOP_N = 10;
+
+/** Extract a `GlobalInsightsStats` from a parsed GlobalInsightsBundle. */
+export function analyzeGlobalInsightsBundle(
+  bundle: GlobalInsightsBundle,
+): GlobalInsightsStats | null {
+  const geoData = bundle.stopGeo?.data;
+  if (!geoData) {
+    return null;
+  }
+
+  interface Accumulator {
+    stops: number;
+    withWp: number;
+    withCn: number;
+    nrPositive: number[];
+    isolationBuckets: IsolationBuckets;
+    cnRcs: number[];
+    cnFreqs: number[];
+    cnScs: number[];
+    hub5: number;
+    hub10: number;
+    hub20: number;
+    mono: number;
+    wpValues: number[];
+    wpUnder200m: number;
+  }
+  const bySource = new Map<string, Accumulator>();
+
+  // Raw per-stop entries, used to build cross-source leaderboards.
+  const allEntries: {
+    source: string;
+    stopId: string;
+    nr: number;
+    rc?: number;
+    freq?: number;
+    sc?: number;
+  }[] = [];
+
+  for (const stopId of Object.keys(geoData)) {
+    const entry = geoData[stopId];
+    const prefix = stopId.split(':', 1)[0] || '?';
+    let bucket = bySource.get(prefix);
+    if (bucket === undefined) {
+      bucket = {
+        stops: 0,
+        withWp: 0,
+        withCn: 0,
+        nrPositive: [],
+        isolationBuckets: emptyIsolationBuckets(),
+        cnRcs: [],
+        cnFreqs: [],
+        cnScs: [],
+        hub5: 0,
+        hub10: 0,
+        hub20: 0,
+        mono: 0,
+        wpValues: [],
+        wpUnder200m: 0,
+      };
+      bySource.set(prefix, bucket);
+    }
+    bucket.stops += 1;
+    const rawEntry: (typeof allEntries)[number] = {
+      source: prefix,
+      stopId,
+      nr: Number.isFinite(entry.nr) ? entry.nr : 0,
+    };
+    if (entry.wp !== undefined && Number.isFinite(entry.wp)) {
+      bucket.withWp += 1;
+      bucket.wpValues.push(entry.wp);
+      if (entry.wp <= 0.2) {
+        bucket.wpUnder200m += 1;
+      }
+    }
+    if (entry.cn !== undefined) {
+      bucket.withCn += 1;
+      const ho = entry.cn.ho;
+      if (ho !== undefined) {
+        if (Number.isFinite(ho.rc)) {
+          bucket.cnRcs.push(ho.rc);
+          if (ho.rc >= 20) {
+            bucket.hub20 += 1;
+          }
+          if (ho.rc >= 10) {
+            bucket.hub10 += 1;
+          }
+          if (ho.rc >= 5) {
+            bucket.hub5 += 1;
+          }
+          if (ho.rc === 1) {
+            bucket.mono += 1;
+          }
+          rawEntry.rc = ho.rc;
+        }
+        if (Number.isFinite(ho.freq)) {
+          bucket.cnFreqs.push(ho.freq);
+          rawEntry.freq = ho.freq;
+        }
+        if (Number.isFinite(ho.sc)) {
+          bucket.cnScs.push(ho.sc);
+          rawEntry.sc = ho.sc;
+        }
+      }
+    }
+    if (Number.isFinite(entry.nr)) {
+      accumulateIsolationBucket(bucket.isolationBuckets, entry.nr);
+      if (entry.nr > 0) {
+        bucket.nrPositive.push(entry.nr);
+      }
+    }
+    allEntries.push(rawEntry);
+  }
+
+  if (bySource.size === 0) {
+    return null;
+  }
+
+  const perSource: StopGeoSourceStats[] = [];
+  let totalStops = 0;
+  for (const [source, bucket] of bySource) {
+    totalStops += bucket.stops;
+    const nrDistribution = computeDistribution(bucket.nrPositive);
+    let connectivity: ConnectivityStats | null = null;
+    if (bucket.withCn > 0) {
+      const rc = computeDistribution(bucket.cnRcs);
+      const freq = computeDistribution(bucket.cnFreqs);
+      const sc = computeDistribution(bucket.cnScs);
+      connectivity = {
+        count: bucket.withCn,
+        rc,
+        rcMax: bucket.cnRcs.length > 0 ? Math.max(...bucket.cnRcs) : 0,
+        freq,
+        freqMax: bucket.cnFreqs.length > 0 ? Math.max(...bucket.cnFreqs) : 0,
+        sc,
+        scMax: bucket.cnScs.length > 0 ? Math.max(...bucket.cnScs) : 0,
+        freqPerSc: sc.mean > 0 ? freq.mean / sc.mean : 0,
+      };
+    }
+    let walkablePortal: WalkablePortalStats | null = null;
+    if (bucket.wpValues.length > 0) {
+      walkablePortal = {
+        count: bucket.wpValues.length,
+        distribution: computeDistribution(bucket.wpValues),
+        minKm: Math.min(...bucket.wpValues),
+        maxKm: Math.max(...bucket.wpValues),
+        under200m: bucket.wpUnder200m,
+      };
+    }
+    perSource.push({
+      source,
+      stops: bucket.stops,
+      withWp: bucket.withWp,
+      withCn: bucket.withCn,
+      nrMinKm: bucket.nrPositive.length > 0 ? Math.min(...bucket.nrPositive) : null,
+      nrMaxKm: bucket.nrPositive.length > 0 ? Math.max(...bucket.nrPositive) : null,
+      nrDistribution,
+      isolationBuckets: bucket.isolationBuckets,
+      connectivity,
+      hubCounts: {
+        hub5: bucket.hub5,
+        hub10: bucket.hub10,
+        hub20: bucket.hub20,
+        mono: bucket.mono,
+      },
+      walkablePortal,
+    });
+  }
+  perSource.sort((a, b) => b.stops - a.stops);
+
+  const leaderboards = buildLeaderboards(allEntries);
+
+  return {
+    totalStops,
+    totalSources: bySource.size,
+    perSource,
+    leaderboards,
+  };
+}
+
+function buildLeaderboards(
+  entries: {
+    source: string;
+    stopId: string;
+    nr: number;
+    rc?: number;
+    freq?: number;
+    sc?: number;
+  }[],
+): GlobalInsightsStats['leaderboards'] {
+  const mostIsolated = [...entries]
+    .filter((e) => e.nr > 0)
+    .sort((a, b) => b.nr - a.nr)
+    .slice(0, TOP_N)
+    .map<LeaderboardEntry>((e) => ({ source: e.source, stopId: e.stopId, nr: e.nr }));
+
+  const mostConnected = [...entries]
+    .filter((e) => e.rc !== undefined)
+    .sort((a, b) => {
+      if (b.rc !== a.rc) {
+        return (b.rc ?? 0) - (a.rc ?? 0);
+      }
+      return (b.freq ?? 0) - (a.freq ?? 0);
+    })
+    .slice(0, TOP_N)
+    .map<LeaderboardEntry>((e) => ({
+      source: e.source,
+      stopId: e.stopId,
+      cnRc: e.rc,
+      cnFreq: e.freq,
+      cnSc: e.sc,
+    }));
+
+  const busiestNeighborhood = [...entries]
+    .filter((e) => e.freq !== undefined)
+    .sort((a, b) => (b.freq ?? 0) - (a.freq ?? 0))
+    .slice(0, TOP_N)
+    .map<LeaderboardEntry>((e) => ({
+      source: e.source,
+      stopId: e.stopId,
+      cnRc: e.rc,
+      cnFreq: e.freq,
+      cnSc: e.sc,
+    }));
+
+  return { mostIsolated, mostConnected, busiestNeighborhood };
+}
+
+function computeDistribution(values: number[]): DistributionStats {
+  const count = values.length;
+  if (count === 0) {
+    return { count: 0, mean: 0, median: 0, p90: 0, std: 0 };
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const sum = sorted.reduce((acc, v) => acc + v, 0);
+  const mean = sum / count;
+  const median = sorted[Math.floor(count / 2)];
+  const p90 = sorted[Math.floor(count * 0.9)];
+  const variance = sorted.reduce((acc, v) => acc + (v - mean) ** 2, 0) / count;
+  const std = Math.sqrt(variance);
+  return { count, mean, median, p90, std };
+}
+
+function emptyIsolationBuckets(): IsolationBuckets {
+  return { zero: 0, under100m: 0, under500m: 0, under1km: 0, under5km: 0, over5km: 0 };
+}
+
+function accumulateIsolationBucket(buckets: IsolationBuckets, nr: number): void {
+  if (nr === 0) {
+    buckets.zero += 1;
+    return;
+  }
+  if (nr <= 0.1) {
+    buckets.under100m += 1;
+    return;
+  }
+  if (nr <= 0.5) {
+    buckets.under500m += 1;
+    return;
+  }
+  if (nr <= 1.0) {
+    buckets.under1km += 1;
+    return;
+  }
+  if (nr <= 5.0) {
+    buckets.under5km += 1;
+    return;
+  }
+  buckets.over5km += 1;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+const STOP_GEO_SUMMARY_LEGEND = [
+  '# Per-source breakdown of stopGeo entries. stopId is parsed as',
+  '# `<prefix>:<rest>` to group rows by data source. The "TOTAL" row',
+  '# aggregates all sources.',
+  '#',
+  '# stops      : stopGeo entries for this source',
+  '# withWp(%)  : share of stops that have `wp` (walkable-portal metric,',
+  '#              requires parent_station data upstream)',
+  '# withCn(%)  : share of stops that have `cn` (connectivity metric,',
+  '#              currently populated for Sunday/holiday pattern only)',
+  '# nrMin(km)  : closest different-route neighbor (excludes nr=0)',
+  '# nrMax(km)  : farthest different-route neighbor',
+].join('\n');
+
+const STOP_GEO_NR_DISTRIBUTION_LEGEND = [
+  '# Distribution of `nr` (km) — distance to the nearest stop served by',
+  '# a different route. Values of 0 are excluded because nr=0 means',
+  '# "not meaningfully isolated" (colocated alternative or no alternative',
+  '# exists), which conflates two very different situations.',
+  '#',
+  '# count : stops with nr > 0',
+  '# mean  : mean distance to nearest different-route stop (km)',
+  '# p50   : median — half of stops have a closer alternative, half farther',
+  '# p90   : 90% of stops have an alternative within this distance',
+  '# std   : population standard deviation (km)',
+].join('\n');
+
+const STOP_GEO_ISOLATION_BUCKETS_LEGEND = [
+  '# Count of stops in each `nr` distance band. Gives the shape of the',
+  '# isolation distribution at a glance — dense urban operators concentrate',
+  '# in the low-distance buckets while rural/long-distance operators extend',
+  '# toward the tail.',
+  '#',
+  '# nr=0       : colocated alternative OR no alternative exists at all',
+  '# 0-100m     : walking-distance different-route stop',
+  '# 100-500m   : short walk to a different-route stop',
+  '# 500m-1km   : moderate walk / ~10 min on foot',
+  '# 1-5km     : no walking alternative, transfer requires another vehicle',
+  '# >5km      : truly isolated stop',
+].join('\n');
+
+const STOP_GEO_CONNECTIVITY_LEGEND = [
+  '# Distribution of `cn.ho` — per-stop connectivity within a 300m radius',
+  '# on Sunday/holiday calendar. Only stops that carry `cn` data are',
+  '# counted (see `withCn(%)` in the Summary).',
+  '#',
+  '# count      : stops with cn.ho present',
+  '# rcMean     : mean routes within 300m',
+  '# rcP50      : median routes within 300m (outlier-resistant)',
+  '# rcP90      : 90th percentile routes within 300m',
+  '# rcMax      : max routes within 300m at any single stop',
+  '# freqMean   : mean departures/day within 300m',
+  '# freqP50    : median departures/day within 300m',
+  '# freqP90    : 90th percentile departures/day within 300m',
+  '# freqMax    : max departures/day within 300m',
+  '# scMean     : mean stops within 300m',
+  '# scP50      : median stops within 300m',
+  '# scMax      : max stops within 300m',
+  '# freqPerSc  : freqMean / scMean — departures per colocated stop.',
+  '#              High = "few stops but high frequency" (urban trunks),',
+  '#              low = "many stops sharing few trips" (residential).',
+].join('\n');
+
+const STOP_GEO_HUB_LEGEND = [
+  '# Counts of hub and monomorphic stops derived from `cn.ho.rc`',
+  '# (number of routes within 300m on holiday/Sunday pattern).',
+  '#',
+  '# hub5+       : stops with 5+ routes within 300m (neighborhood hub)',
+  '# hub10+      : stops with 10+ routes within 300m (major hub)',
+  '# hub20+      : stops with 20+ routes within 300m (trunk hub)',
+  '# mono(rc=1)  : stops where only a single route exists within 300m',
+  '#               (isolated service — either rural or single-operator area)',
+].join('\n');
+
+const STOP_GEO_WP_LEGEND = [
+  '# Distribution of `wp` (km) — distance to the nearest stop with a',
+  '# different `parent_station`. Only populated for sources whose GTFS',
+  '# provides `parent_station` data (see `withWp(%)` in the Summary).',
+  '#',
+  '# count     : stops with wp present',
+  '# min       : closest inter-station walking distance (km)',
+  '# mean/p50  : mean / median walking distance to a different station',
+  '# p90       : 90% of stops have a different station within this distance',
+  '# max       : farthest nearest-different-station distance',
+  '# std       : population standard deviation (km)',
+  '# under200m : stops with wp <= 0.2 km — "hidden walking shortcut"',
+  '#             between two unrelated station complexes',
+].join('\n');
+
+const STOP_GEO_LEADERBOARD_ISOLATED_LEGEND = [
+  '# Top-N stops ranked by `nr` descending — the most isolated stops',
+  '# in the whole dataset. stopId only (no stop name available from',
+  '# GlobalInsightsBundle alone).',
+].join('\n');
+
+const STOP_GEO_LEADERBOARD_CONNECTED_LEGEND = [
+  '# Top-N stops ranked by `cn.ho.rc` descending (ties broken by freq).',
+  '# These are the trunk hubs — highest route density within 300m.',
+].join('\n');
+
+const STOP_GEO_LEADERBOARD_BUSIEST_LEGEND = [
+  '# Top-N stops ranked by `cn.ho.freq` descending — the busiest',
+  '# neighborhoods by departures per day within 300m (holiday/Sunday).',
+].join('\n');
+
+/** Format a GlobalInsightsStats as a multi-section human-readable report. */
+export function formatGlobalInsightsAnalysis(
+  stats: GlobalInsightsStats | null,
+  options: { analyzedAt?: Date } = {},
+): string {
+  const analyzedAt = options.analyzedAt ?? new Date();
+  const header = [
+    '# Athenai Transit — V2 GlobalInsightsBundle analysis',
+    '',
+    `# Analyzed at: ${analyzedAt.toISOString()}`,
+    '# Summary of `public/data-v2/global/insights.json` (kind =',
+    '# `global-insights`). Currently covers the `stopGeo` section only.',
+    '# Sections follow the GlobalInsightsBundle type declaration order.',
+    '# Each subsection has its own inline legend.',
+  ].join('\n');
+
+  if (stats === null) {
+    return `${header}\n\nNo stopGeo data found.`;
+  }
+
+  const sections = [
+    header,
+    '',
+    '# stopGeo',
+    '',
+    formatSummaryTable(stats),
+    '',
+    formatNrDistributionTable(stats.perSource),
+    '',
+    formatIsolationBucketsTable(stats.perSource),
+    '',
+    formatConnectivityTable(stats.perSource),
+    '',
+    formatHubCountsTable(stats.perSource),
+    '',
+    formatWalkablePortalTable(stats.perSource),
+    '',
+    formatLeaderboardMostIsolated(stats.leaderboards.mostIsolated),
+    '',
+    formatLeaderboardMostConnected(stats.leaderboards.mostConnected),
+    '',
+    formatLeaderboardBusiestNeighborhood(stats.leaderboards.busiestNeighborhood),
+  ];
+  return sections.join('\n');
+}
+
+function fmtNum(n: number | null, decimals = 2): string {
+  if (n === null || !Number.isFinite(n)) {
+    return '-';
+  }
+  return n.toFixed(decimals);
+}
+
+function fmtPct(part: number, total: number): string {
+  if (total === 0) {
+    return '-';
+  }
+  return ((part / total) * 100).toFixed(1);
+}
+
+function formatSummaryTable(stats: GlobalInsightsStats): string {
+  const header = ['source', 'stops', 'withWp(%)', 'withCn(%)', 'nrMin(km)', 'nrMax(km)'];
+  const totalWithWp = stats.perSource.reduce((acc, r) => acc + r.withWp, 0);
+  const totalWithCn = stats.perSource.reduce((acc, r) => acc + r.withCn, 0);
+  const nrMins = stats.perSource.map((r) => r.nrMinKm).filter((v): v is number => v !== null);
+  const nrMaxes = stats.perSource.map((r) => r.nrMaxKm).filter((v): v is number => v !== null);
+  const body: string[][] = stats.perSource.map((r) => [
+    r.source,
+    String(r.stops),
+    fmtPct(r.withWp, r.stops),
+    fmtPct(r.withCn, r.stops),
+    fmtNum(r.nrMinKm),
+    fmtNum(r.nrMaxKm),
+  ]);
+  body.push([
+    'TOTAL',
+    String(stats.totalStops),
+    fmtPct(totalWithWp, stats.totalStops),
+    fmtPct(totalWithCn, stats.totalStops),
+    nrMins.length > 0 ? fmtNum(Math.min(...nrMins)) : '-',
+    nrMaxes.length > 0 ? fmtNum(Math.max(...nrMaxes)) : '-',
+  ]);
+  return `## Summary\n\n${STOP_GEO_SUMMARY_LEGEND}\n\n${renderTable(header, body)}`;
+}
+
+function formatNrDistributionTable(rows: StopGeoSourceStats[]): string {
+  const header = ['source', 'count', 'mean(km)', 'p50(km)', 'p90(km)', 'std(km)'];
+  const body = rows.map((r) => [
+    r.source,
+    String(r.nrDistribution.count),
+    fmtNum(r.nrDistribution.mean),
+    fmtNum(r.nrDistribution.median),
+    fmtNum(r.nrDistribution.p90),
+    fmtNum(r.nrDistribution.std),
+  ]);
+  return `## Distribution of nr (km)\n\n${STOP_GEO_NR_DISTRIBUTION_LEGEND}\n\n${renderTable(
+    header,
+    body,
+  )}`;
+}
+
+function formatIsolationBucketsTable(rows: StopGeoSourceStats[]): string {
+  const header = ['source', 'nr=0', '0-100m', '100-500m', '500m-1km', '1-5km', '>5km'];
+  const body = rows.map((r) => {
+    const b = r.isolationBuckets;
+    return [
+      r.source,
+      String(b.zero),
+      String(b.under100m),
+      String(b.under500m),
+      String(b.under1km),
+      String(b.under5km),
+      String(b.over5km),
+    ];
+  });
+  return `## Isolation buckets (nr distance bands)\n\n${STOP_GEO_ISOLATION_BUCKETS_LEGEND}\n\n${renderTable(
+    header,
+    body,
+  )}`;
+}
+
+function formatConnectivityTable(rows: StopGeoSourceStats[]): string {
+  const header = [
+    'source',
+    'count',
+    'rcMean',
+    'rcP50',
+    'rcP90',
+    'rcMax',
+    'freqMean',
+    'freqP50',
+    'freqP90',
+    'freqMax',
+    'scMean',
+    'scP50',
+    'scMax',
+    'freqPerSc',
+  ];
+  const body = rows.map((r) => {
+    const c = r.connectivity;
+    if (c === null) {
+      return [r.source, '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-'];
+    }
+    return [
+      r.source,
+      String(c.count),
+      fmtNum(c.rc.mean, 1),
+      fmtNum(c.rc.median, 1),
+      fmtNum(c.rc.p90, 1),
+      String(c.rcMax),
+      fmtNum(c.freq.mean, 1),
+      fmtNum(c.freq.median, 1),
+      fmtNum(c.freq.p90, 1),
+      String(c.freqMax),
+      fmtNum(c.sc.mean, 1),
+      fmtNum(c.sc.median, 1),
+      String(c.scMax),
+      fmtNum(c.freqPerSc, 1),
+    ];
+  });
+  return `## Connectivity within 300m (cn.ho, holiday/Sunday pattern)\n\n${STOP_GEO_CONNECTIVITY_LEGEND}\n\n${renderTable(
+    header,
+    body,
+  )}`;
+}
+
+function formatHubCountsTable(rows: StopGeoSourceStats[]): string {
+  const header = ['source', 'hub5+', 'hub10+', 'hub20+', 'mono(rc=1)'];
+  const body = rows.map((r) => [
+    r.source,
+    String(r.hubCounts.hub5),
+    String(r.hubCounts.hub10),
+    String(r.hubCounts.hub20),
+    String(r.hubCounts.mono),
+  ]);
+  return `## Hub / monomorphic counts (derived from cn.ho.rc)\n\n${STOP_GEO_HUB_LEGEND}\n\n${renderTable(
+    header,
+    body,
+  )}`;
+}
+
+function formatWalkablePortalTable(rows: StopGeoSourceStats[]): string {
+  const header = [
+    'source',
+    'count',
+    'min(km)',
+    'mean(km)',
+    'p50(km)',
+    'p90(km)',
+    'max(km)',
+    'std(km)',
+    'under200m',
+  ];
+  const body: string[][] = [];
+  for (const r of rows) {
+    const w = r.walkablePortal;
+    if (w === null) {
+      continue;
+    }
+    body.push([
+      r.source,
+      String(w.count),
+      fmtNum(w.minKm),
+      fmtNum(w.distribution.mean),
+      fmtNum(w.distribution.median),
+      fmtNum(w.distribution.p90),
+      fmtNum(w.maxKm),
+      fmtNum(w.distribution.std),
+      String(w.under200m),
+    ]);
+  }
+  if (body.length === 0) {
+    return `## Distribution of wp (km)\n\n${STOP_GEO_WP_LEGEND}\n\n(no source has parent_station data — wp field is empty everywhere)`;
+  }
+  return `## Distribution of wp (km)\n\n${STOP_GEO_WP_LEGEND}\n\n${renderTable(header, body)}`;
+}
+
+function formatLeaderboardMostIsolated(entries: LeaderboardEntry[]): string {
+  const header = ['rank', 'source', 'stopId', 'nr(km)'];
+  const body = entries.map((e, i) => [String(i + 1), e.source, e.stopId, fmtNum(e.nr ?? null)]);
+  return `## Top ${TOP_N} most isolated stops\n\n${STOP_GEO_LEADERBOARD_ISOLATED_LEGEND}\n\n${renderTable(
+    header,
+    body,
+  )}`;
+}
+
+function formatLeaderboardMostConnected(entries: LeaderboardEntry[]): string {
+  const header = ['rank', 'source', 'stopId', 'rc', 'freq', 'sc'];
+  const body = entries.map((e, i) => [
+    String(i + 1),
+    e.source,
+    e.stopId,
+    e.cnRc !== undefined ? String(e.cnRc) : '-',
+    e.cnFreq !== undefined ? String(e.cnFreq) : '-',
+    e.cnSc !== undefined ? String(e.cnSc) : '-',
+  ]);
+  return `## Top ${TOP_N} most connected stops (rc desc)\n\n${STOP_GEO_LEADERBOARD_CONNECTED_LEGEND}\n\n${renderTable(
+    header,
+    body,
+  )}`;
+}
+
+function formatLeaderboardBusiestNeighborhood(entries: LeaderboardEntry[]): string {
+  const header = ['rank', 'source', 'stopId', 'freq', 'rc', 'sc'];
+  const body = entries.map((e, i) => [
+    String(i + 1),
+    e.source,
+    e.stopId,
+    e.cnFreq !== undefined ? String(e.cnFreq) : '-',
+    e.cnRc !== undefined ? String(e.cnRc) : '-',
+    e.cnSc !== undefined ? String(e.cnSc) : '-',
+  ]);
+  return `## Top ${TOP_N} busiest neighborhoods (freq desc)\n\n${STOP_GEO_LEADERBOARD_BUSIEST_LEGEND}\n\n${renderTable(
+    header,
+    body,
+  )}`;
+}
+
+/**
+ * Render a simple padded ASCII table. The first column is left-aligned and
+ * remaining columns are right-aligned so numeric values line up cleanly.
+ */
+function renderTable(header: string[], body: string[][]): string {
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...body.map((row) => row[i]?.length ?? 0)),
+  );
+  const pad = (row: string[]): string =>
+    row.map((cell, i) => (i === 0 ? cell.padEnd(widths[i]) : cell.padStart(widths[i]))).join('  ');
+  const sep = widths.map((w) => '-'.repeat(w)).join('  ');
+  return [pad(header), sep, ...body.map(pad)].join('\n');
+}

--- a/pipeline/scripts/dev/dev-lib/v2-global-insights-analysis.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-global-insights-analysis.ts
@@ -27,7 +27,21 @@
  */
 
 import type { GlobalInsightsBundle } from '../../../../src/types/data/transit-v2-json';
+import { renderTable } from './render-utils';
 import { sortedMedian, sortedPercentile } from './stats-utils';
+
+// ---------------------------------------------------------------------------
+// Configuration constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-N size for every leaderboard rendered by this analyser
+ * (most isolated / most connected / busiest neighborhoods).
+ *
+ * Kept intentionally small so the output stays scannable in a
+ * terminal. Increase if a future analysis needs a deeper view.
+ */
+export const TOP_N = 10;
 
 /** Distribution summary for a numeric value array (unit-agnostic). */
 export interface DistributionStats {
@@ -158,9 +172,6 @@ export interface GlobalInsightsStats {
     busiestNeighborhood: LeaderboardEntry[];
   };
 }
-
-/** Top-N size for the leaderboards. */
-const TOP_N = 10;
 
 /** Extract a `GlobalInsightsStats` from a parsed GlobalInsightsBundle. */
 export function analyzeGlobalInsightsBundle(
@@ -340,6 +351,18 @@ export function analyzeGlobalInsightsBundle(
   };
 }
 
+/**
+ * Tie-breaker comparator used as the **last** sort step for every
+ * leaderboard. Compares by `stopId` (lexicographic ascending) so the
+ * Top-N output is deterministic when two stops have identical
+ * primary / secondary metric values. Without this, `Array.sort` falls
+ * back to engine-defined stability semantics and the leaderboard can
+ * shift between runs over the same data.
+ */
+function tieBreakByStopId(a: { stopId: string }, b: { stopId: string }): number {
+  return a.stopId < b.stopId ? -1 : a.stopId > b.stopId ? 1 : 0;
+}
+
 function buildLeaderboards(
   entries: {
     source: string;
@@ -350,19 +373,29 @@ function buildLeaderboards(
     sc?: number;
   }[],
 ): GlobalInsightsStats['leaderboards'] {
+  // mostIsolated: sort by nr desc, then stopId asc for deterministic ties.
   const mostIsolated = [...entries]
     .filter((e) => e.nr > 0)
-    .sort((a, b) => b.nr - a.nr)
+    .sort((a, b) => {
+      if (b.nr !== a.nr) {
+        return b.nr - a.nr;
+      }
+      return tieBreakByStopId(a, b);
+    })
     .slice(0, TOP_N)
     .map<LeaderboardEntry>((e) => ({ source: e.source, stopId: e.stopId, nr: e.nr }));
 
+  // mostConnected: sort by rc desc, then freq desc, then stopId asc.
   const mostConnected = [...entries]
     .filter((e) => e.rc !== undefined)
     .sort((a, b) => {
       if (b.rc !== a.rc) {
         return (b.rc ?? 0) - (a.rc ?? 0);
       }
-      return (b.freq ?? 0) - (a.freq ?? 0);
+      if (b.freq !== a.freq) {
+        return (b.freq ?? 0) - (a.freq ?? 0);
+      }
+      return tieBreakByStopId(a, b);
     })
     .slice(0, TOP_N)
     .map<LeaderboardEntry>((e) => ({
@@ -373,9 +406,15 @@ function buildLeaderboards(
       cnSc: e.sc,
     }));
 
+  // busiestNeighborhood: sort by freq desc, then stopId asc.
   const busiestNeighborhood = [...entries]
     .filter((e) => e.freq !== undefined)
-    .sort((a, b) => (b.freq ?? 0) - (a.freq ?? 0))
+    .sort((a, b) => {
+      if (b.freq !== a.freq) {
+        return (b.freq ?? 0) - (a.freq ?? 0);
+      }
+      return tieBreakByStopId(a, b);
+    })
     .slice(0, TOP_N)
     .map<LeaderboardEntry>((e) => ({
       source: e.source,
@@ -802,12 +841,3 @@ function formatLeaderboardBusiestNeighborhood(entries: LeaderboardEntry[]): stri
  * Render a simple padded ASCII table. The first column is left-aligned and
  * remaining columns are right-aligned so numeric values line up cleanly.
  */
-function renderTable(header: string[], body: string[][]): string {
-  const widths = header.map((h, i) =>
-    Math.max(h.length, ...body.map((row) => row[i]?.length ?? 0)),
-  );
-  const pad = (row: string[]): string =>
-    row.map((cell, i) => (i === 0 ? cell.padEnd(widths[i]) : cell.padStart(widths[i]))).join('  ');
-  const sep = widths.map((w) => '-'.repeat(w)).join('  ');
-  return [pad(header), sep, ...body.map(pad)].join('\n');
-}

--- a/pipeline/scripts/dev/dev-lib/v2-insights-analysis.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-insights-analysis.ts
@@ -1,0 +1,849 @@
+/**
+ * Pure analysis of a v2 per-source InsightsBundle.
+ *
+ * Aggregates duration statistics from `tripPatternStats`:
+ *   - per-pattern distribution (each pattern counted once)
+ *   - per-trip distribution (each pattern counted `freq` times)
+ * Plus shared min/max across the valid pattern set.
+ *
+ * No I/O. Formatter functions are side-effect free and return strings so
+ * the CLI wrapper can direct them to stdout.
+ */
+
+import type { InsightsBundle } from '../../../../src/types/data/transit-v2-json';
+
+/** Thresholds (minutes) for the "long trip share" columns. */
+export const OVER_THRESHOLDS_MINUTES = [30, 60, 90] as const;
+
+/** Distribution summary for either a per-pattern or a per-trip view. */
+export interface DistributionStats {
+  /** Count of observations in this view. */
+  count: number;
+  /** Arithmetic mean total minutes. */
+  meanMin: number;
+  /** Median (p50) total minutes. */
+  medianMin: number;
+  /** 90th percentile total minutes. */
+  p90Min: number;
+  /** Population standard deviation of total minutes. */
+  stdMin: number;
+}
+
+/** Aggregated duration stats for a single source. */
+export interface InsightsSourceStats {
+  /** Source prefix (e.g. 'kbus'). */
+  source: string;
+  /** Resource nameEn, or prefix when name resolution failed. */
+  nameEn: string;
+  /** Min rd[0] across all valid patterns (same for pattern and trip view). */
+  minMin: number;
+  /** Max rd[0] across all valid patterns (same for pattern and trip view). */
+  maxMin: number;
+  /**
+   * Min / mean / median / max of rd.length (stop count per pattern),
+   * pattern-weighted. Indicates the structural size of each trip pattern.
+   */
+  minStops: number;
+  meanStops: number;
+  medianStops: number;
+  maxStops: number;
+  /** Distribution with each pattern counted exactly once. */
+  byPattern: DistributionStats;
+  /** Distribution with each pattern counted `freq` times. */
+  byTrip: DistributionStats;
+  /**
+   * Percent of trips (freq-weighted) whose rd[0] exceeds each threshold
+   * in {@link OVER_THRESHOLDS_MINUTES}. Same order as the constant.
+   */
+  pctTripOver: number[];
+  /** Service groups summary for this source. */
+  serviceGroups: ServiceGroupsSummary;
+  /** Trip pattern geometry summary, or null when section is absent. */
+  tripPatternGeo: TripPatternGeoSummary | null;
+  /** Stop stats summary, or null when section is absent. */
+  stopStats: StopStatsSummary | null;
+}
+
+/** Summary of the `serviceGroups` section. */
+export interface ServiceGroupsSummary {
+  /** Total number of service groups in this source. */
+  groupCount: number;
+  /** Total count of service_ids across all groups. */
+  serviceIdCount: number;
+  /** Group keys in declared order (e.g. ['wd','sa','su']). */
+  keys: string[];
+  /** Service id count per group, aligned with `keys`. */
+  groupSizes: number[];
+  /** Count of standard keys (wd/sa/su/wk/all). */
+  stdKeyCount: number;
+  /** Count of non-standard keys (everything else, typically d-bitmask). */
+  nonStdKeyCount: number;
+}
+
+const STANDARD_SG_KEYS = new Set(['wd', 'sa', 'su', 'wk', 'all']);
+
+/**
+ * Summary of the `stopStats` section.
+ *
+ * Each stop is represented by its "busiest" values across all service
+ * groups that mention it:
+ *   - freq / rc / rtc → max across groups (peak activity)
+ *   - ed              → min across groups (earliest start of any day)
+ *   - ld              → max across groups (latest end of any day)
+ */
+export interface StopStatsSummary {
+  /** Count of distinct stopIds appearing in any service group. */
+  stops: number;
+  /** Min of per-stop max freq (quietest stop). */
+  minFreq: number;
+  /** Mean of per-stop max freq (departures/day on the busiest day). */
+  meanFreq: number;
+  /** Max of per-stop max freq (busiest stop anywhere). */
+  maxFreq: number;
+  /** Distribution of per-stop max freq across stops. */
+  freqDistribution: DistributionStats;
+  /** Max route count at any single stop. */
+  maxRc: number;
+  /** Max route type count at any single stop. */
+  maxRtc: number;
+  /**
+   * Source-wide earliest departure (minutes from midnight, min of ed).
+   * `null` when no ed values are present.
+   */
+  earliestMinutes: number | null;
+  /**
+   * Source-wide latest departure (minutes from midnight, max of ld).
+   * Values >= 1440 represent overnight service past midnight.
+   * `null` when no ld values are present.
+   */
+  latestMinutes: number | null;
+}
+
+/**
+ * Summary of the `tripPatternGeo` section.
+ *
+ * IMPORTANT: `dist` and `pathDist` are straight-line based (Haversine
+ * between consecutive stop coordinates), not real road distance. They
+ * under-represent actual route length on winding streets.
+ */
+export interface TripPatternGeoSummary {
+  /** Number of patterns with a geo entry. */
+  patterns: number;
+  /** Number of patterns flagged as circular (cl=true). */
+  circular: number;
+  /** Percent of patterns flagged as circular. */
+  circularPct: number;
+  /** Min pathDist across all patterns (km). */
+  pathDistMinKm: number;
+  /** Mean pathDist across all patterns (km). */
+  pathDistMeanKm: number;
+  /** Median pathDist across all patterns (km). */
+  pathDistMedianKm: number;
+  /** Max pathDist across all patterns (km). */
+  pathDistMaxKm: number;
+  /** Full distribution of pathDist (km), all patterns included. */
+  pathDistDistribution: DistributionStats;
+  /**
+   * Mean straight-line dist across non-circular patterns (km). `null`
+   * when there are no non-circular patterns.
+   */
+  distMeanKm: number | null;
+  /**
+   * Median straight-line dist across non-circular patterns (km). `null`
+   * when there are no non-circular patterns.
+   */
+  distMedianKm: number | null;
+  /**
+   * Mean ratio of `dist / pathDist` across non-circular patterns.
+   * 1.0 = perfectly straight, lower = more wandering. `null` when
+   * there are no non-circular patterns.
+   */
+  straightRatioMean: number | null;
+}
+
+/**
+ * Compute summary statistics from an InsightsBundle.
+ *
+ * Returns `null` when the bundle has no `tripPatternStats` data or no valid
+ * patterns (so the caller can skip the source with a warning instead of
+ * emitting a zero-filled row).
+ */
+export function analyzeInsightsBundle(
+  source: string,
+  nameEn: string,
+  bundle: InsightsBundle,
+): InsightsSourceStats | null {
+  const statsData = bundle.tripPatternStats?.data;
+  if (!statsData) {
+    return null;
+  }
+
+  const serviceGroups = summarizeServiceGroups(bundle);
+  const tripPatternGeo = summarizeTripPatternGeo(bundle);
+  const stopStats = summarizeStopStats(bundle);
+
+  const patternValues: number[] = [];
+  const tripValues: number[] = [];
+  const stopCounts: number[] = [];
+
+  for (const serviceGroup of Object.keys(statsData)) {
+    const patterns = statsData[serviceGroup];
+    for (const patternId of Object.keys(patterns)) {
+      const entry = patterns[patternId];
+      const { freq, rd } = entry;
+      if (!Array.isArray(rd) || rd.length < 2) {
+        continue;
+      }
+      const total = rd[0];
+      if (!Number.isFinite(total) || total <= 0) {
+        continue;
+      }
+      patternValues.push(total);
+      stopCounts.push(rd.length);
+      for (let i = 0; i < freq; i++) {
+        tripValues.push(total);
+      }
+    }
+  }
+
+  if (patternValues.length === 0) {
+    return null;
+  }
+
+  const byPattern = computeDistribution(patternValues);
+  const byTrip = computeDistribution(tripValues);
+  const minMin = Math.min(...patternValues);
+  const maxMin = Math.max(...patternValues);
+  const minStops = Math.min(...stopCounts);
+  const maxStops = Math.max(...stopCounts);
+  const meanStops = stopCounts.reduce((acc, v) => acc + v, 0) / stopCounts.length;
+  const sortedStops = [...stopCounts].sort((a, b) => a - b);
+  const medianStops = sortedStops[Math.floor(sortedStops.length / 2)];
+  const pctTripOver = OVER_THRESHOLDS_MINUTES.map((threshold) => {
+    if (tripValues.length === 0) {
+      return 0;
+    }
+    const over = tripValues.filter((v) => v > threshold).length;
+    return (over / tripValues.length) * 100;
+  });
+
+  return {
+    source,
+    nameEn,
+    minMin,
+    maxMin,
+    minStops,
+    meanStops,
+    medianStops,
+    maxStops,
+    byPattern,
+    byTrip,
+    pctTripOver,
+    serviceGroups,
+    tripPatternGeo,
+    stopStats,
+  };
+}
+
+/** Extract a per-source ServiceGroupsSummary from the bundle. */
+function summarizeServiceGroups(bundle: InsightsBundle): ServiceGroupsSummary {
+  const groups = bundle.serviceGroups?.data ?? [];
+  const keys = groups.map((g) => g.key);
+  const groupSizes = groups.map((g) => g.serviceIds.length);
+  const serviceIdCount = groupSizes.reduce((acc, n) => acc + n, 0);
+  const stdKeyCount = keys.filter((k) => STANDARD_SG_KEYS.has(k)).length;
+  const nonStdKeyCount = keys.length - stdKeyCount;
+  return {
+    groupCount: groups.length,
+    serviceIdCount,
+    keys,
+    groupSizes,
+    stdKeyCount,
+    nonStdKeyCount,
+  };
+}
+
+/** Extract a per-source TripPatternGeoSummary from the bundle. */
+function summarizeTripPatternGeo(bundle: InsightsBundle): TripPatternGeoSummary | null {
+  const geoData = bundle.tripPatternGeo?.data;
+  if (!geoData) {
+    return null;
+  }
+  const entries = Object.values(geoData);
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const pathDists = entries.map((e) => e.pathDist).filter((v) => Number.isFinite(v));
+  if (pathDists.length === 0) {
+    return null;
+  }
+
+  const circular = entries.filter((e) => e.cl).length;
+  const circularPct = (circular / entries.length) * 100;
+
+  const pathDistMinKm = Math.min(...pathDists);
+  const pathDistMaxKm = Math.max(...pathDists);
+  const pathDistMeanKm = pathDists.reduce((acc, v) => acc + v, 0) / pathDists.length;
+  const sortedPathDists = [...pathDists].sort((a, b) => a - b);
+  const pathDistMedianKm = sortedPathDists[Math.floor(sortedPathDists.length / 2)];
+  const pathDistDistribution = computeDistribution(pathDists);
+
+  const nonCircular = entries.filter((e) => !e.cl && e.pathDist > 0);
+  const distMeanKm =
+    nonCircular.length > 0
+      ? nonCircular.reduce((acc, e) => acc + e.dist, 0) / nonCircular.length
+      : null;
+  let distMedianKm: number | null = null;
+  if (nonCircular.length > 0) {
+    const sortedDists = nonCircular.map((e) => e.dist).sort((a, b) => a - b);
+    distMedianKm = sortedDists[Math.floor(sortedDists.length / 2)];
+  }
+  const straightRatioMean =
+    nonCircular.length > 0
+      ? nonCircular.reduce((acc, e) => acc + e.dist / e.pathDist, 0) / nonCircular.length
+      : null;
+
+  return {
+    patterns: entries.length,
+    circular,
+    circularPct,
+    pathDistMinKm,
+    pathDistMeanKm,
+    pathDistMedianKm,
+    pathDistMaxKm,
+    pathDistDistribution,
+    distMeanKm,
+    distMedianKm,
+    straightRatioMean,
+  };
+}
+
+/**
+ * Aggregate `stopStats` by taking the "busiest sg" values per stop.
+ *
+ * For each stopId found in any service group, merge across groups:
+ *   freq/rc/rtc = max, ed = min, ld = max. Then summarize across stops.
+ */
+function summarizeStopStats(bundle: InsightsBundle): StopStatsSummary | null {
+  const statsData = bundle.stopStats?.data;
+  if (!statsData) {
+    return null;
+  }
+  // Per-stop best-of aggregation across all service groups.
+  const perStop = new Map<
+    string,
+    { freq: number; rc: number; rtc: number; ed: number | null; ld: number | null }
+  >();
+  for (const sg of Object.keys(statsData)) {
+    const stops = statsData[sg];
+    for (const stopId of Object.keys(stops)) {
+      const s = stops[stopId];
+      const cur = perStop.get(stopId);
+      if (cur === undefined) {
+        perStop.set(stopId, {
+          freq: s.freq,
+          rc: s.rc,
+          rtc: s.rtc,
+          ed: Number.isFinite(s.ed) ? s.ed : null,
+          ld: Number.isFinite(s.ld) ? s.ld : null,
+        });
+      } else {
+        cur.freq = Math.max(cur.freq, s.freq);
+        cur.rc = Math.max(cur.rc, s.rc);
+        cur.rtc = Math.max(cur.rtc, s.rtc);
+        if (Number.isFinite(s.ed)) {
+          cur.ed = cur.ed === null ? s.ed : Math.min(cur.ed, s.ed);
+        }
+        if (Number.isFinite(s.ld)) {
+          cur.ld = cur.ld === null ? s.ld : Math.max(cur.ld, s.ld);
+        }
+      }
+    }
+  }
+
+  if (perStop.size === 0) {
+    return null;
+  }
+
+  const freqs: number[] = [];
+  let maxRc = 0;
+  let maxRtc = 0;
+  let earliest: number | null = null;
+  let latest: number | null = null;
+  for (const [, v] of perStop) {
+    freqs.push(v.freq);
+    if (v.rc > maxRc) {
+      maxRc = v.rc;
+    }
+    if (v.rtc > maxRtc) {
+      maxRtc = v.rtc;
+    }
+    if (v.ed !== null) {
+      earliest = earliest === null ? v.ed : Math.min(earliest, v.ed);
+    }
+    if (v.ld !== null) {
+      latest = latest === null ? v.ld : Math.max(latest, v.ld);
+    }
+  }
+
+  const meanFreq = freqs.reduce((acc, n) => acc + n, 0) / freqs.length;
+  const minFreq = Math.min(...freqs);
+  const maxFreq = Math.max(...freqs);
+  const freqDistribution = computeDistribution(freqs);
+
+  return {
+    stops: perStop.size,
+    minFreq,
+    meanFreq,
+    maxFreq,
+    freqDistribution,
+    maxRc,
+    maxRtc,
+    earliestMinutes: earliest,
+    latestMinutes: latest,
+  };
+}
+
+/**
+ * Compute a DistributionStats from a raw value array.
+ *
+ * Uses population std (divide by n, not n-1) since the values represent the
+ * full observed set, not a sample. Median and p90 use the nearest-rank
+ * method (`arr[floor(n * q)]`) — simple and deterministic for datasets
+ * where interpolation would complicate interpretation.
+ */
+function computeDistribution(values: number[]): DistributionStats {
+  const count = values.length;
+  if (count === 0) {
+    return { count: 0, meanMin: 0, medianMin: 0, p90Min: 0, stdMin: 0 };
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const sum = sorted.reduce((acc, v) => acc + v, 0);
+  const meanMin = sum / count;
+  const medianMin = sorted[Math.floor(count / 2)];
+  const p90Min = sorted[Math.floor(count * 0.9)];
+  const variance = sorted.reduce((acc, v) => acc + (v - meanMin) ** 2, 0) / count;
+  const stdMin = Math.sqrt(variance);
+  return { count, meanMin, medianMin, p90Min, stdMin };
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format one or more source stats as a human-readable multi-section string.
+ *
+ * Rows are sorted by `byTrip.meanMin` descending. Two tables are emitted:
+ *
+ *   1. Overview — source / nameEn / patterns / trips / minMin / maxMin / pctTripOver60
+ *   2. Per-view distribution — for each source, per-pattern and per-trip
+ *      distribution (mean / median / p90 / std)
+ */
+export function formatInsightsAnalysis(
+  rows: InsightsSourceStats[],
+  options: { analyzedAt?: Date } = {},
+): string {
+  if (rows.length === 0) {
+    return 'No insights data found.';
+  }
+  const sorted = [...rows].sort((a, b) => b.byTrip.meanMin - a.byTrip.meanMin);
+  const analyzedAt = options.analyzedAt ?? new Date();
+
+  const sections = [
+    '# Athenai Transit — V2 InsightsBundle analysis',
+    '',
+    `# Analyzed at: ${analyzedAt.toISOString()}`,
+    '# Per-source summary of `public/data-v2/<source>/insights.json`.',
+    '# Covers serviceGroups (calendar segmentation), tripPatternStats',
+    '# (pattern/trip duration distribution), tripPatternGeo (straight-',
+    '# line geometry — handle with care), and stopStats (per-stop',
+    '# activity, aggregated as "busiest service group"). Sections',
+    '# follow the InsightsBundle type declaration order. Each',
+    '# subsection has its own inline legend.',
+    '',
+    '# serviceGroups',
+    '',
+    formatServiceGroupsTable(sorted),
+    '',
+    formatServiceGroupsKeysDetail(sorted),
+    '',
+    '# tripPatternStats',
+    '',
+    formatOverviewTable(sorted),
+    '',
+    formatDistributionTable(sorted),
+    '',
+    '# tripPatternGeo',
+    '',
+    formatTripPatternGeoTable(sorted),
+    '',
+    formatPathDistDistributionTable(sorted),
+    '',
+    '# stopStats',
+    '',
+    formatStopStatsOverview(sorted),
+    '',
+    formatStopStatsDistribution(sorted),
+  ];
+
+  return sections.join('\n');
+}
+
+function fmtNum(n: number, decimals = 1): string {
+  return n.toFixed(decimals);
+}
+
+function formatOverviewTable(rows: InsightsSourceStats[]): string {
+  const overCols = OVER_THRESHOLDS_MINUTES.map((t) => `pctOver${t}(%)`);
+  const header = [
+    'source',
+    'nameEn',
+    'patterns',
+    'trips',
+    'min(min)',
+    'max(min)',
+    'minStops',
+    'meanStops',
+    'medStops',
+    'maxStops',
+    ...overCols,
+  ];
+  const body = rows.map((r) => [
+    r.source,
+    r.nameEn,
+    String(r.byPattern.count),
+    String(r.byTrip.count),
+    fmtNum(r.minMin),
+    fmtNum(r.maxMin),
+    String(r.minStops),
+    fmtNum(r.meanStops),
+    String(r.medianStops),
+    String(r.maxStops),
+    ...r.pctTripOver.map((v) => fmtNum(v)),
+  ]);
+  return `## Overview\n\n${TRIP_PATTERN_STATS_OVERVIEW_LEGEND}\n\n${renderTable(header, body)}`;
+}
+
+function formatDistributionTable(rows: InsightsSourceStats[]): string {
+  const header = ['source', 'view', 'count', 'mean(min)', 'p50(min)', 'p90(min)', 'std(min)'];
+  const body: string[][] = [];
+  for (const r of rows) {
+    body.push([
+      r.source,
+      'pattern',
+      String(r.byPattern.count),
+      fmtNum(r.byPattern.meanMin),
+      fmtNum(r.byPattern.medianMin),
+      fmtNum(r.byPattern.p90Min),
+      fmtNum(r.byPattern.stdMin),
+    ]);
+    body.push([
+      r.source,
+      'trip',
+      String(r.byTrip.count),
+      fmtNum(r.byTrip.meanMin),
+      fmtNum(r.byTrip.medianMin),
+      fmtNum(r.byTrip.p90Min),
+      fmtNum(r.byTrip.stdMin),
+    ]);
+  }
+  return `## Distribution of trip duration (minutes)\n\n${TRIP_PATTERN_STATS_DISTRIBUTION_LEGEND}\n\n${renderTable(header, body)}`;
+}
+
+function formatServiceGroupsTable(rows: InsightsSourceStats[]): string {
+  const header = ['source', 'nameEn', 'groups', 'serviceIds', 'stdKeys', 'nonStdKeys'];
+  const body = rows.map((r) => {
+    const sg = r.serviceGroups;
+    return [
+      r.source,
+      r.nameEn,
+      String(sg.groupCount),
+      String(sg.serviceIdCount),
+      String(sg.stdKeyCount),
+      String(sg.nonStdKeyCount),
+    ];
+  });
+  return `## Summary\n\n${SERVICE_GROUPS_SUMMARY_LEGEND}\n\n${renderTable(header, body)}`;
+}
+
+function formatServiceGroupsKeysDetail(rows: InsightsSourceStats[]): string {
+  const lines: string[] = ['## Keys detail', '', SERVICE_GROUPS_KEYS_DETAIL_LEGEND, ''];
+  for (const r of rows) {
+    const sg = r.serviceGroups;
+    const keysWithSize = sg.keys.map((k, i) => `${k}(${sg.groupSizes[i]})`).join(' ');
+    lines.push(`${r.source.padEnd(8)} ${keysWithSize}`);
+  }
+  return lines.join('\n');
+}
+
+function formatTripPatternGeoTable(rows: InsightsSourceStats[]): string {
+  // Columns suffixed with "*" are derived from the pipeline-estimated
+  // `cl` (circular) flag. See the inline legend below for details.
+  const header = [
+    'source',
+    'nameEn',
+    'patterns',
+    'circular*',
+    'circular*(%)',
+    'pathDistMin(km)',
+    'pathDistMean(km)',
+    'pathDistMed(km)',
+    'pathDistMax(km)',
+    'distMean*(km)',
+    'distMed*(km)',
+    'straightRatio*',
+  ];
+  const body = rows.map((r) => {
+    const g = r.tripPatternGeo;
+    if (g === null) {
+      return [r.source, r.nameEn, '-', '-', '-', '-', '-', '-', '-', '-', '-', '-'];
+    }
+    return [
+      r.source,
+      r.nameEn,
+      String(g.patterns),
+      String(g.circular),
+      fmtNum(g.circularPct),
+      fmtNum(g.pathDistMinKm, 2),
+      fmtNum(g.pathDistMeanKm, 2),
+      fmtNum(g.pathDistMedianKm, 2),
+      fmtNum(g.pathDistMaxKm, 2),
+      g.distMeanKm !== null ? fmtNum(g.distMeanKm, 2) : '-',
+      g.distMedianKm !== null ? fmtNum(g.distMedianKm, 2) : '-',
+      g.straightRatioMean !== null ? fmtNum(g.straightRatioMean, 2) : '-',
+    ];
+  });
+  return `## Overview\n\n${TRIP_PATTERN_GEO_OVERVIEW_LEGEND}\n\n${renderTable(header, body)}`;
+}
+
+function formatPathDistDistributionTable(rows: InsightsSourceStats[]): string {
+  const header = [
+    'source',
+    'count',
+    'min(km)',
+    'mean(km)',
+    'p50(km)',
+    'p90(km)',
+    'max(km)',
+    'std(km)',
+  ];
+  const body = rows.map((r) => {
+    const g = r.tripPatternGeo;
+    if (g === null) {
+      return [r.source, '-', '-', '-', '-', '-', '-', '-'];
+    }
+    const d = g.pathDistDistribution;
+    return [
+      r.source,
+      String(d.count),
+      fmtNum(g.pathDistMinKm, 2),
+      fmtNum(d.meanMin, 2),
+      fmtNum(d.medianMin, 2),
+      fmtNum(d.p90Min, 2),
+      fmtNum(g.pathDistMaxKm, 2),
+      fmtNum(d.stdMin, 2),
+    ];
+  });
+  return `## Distribution of pathDist (km)\n\n${TRIP_PATTERN_GEO_DISTRIBUTION_LEGEND}\n\n${renderTable(header, body)}`;
+}
+
+/** Format minutes-from-midnight as HH:MM, supporting 24h+ values. */
+function fmtHhmm(minutes: number | null): string {
+  if (minutes === null || !Number.isFinite(minutes)) {
+    return '-';
+  }
+  const h = Math.floor(minutes / 60);
+  const m = Math.floor(minutes % 60);
+  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+}
+
+function formatStopStatsOverview(rows: InsightsSourceStats[]): string {
+  const header = [
+    'source',
+    'nameEn',
+    'stops',
+    'meanFreq',
+    'medFreq',
+    'maxFreq',
+    'maxRc',
+    'maxRtc',
+    'earliest',
+    'latest',
+  ];
+  const body = rows.map((r) => {
+    const s = r.stopStats;
+    if (s === null) {
+      return [r.source, r.nameEn, '-', '-', '-', '-', '-', '-', '-', '-'];
+    }
+    return [
+      r.source,
+      r.nameEn,
+      String(s.stops),
+      fmtNum(s.meanFreq),
+      fmtNum(s.freqDistribution.medianMin),
+      String(s.maxFreq),
+      String(s.maxRc),
+      String(s.maxRtc),
+      fmtHhmm(s.earliestMinutes),
+      fmtHhmm(s.latestMinutes),
+    ];
+  });
+  return `## Overview\n\n${STOP_STATS_OVERVIEW_LEGEND}\n\n${renderTable(header, body)}`;
+}
+
+function formatStopStatsDistribution(rows: InsightsSourceStats[]): string {
+  const header = ['source', 'count', 'min', 'mean', 'p50', 'p90', 'max', 'std'];
+  const body = rows.map((r) => {
+    const s = r.stopStats;
+    if (s === null) {
+      return [r.source, '-', '-', '-', '-', '-', '-', '-'];
+    }
+    const d = s.freqDistribution;
+    return [
+      r.source,
+      String(d.count),
+      String(s.minFreq),
+      fmtNum(d.meanMin),
+      fmtNum(d.medianMin),
+      fmtNum(d.p90Min),
+      String(s.maxFreq),
+      fmtNum(d.stdMin),
+    ];
+  });
+  return `## Distribution of stop freq (per day)\n\n${STOP_STATS_DISTRIBUTION_LEGEND}\n\n${renderTable(header, body)}`;
+}
+
+const SERVICE_GROUPS_SUMMARY_LEGEND = [
+  '# Summarizes how the pipeline segments the calendar into service groups',
+  '# for stats lookup.',
+  '#',
+  '# groups      : total number of service groups in this source',
+  '# serviceIds  : total GTFS service_ids across all groups',
+  '# stdKeys     : count of groups with a standard key',
+  '#               (wd=weekday, sa=Saturday, su=Sunday, wk=weekend,',
+  '#                all=every day)',
+  '# nonStdKeys  : count of groups with a non-standard key',
+  '#               (d-bitmask, e.g. d0000100 = Friday only)',
+].join('\n');
+
+const SERVICE_GROUPS_KEYS_DETAIL_LEGEND = [
+  '# Per-source listing of each group key and its service_id count.',
+  '# Useful for spotting unusual weekly patterns or sources with many',
+  '# operating days.',
+].join('\n');
+
+const TRIP_PATTERN_STATS_OVERVIEW_LEGEND = [
+  '# patterns   : distinct trip patterns in the source',
+  '# trips      : total departures (sum of freq across service groups)',
+  '# min / max  : shortest / longest pattern total duration (minutes)',
+  '# minStops   : fewest stops in any pattern (rd.length)',
+  '# meanStops  : mean stops per pattern',
+  '# medStops   : median stops per pattern (outlier-resistant)',
+  '# maxStops   : most stops in any pattern',
+  `# pctOverN   : % of trips (freq-weighted) whose total > N min (N = ${OVER_THRESHOLDS_MINUTES.join(', ')})`,
+].join('\n');
+
+const TRIP_PATTERN_STATS_DISTRIBUTION_LEGEND = [
+  '# Every statistic (mean / p50 / p90 / std) describes the distribution',
+  '# of trip-pattern total duration (rd[0]) in minutes.',
+  '#',
+  '# view = how each pattern contributes to the distribution:',
+  '#   pattern : each distinct trip pattern counted once',
+  '#             (what route shapes this operator designs)',
+  '#   trip    : each pattern counted freq times (actual operated trips)',
+  '#             (what durations riders actually experience)',
+  '#',
+  '# count : number of observations in the view',
+  '# mean  : mean trip duration',
+  '# p50   : median trip duration — half of trips are shorter, half are longer',
+  '# p90   : 90th percentile trip duration — only the longest 10% exceed this',
+  '# std   : standard deviation of trip duration (larger = more spread)',
+].join('\n');
+
+const TRIP_PATTERN_GEO_OVERVIEW_LEGEND = [
+  '# IMPORTANT (straight-line basis):',
+  '#   `dist` and `pathDist` are computed by the pipeline as Haversine',
+  '#   straight-line distances between consecutive stop coordinates.',
+  '#   They do NOT reflect real road distance and will under-represent',
+  '#   winding routes. Handle with care.',
+  '#',
+  '# IMPORTANT (cl is an estimate — columns marked "*"):',
+  '#   The `cl` flag is set when the first and last stop_id in a pattern',
+  '#   are equal — a rule-based guess by the pipeline, not an operator-',
+  '#   authoritative "this is a circular route" declaration. It can miss',
+  '#   circular routes that terminate at a different platform of the',
+  '#   same station, or mis-flag figure-eight routes. Treat all columns',
+  '#   suffixed "*" as estimates.',
+  '#',
+  '# patterns         : number of patterns with a tripPatternGeo entry',
+  '# circular*        : count of patterns flagged as circular (cl=true)',
+  '# circular*(%)     : share of circular-flagged patterns',
+  '# pathDistMin/Max  : shortest/longest sum of stop-to-stop straight',
+  '#                    lines (km)',
+  '# pathDistMean     : mean path distance across all patterns (km)',
+  '# pathDistMed      : median path distance across all patterns (km,',
+  '#                    outlier-resistant)',
+  '# distMean*        : mean origin-to-terminal straight-line distance',
+  '#                    across patterns NOT flagged as circular (km)',
+  '# distMed*         : median origin-to-terminal straight-line distance',
+  '#                    across patterns NOT flagged as circular (km)',
+  '# straightRatio*   : mean of (dist / pathDist) across patterns NOT',
+  '#                    flagged as circular. 1.0 = perfectly straight,',
+  '#                    lower = more detour / wandering',
+].join('\n');
+
+const TRIP_PATTERN_GEO_DISTRIBUTION_LEGEND = [
+  '# Distribution of pathDist across all patterns (cl-independent).',
+  '# Uses the same statistic definitions as the duration distribution:',
+  '#',
+  '# count : number of patterns with a valid pathDist',
+  '# mean  : arithmetic mean path distance (km)',
+  '# p50   : median path distance — half of patterns are shorter',
+  '# p90   : 90th percentile — only the longest 10% exceed this',
+  '# std   : population standard deviation of path distance (km)',
+].join('\n');
+
+const STOP_STATS_OVERVIEW_LEGEND = [
+  '# Per-stop values are aggregated as "busiest service group": for',
+  '# each stopId, freq/rc/rtc take the max across service groups, ed',
+  '# takes the min, ld takes the max. This yields the peak profile',
+  '# for each stop regardless of which weekly pattern (wd/sa/su/etc.)',
+  '# was most representative.',
+  '#',
+  '# stops     : distinct stopIds present in any service group',
+  '# meanFreq  : mean of per-stop busiest-day freq',
+  '# medFreq   : median of per-stop busiest-day freq (outlier-resistant)',
+  '# maxFreq   : max of per-stop busiest-day freq (busiest stop anywhere)',
+  '# maxRc     : max route count at any single stop (hub indicator)',
+  '# maxRtc    : max route-type count at any single stop (multimodal)',
+  '# earliest  : source-wide earliest departure (HH:MM, 24h+ overnight)',
+  '# latest    : source-wide latest departure (HH:MM, 24h+ overnight)',
+].join('\n');
+
+const STOP_STATS_DISTRIBUTION_LEGEND = [
+  '# Distribution of per-stop "busiest day" freq across stops.',
+  '# Each stopId contributes a single value (max freq across its',
+  '# service groups).',
+  '#',
+  '# count : number of stops',
+  '# mean  : mean busiest-day freq per stop',
+  '# p50   : median — half of stops see fewer, half see more',
+  '# p90   : 90% of stops are at most this busy; only the top 10% exceed',
+  '# std   : population standard deviation of per-stop freq',
+].join('\n');
+
+/**
+ * Render a simple padded ASCII table. The first column is left-aligned and
+ * remaining columns are right-aligned so numeric values line up cleanly.
+ */
+function renderTable(header: string[], body: string[][]): string {
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...body.map((row) => row[i]?.length ?? 0)),
+  );
+  const pad = (row: string[]): string =>
+    row.map((cell, i) => (i <= 1 ? cell.padEnd(widths[i]) : cell.padStart(widths[i]))).join('  ');
+  const sep = widths.map((w) => '-'.repeat(w)).join('  ');
+  return [pad(header), sep, ...body.map(pad)].join('\n');
+}

--- a/pipeline/scripts/dev/dev-lib/v2-insights-analysis.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-insights-analysis.ts
@@ -23,6 +23,7 @@
  */
 
 import type { InsightsBundle } from '../../../../src/types/data/transit-v2-json';
+import { sortedMedian, sortedPercentile } from './stats-utils';
 
 /** Thresholds (minutes) for the "long trip share" columns. */
 export const OVER_THRESHOLDS_MINUTES = [30, 60, 90] as const;
@@ -230,7 +231,7 @@ export function analyzeInsightsBundle(
   const maxStops = Math.max(...stopCounts);
   const meanStops = stopCounts.reduce((acc, v) => acc + v, 0) / stopCounts.length;
   const sortedStops = [...stopCounts].sort((a, b) => a - b);
-  const medianStops = sortedStops[Math.floor(sortedStops.length / 2)];
+  const medianStops = sortedMedian(sortedStops);
   const pctTripOver = OVER_THRESHOLDS_MINUTES.map((threshold) => {
     if (tripValues.length === 0) {
       return 0;
@@ -298,7 +299,7 @@ function summarizeTripPatternGeo(bundle: InsightsBundle): TripPatternGeoSummary 
   const pathDistMaxKm = Math.max(...pathDists);
   const pathDistMeanKm = pathDists.reduce((acc, v) => acc + v, 0) / pathDists.length;
   const sortedPathDists = [...pathDists].sort((a, b) => a - b);
-  const pathDistMedianKm = sortedPathDists[Math.floor(sortedPathDists.length / 2)];
+  const pathDistMedianKm = sortedMedian(sortedPathDists);
   const pathDistDistribution = computeDistribution(pathDists);
 
   const nonCircular = entries.filter((e) => !e.cl && e.pathDist > 0);
@@ -309,7 +310,7 @@ function summarizeTripPatternGeo(bundle: InsightsBundle): TripPatternGeoSummary 
   let distMedianKm: number | null = null;
   if (nonCircular.length > 0) {
     const sortedDists = nonCircular.map((e) => e.dist).sort((a, b) => a - b);
-    distMedianKm = sortedDists[Math.floor(sortedDists.length / 2)];
+    distMedianKm = sortedMedian(sortedDists);
   }
   const straightRatioMean =
     nonCircular.length > 0
@@ -421,9 +422,9 @@ function summarizeStopStats(bundle: InsightsBundle): StopStatsSummary | null {
  * Compute a DistributionStats from a raw value array.
  *
  * Uses population std (divide by n, not n-1) since the values represent the
- * full observed set, not a sample. Median and p90 use the nearest-rank
- * method (`arr[floor(n * q)]`) — simple and deterministic for datasets
- * where interpolation would complicate interpretation.
+ * full observed set, not a sample. Median uses the standard mathematical
+ * definition (average of the two middle elements for even-length arrays).
+ * p90 uses the nearest-rank method (`ceil(0.9 * n)` 1-indexed).
  */
 function computeDistribution(values: number[]): DistributionStats {
   const count = values.length;
@@ -433,8 +434,8 @@ function computeDistribution(values: number[]): DistributionStats {
   const sorted = [...values].sort((a, b) => a - b);
   const sum = sorted.reduce((acc, v) => acc + v, 0);
   const meanMin = sum / count;
-  const medianMin = sorted[Math.floor(count / 2)];
-  const p90Min = sorted[Math.floor(count * 0.9)];
+  const medianMin = sortedMedian(sorted);
+  const p90Min = sortedPercentile(sorted, 0.9);
   const variance = sorted.reduce((acc, v) => acc + (v - meanMin) ** 2, 0) / count;
   const stdMin = Math.sqrt(variance);
   return { count, meanMin, medianMin, p90Min, stdMin };

--- a/pipeline/scripts/dev/dev-lib/v2-insights-analysis.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-insights-analysis.ts
@@ -8,6 +8,18 @@
  *
  * No I/O. Formatter functions are side-effect free and return strings so
  * the CLI wrapper can direct them to stdout.
+ *
+ * ## Testing philosophy
+ *
+ * Statistical correctness of the aggregation output is intentionally not
+ * unit-tested. The numbers here are reductions over real pipeline data
+ * whose "ground truth" is that same data, so the practical validation
+ * path is manual review of the printed output. The companion test file
+ * (`__tests__/v2-insights-analysis.test.ts`) contains smoke tests only
+ * — verifying that functions return the expected shape, handle missing
+ * sections gracefully, and format without throwing. Those guard against
+ * type regressions and trivial breakage during refactor, not against
+ * algorithm bugs.
  */
 
 import type { InsightsBundle } from '../../../../src/types/data/transit-v2-json';

--- a/pipeline/scripts/dev/dev-lib/v2-insights-analysis.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-insights-analysis.ts
@@ -23,6 +23,7 @@
  */
 
 import type { InsightsBundle } from '../../../../src/types/data/transit-v2-json';
+import { renderTable } from './render-utils';
 import { sortedMedian, sortedPercentile } from './stats-utils';
 
 /** Thresholds (minutes) for the "long trip share" columns. */
@@ -536,7 +537,7 @@ function formatOverviewTable(rows: InsightsSourceStats[]): string {
     String(r.maxStops),
     ...r.pctTripOver.map((v) => fmtNum(v)),
   ]);
-  return `## Overview\n\n${TRIP_PATTERN_STATS_OVERVIEW_LEGEND}\n\n${renderTable(header, body)}`;
+  return `## Overview\n\n${TRIP_PATTERN_STATS_OVERVIEW_LEGEND}\n\n${renderTable(header, body, 2)}`;
 }
 
 function formatDistributionTable(rows: InsightsSourceStats[]): string {
@@ -562,7 +563,7 @@ function formatDistributionTable(rows: InsightsSourceStats[]): string {
       fmtNum(r.byTrip.stdMin),
     ]);
   }
-  return `## Distribution of trip duration (minutes)\n\n${TRIP_PATTERN_STATS_DISTRIBUTION_LEGEND}\n\n${renderTable(header, body)}`;
+  return `## Distribution of trip duration (minutes)\n\n${TRIP_PATTERN_STATS_DISTRIBUTION_LEGEND}\n\n${renderTable(header, body, 2)}`;
 }
 
 function formatServiceGroupsTable(rows: InsightsSourceStats[]): string {
@@ -578,7 +579,7 @@ function formatServiceGroupsTable(rows: InsightsSourceStats[]): string {
       String(sg.nonStdKeyCount),
     ];
   });
-  return `## Summary\n\n${SERVICE_GROUPS_SUMMARY_LEGEND}\n\n${renderTable(header, body)}`;
+  return `## Summary\n\n${SERVICE_GROUPS_SUMMARY_LEGEND}\n\n${renderTable(header, body, 2)}`;
 }
 
 function formatServiceGroupsKeysDetail(rows: InsightsSourceStats[]): string {
@@ -628,7 +629,7 @@ function formatTripPatternGeoTable(rows: InsightsSourceStats[]): string {
       g.straightRatioMean !== null ? fmtNum(g.straightRatioMean, 2) : '-',
     ];
   });
-  return `## Overview\n\n${TRIP_PATTERN_GEO_OVERVIEW_LEGEND}\n\n${renderTable(header, body)}`;
+  return `## Overview\n\n${TRIP_PATTERN_GEO_OVERVIEW_LEGEND}\n\n${renderTable(header, body, 2)}`;
 }
 
 function formatPathDistDistributionTable(rows: InsightsSourceStats[]): string {
@@ -659,7 +660,7 @@ function formatPathDistDistributionTable(rows: InsightsSourceStats[]): string {
       fmtNum(d.stdMin, 2),
     ];
   });
-  return `## Distribution of pathDist (km)\n\n${TRIP_PATTERN_GEO_DISTRIBUTION_LEGEND}\n\n${renderTable(header, body)}`;
+  return `## Distribution of pathDist (km)\n\n${TRIP_PATTERN_GEO_DISTRIBUTION_LEGEND}\n\n${renderTable(header, body, 2)}`;
 }
 
 /** Format minutes-from-midnight as HH:MM, supporting 24h+ values. */
@@ -703,7 +704,7 @@ function formatStopStatsOverview(rows: InsightsSourceStats[]): string {
       fmtHhmm(s.latestMinutes),
     ];
   });
-  return `## Overview\n\n${STOP_STATS_OVERVIEW_LEGEND}\n\n${renderTable(header, body)}`;
+  return `## Overview\n\n${STOP_STATS_OVERVIEW_LEGEND}\n\n${renderTable(header, body, 2)}`;
 }
 
 function formatStopStatsDistribution(rows: InsightsSourceStats[]): string {
@@ -725,7 +726,7 @@ function formatStopStatsDistribution(rows: InsightsSourceStats[]): string {
       fmtNum(d.stdMin),
     ];
   });
-  return `## Distribution of stop freq (per day)\n\n${STOP_STATS_DISTRIBUTION_LEGEND}\n\n${renderTable(header, body)}`;
+  return `## Distribution of stop freq (per day)\n\n${STOP_STATS_DISTRIBUTION_LEGEND}\n\n${renderTable(header, body, 2)}`;
 }
 
 const SERVICE_GROUPS_SUMMARY_LEGEND = [
@@ -851,12 +852,3 @@ const STOP_STATS_DISTRIBUTION_LEGEND = [
  * Render a simple padded ASCII table. The first column is left-aligned and
  * remaining columns are right-aligned so numeric values line up cleanly.
  */
-function renderTable(header: string[], body: string[][]): string {
-  const widths = header.map((h, i) =>
-    Math.max(h.length, ...body.map((row) => row[i]?.length ?? 0)),
-  );
-  const pad = (row: string[]): string =>
-    row.map((cell, i) => (i <= 1 ? cell.padEnd(widths[i]) : cell.padStart(widths[i]))).join('  ');
-  const sep = widths.map((w) => '-'.repeat(w)).join('  ');
-  return [pad(header), sep, ...body.map(pad)].join('\n');
-}

--- a/pipeline/scripts/dev/dev-lib/v2-insights-analysis.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-insights-analysis.ts
@@ -2,9 +2,23 @@
  * Pure analysis of a v2 per-source InsightsBundle.
  *
  * Aggregates duration statistics from `tripPatternStats`:
- *   - per-pattern distribution (each pattern counted once)
- *   - per-trip distribution (each pattern counted `freq` times)
- * Plus shared min/max across the valid pattern set.
+ *   - **per-(pattern, service-group) distribution** — each pipeline
+ *     record counted once. The same `patternId` running on multiple
+ *     service groups contributes one observation per group, since
+ *     the pipeline records SG-specific median durations and these
+ *     can differ non-trivially even for the "same" pattern.
+ *     Example: `kobus:p1` is `21 / 21 / 20` minutes across `wd / sa
+ *     / su`. Collapsing to a single per-`patternId` observation
+ *     would force a synthetic representative value (or arbitrary
+ *     "first occurrence" pick), discarding the per-SG variance the
+ *     pipeline deliberately preserves. The atom of analysis here is
+ *     therefore the `(serviceGroup, patternId)` tuple — the same
+ *     atom the pipeline keys `tripPatternStats` by.
+ *   - **per-trip distribution** — each pipeline record counted
+ *     `freq` times (so a 3 trips/day pattern contributes 3
+ *     observations per service group).
+ *
+ * Plus shared min/max across the valid set.
  *
  * No I/O. Formatter functions are side-effect free and return strings so
  * the CLI wrapper can direct them to stdout.

--- a/pipeline/scripts/dev/dev-tools.ts
+++ b/pipeline/scripts/dev/dev-tools.ts
@@ -48,6 +48,17 @@ const SCRIPTS: AnalysisScript[] = [
     file: './analyze-v2-name-fields.ts',
     description: 'V2 名称系調査対象の source 別件数集計',
   },
+  {
+    name: 'analyze-v2-insights',
+    file: './analyze-v2-insights.ts',
+    description:
+      'V2 InsightsBundle 集計 (serviceGroups / tripPatternStats / tripPatternGeo / stopStats)',
+  },
+  {
+    name: 'analyze-v2-global-insights',
+    file: './analyze-v2-global-insights.ts',
+    description: 'V2 GlobalInsightsBundle 集計 (stopGeo の source 別カバレッジと nr 分布)',
+  },
 ];
 
 const SCRIPT_DIR = import.meta.dirname;

--- a/src/components/badge/headsign-badge.stories.tsx
+++ b/src/components/badge/headsign-badge.stories.tsx
@@ -9,8 +9,11 @@ import {
   headsignKyotoLongShortJa,
   headsignOtsukaEkimae,
   headsignShinjuku,
+  routeLong,
   stopHeadsignDemachiyanagi,
+  stopHeadsignLong,
   stopHeadsignMusashiKoganeiSouth,
+  tripHeadsignLong,
 } from '../../stories/fixtures';
 import { LANG_COMPARISON_CASES } from '../../stories/lang-comparison';
 import { HeadsignBadge } from './headsign-badge';
@@ -159,6 +162,44 @@ export const WithDirection: Story = {
   args: {
     routeDirection: createRouteDirection({ ...defaultRouteDirection, direction: 0 }),
     infoLevel: 'verbose',
+  },
+};
+
+// --- infoLevel comparison ---
+
+/** Logical long-form fixture for comparison stories. */
+const logicalLongRd = createRouteDirection({
+  route: routeLong,
+  tripHeadsign: tripHeadsignLong,
+  stopHeadsign: stopHeadsignLong,
+});
+
+/**
+ * Side-by-side comparison of all `infoLevel` values against the
+ * logical long-form fixtures (`routeLong`, `tripHeadsignLong`,
+ * `stopHeadsignLong`). Place-name-independent — exercises the full
+ * info-level rendering range without being tied to specific
+ * real-world data.
+ */
+export const LogicalLongInfoLevelComparison: Story = {
+  args: { routeDirection: logicalLongRd },
+  render: (args) => {
+    const levels = ['simple', 'normal', 'detailed', 'verbose'] as const;
+    return (
+      <div className="flex flex-col gap-3">
+        {levels.map((level) => (
+          <div key={level} className="space-y-1">
+            <span className="block text-[10px] text-gray-400">infoLevel: {level}</span>
+            <HeadsignBadge
+              routeDirection={args.routeDirection}
+              infoLevel={level}
+              dataLang={args.dataLang}
+              size={args.size}
+            />
+          </div>
+        ))}
+      </div>
+    );
   },
 };
 

--- a/src/components/badge/route-badge.stories.tsx
+++ b/src/components/badge/route-badge.stories.tsx
@@ -1,5 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { busRoute, busRoute2, noColorRoute, subwayRoute, tramRoute } from '../../stories/fixtures';
+import {
+  busRoute,
+  busRoute2,
+  noColorRoute,
+  routeLong,
+  subwayRoute,
+  tramRoute,
+} from '../../stories/fixtures';
 import { LANG_COMPARISON_CASES } from '../../stories/lang-comparison';
 import { RouteBadge } from './route-badge';
 
@@ -124,6 +131,36 @@ export const SizeComparison: Story = {
       />
     </div>
   ),
+};
+
+// --- infoLevel comparison ---
+
+/**
+ * Side-by-side comparison of all `infoLevel` values against the
+ * logical long-form `routeLong` fixture. Place-name-independent —
+ * exercises the full info-level rendering range without being tied
+ * to specific real-world data.
+ */
+export const LogicalLongInfoLevelComparison: Story = {
+  args: { route: routeLong },
+  render: (args) => {
+    const levels = ['simple', 'normal', 'detailed', 'verbose'] as const;
+    return (
+      <div className="flex flex-col gap-3">
+        {levels.map((level) => (
+          <div key={level} className="space-y-1">
+            <span className="block text-[10px] text-gray-400">infoLevel: {level}</span>
+            <RouteBadge
+              route={args.route}
+              dataLang={args.dataLang}
+              infoLevel={level}
+              size={args.size}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  },
 };
 
 // --- i18n: lang resolution ---

--- a/src/components/departure-item.stories.tsx
+++ b/src/components/departure-item.stories.tsx
@@ -604,6 +604,7 @@ export const LogicalLongInfoLevelComparison: Story = {
               dataLang={['ja']}
               showRouteTypeIcon
               agency={args.agency}
+              showAgency={false}
             />
           </div>
         ))}

--- a/src/components/departure-item.stories.tsx
+++ b/src/components/departure-item.stories.tsx
@@ -623,7 +623,6 @@ export const LogicalLongInfoLevelComparison: Story = {
         dropOffType: 1,
       }),
     ],
-    maxDisplay: 5,
     agency: longAgency,
     onShowTimetable: fn(),
   },

--- a/src/components/departure-item.stories.tsx
+++ b/src/components/departure-item.stories.tsx
@@ -10,14 +10,17 @@ import {
   emptyHeadsign,
   headsignKyotoLong,
   headsignMinowabashi,
-  headsignNakano,
   headsignShimbashiEkimae,
   headsignShinjuku,
   headsignWaseda,
   noColorRoute,
+  routeLong,
   stopHeadsignDemachiyanagi,
+  stopHeadsignLong,
   stopHeadsignMusashiKoganeiSouth,
   tramRoute,
+  tripHeadsignLong,
+  tripHeadsignShort,
 } from '../stories/fixtures';
 import { LANG_COMPARISON_CASES } from '../stories/lang-comparison';
 import { fn } from 'storybook/test';
@@ -38,9 +41,14 @@ function createEntry(
     stopIndex: number;
     totalStops: number;
     direction: 0 | 1;
+    remainingMinutes: number;
+    totalMinutes: number;
+    freq: number;
   }> = {},
 ): ContextualTimetableEntry {
   const depMin = overrides.departureMinutes ?? 870; // 14:30
+  const totalMinutes = overrides.totalMinutes ?? 45;
+  const remainingMinutes = overrides.remainingMinutes ?? Math.round(totalMinutes * 0.8);
   return {
     schedule: {
       departureMinutes: depMin,
@@ -64,7 +72,74 @@ function createEntry(
       isTerminal: overrides.isTerminal ?? false,
       isOrigin: overrides.isOrigin ?? false,
     },
+    insights: {
+      remainingMinutes,
+      totalMinutes,
+      freq: overrides.freq ?? 30,
+    },
     serviceDate: new Date('2026-03-30T00:00:00'),
+  };
+}
+
+/**
+ * Create a ContextualTimetableEntry using the logical long-form
+ * fixtures (`routeLong`, `tripHeadsignLong`, `stopHeadsignLong`).
+ * Intended for place-name-independent stories that exercise
+ * structural/length characteristics.
+ */
+function createLogicalLongEntry(
+  overrides: Partial<{
+    departureMinutes: number;
+    freq: number;
+    totalMinutes: number;
+    remainingMinutes: number;
+    isTerminal: boolean;
+    pickupType: StopServiceType;
+    dropOffType: StopServiceType;
+  }> = {},
+): ContextualTimetableEntry {
+  return {
+    ...createEntry({
+      departureMinutes: overrides.departureMinutes,
+      totalMinutes: overrides.totalMinutes,
+      remainingMinutes: overrides.remainingMinutes,
+      freq: overrides.freq,
+      isTerminal: overrides.isTerminal,
+      pickupType: overrides.pickupType,
+      dropOffType: overrides.dropOffType,
+    }),
+    routeDirection: createRouteDirection({
+      route: routeLong,
+      tripHeadsign: tripHeadsignLong,
+      stopHeadsign: stopHeadsignLong,
+    }),
+  };
+}
+
+/**
+ * Create a ContextualTimetableEntry using the short-form logical
+ * fixtures — short route name, short trip headsign, no stop
+ * headsign. Counterpart to {@link createLogicalLongEntry}.
+ */
+function createLogicalShortEntry(
+  overrides: Partial<{
+    departureMinutes: number;
+    freq: number;
+    totalMinutes: number;
+    remainingMinutes: number;
+  }> = {},
+): ContextualTimetableEntry {
+  return {
+    ...createEntry({
+      departureMinutes: overrides.departureMinutes,
+      totalMinutes: overrides.totalMinutes,
+      remainingMinutes: overrides.remainingMinutes,
+      freq: overrides.freq,
+    }),
+    routeDirection: createRouteDirection({
+      route: baseRoute,
+      tripHeadsign: tripHeadsignShort,
+    }),
   };
 }
 
@@ -325,27 +400,32 @@ export const StopOverridesTrip: Story = {
   },
 };
 
+/**
+ * All languages side by side using the logical long-form fixtures
+ * (`routeLong`, `tripHeadsignLong`, `stopHeadsignLong`). Every
+ * language row gets populated trip + stop headsigns and a verbose
+ * route_long_name so wrap / truncation behaviour is exercised
+ * consistently per language. A second entry uses `tripHeadsignShort`
+ * to show the short-form side by side.
+ */
 export const LangComparison: Story = {
   args: {
     agency,
     entries: [
       {
-        ...createEntry({ route: greenRoute, departureMinutes: 870 }),
+        ...createEntry({ departureMinutes: 870 }),
         routeDirection: createRouteDirection({
-          route: greenRoute,
-          tripHeadsign: headsignShimbashiEkimae,
+          route: routeLong,
+          tripHeadsign: tripHeadsignLong,
+          stopHeadsign: stopHeadsignLong,
         }),
       },
       {
-        ...createEntry({ route: greenRoute, departureMinutes: 885 }),
+        ...createEntry({ departureMinutes: 885 }),
         routeDirection: createRouteDirection({
-          route: greenRoute,
-          tripHeadsign: headsignShimbashiEkimae,
+          route: routeLong,
+          tripHeadsign: tripHeadsignShort,
         }),
-      },
-      {
-        ...createEntry({ route: baseRoute, departureMinutes: 900 }),
-        routeDirection: createRouteDirection({ route: baseRoute, tripHeadsign: headsignNakano }),
       },
     ],
     infoLevel: 'normal',
@@ -493,6 +573,102 @@ const kitchenSinkGroups: { entries: ContextualTimetableEntry[]; agency?: Agency 
     agency,
   },
 ];
+
+// --- Logical data (place-name-independent) ---
+
+/**
+ * Side-by-side comparison of all `infoLevel` values against the
+ * logical long-form fixtures. Place-name-independent alternative to
+ * {@link Detailed} / {@link Verbose} stories.
+ */
+export const LogicalLongInfoLevelComparison: Story = {
+  args: {
+    entries: [
+      createLogicalLongEntry({ departureMinutes: 870 }),
+      createLogicalLongEntry({ departureMinutes: 885 }),
+      createLogicalLongEntry({ departureMinutes: 900 }),
+    ],
+    agency: longAgency,
+  },
+  render: (args) => {
+    const levels = ['simple', 'normal', 'detailed', 'verbose'] as const;
+    return (
+      <div className="flex flex-col gap-3">
+        {levels.map((level) => (
+          <div key={level} className="space-y-1">
+            <span className="block text-[10px] text-gray-400">infoLevel: {level}</span>
+            <DepartureItem
+              entries={args.entries}
+              now={now}
+              infoLevel={level}
+              dataLang={['ja']}
+              showRouteTypeIcon
+              agency={args.agency}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  },
+};
+
+/**
+ * Logical kitchen sink — multiple groups built from logical
+ * fixtures. Mirrors the structure of {@link KitchenSink} but uses
+ * place-name-independent data so it tests layout characteristics
+ * rather than specific names.
+ */
+export const LogicalKitchenSink: Story = {
+  args: { entries: [createLogicalShortEntry()] },
+  render: () => {
+    const groups: { entries: ContextualTimetableEntry[]; agency?: Agency }[] = [
+      // Short form — 3 entries
+      {
+        entries: [
+          createLogicalShortEntry({ departureMinutes: 870 }),
+          createLogicalShortEntry({ departureMinutes: 885 }),
+          createLogicalShortEntry({ departureMinutes: 900 }),
+        ],
+        agency,
+      },
+      // Long form — 3 entries (trip + stop headsign)
+      {
+        entries: [
+          createLogicalLongEntry({ departureMinutes: 872 }),
+          createLogicalLongEntry({ departureMinutes: 892 }),
+          createLogicalLongEntry({ departureMinutes: 912 }),
+        ],
+        agency: longAgency,
+      },
+      // Long form — single terminal entry
+      {
+        entries: [createLogicalLongEntry({ departureMinutes: 880, isTerminal: true })],
+        agency: longAgency,
+      },
+      // Long form — drop-off only
+      {
+        entries: [createLogicalLongEntry({ departureMinutes: 884, pickupType: 1 })],
+        agency: longAgency,
+      },
+    ];
+    return (
+      <div className="max-w-sm rounded-lg bg-[#f5f7fa] p-3 dark:bg-gray-800">
+        {groups.map((group, i) => (
+          <DepartureItem
+            key={i}
+            entries={group.entries}
+            now={now}
+            infoLevel="detailed"
+            dataLang={['ja']}
+            showRouteTypeIcon
+            agency={group.agency}
+            onShowTimetable={fn()}
+          />
+        ))}
+      </div>
+    );
+  },
+};
 
 export const KitchenSink: Story = {
   args: { entries: threeEntries },

--- a/src/components/departure-item.stories.tsx
+++ b/src/components/departure-item.stories.tsx
@@ -588,14 +588,16 @@ const kitchenSinkGroups: { entries: ContextualTimetableEntry[]; agency?: Agency 
 export const LogicalLongInfoLevelComparison: Story = {
   args: {
     // Vary per-entry attributes so the inline `TimetableEntryAttributesLabels`
-    // surfaces every supported flag (terminal / origin / pickup× / dropoff×).
-    // Each row exercises exactly one flag so the story doubles as a label
-    // catalog at a glance:
-    //   1st: plain (no labels)
-    //   2nd: terminal             → 終点
-    //   3rd: origin               → 始発
-    //   4th: pickup unavailable   → 乗×
-    //   5th: dropoff unavailable  → 降×
+    // exercises every supported flag (terminal / origin / pickup× / dropoff×)
+    // across the displayed rows:
+    //   1st: plain                      → no labels
+    //   2nd: origin only                → 始発
+    //   3rd: kitchen sink               → 始発 + 終点 + 乗× + 降×
+    //
+    // The 3rd row deliberately combines all four flags to verify they
+    // can coexist visually within a single row without overflowing or
+    // overlapping the time text. Use `Detailed` / `Verbose` for the
+    // single-flag-per-row variant if needed.
     entries: [
       createLogicalLongEntry({
         departureMinutes: 870,

--- a/src/components/departure-item.stories.tsx
+++ b/src/components/departure-item.stories.tsx
@@ -89,22 +89,26 @@ function createEntry(
  */
 function createLogicalLongEntry(
   overrides: Partial<{
+    arrivalMinutes: number;
     departureMinutes: number;
     freq: number;
     totalMinutes: number;
     remainingMinutes: number;
     isTerminal: boolean;
+    isOrigin: boolean;
     pickupType: StopServiceType;
     dropOffType: StopServiceType;
   }> = {},
 ): ContextualTimetableEntry {
   return {
     ...createEntry({
+      arrivalMinutes: overrides.arrivalMinutes,
       departureMinutes: overrides.departureMinutes,
       totalMinutes: overrides.totalMinutes,
       remainingMinutes: overrides.remainingMinutes,
       freq: overrides.freq,
       isTerminal: overrides.isTerminal,
+      isOrigin: overrides.isOrigin,
       pickupType: overrides.pickupType,
       dropOffType: overrides.dropOffType,
     }),
@@ -583,12 +587,43 @@ const kitchenSinkGroups: { entries: ContextualTimetableEntry[]; agency?: Agency 
  */
 export const LogicalLongInfoLevelComparison: Story = {
   args: {
+    // Vary per-entry attributes so the inline `TimetableEntryAttributesLabels`
+    // surfaces every supported flag (terminal / origin / pickup× / dropoff×).
+    // Each row exercises exactly one flag so the story doubles as a label
+    // catalog at a glance:
+    //   1st: plain (no labels)
+    //   2nd: terminal             → 終点
+    //   3rd: origin               → 始発
+    //   4th: pickup unavailable   → 乗×
+    //   5th: dropoff unavailable  → 降×
     entries: [
-      createLogicalLongEntry({ departureMinutes: 870 }),
-      createLogicalLongEntry({ departureMinutes: 885 }),
-      createLogicalLongEntry({ departureMinutes: 900 }),
+      createLogicalLongEntry({
+        departureMinutes: 870,
+        isOrigin: false,
+        isTerminal: false,
+        pickupType: 0,
+        dropOffType: 0,
+      }),
+      createLogicalLongEntry({
+        arrivalMinutes: 855,
+        departureMinutes: 855,
+        isOrigin: true,
+        isTerminal: false,
+        pickupType: 0,
+        dropOffType: 0,
+      }),
+      createLogicalLongEntry({
+        arrivalMinutes: 900,
+        departureMinutes: 900,
+        isOrigin: true,
+        isTerminal: true,
+        pickupType: 1,
+        dropOffType: 1,
+      }),
     ],
+    maxDisplay: 5,
     agency: longAgency,
+    onShowTimetable: fn(),
   },
   render: (args) => {
     const levels = ['simple', 'normal', 'detailed', 'verbose'] as const;
@@ -605,6 +640,7 @@ export const LogicalLongInfoLevelComparison: Story = {
               showRouteTypeIcon
               agency={args.agency}
               showAgency={false}
+              onShowTimetable={args.onShowTimetable}
             />
           </div>
         ))}

--- a/src/components/departure-item.tsx
+++ b/src/components/departure-item.tsx
@@ -24,6 +24,15 @@ interface DepartureItemProps {
   showRouteTypeIcon: boolean;
   /** Agency object for badge display at detailed+ info level. */
   agency?: Agency;
+  /**
+   * Whether to render the agency badge inside `TripInfo`. Forwarded
+   * verbatim. Callers that know the stop's full agency set should
+   * compute this as `agencies.length > 1` so the badge only appears
+   * when it actually disambiguates between multiple operators.
+   *
+   * @default false
+   */
+  showAgency?: boolean;
   /** Maximum number of departures to display. Defaults to 3. */
   maxDisplay?: number;
   onShowTimetable?: (routeId: string, headsign: string) => void;
@@ -36,6 +45,7 @@ export function DepartureItem({
   dataLang,
   showRouteTypeIcon,
   agency,
+  showAgency = false,
   maxDisplay = 3,
   onShowTimetable,
 }: DepartureItemProps) {
@@ -76,6 +86,7 @@ export function DepartureItem({
           dataLang={dataLang}
           showRouteTypeIcon={showRouteTypeIcon}
           agency={agency}
+          showAgency={showAgency}
         />
       </div>
       <div className="flex items-center gap-3 pl-1">
@@ -97,7 +108,7 @@ export function DepartureItem({
         {displayEntries.map((entry, i) => (
           <span
             key={i}
-            className="inline-flex items-baseline gap-0.5 text-sm text-[#757575] dark:text-gray-400"
+            className="inline-flex items-baseline gap-0.5 text-sm font-bold text-[#757575] dark:text-gray-400"
           >
             {formatAbsoluteTime(displayTimes[i])}
             <TimetableEntryAttributesLabels

--- a/src/components/departure-item.tsx
+++ b/src/components/departure-item.tsx
@@ -90,7 +90,9 @@ export function DepartureItem({
         />
       </div>
       <div className="flex items-center gap-3 pl-1">
-        {/* Relative time hint — easy to scan at a glance (e.g. "あと5分") */}
+        {/* Relative time hint — easy to scan at a glance (e.g. "あと5分").
+            Kept as a non-wrapping single unit so the prefix stays glued to
+            the value even on narrow screens. */}
         {first && (
           <RelativeTime
             departureTime={first}
@@ -100,27 +102,35 @@ export function DepartureItem({
             hidePrefix={diffMs > 90 * 60 * 1000}
           />
         )}
-        {/* Absolute times for all entries including the first.
-            The first entry intentionally appears in both relative and absolute
-            because relative alone (e.g. "あと400分") is hard to interpret.
-            Per Issue #47 / Alt F, each time renders its own per-departure
-            attribute labels (TERM/ORIG/noPickup/noDropOff) inline. */}
-        {displayEntries.map((entry, i) => (
-          <span
-            key={i}
-            className="inline-flex items-baseline gap-0.5 text-sm font-bold text-[#757575] dark:text-gray-400"
-          >
-            {formatAbsoluteTime(displayTimes[i])}
-            <TimetableEntryAttributesLabels
-              attributes={getTimetableEntryAttributes(entry)}
-              size="xs"
-              isDisplayTerminal
-              isDisplayOrigin
-              isDisplayPickupUnavailable
-              isDisplayDropOffUnavailable
-            />
-          </span>
-        ))}
+        {/* Absolute times wrapper — own flex-wrap container so the n
+            absolute time entries can fold onto a second row when the
+            container is narrow, while RelativeTime and the timetable
+            button stay on the original row. `min-w-0 flex-1` lets it
+            consume the remaining inline space and shrink to allow
+            wrapping. */}
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-0.5">
+          {/* Absolute times for all entries including the first.
+              The first entry intentionally appears in both relative and absolute
+              because relative alone (e.g. "あと400分") is hard to interpret.
+              Per Issue #47 / Alt F, each time renders its own per-departure
+              attribute labels (TERM/ORIG/noPickup/noDropOff) inline. */}
+          {displayEntries.map((entry, i) => (
+            <span
+              key={i}
+              className="inline-flex items-center gap-0.5 text-sm font-bold whitespace-nowrap text-[#757575] dark:text-gray-400"
+            >
+              {formatAbsoluteTime(displayTimes[i])}
+              <TimetableEntryAttributesLabels
+                attributes={getTimetableEntryAttributes(entry)}
+                size="xs"
+                isDisplayTerminal
+                isDisplayOrigin
+                isDisplayPickupUnavailable
+                isDisplayDropOffUnavailable
+              />
+            </span>
+          ))}
+        </div>
         {onShowTimetable && (
           <button
             type="button"

--- a/src/components/flat-departure-item.stories.tsx
+++ b/src/components/flat-departure-item.stories.tsx
@@ -339,6 +339,54 @@ export const StopOverridesTrip: Story = {
   },
 };
 
+// --- infoLevel comparison ---
+
+/**
+ * Side-by-side comparison of all `infoLevel` values against the
+ * logical long-form fixtures (`routeLong`, `tripHeadsignLong`,
+ * `stopHeadsignLong`). Place-name-independent — exercises the full
+ * info-level rendering range without being tied to specific
+ * real-world data.
+ */
+export const LogicalLongInfoLevelComparison: Story = {
+  args: {
+    agency,
+    entry: {
+      ...createEntry({ departureMinutes: 870 }),
+      routeDirection: {
+        route: routeLong,
+        tripHeadsign: tripHeadsignLong,
+        stopHeadsign: stopHeadsignLong,
+        direction: 0,
+      },
+    },
+    // showRouteTypeIcon: true,
+  },
+  render: (args) => {
+    const levels: InfoLevel[] = ['simple', 'normal', 'detailed', 'verbose'];
+    return (
+      <div className="flex flex-col gap-3">
+        {levels.map((level) => (
+          <div key={level} className="space-y-1">
+            <span className="block text-[10px] text-gray-400">infoLevel: {level}</span>
+            <FlatDepartureItem
+              entry={args.entry}
+              now={args.now}
+              isFirst={args.isFirst}
+              showRouteTypeIcon={level === 'verbose'}
+              infoLevel={level}
+              dataLang={args.dataLang}
+              agency={args.agency}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  },
+};
+
+// --- i18n: lang resolution ---
+
 /**
  * All supported languages stacked so i18n behaviour is easy to verify
  * at a glance. Uses the logical long-form fixtures

--- a/src/components/flat-departure-item.stories.tsx
+++ b/src/components/flat-departure-item.stories.tsx
@@ -377,6 +377,7 @@ export const LogicalLongInfoLevelComparison: Story = {
               infoLevel={level}
               dataLang={args.dataLang}
               agency={args.agency}
+              showAgency={false}
             />
           </div>
         ))}

--- a/src/components/flat-departure-item.stories.tsx
+++ b/src/components/flat-departure-item.stories.tsx
@@ -1,5 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { ContextualTimetableEntry, StopServiceType } from '../types/app/transit-composed';
+import type { InfoLevel } from '../types/app/settings';
+import type {
+  ContextualTimetableEntry,
+  RouteDirection,
+  StopServiceType,
+} from '../types/app/transit-composed';
 import type { Agency, Route } from '../types/app/transit';
 import {
   agencyTobus as agency,
@@ -13,9 +18,17 @@ import {
   headsignShinjuku,
   headsignWaseda,
   noColorRoute,
+  routeDirectionHeadsignBoth,
+  routeDirectionHeadsignBothMatching,
+  routeDirectionHeadsignNeither,
+  routeDirectionHeadsignStopOnly,
+  routeDirectionHeadsignTripOnly,
+  routeLong,
   stopHeadsignDemachiyanagi,
+  stopHeadsignLong,
   stopHeadsignMusashiKoganeiSouth,
   tramRoute,
+  tripHeadsignLong,
 } from '../stories/fixtures';
 import { LANG_COMPARISON_CASES } from '../stories/lang-comparison';
 import { FlatDepartureItem } from './flat-departure-item';
@@ -35,9 +48,16 @@ function createEntry(
     stopIndex: number;
     totalStops: number;
     direction: 0 | 1;
+    remainingMinutes: number;
+    totalMinutes: number;
+    freq: number;
   }> = {},
 ): ContextualTimetableEntry {
   const depMin = overrides.departureMinutes ?? 870; // 14:30
+  const totalMinutes = overrides.totalMinutes ?? 45;
+  // Default remaining mirrors the default stopIndex (3) against
+  // totalStops (15): roughly 80% of the trip still left to ride.
+  const remainingMinutes = overrides.remainingMinutes ?? Math.round(totalMinutes * 0.8);
   return {
     schedule: {
       departureMinutes: depMin,
@@ -45,7 +65,13 @@ function createEntry(
     },
     routeDirection: {
       route: overrides.route ?? baseRoute,
-      tripHeadsign: { name: overrides.headsign ?? '中野駅', names: {} },
+      // Default to the logical `tripHeadsignLong` fixture so detailed /
+      // verbose info levels see full i18n data without pinning the
+      // story to any specific real-world place. A string override
+      // still works for quick variants (produces an empty `names`
+      // map, single-language only).
+      tripHeadsign:
+        overrides.headsign != null ? { name: overrides.headsign, names: {} } : tripHeadsignLong,
       ...(overrides.stopHeadsign != null
         ? { stopHeadsign: { name: overrides.stopHeadsign, names: {} } }
         : {}),
@@ -60,6 +86,11 @@ function createEntry(
       totalStops: overrides.totalStops ?? 15,
       isTerminal: overrides.isTerminal ?? false,
       isOrigin: overrides.isOrigin ?? false,
+    },
+    insights: {
+      remainingMinutes,
+      totalMinutes,
+      freq: overrides.freq ?? 30,
     },
     serviceDate: new Date('2026-03-30T00:00:00'),
   };
@@ -145,17 +176,94 @@ export const EmptyHeadsign: Story = {
   args: { entry: createEntry({ headsign: '' }) },
 };
 
-// --- Info levels ---
+// --- Headsign state axis ---
 
-export const Detailed: Story = {
-  args: { infoLevel: 'detailed', agency },
+/**
+ * All five logical headsign states stacked, each rendered with the
+ * same base entry. Uses the place-name-independent logical fixtures
+ * (`routeDirectionHeadsignTripOnly` etc.) so each row reads as a
+ * structural test case, not a specific trip.
+ */
+export const HeadsignPatterns: Story = {
+  args: {
+    agency,
+    entry: createEntry(),
+    infoLevel: 'detailed',
+  },
+  render: (args) => {
+    const patterns: { label: string; routeDirection: RouteDirection }[] = [
+      { label: 'trip only (classic)', routeDirection: routeDirectionHeadsignTripOnly },
+      { label: 'stop only (keio-bus pattern)', routeDirection: routeDirectionHeadsignStopOnly },
+      { label: 'both (different)', routeDirection: routeDirectionHeadsignBoth },
+      { label: 'both (matching, redundant)', routeDirection: routeDirectionHeadsignBothMatching },
+      { label: 'neither (fallback to route name)', routeDirection: routeDirectionHeadsignNeither },
+    ];
+    return (
+      <div className="flex max-w-sm flex-col gap-4">
+        {patterns.map((p) => (
+          <div key={p.label}>
+            <div className="mb-1 text-xs font-semibold text-gray-500">{p.label}</div>
+            <div className="rounded-lg bg-[#f5f7fa] p-3 dark:bg-gray-800">
+              <FlatDepartureItem
+                entry={{ ...args.entry, routeDirection: p.routeDirection }}
+                now={args.now}
+                isFirst={args.isFirst}
+                showRouteTypeIcon={args.showRouteTypeIcon}
+                infoLevel={args.infoLevel}
+                dataLang={args.dataLang}
+                agency={args.agency}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  },
 };
 
-export const Verbose: Story = {
+// --- Info levels ---
+
+/**
+ * All four info levels stacked so the progressive disclosure is
+ * easy to compare at a glance. Each level renders the same entry —
+ * only `infoLevel` differs — so the additive features (trip position
+ * indicator, journey time bar, verbose dump, etc.) become visible
+ * row by row.
+ *
+ * Uses the `routeDirectionHeadsignBoth` logical fixture so both the
+ * trip headsign and stop headsign are populated, exercising the
+ * full headsign-rendering path at every info level.
+ */
+export const InfoLevelComparison: Story = {
   args: {
-    infoLevel: 'verbose',
     agency,
-    entry: createEntry({ direction: 0 }),
+    entry: {
+      ...createEntry({ direction: 0 }),
+      routeDirection: routeDirectionHeadsignBoth,
+    },
+  },
+  render: (args) => {
+    const levels: InfoLevel[] = ['simple', 'normal', 'detailed', 'verbose'];
+    return (
+      <div className="flex max-w-sm flex-col gap-4">
+        {levels.map((level) => (
+          <div key={level}>
+            <div className="mb-1 text-xs font-semibold text-gray-500">infoLevel={level}</div>
+            <div className="rounded-lg bg-[#f5f7fa] p-3 dark:bg-gray-800">
+              <FlatDepartureItem
+                entry={args.entry}
+                now={args.now}
+                isFirst={args.isFirst}
+                showRouteTypeIcon={args.showRouteTypeIcon}
+                infoLevel={level}
+                dataLang={args.dataLang}
+                agency={args.agency}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
   },
 };
 
@@ -164,7 +272,7 @@ export const Verbose: Story = {
 /** Multiple flat items as they appear in the stop view. */
 export const MultipleItems: Story = {
   args: { entry: createEntry() },
-  render: () => {
+  render: (args) => {
     const entries = [
       createEntry({ departureMinutes: 870, headsign: '中野駅' }),
       createEntry({ departureMinutes: 885, route: greenRoute, headsign: '新橋駅' }),
@@ -178,11 +286,11 @@ export const MultipleItems: Story = {
           <FlatDepartureItem
             key={i}
             entry={entry}
-            now={now}
-            isFirst={i === 0}
-            showRouteTypeIcon
-            infoLevel="normal"
-            dataLang={['ja']}
+            now={args.now}
+            isFirst={args.isFirst && i === 0}
+            showRouteTypeIcon={args.showRouteTypeIcon}
+            infoLevel={args.infoLevel}
+            dataLang={args.dataLang}
           />
         ))}
       </div>
@@ -231,15 +339,24 @@ export const StopOverridesTrip: Story = {
   },
 };
 
+/**
+ * All supported languages stacked so i18n behaviour is easy to verify
+ * at a glance. Uses the logical long-form fixtures
+ * (`tripHeadsignLong`, `stopHeadsignLong`, `routeLong`) so every
+ * language row gets a populated translation and the stop/trip
+ * headsign overflow paths are exercised per language.
+ */
 export const LangComparison: Story = {
   args: {
     agency,
     entry: {
-      ...createEntry({ route: greenRoute, departureMinutes: 870 }),
-      routeDirection: createRouteDirection({
-        route: greenRoute,
-        tripHeadsign: headsignShimbashiEkimae,
-      }),
+      ...createEntry({ departureMinutes: 870 }),
+      routeDirection: {
+        route: routeLong,
+        tripHeadsign: tripHeadsignLong,
+        stopHeadsign: stopHeadsignLong,
+        direction: 0,
+      },
     },
     infoLevel: 'normal',
   },
@@ -377,18 +494,18 @@ const kitchenSinkItems: {
 ];
 
 export const KitchenSink: Story = {
-  args: { entry: createEntry() },
-  render: () => (
+  args: { entry: createEntry(), infoLevel: 'normal' },
+  render: (args) => (
     <div className="max-w-sm rounded-lg bg-[#f5f7fa] p-3 dark:bg-gray-800">
       {kitchenSinkItems.map(({ entry, agency: a, icon }, i) => (
         <FlatDepartureItem
           key={i}
           entry={entry}
-          now={now}
-          isFirst={i === 0}
-          showRouteTypeIcon={icon ?? false}
-          infoLevel="detailed"
-          dataLang={['ja']}
+          now={args.now}
+          isFirst={args.isFirst && i === 0}
+          showRouteTypeIcon={args.showRouteTypeIcon || (icon ?? false)}
+          infoLevel={args.infoLevel}
+          dataLang={args.dataLang}
           agency={a}
         />
       ))}

--- a/src/components/flat-departure-item.tsx
+++ b/src/components/flat-departure-item.tsx
@@ -10,6 +10,7 @@ import { TripInfo } from './trip-info';
 import { VerboseContextualTimetableEntry } from './verbose/verbose-contextual-timetable-entry';
 import { BaseLabel } from './label/base-label';
 import { TripPositionIndicator } from './label/trip-position-indicator';
+import { JourneyTimeBar } from './journey-time-bar';
 import { useInfoLevel } from '@/hooks/use-info-level';
 
 interface FlatDepartureItemProps {
@@ -66,13 +67,6 @@ export function FlatDepartureItem({
             <>
               <div className="mb-0.5 flex justify-end gap-0.5 whitespace-nowrap">
                 <BaseLabel
-                  size={'sm'}
-                  value={`${entry.patternPosition.stopIndex + 1} / ${entry.patternPosition.totalStops} stops`}
-                  className="bg-gray-500 whitespace-nowrap text-white"
-                />
-              </div>
-              <div className="mb-0.5 flex justify-end gap-0.5 whitespace-nowrap">
-                <BaseLabel
                   size={'xs'}
                   value={at}
                   className="bg-gray-500 whitespace-nowrap text-white"
@@ -104,41 +98,58 @@ export function FlatDepartureItem({
           </div>
         </div>
 
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          {/* Trip Position Indicator */}
-          <TripPositionIndicator
-            stopIndex={entry.patternPosition.stopIndex}
-            totalStops={entry.patternPosition.totalStops}
-            // size="md"
-            size={info.isDetailedEnabled ? 'md' : info.isNormalEnabled ? 'xs' : 'xs'}
-            // size="xs"
-            showTrack={info.isNormalEnabled}
-            infoLevel={infoLevel}
-            // route_color may be empty (e.g. mir/mykbus/sbbus). Pass undefined
-            // in that case so TripPositionIndicator falls back to its default
-            // Tailwind colors instead of producing invalid CSS like "#20".
-            trackColor={bgColor ? `${bgColor}20` : undefined}
-            dotColor={bgColor ? `${bgColor}50` : undefined}
-            currentColor={bgColor}
-          />
+        <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5">
+          {/* Trip Hint */}
+          <div className="mb-0.5 flex items-center justify-end gap-1 whitespace-nowrap">
+            <TripPositionIndicator
+              stopIndex={entry.patternPosition.stopIndex}
+              totalStops={entry.patternPosition.totalStops}
+              // size="md"
+              size={info.isDetailedEnabled ? 'md' : info.isNormalEnabled ? 'xs' : 'xs'}
+              // size="xs"
+              showTrack={info.isNormalEnabled}
+              infoLevel={infoLevel}
+              // route_color may be empty (e.g. mir/mykbus/sbbus). Pass undefined
+              // in that case so TripPositionIndicator falls back to its default
+              // Tailwind colors instead of producing invalid CSS like "#20".
+              trackColor={bgColor ? `${bgColor}20` : undefined}
+              dotColor={bgColor ? `${bgColor}50` : undefined}
+              currentColor={bgColor}
+            />
+            {info.isVerboseEnabled && (
+              <BaseLabel
+                size={'xs'}
+                value={`${entry.patternPosition.stopIndex + 1} / ${entry.patternPosition.totalStops}`}
+                className="bg-gray-500 whitespace-nowrap text-white"
+              />
+            )}
+          </div>
 
-          {showVerbose && (
-            <>
-              <div className="text-[10px] text-gray-500">
-                {entry.insights?.remainingMinutes ?? '-'} / {entry.insights?.totalMinutes ?? '-'}
-              </div>
-              {/* <div className="text-[10px] text-gray-500">{entry.insights?.freq} trips</div> */}
-            </>
+          {info.isDetailedEnabled && (
+            <JourneyTimeBar
+              remainingMinutes={entry.insights?.remainingMinutes}
+              totalMinutes={entry.insights?.totalMinutes}
+              size={info.isDetailedEnabled ? 'md' : 'sm'}
+              color={bgColor}
+              showRMins={info.isVerboseEnabled}
+              showTMins={info.isVerboseEnabled}
+              minsPosition="right"
+              fillDirection="rtl"
+              // fillDirection="ltr"
+            />
           )}
+
           {/* Trip Info */}
-          <TripInfo
-            routeDirection={entry.routeDirection}
-            infoLevel={infoLevel}
-            dataLang={dataLang}
-            showRouteTypeIcon={showRouteTypeIcon}
-            agency={agency}
-            attributes={attributes}
-          />
+          <div className="min-w-0">
+            <TripInfo
+              routeDirection={entry.routeDirection}
+              infoLevel={infoLevel}
+              dataLang={dataLang}
+              showRouteTypeIcon={showRouteTypeIcon}
+              agency={agency}
+              attributes={attributes}
+            />
+          </div>
         </div>
       </div>
       {/* Verbose data */}

--- a/src/components/flat-departure-item.tsx
+++ b/src/components/flat-departure-item.tsx
@@ -28,6 +28,15 @@ interface FlatDepartureItemProps {
   dataLang: readonly string[];
   /** Agency object for badge display at detailed+ info level. */
   agency?: Agency;
+  /**
+   * Whether to render the agency badge inside `TripInfo`. Forwarded
+   * verbatim. Callers that know the stop's full agency set should
+   * compute this as `agencies.length > 1` so the badge only appears
+   * when it actually disambiguates between multiple operators.
+   *
+   * @default false
+   */
+  showAgency?: boolean;
 }
 
 /**
@@ -45,6 +54,7 @@ export function FlatDepartureItem({
   infoLevel,
   dataLang,
   agency,
+  showAgency = false,
 }: FlatDepartureItemProps) {
   const info = useInfoLevel(infoLevel);
   const showVerbose = info.isVerboseEnabled;
@@ -90,7 +100,7 @@ export function FlatDepartureItem({
           )}
           {/* Absolute time — always shown alongside relative for precise reference */}
           <div
-            className="text-base text-[#333] dark:text-gray-100"
+            className="text-base font-bold text-[#333] dark:text-gray-100"
             style={bgColor ? { color: bgColor } : undefined}
           >
             {formatAbsoluteTime(departureTime)}
@@ -136,6 +146,7 @@ export function FlatDepartureItem({
               minsPosition="right"
               fillDirection="rtl"
               // fillDirection="ltr"
+              showEmoji={info.isVerboseEnabled}
             />
           )}
 
@@ -147,6 +158,7 @@ export function FlatDepartureItem({
               dataLang={dataLang}
               showRouteTypeIcon={showRouteTypeIcon}
               agency={agency}
+              showAgency={showAgency}
               attributes={attributes}
             />
           </div>

--- a/src/components/flat-departure-item.tsx
+++ b/src/components/flat-departure-item.tsx
@@ -110,27 +110,29 @@ export function FlatDepartureItem({
 
         <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5">
           {/* Trip Hint */}
-          <div className="mb-0.5 flex items-center justify-end gap-1 whitespace-nowrap">
-            <TripPositionIndicator
-              stopIndex={entry.patternPosition.stopIndex}
-              totalStops={entry.patternPosition.totalStops}
-              // size="md"
-              size={info.isDetailedEnabled ? 'md' : info.isNormalEnabled ? 'xs' : 'xs'}
-              // size="xs"
-              showTrack={info.isNormalEnabled}
-              infoLevel={infoLevel}
-              // route_color may be empty (e.g. mir/mykbus/sbbus). Pass undefined
-              // in that case so TripPositionIndicator falls back to its default
-              // Tailwind colors instead of producing invalid CSS like "#20".
-              trackColor={bgColor ? `${bgColor}20` : undefined}
-              dotColor={bgColor ? `${bgColor}50` : undefined}
-              currentColor={bgColor}
-            />
+          <div className="mb-0.5 flex min-w-0 items-center gap-1">
+            <div className="min-w-0 flex-1">
+              <TripPositionIndicator
+                stopIndex={entry.patternPosition.stopIndex}
+                totalStops={entry.patternPosition.totalStops}
+                // size="md"
+                size={info.isDetailedEnabled ? 'md' : info.isNormalEnabled ? 'xs' : 'xs'}
+                // size="xs"
+                showTrack={info.isNormalEnabled}
+                infoLevel={infoLevel}
+                // route_color may be empty (e.g. mir/mykbus/sbbus). Pass undefined
+                // in that case so TripPositionIndicator falls back to its default
+                // Tailwind colors instead of producing invalid CSS like "#20".
+                trackColor={bgColor ? `${bgColor}20` : undefined}
+                dotColor={bgColor ? `${bgColor}50` : undefined}
+                currentColor={bgColor}
+              />
+            </div>
             {info.isVerboseEnabled && (
               <BaseLabel
                 size={'xs'}
                 value={`${entry.patternPosition.stopIndex + 1} / ${entry.patternPosition.totalStops}`}
-                className="bg-gray-500 whitespace-nowrap text-white"
+                className="shrink-0 bg-gray-500 whitespace-nowrap text-white"
               />
             )}
           </div>

--- a/src/components/journey-time-bar.stories.tsx
+++ b/src/components/journey-time-bar.stories.tsx
@@ -1,0 +1,395 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  JourneyTimeBar,
+  type JourneyTimeBarBorder,
+  type JourneyTimeBarFillDirection,
+  type JourneyTimeBarMinutesPosition,
+  type JourneyTimeBarSize,
+} from './journey-time-bar';
+
+const meta = {
+  title: 'Departure/JourneyTimeBar',
+  component: JourneyTimeBar,
+  argTypes: {
+    remainingMinutes: { control: { type: 'number' } },
+    totalMinutes: { control: { type: 'number' } },
+    size: { control: 'select', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
+    color: { control: 'color' },
+    showRMins: { control: 'boolean' },
+    showTMins: { control: 'boolean' },
+    rTimeLabel: { control: 'text' },
+    tMinsLabel: { control: 'text' },
+    minsPosition: {
+      control: 'inline-radio',
+      options: ['top', 'bottom', 'left', 'right'],
+    },
+    fillDirection: {
+      control: 'inline-radio',
+      options: ['ltr', 'rtl'],
+    },
+    border: { control: 'object' },
+    maxMinutes: { control: { type: 'number', min: 1 } },
+  },
+  args: {
+    remainingMinutes: 20,
+    totalMinutes: 30,
+    size: 'sm',
+    showRMins: false,
+    showTMins: false,
+    minsPosition: 'bottom',
+    fillDirection: 'ltr',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320 }} className="rounded bg-[#f5f7fa] p-3 dark:bg-gray-800">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof JourneyTimeBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Small helper to label each row in a grouped story. */
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="mb-1 text-xs font-semibold text-gray-500">{label}</div>
+      {children}
+    </div>
+  );
+}
+
+/** Default: mid-trip with no labels. Use Controls to tweak any prop. */
+export const Default: Story = {};
+
+/**
+ * Progress variants — different `remainingMinutes` values against the
+ * same 30-min trip, covering origin / mid / near-terminal / terminal.
+ */
+export const ProgressValues: Story = {
+  args: { totalMinutes: 30 },
+  render: ({ ...rest }) => {
+    const samples: { label: string; remaining: number }[] = [
+      { label: 'origin (29/30)', remaining: 29 },
+      { label: 'middle (15/30)', remaining: 15 },
+      { label: 'near terminal (2/30)', remaining: 2 },
+      { label: 'terminal (0/30)', remaining: 0 },
+    ];
+    return (
+      <div className="flex flex-col gap-4">
+        {samples.map((s) => (
+          <Row key={s.label} label={s.label}>
+            <JourneyTimeBar {...rest} remainingMinutes={s.remaining} />
+          </Row>
+        ))}
+      </div>
+    );
+  },
+};
+
+/**
+ * Duration variants — different `totalMinutes` values to show how the
+ * bar width scales against `MAX_BAR_MINUTES` (120) and clamps beyond.
+ */
+export const Durations: Story = {
+  args: {},
+  render: ({ ...rest }) => {
+    const samples: { label: string; remaining: number; total: number }[] = [
+      { label: 'short 10min', remaining: 5, total: 10 },
+      { label: 'median 29min', remaining: 14, total: 29 },
+      { label: 'p90 60min', remaining: 30, total: 60 },
+      { label: 'boundary 120min', remaining: 60, total: 120 },
+      { label: 'kcbus 140min (clamped)', remaining: 70, total: 140 },
+      { label: 'iyt2 730min (clamped)', remaining: 365, total: 730 },
+    ];
+    return (
+      <div className="flex flex-col gap-4">
+        {samples.map((s) => (
+          <Row key={s.label} label={s.label}>
+            <JourneyTimeBar {...rest} remainingMinutes={s.remaining} totalMinutes={s.total} />
+          </Row>
+        ))}
+      </div>
+    );
+  },
+};
+
+/**
+ * All `size` variants stacked with both minute labels on so the
+ * per-size BaseLabel sizing (internal `LABEL_SIZE_FOR_BAR` mapping) is
+ * visible at a glance.
+ */
+export const Sizes: Story = {
+  args: {
+    remainingMinutes: 15,
+    totalMinutes: 30,
+    showRMins: true,
+    showTMins: true,
+    minsPosition: 'left',
+  },
+  render: ({ ...rest }) => {
+    const sizes: JourneyTimeBarSize[] = ['xs', 'sm', 'md', 'lg', 'xl'];
+    return (
+      <div className="flex flex-col gap-4">
+        {sizes.map((s) => (
+          <Row key={s} label={`size=${s}`}>
+            <JourneyTimeBar {...rest} size={s} />
+          </Row>
+        ))}
+      </div>
+    );
+  },
+};
+
+/** Default + route color samples for the `color` prop. */
+export const Colors: Story = {
+  args: { remainingMinutes: 15, totalMinutes: 30 },
+  render: ({ ...rest }) => {
+    const samples: { label: string; color?: string }[] = [
+      { label: 'default (primary)' },
+      { label: 'Oedo #cf3366', color: '#cf3366' },
+      { label: 'Mita #0067b0', color: '#0067b0' },
+      { label: 'Asakusa #ff535f', color: '#ff535f' },
+    ];
+    return (
+      <div className="flex flex-col gap-4">
+        {samples.map((s) => (
+          <Row key={s.label} label={s.label}>
+            <JourneyTimeBar {...rest} color={s.color} />
+          </Row>
+        ))}
+      </div>
+    );
+  },
+};
+
+/** `border` variants — off / default / custom width / dashed / colored. */
+export const Borders: Story = {
+  args: { remainingMinutes: 15, totalMinutes: 30, color: '#cf3366' },
+  render: ({ ...rest }) => {
+    const samples: { label: string; border?: JourneyTimeBarBorder }[] = [
+      { label: 'none (default)' },
+      { label: 'default {}', border: {} },
+      { label: 'width=2', border: { width: 2 } },
+      { label: 'dashed', border: { style: 'dashed' } },
+      { label: 'dotted', border: { style: 'dotted' } },
+      { label: 'custom color', border: { color: '#cf3366' } },
+    ];
+    return (
+      <div className="flex flex-col gap-4">
+        {samples.map((s) => (
+          <Row key={s.label} label={s.label}>
+            <JourneyTimeBar {...rest} border={s.border} />
+          </Row>
+        ))}
+      </div>
+    );
+  },
+};
+
+/** `fillDirection` variants — ltr (default) vs rtl. */
+export const FillDirections: Story = {
+  args: { remainingMinutes: 15, totalMinutes: 30, color: '#cf3366' },
+  render: ({ ...rest }) => {
+    const dirs: JourneyTimeBarFillDirection[] = ['ltr', 'rtl'];
+    return (
+      <div className="flex flex-col gap-4">
+        {dirs.map((d) => (
+          <Row key={d} label={`fillDirection=${d}`}>
+            <JourneyTimeBar {...rest} fillDirection={d} />
+          </Row>
+        ))}
+      </div>
+    );
+  },
+};
+
+/**
+ * `showRMins` × `showTMins` combinations across all four `minsPosition`
+ * values. The 4 positions (top / bottom / left / right) are grouped as
+ * outer sections, and each section lists the 4 show-flag combinations
+ * (none / remaining only / total only / both) so each combo can be
+ * compared in every placement at a glance.
+ */
+export const LabelCombinations: Story = {
+  args: { remainingMinutes: 15, totalMinutes: 30 },
+  render: ({ ...rest }) => {
+    const combos: { label: string; r: boolean; t: boolean }[] = [
+      { label: 'none', r: false, t: false },
+      { label: 'showRMins', r: true, t: false },
+      { label: 'showTMins', r: false, t: true },
+      { label: 'both', r: true, t: true },
+    ];
+    const positions: JourneyTimeBarMinutesPosition[] = [
+      'right',
+      'left',
+      //
+      'top',
+      'bottom',
+    ];
+    return (
+      <div className="flex flex-col gap-6">
+        {positions.map((p) => (
+          <div key={p}>
+            <div className="mb-2 text-sm font-bold text-gray-700 dark:text-gray-300">
+              minsPosition={p}
+            </div>
+            <div className="flex flex-col gap-3">
+              {combos.map((c) => (
+                <Row key={c.label} label={c.label}>
+                  <JourneyTimeBar {...rest} minsPosition={p} showRMins={c.r} showTMins={c.t} />
+                </Row>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  },
+};
+
+/** `rTimeLabel` / `tMinsLabel` prefix variants. */
+export const LabelPrefixes: Story = {
+  args: { remainingMinutes: 15, totalMinutes: 30, showRMins: true, showTMins: true },
+  render: ({ ...rest }) => {
+    const samples: { label: string; r?: string; t?: string }[] = [
+      { label: 'no prefix' },
+      { label: 'Japanese 残り / 全体', r: '残り', t: '全体' },
+      { label: 'remaining only (残り)', r: '残り' },
+      { label: 'total only (全体)', t: '全体' },
+    ];
+    return (
+      <div className="flex flex-col gap-4">
+        {samples.map((s) => (
+          <Row key={s.label} label={s.label}>
+            <JourneyTimeBar {...rest} rTimeLabel={s.r} tMinsLabel={s.t} />
+          </Row>
+        ))}
+      </div>
+    );
+  },
+};
+
+/** All four `minsPosition` values. */
+export const MinutesPositions: Story = {
+  args: {
+    remainingMinutes: 15,
+    totalMinutes: 30,
+    showRMins: true,
+    showTMins: true,
+  },
+  render: ({ ...rest }) => {
+    const positions: JourneyTimeBarMinutesPosition[] = ['top', 'bottom', 'left', 'right'];
+    return (
+      <div className="flex flex-col gap-4">
+        {positions.map((p) => (
+          <Row key={p} label={`minsPosition=${p}`}>
+            <JourneyTimeBar {...rest} minsPosition={p} />
+          </Row>
+        ))}
+      </div>
+    );
+  },
+};
+
+/** Edge cases — missing / zero values. */
+export const MissingData: Story = {
+  args: { showRMins: true, showTMins: true },
+  render: ({ ...rest }) => {
+    const samples: {
+      label: string;
+      remaining: number | undefined;
+      total: number | undefined;
+    }[] = [
+      { label: 'missing total', remaining: 10, total: undefined },
+      { label: 'missing remaining', remaining: undefined, total: 30 },
+      { label: 'both missing', remaining: undefined, total: undefined },
+      { label: 'zero total', remaining: 0, total: 0 },
+    ];
+    return (
+      <div className="flex flex-col gap-4">
+        {samples.map((s) => (
+          <Row key={s.label} label={s.label}>
+            <JourneyTimeBar {...rest} remainingMinutes={s.remaining} totalMinutes={s.total} />
+          </Row>
+        ))}
+      </div>
+    );
+  },
+};
+
+interface DurationSample {
+  label: string;
+  remaining: number;
+  total: number;
+}
+
+interface ColorSample {
+  label: string;
+  color?: string;
+}
+
+const durationSamples: DurationSample[] = [
+  { label: 'origin, 30min trip', remaining: 29, total: 30 },
+  { label: 'mid, 30min trip', remaining: 15, total: 30 },
+  { label: 'near terminal, 30min trip', remaining: 2, total: 30 },
+  { label: 'short 10min', remaining: 5, total: 10 },
+  { label: 'median 29min', remaining: 14, total: 29 },
+  { label: 'p90 60min', remaining: 30, total: 60 },
+  { label: 'p99 116min', remaining: 58, total: 116 },
+  { label: 'kcbus 140min (clamped)', remaining: 70, total: 140 },
+  { label: 'iyt2 730min (clamped)', remaining: 365, total: 730 },
+];
+
+const colorSamples: ColorSample[] = [
+  { label: 'default (primary)' },
+  { label: 'Oedo #cf3366', color: '#cf3366' },
+  { label: 'Mita #0067b0', color: '#0067b0' },
+  { label: 'Asakusa #ff535f', color: '#ff535f' },
+];
+
+/**
+ * Duration × color grid for the active `size` (driven by Controls).
+ * Lets the reader eyeball width scaling, clamp behavior, and color
+ * overrides at a glance. Switch size via the Controls panel.
+ */
+export const KitchenSink: Story = {
+  args: {
+    remainingMinutes: 15,
+    totalMinutes: 30,
+    showRMins: true,
+    showTMins: true,
+    minsPosition: 'right',
+  },
+  render: ({ size, fillDirection, minsPosition, border, showRMins, showTMins }) => (
+    <div className="flex flex-col gap-3">
+      {colorSamples.map((c) => (
+        <div key={c.label}>
+          <div className="text-[10px] text-gray-400">{c.label}</div>
+          <div className="flex flex-col gap-1">
+            {durationSamples.map((d) => (
+              <div key={d.label} className="flex items-center gap-2">
+                <span className="w-48 text-[10px] text-gray-500">{d.label}</span>
+                <div style={{ width: 240 }}>
+                  <JourneyTimeBar
+                    size={size}
+                    color={c.color}
+                    remainingMinutes={d.remaining}
+                    totalMinutes={d.total}
+                    showRMins={showRMins}
+                    showTMins={showTMins}
+                    minsPosition={minsPosition}
+                    fillDirection={fillDirection}
+                    border={border}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/src/components/journey-time-bar.tsx
+++ b/src/components/journey-time-bar.tsx
@@ -53,14 +53,12 @@ interface JourneyTimeBarProps {
   showTMins?: boolean;
   /**
    * Optional prefix rendered before the remaining-minutes value
-   * (e.g., `'残り'` → `'残り5'`). Ignored when `showRemainingMinutes`
-   * is `false`.
+   * (e.g., `'残り'` → `'残り5'`). Ignored when `showRMins` is `false`.
    */
   rTimeLabel?: string;
   /**
    * Optional prefix rendered before the total-minutes value
-   * (e.g., `'全体'` → `'全体25'`). Ignored when `showTotalMinutes`
-   * is `false`.
+   * (e.g., `'全体'` → `'全体25'`). Ignored when `showTMins` is `false`.
    */
   tMinsLabel?: string;
   /**
@@ -99,15 +97,27 @@ type JourneyTimeBarStyle = CSSProperties & {
 /**
  * A progress bar visualizing journey time.
  *
- * The bar's width scales with `totalMinutes` (capped at `MAX_BAR_MINUTES`),
- * so longer trips get visually longer bars. The filled portion represents
- * the remaining ratio (`remaining / total`), so the bar empties as the
- * trip progresses.
+ * The bar's width scales with `totalMinutes` (capped at
+ * `DEFAULT_MAX_BAR_MINUTES`, overridable via the `maxMinutes` prop),
+ * so longer trips get visually longer bars. The filled portion
+ * represents the remaining ratio (`remaining / total`), so the bar
+ * empties as the trip progresses.
  *
- * The caller decides which numeric labels to show via
- * `showRemainingMinutes` / `showTotalMinutes` and where to place them via
- * `minutesPosition`. When both flags are on, the combined form `"r / t"`
- * is rendered.
+ * The caller decides which numeric labels to show via `showRMins` /
+ * `showTMins` and where to place them via `minsPosition`. When both
+ * flags are on, the combined form `"r / t"` is rendered.
+ *
+ * ## `color` prop format requirement
+ *
+ * When `color` is provided, the indicator uses it verbatim and the
+ * track is derived as `${color}33` — i.e. the same color with a
+ * `33` (≈ 20%) alpha hex suffix. **`color` therefore must be a
+ * 6-digit hex string starting with `#` (`#RRGGBB`)** so the
+ * concatenation produces a valid 8-hex CSS color (`#RRGGBBAA`).
+ * Production callers (`FlatDepartureItem`) always pass
+ * `#${route.route_color}`, which is guaranteed by the GTFS
+ * `routes.txt` spec to be 6 hex chars. Named CSS colors, `rgb(...)`,
+ * and `hsl(...)` strings are NOT supported.
  */
 export function JourneyTimeBar({
   remainingMinutes,

--- a/src/components/journey-time-bar.tsx
+++ b/src/components/journey-time-bar.tsx
@@ -76,6 +76,8 @@ interface JourneyTimeBarProps {
    * the terminal end of the bar ("remaining until arrival").
    */
   fillDirection?: JourneyTimeBarFillDirection;
+
+  showEmoji?: boolean;
 }
 
 /** Total minutes that map to a full-width bar; longer trips are clamped. */
@@ -120,6 +122,7 @@ export function JourneyTimeBar({
   tMinsLabel,
   minsPosition: minutesPosition = 'bottom',
   fillDirection = 'ltr',
+  showEmoji = false,
 }: JourneyTimeBarProps) {
   // Delegate all time math (sanitize, clamp, progress ratio, label
   // rounding) to the domain layer. The Result type lets us bail out
@@ -216,40 +219,16 @@ export function JourneyTimeBar({
     />
   );
 
-  // Horizontal layout (label and bar inline on the same row).
-  //
-  // - `flex w-full`        : occupy the parent's full width so the bar's
-  //                          percentage width resolves correctly
-  // - `items-center`       : center-align the label pill to the bar
-  // - `gap-1`              : comfortable inline spacing (4px)
-  if (minutesPosition === 'left' || minutesPosition === 'right') {
-    const labelFirst = minutesPosition === 'left';
-    return (
-      <div className="flex w-full items-center gap-1">
-        {labelFirst && label}
-        {bar}
-        {!labelFirst && label}
-      </div>
-    );
-  }
+  const isHorizontal = minutesPosition === 'left' || minutesPosition === 'right';
+  const labelFirst = minutesPosition === 'left' || minutesPosition === 'top';
+  const wrapperClassName = isHorizontal
+    ? 'flex w-full items-center gap-1'
+    : 'flex w-full flex-col items-start gap-0.5';
 
-  // Vertical layout (label stacked above/below the bar).
-  //
-  // - `flex w-full flex-col` : stack children, keep the container at
-  //                            parent width so the bar percentage
-  //                            resolves against the full width
-  // - `items-start`          : stop BaseLabel from stretching to the
-  //                            full container width (default
-  //                            `items-stretch` would otherwise turn
-  //                            the small pill into a wide block)
-  // - `gap-0.5`              : tight 2px breathing room between the
-  //                            label pill and the bar (the bar itself
-  //                            is only 2–12px tall so a large gap
-  //                            would dwarf it)
-  const labelFirst = minutesPosition === 'top';
   return (
-    <div className="flex w-full flex-col items-start gap-0.5">
+    <div className={wrapperClassName}>
       {labelFirst && label}
+      {showEmoji && '⏳'}
       {bar}
       {!labelFirst && label}
     </div>

--- a/src/components/journey-time-bar.tsx
+++ b/src/components/journey-time-bar.tsx
@@ -1,0 +1,257 @@
+import type { CSSProperties } from 'react';
+import { computeJourneyTime } from '../domain/transit/journey-time';
+import { BaseLabel, type BaseLabelSize } from './label/base-label';
+import { Progress } from './ui/progress';
+
+export type JourneyTimeBarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type JourneyTimeBarMinutesPosition = 'top' | 'bottom' | 'left' | 'right';
+export type JourneyTimeBarFillDirection = 'ltr' | 'rtl';
+export type JourneyTimeBarBorderStyle = 'solid' | 'dashed' | 'dotted';
+
+export interface JourneyTimeBarBorder {
+  /** Border width in pixels. Default `1`. */
+  width?: number;
+  /** Border color as a CSS color string. Default subtle gray. */
+  color?: string;
+  /** Border line style. Default `'solid'`. */
+  style?: JourneyTimeBarBorderStyle;
+}
+
+const DEFAULT_BORDER_WIDTH = 1;
+const DEFAULT_BORDER_COLOR = 'rgba(156, 163, 175, 0.5)';
+const DEFAULT_BORDER_STYLE: JourneyTimeBarBorderStyle = 'solid';
+
+interface JourneyTimeBarProps {
+  /** Remaining minutes from the current stop to the terminal. */
+  remainingMinutes: number | undefined;
+  /** Total minutes of the full trip pattern. */
+  totalMinutes: number | undefined;
+  /**
+   * Total minutes that map to a full-width bar. Trips longer than this
+   * are clamped (bar stays at 100% width). Defaults to
+   * {@link DEFAULT_MAX_BAR_MINUTES} (`120`). Non-positive / non-finite
+   * values fall back to the default.
+   */
+  maxMinutes?: number;
+  /** Size variant. Default `'sm'`. */
+  size?: JourneyTimeBarSize;
+  /**
+   * Fill color for the traveled portion, as a CSS color string (e.g., a
+   * GTFS `route_color` hex like `'#1976D2'`). When omitted, falls back to
+   * the shadcn primary color.
+   */
+  color?: string;
+  /**
+   * Optional outline drawn around the bar. Omit for no border (default);
+   * pass `{}` for the default subtle gray outline or provide any subset
+   * of `width` / `color` / `style` to override individual fields.
+   */
+  border?: JourneyTimeBarBorder;
+  /** Whether to render the remaining-minutes label. Default `false`. */
+  showRMins?: boolean;
+  /** Whether to render the total-minutes label. Default `false`. */
+  showTMins?: boolean;
+  /**
+   * Optional prefix rendered before the remaining-minutes value
+   * (e.g., `'残り'` → `'残り5'`). Ignored when `showRemainingMinutes`
+   * is `false`.
+   */
+  rTimeLabel?: string;
+  /**
+   * Optional prefix rendered before the total-minutes value
+   * (e.g., `'全体'` → `'全体25'`). Ignored when `showTotalMinutes`
+   * is `false`.
+   */
+  tMinsLabel?: string;
+  /**
+   * Where to place the minutes label relative to the bar.
+   * `'top'` / `'bottom'` stack vertically; `'left'` / `'right'` flow
+   * inline alongside the bar. Default `'bottom'`.
+   */
+  minsPosition?: JourneyTimeBarMinutesPosition;
+  /**
+   * Fill direction. `'ltr'` fills from the left edge growing right
+   * (default — emphasizes "you can ride this far"). `'rtl'` fills from
+   * the right edge growing left, so the colored section sits next to
+   * the terminal end of the bar ("remaining until arrival").
+   */
+  fillDirection?: JourneyTimeBarFillDirection;
+}
+
+/** Total minutes that map to a full-width bar; longer trips are clamped. */
+const DEFAULT_MAX_BAR_MINUTES = 120;
+
+const SIZE_HEIGHT_CLS: Record<JourneyTimeBarSize, string> = {
+  xs: 'h-0.5',
+  sm: 'h-1',
+  md: 'h-1.5',
+  lg: 'h-2',
+  xl: 'h-3',
+};
+
+type JourneyTimeBarStyle = CSSProperties & {
+  '--jtb-fill-color'?: string;
+  '--jtb-track-color'?: string;
+};
+
+/**
+ * A progress bar visualizing journey time.
+ *
+ * The bar's width scales with `totalMinutes` (capped at `MAX_BAR_MINUTES`),
+ * so longer trips get visually longer bars. The filled portion represents
+ * the remaining ratio (`remaining / total`), so the bar empties as the
+ * trip progresses.
+ *
+ * The caller decides which numeric labels to show via
+ * `showRemainingMinutes` / `showTotalMinutes` and where to place them via
+ * `minutesPosition`. When both flags are on, the combined form `"r / t"`
+ * is rendered.
+ */
+export function JourneyTimeBar({
+  remainingMinutes,
+  totalMinutes,
+  maxMinutes,
+  size = 'sm',
+  color,
+  border,
+  showRMins = false,
+  showTMins = false,
+  rTimeLabel,
+  tMinsLabel,
+  minsPosition: minutesPosition = 'bottom',
+  fillDirection = 'ltr',
+}: JourneyTimeBarProps) {
+  // Delegate all time math (sanitize, clamp, progress ratio, label
+  // rounding) to the domain layer. The Result type lets us bail out
+  // early when there is no usable total to render against.
+  const timeResult = computeJourneyTime({ remainingMinutes, totalMinutes });
+  if (!timeResult.ok) {
+    return null;
+  }
+  const { safeTotalMinutes, progressValue, displayTotalMinutes, displayRemainingMinutes } =
+    timeResult.value;
+
+  // Width scaling is a UI concern — it depends on the visual
+  // convention of "this is the full-width threshold", not on the time
+  // data itself. Kept local to the component so the domain helper
+  // stays pure time math.
+  const safeMaxMinutes =
+    maxMinutes != null && Number.isFinite(maxMinutes) && maxMinutes > 0
+      ? maxMinutes
+      : DEFAULT_MAX_BAR_MINUTES;
+  const widthPercent = Math.min((safeTotalMinutes / safeMaxMinutes) * 100, 100);
+
+  // When a color prop is provided, override both the track (lighter) and
+  // the indicator (solid) via CSS variables + arbitrary child selector, so
+  // the route color flows through without modifying shadcn upstream code.
+  const colorClass = color
+    ? 'bg-[var(--jtb-track-color)] [&>[data-slot=progress-indicator]]:bg-[var(--jtb-fill-color)]'
+    : '';
+  // Right-aligned fill is implemented by mirroring the whole bar via
+  // `scaleX(-1)`. Both track and indicator use `rounded-full`, so the
+  // mirror is visually indistinguishable from a truly right-anchored
+  // fill and avoids reimplementing shadcn Progress.
+  const borderStyle: CSSProperties = border
+    ? {
+        borderWidth: `${border.width ?? DEFAULT_BORDER_WIDTH}px`,
+        borderColor: border.color ?? DEFAULT_BORDER_COLOR,
+        borderStyle: border.style ?? DEFAULT_BORDER_STYLE,
+      }
+    : {};
+  const barStyle: JourneyTimeBarStyle = {
+    width: `${widthPercent}%`,
+    ...(fillDirection === 'rtl' ? { transform: 'scaleX(-1)' } : {}),
+    ...(color
+      ? {
+          '--jtb-fill-color': color,
+          '--jtb-track-color': `${color}33`,
+        }
+      : {}),
+    ...borderStyle,
+  };
+
+  const showLabel = showRMins || showTMins;
+  // `displayTotalMinutes` is always present in a successful result;
+  // `displayRemainingMinutes` is `null` only when the upstream
+  // remaining value is missing / invalid (shown as `-`).
+  const r = displayRemainingMinutes ?? '-';
+  const t = displayTotalMinutes;
+  const rText = `${rTimeLabel ?? ''}${r}`;
+  const tText = `${tMinsLabel ?? ''}${t}`;
+  const labelText =
+    showRMins && showTMins ? `${rText} / ${tText}` : showRMins ? rText : showTMins ? tText : '';
+
+  let labelSize: BaseLabelSize = 'md';
+  switch (size) {
+    case 'xs':
+      labelSize = 'xs';
+      break;
+    case 'sm':
+      labelSize = 'xs';
+      break;
+    case 'md':
+      labelSize = 'xs';
+      break;
+    case 'lg':
+      labelSize = 'xs';
+      break;
+    case 'xl':
+      labelSize = 'xs';
+      break;
+  }
+  const label = showLabel ? (
+    <BaseLabel
+      size={labelSize}
+      value={labelText}
+      className={`whitespace-nowrap text-white ${color ? '' : 'bg-gray-500'}`}
+      style={color ? { backgroundColor: color } : undefined}
+    />
+  ) : null;
+
+  const bar = (
+    <Progress
+      value={progressValue}
+      className={`${SIZE_HEIGHT_CLS[size]} ${colorClass}`.trim()}
+      style={barStyle}
+    />
+  );
+
+  // Horizontal layout (label and bar inline on the same row).
+  //
+  // - `flex w-full`        : occupy the parent's full width so the bar's
+  //                          percentage width resolves correctly
+  // - `items-center`       : center-align the label pill to the bar
+  // - `gap-1`              : comfortable inline spacing (4px)
+  if (minutesPosition === 'left' || minutesPosition === 'right') {
+    const labelFirst = minutesPosition === 'left';
+    return (
+      <div className="flex w-full items-center gap-1">
+        {labelFirst && label}
+        {bar}
+        {!labelFirst && label}
+      </div>
+    );
+  }
+
+  // Vertical layout (label stacked above/below the bar).
+  //
+  // - `flex w-full flex-col` : stack children, keep the container at
+  //                            parent width so the bar percentage
+  //                            resolves against the full width
+  // - `items-start`          : stop BaseLabel from stretching to the
+  //                            full container width (default
+  //                            `items-stretch` would otherwise turn
+  //                            the small pill into a wide block)
+  // - `gap-0.5`              : tight 2px breathing room between the
+  //                            label pill and the bar (the bar itself
+  //                            is only 2–12px tall so a large gap
+  //                            would dwarf it)
+  const labelFirst = minutesPosition === 'top';
+  return (
+    <div className="flex w-full flex-col items-start gap-0.5">
+      {labelFirst && label}
+      {bar}
+      {!labelFirst && label}
+    </div>
+  );
+}

--- a/src/components/journey-time-bar.tsx
+++ b/src/components/journey-time-bar.tsx
@@ -251,7 +251,11 @@ export function JourneyTimeBar({
   return (
     <div className={wrapperClassName}>
       {labelFirst && label}
-      {showEmoji && '⏳'}
+      {showEmoji && (
+        <span aria-hidden="true" className="shrink-0">
+          ⏳
+        </span>
+      )}
       {bar}
       {!labelFirst && label}
     </div>

--- a/src/components/journey-time-bar.tsx
+++ b/src/components/journey-time-bar.tsx
@@ -184,6 +184,12 @@ export function JourneyTimeBar({
   const labelText =
     showRMins && showTMins ? `${rText} / ${tText}` : showRMins ? rText : showTMins ? tText : '';
 
+  // Label size is intentionally fixed to 'xs' across every bar size.
+  // Visual review showed that even the largest bar (xl, h-3) reads
+  // best with an xs pill — the label is subordinate to the bar and
+  // shouldn't grow with it. The switch is retained as scaffolding so
+  // a future variant can opt into a different mapping per `size`
+  // without re-introducing the branching structure.
   let labelSize: BaseLabelSize = 'md';
   switch (size) {
     case 'xs':
@@ -211,9 +217,16 @@ export function JourneyTimeBar({
     />
   ) : null;
 
+  // Accessibility: Radix `Progress.Root` already sets `role="progressbar"`,
+  // `aria-valuemin=0`, `aria-valuemax=100`, and `aria-valuenow={value}`.
+  // We add a journey-time-specific `aria-label` so screen readers surface
+  // the meaning of the bar (remaining vs total) rather than just a bare
+  // percentage. Falls back to "?" when the remaining value is missing.
+  const ariaLabel = `Journey time: ${displayRemainingMinutes ?? '?'} of ${displayTotalMinutes} minutes remaining`;
   const bar = (
     <Progress
       value={progressValue}
+      aria-label={ariaLabel}
       className={`${SIZE_HEIGHT_CLS[size]} ${colorClass}`.trim()}
       style={barStyle}
     />

--- a/src/components/label/timetable-entry-attributes-labels.tsx
+++ b/src/components/label/timetable-entry-attributes-labels.tsx
@@ -39,18 +39,18 @@ export function TimetableEntryAttributesLabels({
 
   return (
     <span className="inline-flex items-baseline gap-0.5">
-      {showTerminal && (
-        <BaseLabel
-          size={size}
-          value={t('timetable.entry.terminal')}
-          className="bg-gray-500 text-white"
-        />
-      )}
       {showOrigin && (
         <BaseLabel
           size={size}
           value={t('timetable.entry.origin')}
           className="bg-blue-500 text-white"
+        />
+      )}
+      {showTerminal && (
+        <BaseLabel
+          size={size}
+          value={t('timetable.entry.terminal')}
+          className="bg-gray-500 text-white"
         />
       )}
       {showPickupUnavailable && (

--- a/src/components/label/trip-position-indicator.tsx
+++ b/src/components/label/trip-position-indicator.tsx
@@ -141,13 +141,16 @@ export function TripPositionIndicator({
     : undefined;
   const positionLabel = `Stop ${stopIndex + 1} of ${safeTotalStops}`;
   return (
-    <span
-      className={`relative inline-flex w-full items-center justify-between ${sizeCls.height} ${sizeCls.pad} ${trackCls}`}
-      style={containerStyle}
-      aria-label={positionLabel}
-      title={positionLabel}
-    >
-      {dots}
-    </span>
+    <>
+      {infoLevel === 'verbose' && '🚏'}
+      <span
+        className={`relative inline-flex w-full items-center justify-between ${sizeCls.height} ${sizeCls.pad} ${trackCls}`}
+        style={containerStyle}
+        aria-label={positionLabel}
+        title={positionLabel}
+      >
+        {dots}
+      </span>
+    </>
   );
 }

--- a/src/components/label/trip-position-indicator.tsx
+++ b/src/components/label/trip-position-indicator.tsx
@@ -141,16 +141,22 @@ export function TripPositionIndicator({
     : undefined;
   const positionLabel = `Stop ${stopIndex + 1} of ${safeTotalStops}`;
   return (
-    <>
-      {infoLevel === 'verbose' && '🚏'}
+    <span
+      className="inline-flex w-full items-center gap-1"
+      aria-label={positionLabel}
+      title={positionLabel}
+    >
+      {infoLevel === 'verbose' && (
+        <span aria-hidden="true" className="shrink-0">
+          🚏
+        </span>
+      )}
       <span
-        className={`relative inline-flex w-full items-center justify-between ${sizeCls.height} ${sizeCls.pad} ${trackCls}`}
+        className={`relative inline-flex min-w-0 flex-1 items-center justify-between ${sizeCls.height} ${sizeCls.pad} ${trackCls}`}
         style={containerStyle}
-        aria-label={positionLabel}
-        title={positionLabel}
       >
         {dots}
       </span>
-    </>
+    </span>
   );
 }

--- a/src/components/marker/stop-markers-dom.stories.tsx
+++ b/src/components/marker/stop-markers-dom.stories.tsx
@@ -3,6 +3,7 @@ import { fn } from 'storybook/test';
 import { MapContainer } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import { APP_ROUTE_TYPES } from '../../config/route-types';
+import { LANG_COMPARISON_CASES } from '../../stories/lang-comparison';
 import type { InfoLevel } from '../../types/app/settings';
 import type { ContextualTimetableEntry } from '../../types/app/transit-composed';
 import type { Agency, AppRouteTypeValue, Stop } from '../../types/app/transit';
@@ -259,6 +260,97 @@ const kitchenSinkArgs = {
   disableDimming: false,
   includeNearbyDepartures: true,
   dataLang: ['ja', 'en', 'de'],
+};
+
+// --- infoLevel comparison ---
+
+/**
+ * Side-by-side comparison of all `infoLevel` values rendered as
+ * stacked map instances. Each map uses a reduced height so the
+ * 4-up layout remains usable. Heavy — multiple Leaflet instances.
+ */
+export const LogicalLongInfoLevelComparison: Story = {
+  args: { showTooltip: true, disableDimming: true },
+  render: (args) => {
+    const levels = ['simple', 'normal', 'detailed', 'verbose'] as const;
+    return (
+      <div className="flex flex-col gap-3">
+        {levels.map((level) => (
+          <div key={level} className="space-y-1">
+            <span className="block text-[10px] text-gray-400">infoLevel: {level}</span>
+            <div className="w-full rounded-lg bg-[#f3f6fb] p-2">
+              <MapContainer
+                center={storyMapCenter}
+                zoom={15}
+                style={{ height: '220px', width: '100%' }}
+                zoomControl={false}
+                attributionControl={false}
+              >
+                <StopMarkersDom
+                  stops={storyStops}
+                  selectedStopId={args.selectedStopId}
+                  routeTypeMap={routeTypeMap}
+                  nearbyDepartures={args.includeNearbyDepartures ? nearbyDepartures : undefined}
+                  time={storyNow}
+                  infoLevel={level}
+                  dataLang={args.dataLang}
+                  onStopSelected={fn()}
+                  showTooltip={args.showTooltip}
+                  agenciesMap={agenciesMap}
+                  disableDimming={args.disableDimming}
+                />
+              </MapContainer>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  },
+};
+
+// --- i18n: lang resolution ---
+
+/**
+ * All supported languages side by side, each rendered as its own
+ * map instance. Heavy — multiple Leaflet instances. Stops with
+ * populated `stop_names` translations (e.g. {@link stopC}) reflect
+ * the lang change; stops without translations fall back to
+ * `stop_name`.
+ */
+export const LangComparison: Story = {
+  args: { showTooltip: true, disableDimming: true, infoLevel: 'normal' },
+  render: (args) => (
+    <div className="flex flex-col gap-3">
+      {LANG_COMPARISON_CASES.map(({ dataLang, label }) => (
+        <div key={label} className="space-y-1">
+          <span className="block text-[10px] text-gray-400">{label}</span>
+          <div className="w-full rounded-lg bg-[#f3f6fb] p-2">
+            <MapContainer
+              center={storyMapCenter}
+              zoom={15}
+              style={{ height: '220px', width: '100%' }}
+              zoomControl={false}
+              attributionControl={false}
+            >
+              <StopMarkersDom
+                stops={storyStops}
+                selectedStopId={args.selectedStopId}
+                routeTypeMap={routeTypeMap}
+                nearbyDepartures={args.includeNearbyDepartures ? nearbyDepartures : undefined}
+                time={storyNow}
+                infoLevel={args.infoLevel}
+                dataLang={dataLang}
+                onStopSelected={fn()}
+                showTooltip={args.showTooltip}
+                agenciesMap={agenciesMap}
+                disableDimming={args.disableDimming}
+              />
+            </MapContainer>
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
 };
 
 // --- Kitchen sink ---

--- a/src/components/nearby-stop.tsx
+++ b/src/components/nearby-stop.tsx
@@ -175,41 +175,50 @@ export function NearbyStop({
         </p>
       )}
       {displayDepartures.length > 0 ? (
-        viewId === 'stop' ? (
-          displayDepartures
-            .slice(0, 5)
-            .map((entry, i) => (
-              <FlatDepartureItem
-                key={`${entry.routeDirection.route.route_id}__${getEffectiveHeadsign(entry.routeDirection)}__${entry.schedule.departureMinutes}__${i}`}
-                entry={entry}
-                now={now}
-                isFirst={i === 0}
-                showRouteTypeIcon={showRouteTypeIconForAllDepartures}
-                infoLevel={infoLevel}
-                dataLang={dataLang}
-                agency={agencies.find((a) => a.agency_id === entry.routeDirection.route.agency_id)}
-              />
-            ))
-        ) : (
-          grouped.map(([key, entries]) => (
-            <DepartureItem
-              key={`${stop.stop_id}__${key}`}
-              entries={entries}
-              now={now}
-              infoLevel={infoLevel}
-              dataLang={dataLang}
-              showRouteTypeIcon={showRouteTypeIconForAllDepartures}
-              agency={agencies.find(
-                (a) => a.agency_id === entries[0].routeDirection.route.agency_id,
-              )}
-              onShowTimetable={
-                onShowTimetable
-                  ? (routeId, headsign) => onShowTimetable(stop.stop_id, routeId, headsign)
-                  : undefined
-              }
-            />
-          ))
-        )
+        // Multi-operator stops are rare in the current dataset, so the
+        // agency badge would be redundant noise on single-operator stops
+        // (the operator is implied by the stop itself). Only surface the
+        // agency badge when there is something to disambiguate.
+        (() => {
+          const showAgency = info.isVerboseEnabled || agencies.length > 1;
+          return viewId === 'stop'
+            ? displayDepartures
+                .slice(0, 5)
+                .map((entry, i) => (
+                  <FlatDepartureItem
+                    key={`${entry.routeDirection.route.route_id}__${getEffectiveHeadsign(entry.routeDirection)}__${entry.schedule.departureMinutes}__${i}`}
+                    entry={entry}
+                    now={now}
+                    isFirst={i === 0}
+                    showRouteTypeIcon={showRouteTypeIconForAllDepartures}
+                    infoLevel={infoLevel}
+                    dataLang={dataLang}
+                    agency={agencies.find(
+                      (a) => a.agency_id === entry.routeDirection.route.agency_id,
+                    )}
+                    showAgency={showAgency}
+                  />
+                ))
+            : grouped.map(([key, entries]) => (
+                <DepartureItem
+                  key={`${stop.stop_id}__${key}`}
+                  entries={entries}
+                  now={now}
+                  infoLevel={infoLevel}
+                  dataLang={dataLang}
+                  showRouteTypeIcon={showRouteTypeIconForAllDepartures}
+                  agency={agencies.find(
+                    (a) => a.agency_id === entries[0].routeDirection.route.agency_id,
+                  )}
+                  showAgency={showAgency}
+                  onShowTimetable={
+                    onShowTimetable
+                      ? (routeId, headsign) => onShowTimetable(stop.stop_id, routeId, headsign)
+                      : undefined
+                  }
+                />
+              ));
+        })()
       ) : (
         // Show the fallback message in the departures area whenever there
         // are no upcoming entries. When `displayDepartures.length === 0`,

--- a/src/components/stop-summary.stories.tsx
+++ b/src/components/stop-summary.stories.tsx
@@ -189,6 +189,50 @@ export const WithDistanceBadge: Story = {
   ),
 };
 
+// --- infoLevel comparison ---
+
+/**
+ * Side-by-side comparison of all `infoLevel` values against the
+ * long-form fixtures (`longNameStop` + multi-route + multi-agency).
+ * Place-name-independent — exercises the full info-level rendering
+ * range against the densest realistic prop combination.
+ */
+export const LogicalLongInfoLevelComparison: Story = {
+  args: {
+    stop: longNameStop,
+    routeTypes: [0, 3] as AppRouteTypeValue[],
+    agencies: allAgencies,
+    routes: allRoutes,
+    stopServiceState: 'boardable',
+    dataLang: ['ja'],
+  },
+  render: (args) => {
+    const levels = ['simple', 'normal', 'detailed', 'verbose'] as const;
+    return (
+      <div className="flex flex-col gap-3">
+        {levels.map((level) => (
+          <div key={level} className="space-y-1">
+            <span className="block text-[10px] text-gray-400">infoLevel: {level}</span>
+            <StopSummary
+              stop={args.stop}
+              routeTypes={args.routeTypes}
+              agencies={args.agencies}
+              routes={args.routes}
+              infoLevel={level}
+              dataLang={args.dataLang}
+              stopServiceState={args.stopServiceState}
+              agencyBadgeSize={args.agencyBadgeSize}
+              routeBadgeSize={args.routeBadgeSize}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  },
+};
+
+// --- i18n: lang resolution ---
+
 export const LangComparison: Story = {
   args: {
     stop: longNameStop,

--- a/src/components/trip-info.stories.tsx
+++ b/src/components/trip-info.stories.tsx
@@ -7,8 +7,11 @@ import {
   headsignKyotoLongShortJa,
   headsignMinowabashi,
   headsignNakano,
+  routeLong,
   stopHeadsignDemachiyanagi,
+  stopHeadsignLong,
   stopHeadsignMusashiKoganeiSouth,
+  tripHeadsignLong,
 } from '../stories/fixtures';
 import { LANG_COMPARISON_CASES } from '../stories/lang-comparison';
 import { TripInfo } from './trip-info';
@@ -101,6 +104,18 @@ const stopOverridesTripRd = createRouteDirection({
   route: kyotoBusRoute,
   tripHeadsign: headsignKyotoLongShortJa,
   stopHeadsign: stopHeadsignDemachiyanagi,
+});
+
+/**
+ * Logical long-form RouteDirection — uses the 9-language fixtures
+ * from `src/stories/fixtures.ts` so every lang row in
+ * {@link LangComparison} gets a populated trip headsign, stop
+ * headsign, and route long name.
+ */
+const logicalLongRd = createRouteDirection({
+  route: routeLong,
+  tripHeadsign: tripHeadsignLong,
+  stopHeadsign: stopHeadsignLong,
 });
 
 const emptyAttributes: TimetableEntryAttributes = {
@@ -299,11 +314,53 @@ export const StopOverridesTripVerbose: Story = {
   args: { routeDirection: stopOverridesTripRd, agency: kyotoAgency, infoLevel: 'verbose' },
 };
 
+// --- infoLevel comparison ---
+
+/**
+ * Side-by-side comparison of all `infoLevel` values against the
+ * logical long-form fixtures (`routeLong`, `tripHeadsignLong`,
+ * `stopHeadsignLong`). Place-name-independent — exercises the full
+ * info-level rendering range without being tied to specific
+ * real-world data.
+ */
+export const LogicalLongInfoLevelComparison: Story = {
+  args: { routeDirection: logicalLongRd, agency },
+  render: (args) => {
+    const levels = ['simple', 'normal', 'detailed', 'verbose'] as const;
+    return (
+      <div className="flex flex-col gap-3">
+        {levels.map((level) => (
+          <div key={level} className="space-y-1">
+            <span className="block text-[10px] text-gray-400">infoLevel: {level}</span>
+            <TripInfo
+              routeDirection={args.routeDirection}
+              infoLevel={level}
+              dataLang={args.dataLang}
+              showRouteTypeIcon={args.showRouteTypeIcon}
+              agency={args.agency}
+              attributes={args.attributes}
+              size={args.size}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  },
+};
+
 // --- i18n: lang resolution ---
 
-/** All languages side by side. */
+/**
+ * All languages side by side.
+ *
+ * Uses the logical long-form fixtures (`routeLong`,
+ * `tripHeadsignLong`, `stopHeadsignLong`) so every supported
+ * language row is guaranteed to have populated translations for
+ * both the trip headsign and the stop headsign, exercising the
+ * wrap / truncation paths consistently per language.
+ */
 export const LangComparison: Story = {
-  args: { routeDirection: kyotoBusRd, agency: kyotoAgency },
+  args: { routeDirection: logicalLongRd, agency },
   render: (args) => (
     <div className="flex flex-col gap-3">
       {LANG_COMPARISON_CASES.map(({ dataLang, label }) => (

--- a/src/components/trip-info.stories.tsx
+++ b/src/components/trip-info.stories.tsx
@@ -134,12 +134,14 @@ const meta = {
     dataLang: ['ja'],
     showRouteTypeIcon: true,
     agency,
+    showAgency: false,
     attributes: emptyAttributes,
     size: 'default',
   },
   argTypes: {
     infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
     showRouteTypeIcon: { control: 'boolean' },
+    showAgency: { control: 'boolean' },
     size: { control: 'inline-radio', options: ['sm', 'default'] },
     attributes: { control: 'object' },
   },
@@ -165,6 +167,25 @@ export const TramRoute: Story = {
 
 export const KyotoBusRoute: Story = {
   args: { routeDirection: kyotoBusRd, agency: kyotoAgency },
+};
+
+// --- Agency badge ---
+
+/**
+ * Visualizes the `showAgency={true}` rendering path. Conceptually
+ * this represents the multi-operator-stop scenario: when the
+ * underlying stop has more than one agency, `nearby-stop.tsx` opts
+ * in by passing `showAgency={agencies.length > 1}`, and the badge
+ * appears to disambiguate which operator runs this trip.
+ *
+ * Single-operator stops (the common case) intentionally render
+ * without the agency badge to avoid redundant noise.
+ */
+export const MultiAgenciesStop: Story = {
+  args: {
+    showAgency: true,
+    infoLevel: 'detailed',
+  },
 };
 
 // --- Attributes ---

--- a/src/components/trip-info.tsx
+++ b/src/components/trip-info.tsx
@@ -69,8 +69,17 @@ interface TripInfoProps {
   dataLang: readonly string[];
   /** Whether to show the route type emoji icon. */
   showRouteTypeIcon?: boolean;
-  /** Agency operating this trip. Shown at detailed+ info level. */
+  /** Agency operating this trip. Rendered only when `showAgency` is true. */
   agency?: Agency;
+  /**
+   * Whether to render the agency badge. The badge is still gated by
+   * `infoLevel >= detailed` and the presence of `agency`, but this
+   * flag lets callers opt out entirely (e.g. in compact contexts
+   * where the agency would compete with the route badge for space).
+   *
+   * @default false
+   */
+  showAgency?: boolean;
   /**
    * Per-entry boolean attributes (terminal / origin / pickup-unavailable /
    * drop-off-unavailable). When provided, rendered via the shared
@@ -106,6 +115,7 @@ export function TripInfo({
   dataLang,
   showRouteTypeIcon = false,
   agency,
+  showAgency = false,
   attributes,
   size = 'default',
   ellipsisHeadsign = false,
@@ -173,7 +183,7 @@ export function TripInfo({
         size={size === 'sm' ? 'sm' : undefined}
         disableVerbose={true}
       />
-      {info.isDetailedEnabled && agency && (
+      {info.isDetailedEnabled && agency && showAgency && (
         <AgencyBadge
           size="xs"
           agency={agency}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Progress as ProgressPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn('bg-primary/20 relative h-2 w-full overflow-hidden rounded-full', className)}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="bg-primary h-full w-full flex-1 transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+}
+
+export { Progress };

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -11,13 +11,14 @@ function Progress({
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
+      value={value}
       className={cn('bg-primary/20 relative h-2 w-full overflow-hidden rounded-full', className)}
       {...props}
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
         className="bg-primary h-full w-full flex-1 transition-all"
-        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+        style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
       />
     </ProgressPrimitive.Root>
   );

--- a/src/domain/transit/__tests__/journey-time.test.ts
+++ b/src/domain/transit/__tests__/journey-time.test.ts
@@ -107,6 +107,34 @@ describe('computeJourneyTime', () => {
       expect(r.value.progressValue).toBe(0);
     });
 
+    it('treats sub-epsilon negative remaining as missing', () => {
+      // Boundary: a value just below zero (e.g. floating-point noise)
+      // must still be rejected by the `>= 0` check, not silently
+      // accepted as "essentially zero".
+      const r = computeJourneyTime({ remainingMinutes: -Number.EPSILON, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.safeRemainingMinutes).toBeUndefined();
+      expect(r.value.progressValue).toBe(0);
+      expect(r.value.displayRemainingMinutes).toBeNull();
+    });
+
+    it('accepts exactly zero remaining as a valid (fully-arrived) value', () => {
+      // Counterpart to the sub-epsilon test: zero is valid and means
+      // "trip is over". safeRemaining must be 0, progress 0%, and
+      // the display label must read "0".
+      const r = computeJourneyTime({ remainingMinutes: 0, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.safeRemainingMinutes).toBe(0);
+      expect(r.value.progressValue).toBe(0);
+      expect(r.value.displayRemainingMinutes).toBe(0);
+    });
+
     it('treats NaN remaining as missing', () => {
       const r = computeJourneyTime({ remainingMinutes: Number.NaN, totalMinutes: 30 });
       expect(r.ok).toBe(true);

--- a/src/domain/transit/__tests__/journey-time.test.ts
+++ b/src/domain/transit/__tests__/journey-time.test.ts
@@ -1,0 +1,498 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeJourneyTime } from '../journey-time';
+
+describe('computeJourneyTime', () => {
+  describe('failure reasons', () => {
+    it('returns no-total when totalMinutes is undefined', () => {
+      const r = computeJourneyTime({ remainingMinutes: 15, totalMinutes: undefined });
+      expect(r.ok).toBe(false);
+      expect(r.ok === false && r.reason).toBe('no-total');
+    });
+
+    it('returns invalid-total when totalMinutes is NaN', () => {
+      const r = computeJourneyTime({ remainingMinutes: 15, totalMinutes: Number.NaN });
+      expect(r.ok).toBe(false);
+      expect(r.ok === false && r.reason).toBe('invalid-total');
+    });
+
+    it('returns invalid-total when totalMinutes is Infinity', () => {
+      const r = computeJourneyTime({
+        remainingMinutes: 15,
+        totalMinutes: Number.POSITIVE_INFINITY,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.ok === false && r.reason).toBe('invalid-total');
+    });
+
+    it('returns invalid-total when totalMinutes is zero', () => {
+      const r = computeJourneyTime({ remainingMinutes: 0, totalMinutes: 0 });
+      expect(r.ok).toBe(false);
+      expect(r.ok === false && r.reason).toBe('invalid-total');
+    });
+
+    it('returns invalid-total when totalMinutes is negative', () => {
+      const r = computeJourneyTime({ remainingMinutes: 5, totalMinutes: -10 });
+      expect(r.ok).toBe(false);
+      expect(r.ok === false && r.reason).toBe('invalid-total');
+    });
+  });
+
+  describe('sub-minute totals (clamp to 1-minute display floor)', () => {
+    // Real pipeline data is not expected to produce sub-minute
+    // totals, but positive-but-below-round-to-1 values must still
+    // render as "1" rather than degenerating to "0 / 0".
+    it('clamps totalMinutes=0.2 to display 1', () => {
+      const r = computeJourneyTime({ remainingMinutes: 0.2, totalMinutes: 0.2 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.safeTotalMinutes).toBe(0.2);
+      expect(r.value.displayTotalMinutes).toBe(1);
+      expect(r.value.displayRemainingMinutes).toBe(1);
+    });
+
+    it('clamps totalMinutes=0.1 with remaining=0 to display "0 / 1"', () => {
+      const r = computeJourneyTime({ remainingMinutes: 0, totalMinutes: 0.1 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.displayTotalMinutes).toBe(1);
+      expect(r.value.displayRemainingMinutes).toBe(0);
+      expect(r.value.progressValue).toBe(0);
+    });
+
+    it('clamps the boundary 0.49 to display 1', () => {
+      const r = computeJourneyTime({ remainingMinutes: 0, totalMinutes: 0.49 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.displayTotalMinutes).toBe(1);
+    });
+
+    it('handles the exact boundary 0.5 (natural round to 1)', () => {
+      const r = computeJourneyTime({ remainingMinutes: 0.5, totalMinutes: 0.5 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.displayTotalMinutes).toBe(1);
+      expect(r.value.displayRemainingMinutes).toBe(1);
+    });
+  });
+
+  describe('soft remaining handling', () => {
+    it('succeeds with undefined remaining, marking fill as zero', () => {
+      const r = computeJourneyTime({ remainingMinutes: undefined, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.safeRemainingMinutes).toBeUndefined();
+      expect(r.value.progressValue).toBe(0);
+      expect(r.value.displayRemainingMinutes).toBeNull();
+      expect(r.value.displayTotalMinutes).toBe(30);
+    });
+
+    it('treats negative remaining as missing', () => {
+      const r = computeJourneyTime({ remainingMinutes: -5, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.safeRemainingMinutes).toBeUndefined();
+      expect(r.value.progressValue).toBe(0);
+    });
+
+    it('treats NaN remaining as missing', () => {
+      const r = computeJourneyTime({ remainingMinutes: Number.NaN, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.safeRemainingMinutes).toBeUndefined();
+    });
+
+    it('treats Infinity remaining as missing', () => {
+      const r = computeJourneyTime({
+        remainingMinutes: Number.POSITIVE_INFINITY,
+        totalMinutes: 30,
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.safeRemainingMinutes).toBeUndefined();
+      expect(r.value.progressValue).toBe(0);
+    });
+  });
+
+  describe('null inputs (defensive)', () => {
+    it('treats null totalMinutes as no-total', () => {
+      const r = computeJourneyTime({
+        remainingMinutes: 15,
+        // @ts-expect-error `null` is not in the declared type but can
+        // sneak in at runtime via property access on optional fields.
+        totalMinutes: null,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.ok === false && r.reason).toBe('no-total');
+    });
+
+    it('treats null remainingMinutes as missing', () => {
+      const r = computeJourneyTime({
+        // @ts-expect-error runtime null guard
+        remainingMinutes: null,
+        totalMinutes: 30,
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.safeRemainingMinutes).toBeUndefined();
+    });
+  });
+
+  describe('relationship clamp (remaining > total)', () => {
+    it('clamps remaining to total when it exceeds', () => {
+      const r = computeJourneyTime({ remainingMinutes: 40, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.safeRemainingMinutes).toBe(30);
+      expect(r.value.progressValue).toBe(100);
+    });
+
+    it('preserves remaining when below total', () => {
+      const r = computeJourneyTime({ remainingMinutes: 20, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.safeRemainingMinutes).toBe(20);
+    });
+  });
+
+  describe('progressValue', () => {
+    it('returns 0 at terminal (remaining=0)', () => {
+      const r = computeJourneyTime({ remainingMinutes: 0, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(0);
+    });
+
+    it('returns 100 at origin (remaining=total)', () => {
+      const r = computeJourneyTime({ remainingMinutes: 30, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(100);
+    });
+
+    it('returns 50 at midpoint', () => {
+      const r = computeJourneyTime({ remainingMinutes: 15, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(50);
+    });
+
+    it('handles fractional total/remaining', () => {
+      const r = computeJourneyTime({ remainingMinutes: 49.25, totalMinutes: 98.5 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(50);
+    });
+  });
+
+  describe('display rounding (integer labels)', () => {
+    it('rounds integer inputs unchanged', () => {
+      const r = computeJourneyTime({ remainingMinutes: 15, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.displayTotalMinutes).toBe(30);
+      expect(r.value.displayRemainingMinutes).toBe(15);
+    });
+
+    it('rounds fractional total to nearest integer', () => {
+      const r = computeJourneyTime({ remainingMinutes: 0, totalMinutes: 98.5 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.displayTotalMinutes).toBe(99);
+      expect(r.value.displayRemainingMinutes).toBe(0);
+    });
+
+    it('derives remaining from rounded total ratio (midpoint)', () => {
+      const r = computeJourneyTime({ remainingMinutes: 49.25, totalMinutes: 98.5 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      // ratio = 0.5, rounded total = 99, derived remaining = 50
+      expect(r.value.displayTotalMinutes).toBe(99);
+      expect(r.value.displayRemainingMinutes).toBe(50);
+    });
+  });
+
+  describe('label consistency at 100% (display pair must never drift)', () => {
+    it('integer total', () => {
+      const r = computeJourneyTime({ remainingMinutes: 30, totalMinutes: 30 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(100);
+      expect(r.value.displayRemainingMinutes).toBe(r.value.displayTotalMinutes);
+      expect(r.value.displayTotalMinutes).toBe(30);
+    });
+
+    it('fractional total rounding up (98.5 -> 99)', () => {
+      const r = computeJourneyTime({ remainingMinutes: 98.5, totalMinutes: 98.5 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(100);
+      expect(r.value.displayRemainingMinutes).toBe(r.value.displayTotalMinutes);
+      expect(r.value.displayTotalMinutes).toBe(99);
+    });
+
+    it('fractional total rounding down (113.4 -> 113)', () => {
+      const r = computeJourneyTime({ remainingMinutes: 113.4, totalMinutes: 113.4 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(100);
+      expect(r.value.displayRemainingMinutes).toBe(r.value.displayTotalMinutes);
+      expect(r.value.displayTotalMinutes).toBe(113);
+    });
+
+    it('very small total (2.5 -> 3)', () => {
+      const r = computeJourneyTime({ remainingMinutes: 2.5, totalMinutes: 2.5 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(100);
+      expect(r.value.displayRemainingMinutes).toBe(r.value.displayTotalMinutes);
+      expect(r.value.displayTotalMinutes).toBe(3);
+    });
+
+    it('clamped from overflow input (remaining > total)', () => {
+      const r = computeJourneyTime({ remainingMinutes: 200, totalMinutes: 98.5 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(100);
+      expect(r.value.safeRemainingMinutes).toBe(98.5);
+      expect(r.value.displayRemainingMinutes).toBe(r.value.displayTotalMinutes);
+      expect(r.value.displayTotalMinutes).toBe(99);
+    });
+
+    it('property check across a range of fractional totals', () => {
+      const totals = [
+        1, 1.1, 1.5, 1.9, 10.25, 30, 45.5, 60.4, 60.5, 98.5, 99.49, 99.5, 113.4, 120, 140.7,
+      ];
+      for (const total of totals) {
+        const r = computeJourneyTime({ remainingMinutes: total, totalMinutes: total });
+        expect(r.ok, `ok for total=${total}`).toBe(true);
+        if (!r.ok) {
+          continue;
+        }
+        expect(r.value.progressValue, `progressValue for total=${total}`).toBe(100);
+        expect(r.value.displayRemainingMinutes, `display pair for total=${total}`).toBe(
+          r.value.displayTotalMinutes,
+        );
+      }
+    });
+  });
+
+  describe('label consistency at 0% (display remaining must be 0)', () => {
+    it('always displays 0 at terminal for any fractional total', () => {
+      const totals = [1, 1.5, 10.25, 98.5, 113.4, 120, 140.7];
+      for (const total of totals) {
+        const r = computeJourneyTime({ remainingMinutes: 0, totalMinutes: total });
+        expect(r.ok, `ok for total=${total}`).toBe(true);
+        if (!r.ok) {
+          continue;
+        }
+        expect(r.value.progressValue, `progressValue for total=${total}`).toBe(0);
+        expect(r.value.displayRemainingMinutes, `display remaining for total=${total}`).toBe(0);
+      }
+    });
+  });
+
+  describe('invariants', () => {
+    it('displayRemainingMinutes never exceeds displayTotalMinutes', () => {
+      const samples: { r: number; t: number }[] = [
+        { r: 0, t: 30 },
+        { r: 0.5, t: 0.5 }, // smallest valid total (rounds to 1)
+        { r: 0.3, t: 0.5 },
+        { r: 29.9, t: 30 },
+        { r: 30, t: 30 },
+        { r: 98.4, t: 98.5 },
+        { r: 98.5, t: 98.5 },
+        { r: 500, t: 98.5 }, // overflow-clamped to 98.5
+        { r: 1.4, t: 1.5 },
+        { r: 113.3, t: 113.4 },
+      ];
+      for (const { r, t } of samples) {
+        const result = computeJourneyTime({ remainingMinutes: r, totalMinutes: t });
+        expect(result.ok, `ok for r=${r} t=${t}`).toBe(true);
+        if (!result.ok) {
+          continue;
+        }
+        const disp = result.value.displayRemainingMinutes;
+        if (disp === null) {
+          continue;
+        }
+        expect(disp, `displayRemaining<=displayTotal for r=${r} t=${t}`).toBeLessThanOrEqual(
+          result.value.displayTotalMinutes,
+        );
+      }
+    });
+
+    it('displayTotalMinutes is always >= 1 in a successful result', () => {
+      // Any total that the function accepts must render as at least
+      // `1` minute — otherwise the label degenerates to `0 / 0`.
+      const samples: number[] = [
+        0.5, // exact boundary
+        0.51,
+        0.9,
+        1,
+        1.4,
+        1.5,
+        2.5,
+        30,
+        98.5,
+        120,
+        140,
+        730,
+      ];
+      for (const total of samples) {
+        const r = computeJourneyTime({ remainingMinutes: 0, totalMinutes: total });
+        expect(r.ok, `ok for total=${total}`).toBe(true);
+        if (!r.ok) {
+          continue;
+        }
+        expect(
+          r.value.displayTotalMinutes,
+          `displayTotalMinutes>=1 for total=${total}`,
+        ).toBeGreaterThanOrEqual(1);
+      }
+    });
+
+    it('clamps all sub-minute totals in (0, 0.5) to display 1', () => {
+      // Anything strictly positive but below 0.5 must still round to
+      // at least 1 for display, so the label never degenerates.
+      const samples: number[] = [0.01, 0.1, 0.2, 0.3, 0.4, 0.49, 0.4999];
+      for (const total of samples) {
+        const r = computeJourneyTime({ remainingMinutes: total, totalMinutes: total });
+        expect(r.ok, `ok for total=${total}`).toBe(true);
+        if (!r.ok) {
+          continue;
+        }
+        expect(r.value.displayTotalMinutes, `displayTotalMinutes>=1 for total=${total}`).toBe(1);
+        expect(r.value.displayRemainingMinutes, `display pair at 100% for total=${total}`).toBe(
+          r.value.displayTotalMinutes,
+        );
+      }
+    });
+
+    it('progressValue stays in [0, 100] for any valid input', () => {
+      const samples: { r: number; t: number }[] = [
+        { r: 0, t: 30 },
+        { r: 0.0001, t: 30 },
+        { r: 15, t: 30 },
+        { r: 29.9999, t: 30 },
+        { r: 30, t: 30 },
+        { r: 500, t: 30 }, // overflow-clamped
+        { r: 0, t: 0.5 },
+        { r: 0.25, t: 0.5 },
+        { r: 0.5, t: 0.5 },
+      ];
+      for (const { r, t } of samples) {
+        const result = computeJourneyTime({ remainingMinutes: r, totalMinutes: t });
+        expect(result.ok, `ok for r=${r} t=${t}`).toBe(true);
+        if (!result.ok) {
+          continue;
+        }
+        expect(result.value.progressValue, `lo for r=${r} t=${t}`).toBeGreaterThanOrEqual(0);
+        expect(result.value.progressValue, `hi for r=${r} t=${t}`).toBeLessThanOrEqual(100);
+      }
+    });
+  });
+
+  describe('real-world samples from pipeline insights', () => {
+    it('kobus p1: total=48, mid-trip remaining=24', () => {
+      const r = computeJourneyTime({ remainingMinutes: 24, totalMinutes: 48 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(50);
+      expect(r.value.displayTotalMinutes).toBe(48);
+      expect(r.value.displayRemainingMinutes).toBe(24);
+    });
+
+    it('minkuru 梅70: fractional total=98.5, at origin', () => {
+      const r = computeJourneyTime({ remainingMinutes: 98.5, totalMinutes: 98.5 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(100);
+      expect(r.value.displayTotalMinutes).toBe(99);
+      expect(r.value.displayRemainingMinutes).toBe(99);
+    });
+
+    it('minkuru 梅70: fractional total=98.5, at terminal', () => {
+      const r = computeJourneyTime({ remainingMinutes: 0, totalMinutes: 98.5 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(0);
+      expect(r.value.displayTotalMinutes).toBe(99);
+      expect(r.value.displayRemainingMinutes).toBe(0);
+    });
+
+    it('kcbus max 140min: at midpoint', () => {
+      const r = computeJourneyTime({ remainingMinutes: 70, totalMinutes: 140 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(50);
+      expect(r.value.displayTotalMinutes).toBe(140);
+      expect(r.value.displayRemainingMinutes).toBe(70);
+    });
+
+    it('iyt2 overnight bus 730min: at origin', () => {
+      const r = computeJourneyTime({ remainingMinutes: 730, totalMinutes: 730 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) {
+        return;
+      }
+      expect(r.value.progressValue).toBe(100);
+      expect(r.value.displayTotalMinutes).toBe(730);
+      expect(r.value.displayRemainingMinutes).toBe(730);
+    });
+  });
+});

--- a/src/domain/transit/journey-time.ts
+++ b/src/domain/transit/journey-time.ts
@@ -1,0 +1,156 @@
+/**
+ * Pure numeric calculations for journey-time visualization.
+ *
+ * Handles the "time math" layer — input sanitization, remaining/total
+ * relationship enforcement, progress ratio, and integer rounding for
+ * display labels. Visual concerns like bar width scaling
+ * (`maxMinutes`) are left to the UI layer because they reflect
+ * rendering judgment, not a property of the underlying duration data.
+ *
+ * The function returns a tagged union so callers can discriminate
+ * "can render" vs "cannot render" at a single gate:
+ *
+ * ```ts
+ * const result = computeJourneyTime({ remainingMinutes, totalMinutes });
+ * if (!result.ok) {
+ *   return null; // insufficient data — nothing meaningful to show
+ * }
+ * const { progressValue, displayTotalMinutes, ... } = result.value;
+ * ```
+ *
+ * A missing or invalid `totalMinutes` is a hard failure because the
+ * bar cannot even decide its width without it. A missing
+ * `remainingMinutes` is soft: the function still succeeds but marks
+ * the fill / remaining-label fields as "no data".
+ */
+
+/** Raw inputs taken straight from upstream data (typically pipeline insights). */
+export interface JourneyTimeInput {
+  /** Remaining minutes from the current stop to the terminal. */
+  remainingMinutes: number | undefined;
+  /** Total minutes of the full trip pattern. */
+  totalMinutes: number | undefined;
+}
+
+/** Computed values needed to render a journey-time bar / label pair. */
+export interface ComputedJourneyTime {
+  /**
+   * Sanitized total minutes (raw decimal). Always a positive finite
+   * number in a successful result.
+   */
+  safeTotalMinutes: number;
+  /**
+   * Sanitized remaining minutes, clamped to `safeTotalMinutes`.
+   * `undefined` when the remaining value is missing / invalid — the
+   * bar cannot show a fill ratio in that case, but it can still be
+   * drawn at 0% width-scaling against `safeTotalMinutes`.
+   */
+  safeRemainingMinutes: number | undefined;
+  /**
+   * Bar fill percentage (0-100). `0` when `safeRemainingMinutes` is
+   * missing.
+   */
+  progressValue: number;
+  /**
+   * Integer-rounded total minutes for label display. Always present
+   * in a successful result.
+   */
+  displayTotalMinutes: number;
+  /**
+   * Integer-rounded remaining minutes for label display. Derived
+   * from the rounded total via the remaining ratio, so when
+   * `progressValue` is `100` the label always reads `x / x` — never
+   * `98 / 99` etc. `null` when `safeRemainingMinutes` is missing.
+   */
+  displayRemainingMinutes: number | null;
+}
+
+/**
+ * Reason for a {@link JourneyTimeResult} failure.
+ *
+ * - `no-total`: `totalMinutes` is `null` / `undefined`.
+ * - `invalid-total`: `totalMinutes` is present but cannot be used
+ *   (`NaN`, `Infinity`, zero, or negative).
+ *
+ * Sub-minute but positive values (e.g. `0.2`) are NOT rejected —
+ * they are clamped to a display floor of `1` minute so the label
+ * never degenerates to `0 / 0`. See the `displayTotalMinutes`
+ * calculation in {@link computeJourneyTime}.
+ */
+export type JourneyTimeFailureReason = 'no-total' | 'invalid-total';
+
+/** Result of {@link computeJourneyTime}. */
+export type JourneyTimeResult =
+  | { ok: true; value: ComputedJourneyTime }
+  | { ok: false; reason: JourneyTimeFailureReason };
+
+/**
+ * Compute journey-time values for display.
+ *
+ * Sanitizes input, enforces `remaining <= total`, produces the bar
+ * fill ratio, and rounds display values consistently so the label
+ * ratio matches the bar fill at the endpoints (0% and 100%).
+ *
+ * @param input - Raw remaining/total minutes (may be undefined / NaN / negative).
+ * @returns Tagged union — `{ ok: true, value }` when computable, or
+ *          `{ ok: false, reason }` when the total is missing / invalid.
+ */
+export function computeJourneyTime(input: JourneyTimeInput): JourneyTimeResult {
+  const { remainingMinutes, totalMinutes } = input;
+
+  if (totalMinutes == null) {
+    return { ok: false, reason: 'no-total' };
+  }
+  if (!Number.isFinite(totalMinutes) || totalMinutes <= 0) {
+    return { ok: false, reason: 'invalid-total' };
+  }
+  const safeTotalMinutes = totalMinutes;
+
+  // Sanitize remaining: reject null / undefined / NaN / Infinity / negative.
+  const sanitizedRemaining =
+    remainingMinutes != null && Number.isFinite(remainingMinutes) && remainingMinutes >= 0
+      ? remainingMinutes
+      : undefined;
+
+  // Enforce `remaining <= total` so downstream rendering sees a
+  // self-consistent pair even when upstream data has anomalies.
+  const safeRemainingMinutes =
+    sanitizedRemaining !== undefined ? Math.min(sanitizedRemaining, safeTotalMinutes) : undefined;
+
+  // Progress fill percentage. Clamp to `[0, 100]` so numeric edge
+  // cases cannot push the indicator past the track edges.
+  const progressValue =
+    safeRemainingMinutes !== undefined
+      ? Math.min(100, Math.max(0, (safeRemainingMinutes / safeTotalMinutes) * 100))
+      : 0;
+
+  // Rounded display values. The pipeline rounds `rd[i]` to 1 decimal
+  // place, so fractional inputs like `98.5` do occur. Round the total
+  // first, then derive the remaining value from the rounded total so
+  // the label ratio stays consistent with the bar fill — specifically,
+  // at 100% fill (`safeRemaining === safeTotal`) the label always
+  // reads `x / x`.
+  //
+  // Clamp the display total to a minimum of `1` so sub-minute values
+  // like `0.2` (which round to `0`) still produce a meaningful label
+  // instead of `0 / 0`. Real pipeline data is not expected to go
+  // below ~1 min, but a positive total is by definition "something",
+  // not "nothing" — displaying it as 1 min is more graceful than
+  // rejecting or zero-labelling it.
+  const displayTotalMinutes = Math.max(1, Math.round(safeTotalMinutes));
+  const displayRemainingMinutes =
+    safeRemainingMinutes !== undefined
+      ? Math.round((safeRemainingMinutes / safeTotalMinutes) * displayTotalMinutes)
+      : null;
+
+  return {
+    ok: true,
+    value: {
+      safeTotalMinutes,
+      safeRemainingMinutes,
+      progressValue,
+      displayTotalMinutes,
+      displayRemainingMinutes,
+    },
+  };
+}

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -635,6 +635,95 @@ export const allRoutes: Route[] = [
 ];
 
 // ---------------------------------------------------------------------------
+// Logical Route fixtures — length axis
+// ---------------------------------------------------------------------------
+//
+// These routes are deliberately abstract (no real GTFS source) so
+// stories exercising label wrapping / truncation don't break when
+// real transit data changes. Each fixture covers every
+// {@link SUPPORTED_LANGS} entry for both `route_short_names` and
+// `route_long_names`, paired with a route color / text color so
+// chip-style rendering has something to work with.
+
+/**
+ * Synthetic short route — 2-char `route_short_name` and a compact
+ * endpoint-to-endpoint `route_long_name`. Models a typical urban
+ * bus line code.
+ */
+export const routeShort: Route = {
+  route_id: 'fixture:route-short',
+  route_short_name: 'S1',
+  route_short_names: {
+    ja: 'S1',
+    'ja-Hrkt': 'えすいち',
+    en: 'S1',
+    'zh-Hans': 'S1',
+    'zh-Hant': 'S1',
+    ko: 'S1',
+    de: 'S1',
+    es: 'S1',
+    fr: 'S1',
+  },
+  route_long_name: 'Sample Line S1 — Alpha ↔ Bravo',
+  route_long_names: {
+    ja: 'サンプル路線 S1 アルファ ⇔ ブラボー',
+    'ja-Hrkt': 'さんぷる ろせん えすいち あるふぁ ⇔ ぶらぼー',
+    en: 'Sample Line S1 — Alpha ↔ Bravo',
+    'zh-Hans': '样本线 S1 甲 ⇔ 乙',
+    'zh-Hant': '樣本線 S1 甲 ⇔ 乙',
+    ko: '샘플 노선 S1 알파 ⇔ 브라보',
+    de: 'Beispiellinie S1 — Alpha ⇔ Bravo',
+    es: 'Línea de Muestra S1 — Alfa ⇔ Bravo',
+    fr: 'Ligne d’Exemple S1 — Alpha ⇔ Bravo',
+  },
+  route_type: 3,
+  route_color: '1976D2',
+  route_text_color: 'FFFFFF',
+  agency_id: 'fixture:agency',
+};
+
+/**
+ * Synthetic long route — the longer end of the length axis. Models
+ * a Kyoto-city-bus / Tokyo-tram style line whose `route_long_name`
+ * is a system number followed by a bullet-separated list of
+ * waypoints, long enough to exercise wrapping / truncation paths
+ * in every {@link SUPPORTED_LANGS} entry.
+ */
+export const routeLong: Route = {
+  route_id: 'fixture:route-long',
+  route_short_name: 'L99',
+  route_short_names: {
+    ja: 'L99',
+    'ja-Hrkt': 'える きゅうじゅうきゅう',
+    en: 'L99',
+    'zh-Hans': 'L99',
+    'zh-Hant': 'L99',
+    ko: 'L99',
+    de: 'L99',
+    es: 'L99',
+    fr: 'L99',
+  },
+  route_long_name:
+    'Sample Line L99 System — Alpha Park · Bravo Station · Charlie Mall · Delta Harbor · Echo Terminal',
+  route_long_names: {
+    ja: 'サンプル L99 号系統 アルファ公園・ブラボー駅・チャーリー商店街・デルタ港・エコーターミナル',
+    'ja-Hrkt':
+      'さんぷる える きゅうじゅうきゅう ごうけいとう あるふぁ こうえん・ぶらぼー えき・ちゃーりー しょうてんがい・でるたこう・えこー たーみなる',
+    en: 'Sample Line L99 System — Alpha Park · Bravo Station · Charlie Mall · Delta Harbor · Echo Terminal',
+    'zh-Hans': '样本线 L99 系统 甲公园・乙站・丙商店街・丁港・戊总站',
+    'zh-Hant': '樣本線 L99 系統 甲公園・乙站・丙商店街・丁港・戊總站',
+    ko: '샘플 노선 L99 계통 알파공원・브라보역・찰리 상점가・델타항・에코 터미널',
+    de: 'Beispiellinie L99 System — Alpha-Park · Bahnhof Bravo · Charlie-Markt · Delta-Hafen · Echo-Terminal',
+    es: 'Línea de Muestra L99 Sistema — Parque Alfa · Estación Bravo · Galería Charlie · Puerto Delta · Terminal Echo',
+    fr: 'Ligne d’Exemple L99 Système — Parc Alpha · Gare Bravo · Galerie Charlie · Port Delta · Terminal Echo',
+  },
+  route_type: 3,
+  route_color: 'E60012',
+  route_text_color: 'FFFFFF',
+  agency_id: 'fixture:agency',
+};
+
+// ---------------------------------------------------------------------------
 // Stops
 // ---------------------------------------------------------------------------
 
@@ -669,6 +758,66 @@ export const longNameStop: Stop = {
     'zh-Hans': '东京都立产业技术研究中心前',
     'zh-Hant': '東京都立產業技術研究中心前',
   },
+};
+
+// ---------------------------------------------------------------------------
+// Logical Stop fixtures — length axis
+// ---------------------------------------------------------------------------
+//
+// Abstract placeholder stops in the same short/long × 9-language
+// shape as `tripHeadsignShort`/`tripHeadsignLong` and
+// `routeShort`/`routeLong`. Use these when the story cares about
+// the logical length category rather than any specific real stop.
+
+/**
+ * Synthetic short stop — a compact stop name at the shorter end of
+ * typical transit data. Covers every {@link SUPPORTED_LANGS} entry.
+ */
+export const stopShort: Stop = {
+  stop_id: 'fixture:stop-short',
+  stop_name: 'Alpha Park Stop',
+  stop_names: {
+    ja: 'アルファ公園前',
+    'ja-Hrkt': 'あるふぁ こうえん まえ',
+    en: 'Alpha Park Stop',
+    'zh-Hans': '甲公园前',
+    'zh-Hant': '甲公園前',
+    ko: '알파공원 앞',
+    de: 'Haltestelle Alpha-Park',
+    es: 'Parada Parque Alfa',
+    fr: 'Arrêt Parc Alpha',
+  },
+  stop_lat: 35.6939,
+  stop_lon: 139.8118,
+  location_type: 0,
+  agency_id: 'fixture:agency',
+};
+
+/**
+ * Synthetic long stop — exercises wrapping / truncation paths for
+ * the stop name slot. Modelled after verbose real-world entries
+ * like '東京都立産業技術研究センター前' but abstracted away from
+ * any real place.
+ */
+export const stopLong: Stop = {
+  stop_id: 'fixture:stop-long',
+  stop_name: 'Charlie Mall Central Entrance — East Wing Bus Stop',
+  stop_names: {
+    ja: 'チャーリー商店街 中央口 東棟 バス停',
+    'ja-Hrkt': 'ちゃーりー しょうてんがい ちゅうおうぐち ひがしとう ばすてい',
+    en: 'Charlie Mall Central Entrance — East Wing Bus Stop',
+    'zh-Hans': '丙商店街 中央入口 东栋 公交站',
+    'zh-Hant': '丙商店街 中央入口 東棟 公車站',
+    ko: '찰리 상점가 중앙 입구 동관 버스정류장',
+    de: 'Charlie-Markt Haupteingang — Ostflügel Bushaltestelle',
+    es: 'Parada de Autobús Galería Charlie — Entrada Principal Ala Este',
+    fr: 'Arrêt de Bus Galerie Charlie — Entrée Principale Aile Est',
+  },
+  stop_lat: 35.6945,
+  stop_lon: 139.8122,
+  location_type: 0,
+  wheelchair_boarding: 1,
+  agency_id: 'fixture:agency',
 };
 
 // ---------------------------------------------------------------------------
@@ -842,6 +991,125 @@ export const stopHeadsignMusashiKoganeiSouth: TranslatableText = {
   },
 };
 
+// ---------------------------------------------------------------------------
+// Logical headsign fixtures — place-name independent
+// ---------------------------------------------------------------------------
+//
+// The fixtures below are deliberately abstracted away from real-world
+// place names (中野駅 / 新橋駅前 / 武蔵小金井駅南口 / ...). They exist
+// to drive stories that exercise the component's *logical* handling
+// of each headsign state — trip-only, stop-only, both, etc. — so the
+// failure mode reads as "the trip-only branch is broken" rather than
+// "the Nakano fixture broke". Use these for structural / regression
+// stories; keep the named real-place fixtures above for cases where
+// the visual language of actual transit data is the point.
+
+/**
+ * Synthetic long trip headsign — an obviously-fake placeholder
+ * covering every {@link SUPPORTED_LANGS} entry. The value is
+ * intentionally abstract (no real place name) while sized to the
+ * longer end of realistic bus / train headsign character counts,
+ * so layout tests exercise the wrapping and truncation paths they
+ * will see in production.
+ */
+export const tripHeadsignLong: TranslatableText = {
+  name: 'Sample Trip Destination — Alpha Park via Central Plaza',
+  names: {
+    ja: 'サンプル行先 アルファ公園 経由 中央広場',
+    'ja-Hrkt': 'さんぷる いきさき あるふぁ こうえん けいゆ ちゅうおう ひろば',
+    en: 'Sample Trip Destination — Alpha Park via Central Plaza',
+    'zh-Hans': '样本 终点站 甲公园 途经 中央广场',
+    'zh-Hant': '樣本 終點站 甲公園 途經 中央廣場',
+    ko: '샘플 행선지 알파공원 경유 중앙광장',
+    de: 'Beispielziel — Alpha-Park über Zentralplatz',
+    es: 'Destino de Muestra — Parque Alfa vía Plaza Central',
+    fr: 'Destination Échantillon — Parc Alpha via la Place Centrale',
+  },
+};
+
+/**
+ * Synthetic short trip headsign — counterpart to
+ * {@link tripHeadsignLong}, intentionally shorter so stories can
+ * compare headsigns of different lengths side by side.
+ */
+export const tripHeadsignShort: TranslatableText = {
+  name: 'Sample — Bravo Station',
+  names: {
+    ja: 'サンプル ブラボー駅',
+    'ja-Hrkt': 'さんぷる ぶらぼーえき',
+    en: 'Sample — Bravo Station',
+    'zh-Hans': '样本 乙站',
+    'zh-Hant': '樣本 乙站',
+    ko: '샘플 브라보역',
+    de: 'Beispiel — Bahnhof Bravo',
+    es: 'Muestra — Estación Bravo',
+    fr: 'Exemple — Gare Bravo',
+  },
+};
+
+/**
+ * Synthetic short stop headsign — placeholder for the stop-level
+ * slot so stories can tell it apart from the trip-level values
+ * above. Intentionally short so stories can contrast against
+ * {@link stopHeadsignLong}.
+ */
+export const stopHeadsignShort: TranslatableText = {
+  name: 'Sub — Charlie Mall',
+  names: {
+    ja: '副行先 チャーリー商店街',
+    'ja-Hrkt': 'ふくいきさき ちゃーりーしょうてんがい',
+    en: 'Sub — Charlie Mall',
+    'zh-Hans': '副终点 丙商店街',
+    'zh-Hant': '副終點 丙商店街',
+    ko: '부차행선 찰리 상점가',
+    de: 'Unterziel — Charlie-Markt',
+    es: 'Sub-destino — Galería Charlie',
+    fr: 'Sous-destination — Galerie Charlie',
+  },
+};
+
+/**
+ * Synthetic long stop headsign — exercises the wrapping /
+ * truncation paths for the stop-level slot. Includes a "via"
+ * waypoint modelled after routes like the Kyoto city bus loops.
+ */
+export const stopHeadsignLong: TranslatableText = {
+  name: 'Sub-destination — Delta Harbor via Riverside Terminal',
+  names: {
+    ja: '副行先 デルタ港 経由 リバーサイド ターミナル',
+    'ja-Hrkt': 'ふくいきさき でるたこう けいゆ りばーさいど たーみなる',
+    en: 'Sub-destination — Delta Harbor via Riverside Terminal',
+    'zh-Hans': '副终点 丁港 途经 河畔总站',
+    'zh-Hant': '副終點 丁港 途經 河畔總站',
+    ko: '부차행선 델타항 경유 리버사이드 터미널',
+    de: 'Unterziel — Delta-Hafen über Uferterminal',
+    es: 'Sub-destino — Puerto Delta vía Terminal Ribereño',
+    fr: 'Sous-destination — Port Delta via le Terminal Riverain',
+  },
+};
+
+/** Single-character headsign — exercises minimum-length rendering. */
+export const headsignShort: TranslatableText = {
+  name: 'X',
+  names: {
+    ja: 'X',
+    en: 'X',
+  },
+};
+
+/**
+ * Long multi-part headsign — exercises wrap / truncation / overflow
+ * handling. Not a real place; the text is deliberately synthetic.
+ */
+export const headsignLong: TranslatableText = {
+  name: 'Very Long Destination Via Many Intermediate Points',
+  names: {
+    ja: '非常に長い目的地 経由地点を多数含む 行先',
+    'ja-Hrkt': 'ひじょうに ながい もくてきち けいゆ ちてん を たすう ふくむ いきさき',
+    en: 'Very Long Destination Via Many Intermediate Points',
+  },
+};
+
 /** Default service date for stories. */
 export const storyServiceDate = new Date('2026-03-30T00:00:00');
 
@@ -872,6 +1140,73 @@ export function createRouteDirection(
     direction: overrides.direction,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Logical RouteDirection fixtures — headsign state axis
+// ---------------------------------------------------------------------------
+//
+// Each fixture is a coherent RouteDirection pinned to a specific
+// headsign-state combination so stories can pick "the trip-only
+// case" / "the stop-only case" / "the both case" etc. without
+// hand-assembling parts whose consistency can silently drift.
+
+/**
+ * Trip-only headsign: the classic case. `tripHeadsign` is populated,
+ * `stopHeadsign` is absent. Covers most straightforward bus routes.
+ */
+export const routeDirectionHeadsignTripOnly: RouteDirection = {
+  route: busRoute,
+  tripHeadsign: tripHeadsignLong,
+  direction: 0,
+};
+
+/**
+ * Stop-only headsign: keio-bus pattern. `tripHeadsign` is empty,
+ * `stopHeadsign` overrides the trip-level destination. The UI must
+ * promote `stopHeadsign` to the primary label slot.
+ */
+export const routeDirectionHeadsignStopOnly: RouteDirection = {
+  route: busRoute,
+  tripHeadsign: emptyHeadsign,
+  stopHeadsign: stopHeadsignShort,
+  direction: 0,
+};
+
+/**
+ * Both headsigns present and different. Typical when the route goes
+ * to `tripHeadsignLong` but this particular stop's next service is
+ * routed via `stopHeadsignShort`. The UI should show both with their
+ * respective source markers (🪧 trip / 📍 stop).
+ */
+export const routeDirectionHeadsignBoth: RouteDirection = {
+  route: busRoute,
+  tripHeadsign: tripHeadsignLong,
+  stopHeadsign: stopHeadsignShort,
+  direction: 0,
+};
+
+/**
+ * Both headsigns present but identical (redundant upstream data).
+ * The UI should collapse the duplicate so the user is not shown the
+ * same text twice.
+ */
+export const routeDirectionHeadsignBothMatching: RouteDirection = {
+  route: busRoute,
+  tripHeadsign: tripHeadsignLong,
+  stopHeadsign: tripHeadsignLong,
+  direction: 0,
+};
+
+/**
+ * Neither headsign populated — data-quality worst case. The UI must
+ * fall back to `route_short_name` / `route_long_name` without
+ * surfacing empty strings.
+ */
+export const routeDirectionHeadsignNeither: RouteDirection = {
+  route: busRoute,
+  tripHeadsign: emptyHeadsign,
+  direction: 0,
+};
 
 export function createEntry(
   overrides: Partial<{


### PR DESCRIPTION
## Summary

- **JourneyTimeBar**: new component wrapping `computeJourneyTime` (pure domain helper with Result-type API + 40 tests). Wired into `FlatDepartureItem` at `infoLevel >= detailed`.
- **TripInfo.showAgency**: explicit opt-in gate (default `false`). `nearby-stop.tsx` now passes `showAgency = info.isVerboseEnabled || agencies.length > 1` so the badge only surfaces when it disambiguates between operators (rare in current data).
- **DepartureItem layout fix**: absolute-times row now wraps cleanly on narrow screens. RelativeTime stays as a non-wrapping unit, the n absolute time entries fold into a `flex-wrap` sub-container, button stays at the end.
- **Logical fixtures + stories**: place-name-independent long/short fixtures (`routeLong`, `tripHeadsignLong`, `stopHeadsignLong`, etc.) with full 9-language translations. New `LogicalLongInfoLevelComparison` stories standardised across DepartureItem, FlatDepartureItem, TripInfo, HeadsignBadge, RouteBadge, StopSummary, StopMarkersDom for visual verification of the full infoLevel rendering range.
- **Verbose emoji hints**: TripPositionIndicator prefixes 🚏 in verbose mode; JourneyTimeBar gains an opt-in `showEmoji` prop (⏳).
- **Per-departure attribute label catalog**: `LogicalLongInfoLevelComparison` (DepartureItem) now exercises every supported `TimetableEntryAttributesLabels` flag (terminal / origin / pickup× / dropoff×).
- **Pipeline dev analyzers**: `analyze-v2-insights.ts` + `analyze-v2-global-insights.ts` for operational review of the v2 InsightsBundle / GlobalInsightsBundle, with smoke tests.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 2533 tests pass
- [x] \`npm run build\` — webapp builds
- [x] Storybook: visit each \`LogicalLongInfoLevelComparison\` story for DepartureItem / FlatDepartureItem / TripInfo / HeadsignBadge / RouteBadge / StopSummary / StopMarkersDom and verify the four infoLevels render correctly
- [x] Storybook: \`Departure/DepartureItem/LogicalLongInfoLevelComparison\` — verify the per-entry attribute labels (終点 / 始発 / 乗× / 降×) render and the absolute-times row wraps cleanly on narrow widths
- [x] Storybook: \`Departure/TripInfo/MultiAgenciesStop\` — verify the agency badge appears
- [x] Real device check: open a single-operator stop in nearby-stop view and confirm the agency badge no longer renders by default; open a multi-operator stop and confirm it does

🤖 Generated with [Claude Code](https://claude.com/claude-code)