### PR TITLE
Improve nearby stops UI and responsive map layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ and this project adheres to [CalVer](https://calver.org/).
 - Align the `AgencyBadge` size vocabulary with `BaseLabel` (`md | sm | xs`) and delete the legacy `'default'` (12px) size, which was unused in production. Callers move to the new vocabulary explicitly — `stop-summary.tsx` / `trip-info.tsx` / `marker/stop-summary.tsx` preserve their visual size, while `timetable-header.tsx` accepts a 12px → 10px downgrade. The hand-rolled `sizeVariants` map is removed in favor of BaseLabel's built-in sizes.
 - Add outlines to `AgencyBadge` and `HeadsignBadge`. `HeadsignBadge` always renders a theme-aware neutral gray resolved at runtime via `useThemeNeutralBorderColor`; `AgencyBadge` computes a context cascade via `resolveContextBorderColor` and leaves the border toggle to the caller (`showBorder`). Both use inline `borderColor` via `BaseBadge` so theme changes stay reactive.
 - Update the `AgencyBadge` TSDoc to match the shipped border behavior: the outline is derived from `useThemeContrastBackgroundColor` + `resolveContextBorderColor`, not `useThemeNeutralBorderColor`.
+- nearby-stops の一覧に時刻表ダイアログと同系統の scroll fade edge を追加し、BottomSheet header の verbose view hint を一旦非表示にした。合わせて `view.routeHeadsign.label` を `Route/Dest` / `路線 / 行先` に更新し、map + bottom sheet の高さ制御を `MapBottomSheetLayout` と `resolveMapBottomSheetLayoutPreset` に集約した。viewport 高さに応じて map / sheet の比率を `60:40` → `50:50` → `40:60` で切り替える。
 
 ### Fixed
 
 - `BaseBadge` now applies inline `fgColor` / `borderColor` independently of `bgColor`, so callers can use caller-resolved text or outline colors without also forcing an inline background. Add a focused component regression test for the `borderColor`-without-`bgColor` case.
+- `MapView` に `heightClassName` 変更時の `invalidateSize()` を追加し、bottom sheet 展開や responsive layout 切り替え後も Leaflet が現在のコンテナサイズを再認識するようにした。
 
 ## [2026.04.21]
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -43,8 +43,7 @@ import {
   prepareStopTimetable,
   prepareRouteHeadsignTimetable,
 } from './domain/transit/timetable-filter';
-import { MapView } from './components/map/map-view';
-import { BottomSheet } from './components/bottom-sheet';
+import { MapBottomSheetLayout } from './components/map-bottom-sheet-layout';
 import { TimeControls } from './components/time-controls';
 import { TimetableModal, type TimetableData } from './components/dialog/timetable-modal';
 import { StopSearchModal } from './components/dialog/stop-search-modal';
@@ -761,73 +760,74 @@ export default function App({ loadResult }: AppProps) {
 
   return (
     <>
-      <div className="relative">
-        <MapView
-          inBoundStops={inBoundStops}
-          radiusStops={radiusStops}
-          selectedStopId={selectedStopId}
-          focusPosition={focusPosition}
-          stopTimes={stopTimes}
-          routeTypeMap={routeTypeMap}
-          routeShapes={routeShapes}
-          selectionInfo={selectionInfo}
-          routeStops={routeStops}
-          // routeStops={[]}
-          visibleStopTypes={visibleStopTypes}
-          visibleRouteShapes={visibleRouteShapes}
-          tileIndex={settings.tileIndex}
-          renderMode={settings.renderMode}
-          perfMode={settings.perfMode}
-          infoLevel={settings.infoLevel}
-          dataLang={dataLang}
-          time={dateTime}
-          onBoundsChanged={handleBoundsChanged}
-          onStopSelected={handleSelectStop}
-          onFetchStopTimes={handleFetchStopTimes}
-          onToggleStopType={handleToggleStopType}
-          onToggleBusShapes={handleToggleBusShapes}
-          onToggleNonBusShapes={handleToggleNonBusShapes}
-          onCycleTile={handleCycleTile}
-          onToggleRenderMode={handleToggleRenderMode}
-          onTogglePerfMode={handleTogglePerfMode}
-          onCycleInfoLevel={handleCycleInfoLevel}
-          onDeselectStop={deselectStop}
-          onRouteShapeSelected={selectRouteShape}
-          resolveRouteFreq={resolveRouteFreq}
-          theme={settings.theme}
-          doubleTapDrag={settings.doubleTapDrag}
-          onToggleDarkMode={handleToggleDarkMode}
-          onCycleLang={handleCycleLang}
-          onSearchClick={() => setSearchModalOpen(true)}
-          onInfoClick={() => setInfoDialogOpen(true)}
-          stopHistory={history}
-          onHistorySelect={handleHistorySelect}
-          anchors={anchors}
-          onPortalSelect={handlePortalSelect}
-          lookupAnchorStopMeta={lookupAnchorStopMeta}
-        />
-        <TimeControls
-          time={dateTime}
-          isCustomTime={isCustomTime}
-          onResetToNow={resetToNow}
-          onCustomTimeSet={setCustomTime}
-        />
-      </div>
-      <BottomSheet
-        stopTimes={filteredStopTimes}
-        selectedStopId={selectedStopId}
-        isNearbyLoading={isNearbyLoading}
-        hasNearbyLoaded={hasNearbyLoaded}
-        dataConfig={perfProfile.data}
-        time={dateTime}
-        mapCenter={mapCenter}
-        infoLevel={settings.infoLevel}
-        dataLang={dataLang}
-        anchorIds={anchorIds}
-        onStopSelected={handleSelectStopById}
-        onShowTimetable={handleShowTimetable}
-        onShowStopTimetable={handleShowStopTimetable}
-        onToggleAnchor={handleToggleAnchor}
+      <MapBottomSheetLayout
+        mapViewProps={{
+          inBoundStops,
+          radiusStops,
+          selectedStopId,
+          focusPosition,
+          stopTimes,
+          routeTypeMap,
+          routeShapes,
+          selectionInfo,
+          routeStops,
+          visibleStopTypes,
+          visibleRouteShapes,
+          tileIndex: settings.tileIndex,
+          renderMode: settings.renderMode,
+          perfMode: settings.perfMode,
+          infoLevel: settings.infoLevel,
+          dataLang,
+          time: dateTime,
+          onBoundsChanged: handleBoundsChanged,
+          onStopSelected: handleSelectStop,
+          onFetchStopTimes: handleFetchStopTimes,
+          onToggleStopType: handleToggleStopType,
+          onToggleBusShapes: handleToggleBusShapes,
+          onToggleNonBusShapes: handleToggleNonBusShapes,
+          onCycleTile: handleCycleTile,
+          onToggleRenderMode: handleToggleRenderMode,
+          onTogglePerfMode: handleTogglePerfMode,
+          onCycleInfoLevel: handleCycleInfoLevel,
+          onDeselectStop: deselectStop,
+          onRouteShapeSelected: selectRouteShape,
+          resolveRouteFreq,
+          theme: settings.theme,
+          doubleTapDrag: settings.doubleTapDrag,
+          onToggleDarkMode: handleToggleDarkMode,
+          onCycleLang: handleCycleLang,
+          onSearchClick: () => setSearchModalOpen(true),
+          onInfoClick: () => setInfoDialogOpen(true),
+          stopHistory: history,
+          onHistorySelect: handleHistorySelect,
+          anchors,
+          onPortalSelect: handlePortalSelect,
+          lookupAnchorStopMeta,
+        }}
+        bottomSheetProps={{
+          stopTimes: filteredStopTimes,
+          selectedStopId,
+          isNearbyLoading,
+          hasNearbyLoaded,
+          dataConfig: perfProfile.data,
+          time: dateTime,
+          mapCenter,
+          infoLevel: settings.infoLevel,
+          dataLang,
+          anchorIds,
+          onStopSelected: handleSelectStopById,
+          onShowTimetable: handleShowTimetable,
+          onShowStopTimetable: handleShowStopTimetable,
+          onToggleAnchor: handleToggleAnchor,
+        }}
+        mapOverlay={
+          <TimeControls
+            time={dateTime}
+            isCustomTime={isCustomTime}
+            onResetToNow={resetToNow}
+            onCustomTimeSet={setCustomTime}
+          />
+        }
       />
       <StopSearchModal
         repo={repo}

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -40,7 +40,7 @@ export function BottomSheetHeader({
   dataLang,
   showOperatingStopsOnly,
   viewId,
-  selectedView,
+  selectedView: _selectedView,
   infoLevel,
   presentRouteTypes,
   hiddenRouteTypes,
@@ -131,7 +131,7 @@ export function BottomSheetHeader({
           );
         })}
       </div>
-      {selectedView && info.isVerboseEnabled && (
+      {/* {selectedView && info.isVerboseEnabled && (
         <div className="mt-1">
           <p className="text-[11px] text-[#888] dark:text-gray-400">{t(selectedView.titleKey)}</p>
           {info.isDetailedEnabled && (
@@ -140,7 +140,7 @@ export function BottomSheetHeader({
             </p>
           )}
         </div>
-      )}
+      )} */}
     </div>
   );
 }

--- a/src/components/bottom-sheet-stops.tsx
+++ b/src/components/bottom-sheet-stops.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
 import type { LatLng } from '../types/app/map';
 import type { InfoLevel } from '../types/app/settings';
 import type { AppRouteTypeValue, TimetableEntriesState } from '../types/app/transit';
@@ -52,39 +52,103 @@ export function BottomSheetStops({
   onShowStopTimetable,
   onToggleAnchor,
 }: BottomSheetStopsProps) {
+  const stopIdsKey = useMemo(() => stopTimes.map((swc) => swc.stop.stop_id).join(','), [stopTimes]);
+  const scrollFade = useScrollFades(contentRef, stopIdsKey);
+
   return (
-    <div
-      className="grid flex-1 grid-cols-1 content-start gap-0 overflow-y-auto px-4 pb-0 sm:grid-cols-2 sm:gap-x-4 lg:grid-cols-3"
-      ref={contentRef}
-    >
-      {stopTimes.map((swc, i) => {
-        const props: NearbyStopProps = {
-          data: swc,
-          // Fallback to 'no-service' if the Map is missing this stop_id
-          // (shouldn't happen — the Map and this `stopTimes` prop are
-          // both derived from the same upstream stops list — but stay
-          // defensive in case of race conditions during rerender).
-          upcomingEntriesState: upcomingEntriesStates.get(swc.stop.stop_id) ?? 'no-service',
-          isSelected: selectedStopId === swc.stop.stop_id,
-          now,
-          mapCenter,
-          infoLevel,
-          dataLang,
-          viewId,
-          isAnchor: anchorIds.has(swc.stop.stop_id),
-          onStopSelected,
-          onShowTimetable,
-          onShowStopTimetable,
-          onToggleAnchor,
-        };
-        // Eager render: first N stops, or the selected stop (so scroll-to-selected works)
-        return i < EAGER_RENDER_COUNT || props.isSelected ? (
-          <NearbyStop key={swc.stop.stop_id} {...props} />
-        ) : (
-          <LazyNearbyStop key={swc.stop.stop_id} scrollRoot={contentRef} {...props} />
-        );
-      })}
+    <div className="relative min-h-0 flex-1">
+      {scrollFade.showTop && <ScrollFadeEdge position="top" />}
+      <div
+        className="grid h-full grid-cols-1 content-start gap-0 overflow-y-auto px-4 pb-0 sm:grid-cols-2 sm:gap-x-4 lg:grid-cols-3"
+        ref={contentRef}
+        onScroll={scrollFade.handleScroll}
+      >
+        {stopTimes.map((swc, i) => {
+          const props: NearbyStopProps = {
+            data: swc,
+            // Fallback to 'no-service' if the Map is missing this stop_id
+            // (shouldn't happen — the Map and this `stopTimes` prop are
+            // both derived from the same upstream stops list — but stay
+            // defensive in case of race conditions during rerender).
+            upcomingEntriesState: upcomingEntriesStates.get(swc.stop.stop_id) ?? 'no-service',
+            isSelected: selectedStopId === swc.stop.stop_id,
+            now,
+            mapCenter,
+            infoLevel,
+            dataLang,
+            viewId,
+            isAnchor: anchorIds.has(swc.stop.stop_id),
+            onStopSelected,
+            onShowTimetable,
+            onShowStopTimetable,
+            onToggleAnchor,
+          };
+          // Eager render: first N stops, or the selected stop (so scroll-to-selected works)
+          return i < EAGER_RENDER_COUNT || props.isSelected ? (
+            <NearbyStop key={swc.stop.stop_id} {...props} />
+          ) : (
+            <LazyNearbyStop key={swc.stop.stop_id} scrollRoot={contentRef} {...props} />
+          );
+        })}
+      </div>
+      {scrollFade.showBottom && <ScrollFadeEdge position="bottom" />}
     </div>
+  );
+}
+
+function useScrollFades(ref: RefObject<HTMLDivElement | null>, resetKey: string) {
+  const [fadeState, setFadeState] = useState({ showTop: false, showBottom: false });
+
+  const updateFadeState = useCallback(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+
+    const showTop = el.scrollTop > 1;
+    const showBottom = el.scrollTop + el.clientHeight < el.scrollHeight - 1;
+
+    setFadeState((prev) =>
+      prev.showTop === showTop && prev.showBottom === showBottom ? prev : { showTop, showBottom },
+    );
+  }, [ref]);
+
+  useEffect(() => {
+    updateFadeState();
+
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateFadeState();
+    });
+
+    resizeObserver.observe(el);
+
+    window.addEventListener('resize', updateFadeState);
+    const frameId = requestAnimationFrame(updateFadeState);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener('resize', updateFadeState);
+      resizeObserver.disconnect();
+    };
+  }, [ref, resetKey, updateFadeState]);
+
+  return {
+    handleScroll: updateFadeState,
+    showTop: fadeState.showTop,
+    showBottom: fadeState.showBottom,
+  };
+}
+
+function ScrollFadeEdge({ position }: { position: 'top' | 'bottom' }) {
+  return position === 'top' ? (
+    <div className="from-background via-background/50 pointer-events-none sticky top-0 z-10 -mb-10 h-10 bg-linear-to-b to-transparent" />
+  ) : (
+    <div className="from-background via-background/50 pointer-events-none sticky bottom-0 z-10 -mt-10 h-10 bg-linear-to-t to-transparent" />
   );
 }
 

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -16,8 +16,6 @@ import { BottomSheetHeader } from './bottom-sheet-header';
 import { BottomSheetStops } from './bottom-sheet-stops';
 
 const DRAG_THRESHOLD = 50;
-const COLLAPSED_HEIGHT_CLASS = 'h-[40dvh]';
-const EXPANDED_HEIGHT_CLASS = 'h-[70dvh]';
 
 /** Auto-enable "show operating stops only" filter at 22:00 in service day minutes. */
 const LATE_NIGHT_THRESHOLD_MINUTES = 22 * 60;
@@ -51,7 +49,7 @@ export interface NearbyStopsCounts {
   filtered: number;
 }
 
-interface BottomSheetProps {
+export interface BottomSheetProps {
   stopTimes: StopWithContext[];
   selectedStopId: string | null;
   isNearbyLoading: boolean;
@@ -69,6 +67,14 @@ interface BottomSheetProps {
   onShowStopTimetable?: (stopId: string) => void;
   /** Toggle anchor (bookmark) status for a stop. */
   onToggleAnchor: (stopId: string, routeTypes: AppRouteTypeValue[]) => void;
+  /** Collapsed-state height class applied to the sheet root. */
+  collapsedHeightClassName?: string;
+  /** Expanded-state height class applied to the sheet root. */
+  expandedHeightClassName?: string;
+  /** Controlled expanded state. */
+  expanded?: boolean;
+  /** Controlled expanded state setter. */
+  onExpandedChange?: (expanded: boolean) => void;
 }
 
 export function BottomSheet({
@@ -86,8 +92,23 @@ export function BottomSheet({
   onShowTimetable,
   onShowStopTimetable,
   onToggleAnchor,
+  collapsedHeightClassName = 'h-[40dvh]',
+  expandedHeightClassName = 'h-[70dvh]',
+  expanded: expandedProp,
+  onExpandedChange,
 }: BottomSheetProps) {
-  const [expanded, setExpanded] = useState(false);
+  const [uncontrolledExpanded, setUncontrolledExpanded] = useState(false);
+  const expanded = expandedProp ?? uncontrolledExpanded;
+  const setExpanded = useCallback(
+    (nextExpanded: boolean) => {
+      if (onExpandedChange) {
+        onExpandedChange(nextExpanded);
+        return;
+      }
+      setUncontrolledExpanded(nextExpanded);
+    },
+    [onExpandedChange],
+  );
   const [viewId, setViewId] = useState(DEFAULT_VIEW_ID);
   const isLateNight = getServiceDayMinutes(now) >= LATE_NIGHT_THRESHOLD_MINUTES;
   // User can toggle manually; null means "use auto (isLateNight)".
@@ -197,19 +218,22 @@ export function BottomSheet({
     touchStartY.current = e.touches[0].clientY;
   }, []);
 
-  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
-    const deltaY = e.changedTouches[0].clientY - touchStartY.current;
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      const deltaY = e.changedTouches[0].clientY - touchStartY.current;
 
-    if (Math.abs(deltaY) < DRAG_THRESHOLD) {
-      return;
-    }
+      if (Math.abs(deltaY) < DRAG_THRESHOLD) {
+        return;
+      }
 
-    if (deltaY < 0) {
-      setExpanded(true);
-    } else {
-      setExpanded(false);
-    }
-  }, []);
+      if (deltaY < 0) {
+        setExpanded(true);
+      } else {
+        setExpanded(false);
+      }
+    },
+    [setExpanded],
+  );
 
   const stopIdsKey = useMemo(() => stopTimes.map((d) => d.stop.stop_id).join(','), [stopTimes]);
 
@@ -235,21 +259,21 @@ export function BottomSheet({
       setExpanded(false);
       onStopSelected(stopId);
     },
-    [onStopSelected],
+    [onStopSelected, setExpanded],
   );
 
   return (
     <div
       className={cn(
         'fixed right-0 bottom-0 left-0 z-1000 flex touch-none flex-col overflow-hidden rounded-t-2xl bg-white shadow-[0_-2px_12px_rgba(0,0,0,0.15)] transition-[height] duration-300 ease-in-out dark:bg-gray-900',
-        expanded ? EXPANDED_HEIGHT_CLASS : COLLAPSED_HEIGHT_CLASS,
+        expanded ? expandedHeightClassName : collapsedHeightClassName,
       )}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
     >
       <div
         className="flex shrink-0 cursor-grab justify-center py-2 pb-1"
-        onClick={() => setExpanded((v) => !v)}
+        onClick={() => setExpanded(!expanded)}
       >
         <div className="h-1 w-9 rounded-sm bg-[#bdbdbd] dark:bg-gray-600" />
       </div>

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -15,6 +15,8 @@ import { cn } from '../lib/utils';
 import { BottomSheetHeader } from './bottom-sheet-header';
 import { BottomSheetStops } from './bottom-sheet-stops';
 
+type ExpandedStateAction = boolean | ((prevExpanded: boolean) => boolean);
+
 const DRAG_THRESHOLD = 50;
 
 /** Auto-enable "show operating stops only" filter at 22:00 in service day minutes. */
@@ -74,7 +76,7 @@ export interface BottomSheetProps {
   /** Controlled expanded state. */
   expanded?: boolean;
   /** Controlled expanded state setter. */
-  onExpandedChange?: (expanded: boolean) => void;
+  onExpandedChange?: (expanded: ExpandedStateAction) => void;
 }
 
 export function BottomSheet({
@@ -100,7 +102,7 @@ export function BottomSheet({
   const [uncontrolledExpanded, setUncontrolledExpanded] = useState(false);
   const expanded = expandedProp ?? uncontrolledExpanded;
   const setExpanded = useCallback(
-    (nextExpanded: boolean) => {
+    (nextExpanded: ExpandedStateAction) => {
       if (onExpandedChange) {
         onExpandedChange(nextExpanded);
         return;
@@ -273,7 +275,7 @@ export function BottomSheet({
     >
       <div
         className="flex shrink-0 cursor-grab justify-center py-2 pb-1"
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => setExpanded((prevExpanded) => !prevExpanded)}
       >
         <div className="h-1 w-9 rounded-sm bg-[#bdbdbd] dark:bg-gray-600" />
       </div>

--- a/src/components/map-bottom-sheet-layout.tsx
+++ b/src/components/map-bottom-sheet-layout.tsx
@@ -1,11 +1,11 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { BottomSheet, type BottomSheetProps } from './bottom-sheet';
 import { MapView, type MapViewProps } from './map/map-view';
+import { useViewportHeight } from '../hooks/use-viewport-height';
+import { resolveMapBottomSheetLayoutPreset } from '../utils/map-bottom-sheet-layout-preset';
+import { createLogger } from '../lib/logger';
 
-const COLLAPSED_MAP_HEIGHT_CLASS = 'h-[60dvh]';
-const EXPANDED_MAP_HEIGHT_CLASS = 'h-[60dvh]';
-const COLLAPSED_SHEET_HEIGHT_CLASS = 'h-[40dvh]';
-const EXPANDED_SHEET_HEIGHT_CLASS = 'h-[70dvh]';
+const logger = createLogger('MapBottomSheetLayout');
 
 interface MapBottomSheetLayoutProps {
   mapViewProps: MapViewProps;
@@ -19,13 +19,25 @@ export function MapBottomSheetLayout({
   mapOverlay,
 }: MapBottomSheetLayoutProps) {
   const [expanded, setExpanded] = useState(false);
+  const viewportHeight = useViewportHeight();
+  const layoutPreset = resolveMapBottomSheetLayoutPreset(viewportHeight);
+
+  useEffect(() => {
+    logger.debug(
+      `viewportHeight=${viewportHeight}, collapsedMap=${layoutPreset.collapsedMapHeightClassName}, expandedMap=${layoutPreset.expandedMapHeightClassName}, collapsedSheet=${layoutPreset.collapsedSheetHeightClassName}, expandedSheet=${layoutPreset.expandedSheetHeightClassName}`,
+    );
+  }, [layoutPreset, viewportHeight]);
 
   return (
     <>
       <div className="relative">
         <MapView
           {...mapViewProps}
-          heightClassName={expanded ? EXPANDED_MAP_HEIGHT_CLASS : COLLAPSED_MAP_HEIGHT_CLASS}
+          heightClassName={
+            expanded
+              ? layoutPreset.expandedMapHeightClassName
+              : layoutPreset.collapsedMapHeightClassName
+          }
         />
         {mapOverlay}
       </div>
@@ -33,8 +45,8 @@ export function MapBottomSheetLayout({
         {...bottomSheetProps}
         expanded={expanded}
         onExpandedChange={setExpanded}
-        collapsedHeightClassName={COLLAPSED_SHEET_HEIGHT_CLASS}
-        expandedHeightClassName={EXPANDED_SHEET_HEIGHT_CLASS}
+        collapsedHeightClassName={layoutPreset.collapsedSheetHeightClassName}
+        expandedHeightClassName={layoutPreset.expandedSheetHeightClassName}
       />
     </>
   );

--- a/src/components/map-bottom-sheet-layout.tsx
+++ b/src/components/map-bottom-sheet-layout.tsx
@@ -8,8 +8,11 @@ import { createLogger } from '../lib/logger';
 const logger = createLogger('MapBottomSheetLayout');
 
 interface MapBottomSheetLayoutProps {
-  mapViewProps: MapViewProps;
-  bottomSheetProps: BottomSheetProps;
+  mapViewProps: Omit<MapViewProps, 'heightClassName'>;
+  bottomSheetProps: Omit<
+    BottomSheetProps,
+    'collapsedHeightClassName' | 'expandedHeightClassName' | 'expanded' | 'onExpandedChange'
+  >;
   mapOverlay?: ReactNode;
 }
 

--- a/src/components/map-bottom-sheet-layout.tsx
+++ b/src/components/map-bottom-sheet-layout.tsx
@@ -1,0 +1,41 @@
+import { useState, type ReactNode } from 'react';
+import { BottomSheet, type BottomSheetProps } from './bottom-sheet';
+import { MapView, type MapViewProps } from './map/map-view';
+
+const COLLAPSED_MAP_HEIGHT_CLASS = 'h-[60dvh]';
+const EXPANDED_MAP_HEIGHT_CLASS = 'h-[60dvh]';
+const COLLAPSED_SHEET_HEIGHT_CLASS = 'h-[40dvh]';
+const EXPANDED_SHEET_HEIGHT_CLASS = 'h-[70dvh]';
+
+interface MapBottomSheetLayoutProps {
+  mapViewProps: MapViewProps;
+  bottomSheetProps: BottomSheetProps;
+  mapOverlay?: ReactNode;
+}
+
+export function MapBottomSheetLayout({
+  mapViewProps,
+  bottomSheetProps,
+  mapOverlay,
+}: MapBottomSheetLayoutProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <>
+      <div className="relative">
+        <MapView
+          {...mapViewProps}
+          heightClassName={expanded ? EXPANDED_MAP_HEIGHT_CLASS : COLLAPSED_MAP_HEIGHT_CLASS}
+        />
+        {mapOverlay}
+      </div>
+      <BottomSheet
+        {...bottomSheetProps}
+        expanded={expanded}
+        onExpandedChange={setExpanded}
+        collapsedHeightClassName={COLLAPSED_SHEET_HEIGHT_CLASS}
+        expandedHeightClassName={EXPANDED_SHEET_HEIGHT_CLASS}
+      />
+    </>
+  );
+}

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -307,6 +307,7 @@ export function MapView({
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
   const [userLocation, setUserLocation] = useState<UserLocation | null>(null);
   const [zoom, setZoom] = useState(INITIAL_ZOOM);
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
   const { nearby: nearbyRenderMode, far: farRenderMode } = resolveRenderModes(renderMode, zoom);
 
@@ -346,21 +347,33 @@ export function MapView({
   const handleLocated = useCallback((location: UserLocation) => setUserLocation(location), []);
 
   useEffect(() => {
-    if (!mapInstance) {
+    if (!mapInstance || !wrapperRef.current) {
       return;
     }
 
-    const frameId = requestAnimationFrame(() => {
-      mapInstance.invalidateSize({ animate: false });
+    let frameId = 0;
+    const invalidateMapSize = () => {
+      cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(() => {
+        mapInstance.invalidateSize({ animate: false });
+      });
+    };
+
+    invalidateMapSize();
+
+    const resizeObserver = new ResizeObserver(() => {
+      invalidateMapSize();
     });
+    resizeObserver.observe(wrapperRef.current);
 
     return () => {
       cancelAnimationFrame(frameId);
+      resizeObserver.disconnect();
     };
-  }, [mapInstance, heightClassName]);
+  }, [mapInstance]);
 
   return (
-    <div className={`relative w-full ${heightClassName ?? 'h-[60dvh]'}`}>
+    <div ref={wrapperRef} className={`relative w-full ${heightClassName ?? 'h-[60dvh]'}`}>
       {/* Invert map tiles in dark mode via CSS filter on the tile pane */}
       {theme === 'dark' && (
         <style>{`.leaflet-tile-pane { filter: invert(1) hue-rotate(180deg); }`}</style>

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -197,7 +197,7 @@ function DistanceRings() {
   );
 }
 
-interface MapViewProps {
+export interface MapViewProps {
   /** Stops within the current viewport. Used for simplified marker rendering. */
   inBoundStops: StopWithMeta[];
   /** Stops within the nearby radius. Used for edge markers and detailed display. */
@@ -256,6 +256,8 @@ interface MapViewProps {
    * data at render time, regardless of viewport position.
    */
   lookupAnchorStopMeta: (stopId: string) => StopWithMeta | null;
+  /** Height class applied to the outer map container. */
+  heightClassName?: string;
 }
 
 export function MapView({
@@ -300,6 +302,7 @@ export function MapView({
   onHistorySelect,
   anchors,
   onPortalSelect,
+  heightClassName,
 }: MapViewProps) {
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
   const [userLocation, setUserLocation] = useState<UserLocation | null>(null);
@@ -343,7 +346,7 @@ export function MapView({
   const handleLocated = useCallback((location: UserLocation) => setUserLocation(location), []);
 
   return (
-    <div className="relative h-[60dvh] w-full">
+    <div className={`relative w-full ${heightClassName ?? 'h-[60dvh]'}`}>
       {/* Invert map tiles in dark mode via CSS filter on the tile pane */}
       {theme === 'dark' && (
         <style>{`.leaflet-tile-pane { filter: invert(1) hue-rotate(180deg); }`}</style>

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -345,6 +345,20 @@ export function MapView({
 
   const handleLocated = useCallback((location: UserLocation) => setUserLocation(location), []);
 
+  useEffect(() => {
+    if (!mapInstance) {
+      return;
+    }
+
+    const frameId = requestAnimationFrame(() => {
+      mapInstance.invalidateSize({ animate: false });
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [mapInstance, heightClassName]);
+
   return (
     <div className={`relative w-full ${heightClassName ?? 'h-[60dvh]'}`}>
       {/* Invert map tiles in dark mode via CSS filter on the tile pane */}

--- a/src/hooks/use-viewport-height.ts
+++ b/src/hooks/use-viewport-height.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+function getViewportHeight(): number {
+  if (typeof window === 'undefined') {
+    return 0;
+  }
+
+  return window.visualViewport?.height ?? window.innerHeight;
+}
+
+/**
+ * Observe the effective viewport height for responsive mobile layout decisions.
+ *
+ * Uses `visualViewport.height` when available so the value tracks browser UI
+ * chrome changes on mobile Safari more closely than `window.innerHeight`.
+ *
+ * @returns Current viewport height in CSS pixels.
+ */
+export function useViewportHeight(): number {
+  const [viewportHeight, setViewportHeight] = useState(() => getViewportHeight());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const updateViewportHeight = () => {
+      setViewportHeight(getViewportHeight());
+    };
+
+    updateViewportHeight();
+
+    window.addEventListener('resize', updateViewportHeight);
+    window.visualViewport?.addEventListener('resize', updateViewportHeight);
+    window.visualViewport?.addEventListener('scroll', updateViewportHeight);
+
+    return () => {
+      window.removeEventListener('resize', updateViewportHeight);
+      window.visualViewport?.removeEventListener('resize', updateViewportHeight);
+      window.visualViewport?.removeEventListener('scroll', updateViewportHeight);
+    };
+  }, []);
+
+  return viewportHeight;
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -4,12 +4,12 @@
   },
   "view": {
     "stop": {
-      "label": "ALL",
-      "title": "All",
+      "label": "Stop",
+      "title": "By stop",
       "description": "Show all services in chronological order"
     },
     "routeHeadsign": {
-      "label": "Route",
+      "label": "Route/Dest",
       "title": "By route + destination",
       "description": "Group by route and destination"
     },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -4,12 +4,12 @@
   },
   "view": {
     "stop": {
-      "label": "ALL",
-      "title": "すべて",
+      "label": "のりば",
+      "title": "のりば別",
       "description": "全ての時間を表示します"
     },
     "routeHeadsign": {
-      "label": "路線+行先",
+      "label": "路線 / 行先",
       "title": "路線+行先別",
       "description": "路線と行先の組み合わせでグループ化して表示します"
     },

--- a/src/utils/__tests__/map-bottom-sheet-layout-preset.test.ts
+++ b/src/utils/__tests__/map-bottom-sheet-layout-preset.test.ts
@@ -23,25 +23,25 @@ describe('resolveMapBottomSheetLayoutPreset', () => {
   it('returns the medium preset for medium-tall viewports', () => {
     expect(resolveMapBottomSheetLayoutPreset(900)).toEqual({
       collapsedMapHeightClassName: 'h-[50dvh]',
-      expandedMapHeightClassName: 'h-[50dvh]',
+      expandedMapHeightClassName: 'h-[40dvh]',
       collapsedSheetHeightClassName: 'h-[50dvh]',
-      expandedSheetHeightClassName: 'h-[70dvh]',
+      expandedSheetHeightClassName: 'h-[60dvh]',
     });
   });
 
   it('returns the desktop preset for very tall viewports', () => {
     expect(resolveMapBottomSheetLayoutPreset(1100)).toEqual({
       collapsedMapHeightClassName: 'h-[50dvh]',
-      expandedMapHeightClassName: 'h-[50dvh]',
+      expandedMapHeightClassName: 'h-[40dvh]',
       collapsedSheetHeightClassName: 'h-[50dvh]',
-      expandedSheetHeightClassName: 'h-[70dvh]',
+      expandedSheetHeightClassName: 'h-[60dvh]',
     });
   });
 
   it('returns the desktop preset after the tall threshold', () => {
     expect(resolveMapBottomSheetLayoutPreset(1300)).toEqual({
       collapsedMapHeightClassName: 'h-[40dvh]',
-      expandedMapHeightClassName: 'h-[40dvh]',
+      expandedMapHeightClassName: 'h-[30dvh]',
       collapsedSheetHeightClassName: 'h-[60dvh]',
       expandedSheetHeightClassName: 'h-[70dvh]',
     });

--- a/src/utils/__tests__/map-bottom-sheet-layout-preset.test.ts
+++ b/src/utils/__tests__/map-bottom-sheet-layout-preset.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { resolveMapBottomSheetLayoutPreset } from '../map-bottom-sheet-layout-preset';
+
+describe('resolveMapBottomSheetLayoutPreset', () => {
+  it('keeps the default smartphone preset for short viewports', () => {
+    expect(resolveMapBottomSheetLayoutPreset(640)).toEqual({
+      collapsedMapHeightClassName: 'h-[60dvh]',
+      expandedMapHeightClassName: 'h-[60dvh]',
+      collapsedSheetHeightClassName: 'h-[40dvh]',
+      expandedSheetHeightClassName: 'h-[70dvh]',
+    });
+  });
+
+  it('keeps the default smartphone preset for mid-height viewports', () => {
+    expect(resolveMapBottomSheetLayoutPreset(760)).toEqual({
+      collapsedMapHeightClassName: 'h-[60dvh]',
+      expandedMapHeightClassName: 'h-[60dvh]',
+      collapsedSheetHeightClassName: 'h-[40dvh]',
+      expandedSheetHeightClassName: 'h-[70dvh]',
+    });
+  });
+
+  it('returns the medium preset for medium-tall viewports', () => {
+    expect(resolveMapBottomSheetLayoutPreset(900)).toEqual({
+      collapsedMapHeightClassName: 'h-[50dvh]',
+      expandedMapHeightClassName: 'h-[50dvh]',
+      collapsedSheetHeightClassName: 'h-[50dvh]',
+      expandedSheetHeightClassName: 'h-[70dvh]',
+    });
+  });
+
+  it('returns the desktop preset for very tall viewports', () => {
+    expect(resolveMapBottomSheetLayoutPreset(1100)).toEqual({
+      collapsedMapHeightClassName: 'h-[50dvh]',
+      expandedMapHeightClassName: 'h-[50dvh]',
+      collapsedSheetHeightClassName: 'h-[50dvh]',
+      expandedSheetHeightClassName: 'h-[70dvh]',
+    });
+  });
+
+  it('returns the desktop preset after the tall threshold', () => {
+    expect(resolveMapBottomSheetLayoutPreset(1300)).toEqual({
+      collapsedMapHeightClassName: 'h-[40dvh]',
+      expandedMapHeightClassName: 'h-[40dvh]',
+      collapsedSheetHeightClassName: 'h-[60dvh]',
+      expandedSheetHeightClassName: 'h-[70dvh]',
+    });
+  });
+
+  it('falls back to regular preset when viewport height is unavailable', () => {
+    expect(resolveMapBottomSheetLayoutPreset(0)).toEqual({
+      collapsedMapHeightClassName: 'h-[60dvh]',
+      expandedMapHeightClassName: 'h-[60dvh]',
+      collapsedSheetHeightClassName: 'h-[40dvh]',
+      expandedSheetHeightClassName: 'h-[70dvh]',
+    });
+  });
+});

--- a/src/utils/map-bottom-sheet-layout-preset.ts
+++ b/src/utils/map-bottom-sheet-layout-preset.ts
@@ -18,8 +18,8 @@ const REGULAR_LAYOUT_PRESET: MapBottomSheetLayoutPreset = {
 const MEDIUM_LAYOUT_PRESET: MapBottomSheetLayoutPreset = {
   collapsedMapHeightClassName: 'h-[50dvh]',
   collapsedSheetHeightClassName: 'h-[50dvh]',
-  expandedMapHeightClassName: 'h-[50dvh]',
-  expandedSheetHeightClassName: 'h-[70dvh]',
+  expandedMapHeightClassName: 'h-[40dvh]',
+  expandedSheetHeightClassName: 'h-[60dvh]',
 };
 
 const TALL_LAYOUT_PRESET: MapBottomSheetLayoutPreset = {

--- a/src/utils/map-bottom-sheet-layout-preset.ts
+++ b/src/utils/map-bottom-sheet-layout-preset.ts
@@ -1,0 +1,55 @@
+export interface MapBottomSheetLayoutPreset {
+  collapsedMapHeightClassName: string;
+  expandedMapHeightClassName: string;
+  collapsedSheetHeightClassName: string;
+  expandedSheetHeightClassName: string;
+}
+
+const MEDIUM_VIEWPORT_MIN_HEIGHT = 800;
+const TALL_VIEWPORT_MIN_HEIGHT = 1200;
+
+const REGULAR_LAYOUT_PRESET: MapBottomSheetLayoutPreset = {
+  collapsedMapHeightClassName: 'h-[60dvh]',
+  collapsedSheetHeightClassName: 'h-[40dvh]',
+  expandedMapHeightClassName: 'h-[60dvh]',
+  expandedSheetHeightClassName: 'h-[70dvh]',
+};
+
+const MEDIUM_LAYOUT_PRESET: MapBottomSheetLayoutPreset = {
+  collapsedMapHeightClassName: 'h-[50dvh]',
+  collapsedSheetHeightClassName: 'h-[50dvh]',
+  expandedMapHeightClassName: 'h-[50dvh]',
+  expandedSheetHeightClassName: 'h-[70dvh]',
+};
+
+const TALL_LAYOUT_PRESET: MapBottomSheetLayoutPreset = {
+  collapsedMapHeightClassName: 'h-[40dvh]',
+  collapsedSheetHeightClassName: 'h-[60dvh]',
+  expandedMapHeightClassName: 'h-[30dvh]',
+  expandedSheetHeightClassName: 'h-[70dvh]',
+};
+
+/**
+ * Resolve map and bottom-sheet height classes from viewport height.
+ *
+ * The default layout keeps the map at 60dvh so map overlay controls remain
+ * fully visible on most smartphones. Mid-height screens switch to 50dvh, and
+ * very tall screens switch to 40dvh because they still preserve enough
+ * absolute height for the same UI.
+ *
+ * @param viewportHeight - Effective viewport height in CSS pixels.
+ * @returns Height class preset for the current screen size.
+ */
+export function resolveMapBottomSheetLayoutPreset(
+  viewportHeight: number,
+): MapBottomSheetLayoutPreset {
+  if (viewportHeight >= TALL_VIEWPORT_MIN_HEIGHT) {
+    return TALL_LAYOUT_PRESET;
+  }
+
+  if (viewportHeight >= MEDIUM_VIEWPORT_MIN_HEIGHT) {
+    return MEDIUM_LAYOUT_PRESET;
+  }
+
+  return REGULAR_LAYOUT_PRESET;
+}


### PR DESCRIPTION
## Summary
- add scroll fade edges to the nearby stops list and hide the verbose view hint
- clarify stop and route/headsign labels in English and Japanese locales
- centralize map and bottom-sheet sizing and make the layout responsive to viewport height
- invalidate Leaflet size when the map container height changes so focus pan uses the current container size

## Validation
- npm run format
- npm run lint
- npm run build
- targeted Vitest coverage for map-bottom-sheet-layout preset logic