### PR TITLE
Refactor trip inspection and enable timetable access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [CalVer](https://calver.org/).
 - `StopSummary` に display flag 群 (agency / trip count / connectivity 等) を追加し、nearby-stop / marker context で切替可能に。
 - `dataLang` prop を `TripInfo` / `StopInfo` / `StopSummary` / `StopTimeItem` 等に rename/統一 (reader locale fallback chain を明示)。
 - `JourneyTimeBar` Storybook の args を実サイズ値に近づけて調整。
+- `VerboseTimetableEntries` / `VerboseTimetableGridEntry` / `VerboseContextualTimetableEntry` / `VerboseHeadsign` の構成を整理し、timetable entry の verbose 表示を共通の building block で組み立てるよう refactor。
+- verbose/debug 用 `<summary>` (stop-summary / timetable-grid / verbose-\* 全般) に `tabIndex={-1}` を付与し、キーボード tab 移動の焦点対象から除外。
 
 ### Fixed
 
@@ -37,6 +39,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - `TripInspectionDialog` summary の emoji / position label 表示を現在の info level 設定に揃え、情報レベル切替で冗長な indicator が残る問題を修正 (Refs: #147)。
 - `MockRepository` の再構成 trip で停車時刻が進行しない問題を修正 (pattern stops の travel offset を upcoming / full-day / trip snapshot の各経路で適用)。併せて `r6-*` モック停留所の配置を東側に移動。`bus_yukkuri01` trip の timing 回帰テストを追加。
 - `MockRepository` の日本語 headsign 定義が欠落していた問題を修正。
+- `StopTimeTimeInfo` / `StopTimesItem` の trip inspect トリガーボタンに `focus-visible` ring を追加し、キーボード操作時のフォーカス可視性を確保 (a11y)。
 
 ## [2026.04.23]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,32 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ### Added
 
+- `TripInspectionDialog` (`src/components/dialog/trip-inspection-dialog.tsx`) を追加。trip の全停車駅を時刻・停車位置付きで一覧表示する modal。選択行 auto-scroll / 情報レベル連動表示に対応 (Refs: #147)。
+- `useTripInspection` hook (`src/hooks/use-trip-inspection.ts`) を追加。app 層から trip inspection dialog の open/close を扱う。
+- `TripInspectionTarget` 型を追加 (`src/types/app/transit-composed.ts`)。trip inspection の入口を stop-time entry 由来に限定せず一般化。
+- `StopTimeDetailInfo` / `StopTimeTimeInfo` / `AbsoluteStopTime` コンポーネントを追加。`StopTimeItem` から building block を分離し、TripInspectionDialog の row layout と共有。
+- `TimetableGridEntry` / `TimetableModal` から trip inspection を起動する動線を追加。
+- Display size primitive を共通化する alias を追加 (`src/components/shared/display-size.ts`)。
+- `time-style.ts` に explicit time band 定義を追加 (morning / daytime / evening / night band を明示)。
 - Pipeline: りんかい線 (東京臨海高速鉄道株式会社) の GTFS データソースを追加 (prefix `twrr`, route_type 2 rail)。8 駅 / 1 路線。`shapes.txt` は含まれないが MLIT 国土数値情報 (臨海副都心線) 経由で路線図に対応。`data-source-settings` の `routeTypes` は `[1, 2]` (subway + rail) — 実態として地下鉄区間を含むため将来の Source 選択 UI 用に両方を宣言。
 - About: りんかい線のクレジット・データ情報を追加。
+
+### Changed
+
+- `StopTimeItem` を building block (`StopTimeDetailInfo` / `StopTimeTimeInfo`) に分離し、`TripInspectionDialog` と共通化 (260 行 → 約 100 行 + 子コンポーネント)。
+- `StopTimeItem` の絶対/相対時刻受け渡しを explicit な time props に変更し、caller 側で表示ポリシーを制御可能に。
+- `StopSummary` に display flag 群 (agency / trip count / connectivity 等) を追加し、nearby-stop / marker context で切替可能に。
+- `dataLang` prop を `TripInfo` / `StopInfo` / `StopSummary` / `StopTimeItem` 等に rename/統一 (reader locale fallback chain を明示)。
+- `JourneyTimeBar` Storybook の args を実サイズ値に近づけて調整。
+
+### Fixed
+
+- `verbose-timetable-entries` で headsign が未設定の場合の表示を専用ラベル (`— headsign なし` 等) に切替え、空文字レンダリングを解消。
+- `PillButton` の `cursor: pointer` が欠落していた問題を修正。
+- `TripInspectionDialog` を開いた直後の scroll 位置が安定しない問題を修正 (選択行 auto-scroll のタイミング調整)。
+- `TripInspectionDialog` summary の emoji / position label 表示を現在の info level 設定に揃え、情報レベル切替で冗長な indicator が残る問題を修正 (Refs: #147)。
+- `MockRepository` の再構成 trip で停車時刻が進行しない問題を修正 (pattern stops の travel offset を upcoming / full-day / trip snapshot の各経路で適用)。併せて `r6-*` モック停留所の配置を東側に移動。`bus_yukkuri01` trip の timing 回帰テストを追加。
+- `MockRepository` の日本語 headsign 定義が欠落していた問題を修正。
 
 ## [2026.04.23]
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -869,6 +869,7 @@ export default function App({ loadResult }: AppProps) {
         time={dateTime}
         infoLevel={settings.infoLevel}
         dataLangs={langChain}
+        onInspectTrip={openTripInspection}
         onClose={() => setTimetableModal(null)}
       />
       <Toaster

--- a/src/components/absolute-stop-time.tsx
+++ b/src/components/absolute-stop-time.tsx
@@ -14,9 +14,13 @@ export interface AbsoluteStopTimeProps {
   /** Formatted absolute time text. */
   timeText: string;
   /** Text color derived from the route color. */
-  textColor: string;
+  textColor?: string;
   /** Size variant. @default 'md' */
   size?: ExtendedDisplaySize;
+  /** Font weight override for the rendered time value. */
+  weight?: 'normal' | 'bold';
+  /** Additional utility classes for the rendered time value. */
+  className?: string;
   /** Whether to render the departure marker suffix next to the time. */
   showDepartureMarker: boolean;
   /** Whether to render the arrival marker suffix next to the time. */
@@ -29,14 +33,21 @@ export function AbsoluteStopTime({
   showDepartureMarker,
   textColor,
   size = 'md',
+  weight = 'bold',
+  className,
 }: AbsoluteStopTimeProps) {
   const { t } = useTranslation();
   const variant = absoluteTimeVariants[size];
 
   return (
     <div
-      className={cn('font-bold text-[#333] dark:text-gray-100', variant.time)}
-      style={{ color: textColor }}
+      className={cn(
+        weight === 'bold' ? 'font-bold' : 'font-normal',
+        'text-[#333] dark:text-gray-100',
+        variant.time,
+        className,
+      )}
+      style={textColor ? { color: textColor } : undefined}
     >
       {timeText}
       {showArrivalMarker && (

--- a/src/components/bottom-sheet-stops.tsx
+++ b/src/components/bottom-sheet-stops.tsx
@@ -3,7 +3,7 @@ import { useScrollFades } from '@/hooks/use-scroll-fades';
 import type { LatLng } from '../types/app/map';
 import type { InfoLevel } from '../types/app/settings';
 import type { AppRouteTypeValue, TimetableEntriesState } from '../types/app/transit';
-import type { ContextualTimetableEntry, StopWithContext } from '../types/app/transit-composed';
+import type { StopWithContext, TripInspectionTarget } from '../types/app/transit-composed';
 import { ScrollFadeEdge } from './shared/scroll-fade-edge';
 import { NearbyStop, type NearbyStopProps } from './nearby-stop';
 
@@ -37,7 +37,7 @@ interface BottomSheetStopsProps {
   /** Toggle anchor (bookmark) status for a stop. */
   onToggleAnchor: (stopId: string, routeTypes: AppRouteTypeValue[]) => void;
   /** Optional callback for inspecting one concrete trip. */
-  onInspectTrip?: (entry: ContextualTimetableEntry) => void;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
 export function BottomSheetStops({

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -3,7 +3,7 @@ import type { LatLng } from '../types/app/map';
 import type { DataConfig } from '../config/perf-profiles';
 import type { InfoLevel } from '../types/app/settings';
 import type { Agency, AppRouteTypeValue, TimetableEntriesState } from '../types/app/transit';
-import type { ContextualTimetableEntry, StopWithContext } from '../types/app/transit-composed';
+import type { StopWithContext, TripInspectionTarget } from '../types/app/transit-composed';
 import { collectPresentAgencies } from '../domain/transit/collect-present-agencies';
 import { collectPresentRouteTypes } from '../domain/transit/collect-present-route-types';
 import { filterByAgency, filterByRouteType } from '../domain/transit/timetable-filter';
@@ -70,7 +70,7 @@ export interface BottomSheetProps {
   /** Toggle anchor (bookmark) status for a stop. */
   onToggleAnchor: (stopId: string, routeTypes: AppRouteTypeValue[]) => void;
   /** Optional callback for inspecting one concrete trip. */
-  onInspectTrip?: (entry: ContextualTimetableEntry) => void;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
   /** Collapsed-state height class applied to the sheet root. */
   collapsedHeightClassName?: string;
   /** Expanded-state height class applied to the sheet root. */

--- a/src/components/button/pill-button.tsx
+++ b/src/components/button/pill-button.tsx
@@ -91,6 +91,7 @@ export function PillButton({
       disabled={disabled}
       className={cn(
         'inline-flex shrink-0 items-center rounded-full font-medium whitespace-nowrap transition-colors select-none [-webkit-touch-callout:none]',
+        onClick && !disabled && 'cursor-pointer',
         sizeVariants[size] ?? sizeVariants.default,
         active
           ? activeBg

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -12,7 +12,7 @@ import { getServiceDayMinutes } from '@/domain/transit/service-day';
 import { useScrollFades } from '@/hooks/use-scroll-fades';
 import type { InfoLevel } from '@/types/app/settings';
 import type { Agency, Route, Stop, StopServiceState } from '@/types/app/transit';
-import type { TimetableEntry } from '@/types/app/transit-composed';
+import type { TimetableEntry, TripInspectionTarget } from '@/types/app/transit-composed';
 import type { TimetableOmitted } from '@/types/app/repository';
 import { useInfoLevel } from '@/hooks/use-info-level';
 import { DAY_COLOR_CATEGORY_CLASSES } from '@/utils/day-of-week';
@@ -57,10 +57,18 @@ interface TimetableModalProps {
   infoLevel: InfoLevel;
   /** Display language chain for translated GTFS/ODPT data names. */
   dataLangs: readonly string[];
+  onInspectTrip?: (target: TripInspectionTarget) => void;
   onClose: () => void;
 }
 
-export function TimetableModal({ data, time, infoLevel, dataLangs, onClose }: TimetableModalProps) {
+export function TimetableModal({
+  data,
+  time,
+  infoLevel,
+  dataLangs,
+  onInspectTrip,
+  onClose,
+}: TimetableModalProps) {
   const { t, i18n } = useTranslation();
   const open = data !== null;
   const info = useInfoLevel(infoLevel);
@@ -266,6 +274,7 @@ export function TimetableModal({ data, time, infoLevel, dataLangs, onClose }: Ti
           <div className="px-4 pt-3 pb-4">
             <TimetableGrid
               timetableEntries={filteredTimetableEntries}
+              serviceDate={data.serviceDate}
               showHeadsign={
                 info.isVerboseEnabled ||
                 new Set(
@@ -279,6 +288,7 @@ export function TimetableModal({ data, time, infoLevel, dataLangs, onClose }: Ti
               dataLangs={dataLangs}
               agencies={data.agencies}
               omitted={data.omitted}
+              onInspectTrip={onInspectTrip}
             />
           </div>
           {gridScroll.showBottom && (

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -168,6 +168,14 @@ function TripInspectionStopRow({
   const stopAgency = stopMeta?.agencies.find(
     (agency) => agency.agency_id === stop.timetableEntry.routeDirection.route.agency_id,
   );
+  const stopRoute = stop.timetableEntry.routeDirection.route;
+  const { routeColor } = resolveRouteColors(stopRoute, 'css-hex');
+  const routeColorAssessment = useThemeContrastAssessment(routeColor, LOW_CONTRAST_BADGE_MIN_RATIO);
+  const contrastAdjustedRouteColors = getContrastAdjustedRouteColors(
+    stopRoute,
+    routeColorAssessment.isLowContrast,
+    'css-hex',
+  );
   const stopAgencyLangs = stop.stopMeta
     ? resolveAgencyLang(stop.stopMeta.agencies, stop.stopMeta.stop.agency_id)
     : DEFAULT_AGENCY_LANG;
@@ -230,13 +238,19 @@ function TripInspectionStopRow({
           )}
         </div>
         <StopTimeTimeInfo
-          entry={contextualTimetableEntry}
+          arrivalMinutes={stop.timetableEntry.schedule.arrivalMinutes}
+          departureMinutes={stop.timetableEntry.schedule.departureMinutes}
+          serviceDate={serviceDate}
           now={now}
+          size="md"
+          // size="lg"
+          // size="xl"
           showArrivalTime={showArrivalTime}
           showDepartureTime={showDepartureTime}
           collapseArrivalWhenSameAsDeparture={true}
           forceShowRelativeTime={true}
           showVerbose={false}
+          textAppearance={{ color: contrastAdjustedRouteColors.color }}
         />
       </div>
       {/* StopTimeDetailInfo  */}

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -548,10 +548,10 @@ export function TripInspectionDialog({
               infoLevel={infoLevel}
               showBorder={true}
             />
-            {headsignTitle ? (
+            {headsignTitle.length > 0 ? (
               <span className="truncate">{headsignTitle}</span>
             ) : (
-              t('tripInspection.title')
+              t('tripInspection.titleWithNoHeadsign')
             )}
           </DialogTitle>
           <DialogDescription asChild className="text-center sm:text-center">

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -243,8 +243,6 @@ function TripInspectionStopRow({
           serviceDate={serviceDate}
           now={now}
           size="md"
-          // size="lg"
-          // size="xl"
           showArrivalTime={showArrivalTime}
           showDepartureTime={showDepartureTime}
           collapseArrivalWhenSameAsDeparture={true}

--- a/src/components/nearby-stop.tsx
+++ b/src/components/nearby-stop.tsx
@@ -11,7 +11,7 @@ import { useInfoLevel } from '../hooks/use-info-level';
 import type { LatLng } from '../types/app/map';
 import type { InfoLevel } from '../types/app/settings';
 import type { AppRouteTypeValue, TimetableEntriesState } from '../types/app/transit';
-import type { StopWithContext } from '../types/app/transit-composed';
+import type { StopWithContext, TripInspectionTarget } from '../types/app/transit-composed';
 import { StopInfo } from './stop-info';
 import { StopTimeItem } from './stop-time-item';
 import { StopTimesItem } from './stop-times-item';
@@ -43,7 +43,7 @@ export interface NearbyStopProps {
   /** Toggle anchor (bookmark) status for this stop. */
   onToggleAnchor: (stopId: string, routeTypes: AppRouteTypeValue[]) => void;
   /** Optional callback for inspecting one concrete trip. */
-  onInspectTrip?: (entry: StopWithContext['stopTimes'][number]) => void;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
 interface NearbyStopActionButtonsProps {

--- a/src/components/stop-summary.tsx
+++ b/src/components/stop-summary.tsx
@@ -181,13 +181,21 @@ export function StopSummary({
 
       {showVerbose && (
         <details className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-          <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+          <summary
+            tabIndex={-1}
+            className="cursor-pointer select-none"
+            onClick={(e) => e.stopPropagation()}
+          >
             [META]
           </summary>
           <div className="mt-1 ml-2 space-y-1">
             <VerboseAgencies agencies={agencies} infoLevel={infoLevel} dataLang={dataLangs} />
             <details className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-              <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+              <summary
+                tabIndex={-1}
+                className="cursor-pointer select-none"
+                onClick={(e) => e.stopPropagation()}
+              >
                 [Stop]
               </summary>
               <div className="border-app-neutral mt-1 overflow-x-auto rounded border border-dashed p-1 whitespace-nowrap">

--- a/src/components/stop-time-item.tsx
+++ b/src/components/stop-time-item.tsx
@@ -8,7 +8,7 @@ import { useThemeContrastAssessment } from '@/hooks/use-is-low-contrast-against-
 import { getTimetableEntryAttributes } from '../domain/transit/timetable-entry-attributes';
 import type { InfoLevel } from '../types/app/settings';
 import type { Agency } from '../types/app/transit';
-import type { ContextualTimetableEntry } from '../types/app/transit-composed';
+import type { ContextualTimetableEntry, TripInspectionTarget } from '../types/app/transit-composed';
 import { StopTimeDetailInfo } from './stop-time-detail-info';
 import { StopTimeTimeInfo } from './stop-time-time-info';
 import { VerboseContextualTimetableEntry } from './verbose/verbose-contextual-timetable-entry';
@@ -44,7 +44,7 @@ interface StopTimeItemProps {
    */
   showAgency?: boolean;
   /** Optional callback for inspecting this concrete trip entry. */
-  onInspectTrip?: (entry: ContextualTimetableEntry) => void;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
 /**
@@ -100,7 +100,7 @@ export function StopTimeItem({
             tripLocator: entry.tripLocator,
             stopIndex: entry.patternPosition.stopIndex,
           }}
-          onInspectTrip={onInspectTrip ? () => onInspectTrip(entry) : undefined}
+          onInspectTrip={onInspectTrip}
         />
 
         <StopTimeDetailInfo

--- a/src/components/stop-time-item.tsx
+++ b/src/components/stop-time-item.tsx
@@ -1,4 +1,10 @@
+import { LOW_CONTRAST_BADGE_MIN_RATIO } from '@/domain/transit/color-resolver/contrast-thresholds';
+import {
+  getContrastAdjustedRouteColors,
+  resolveRouteColors,
+} from '@/domain/transit/color-resolver/route-colors';
 import { useInfoLevel } from '@/hooks/use-info-level';
+import { useThemeContrastAssessment } from '@/hooks/use-is-low-contrast-against-theme';
 import { getTimetableEntryAttributes } from '../domain/transit/timetable-entry-attributes';
 import type { InfoLevel } from '../types/app/settings';
 import type { Agency } from '../types/app/transit';
@@ -65,19 +71,36 @@ export function StopTimeItem({
   const info = useInfoLevel(infoLevel);
   const showVerbose = info.isVerboseEnabled;
   const attributes = getTimetableEntryAttributes(entry);
+  const { route } = entry.routeDirection;
+  const { routeColor } = resolveRouteColors(route, 'css-hex');
+  const routeColorAssessment = useThemeContrastAssessment(routeColor, LOW_CONTRAST_BADGE_MIN_RATIO);
+  const contrastAdjustedRouteColors = getContrastAdjustedRouteColors(
+    route,
+    routeColorAssessment.isLowContrast,
+    'css-hex',
+  );
 
   return (
     <div className="border-b border-[#e0e0e0] py-1 last:border-b-0 dark:border-gray-700">
       <div className="flex gap-2">
         <StopTimeTimeInfo
-          entry={entry}
+          arrivalMinutes={entry.schedule.arrivalMinutes}
+          departureMinutes={entry.schedule.departureMinutes}
+          serviceDate={entry.serviceDate}
           now={now}
+          size="md"
           showArrivalTime={showArrivalTime}
           showDepartureTime={showDepartureTime}
           collapseArrivalWhenSameAsDeparture={collapseArrivalWhenSameAsDeparture}
           forceShowRelativeTime={forceShowRelativeTime}
           showVerbose={showVerbose}
-          onInspectTrip={onInspectTrip}
+          textAppearance={{ color: contrastAdjustedRouteColors.color }}
+          inspectTarget={{
+            serviceDate: entry.serviceDate,
+            tripLocator: entry.tripLocator,
+            stopIndex: entry.patternPosition.stopIndex,
+          }}
+          onInspectTrip={onInspectTrip ? () => onInspectTrip(entry) : undefined}
         />
 
         <StopTimeDetailInfo

--- a/src/components/stop-time-time-info.tsx
+++ b/src/components/stop-time-time-info.tsx
@@ -1,28 +1,17 @@
 import { AbsoluteStopTime } from '@/components/absolute-stop-time';
-import { LOW_CONTRAST_BADGE_MIN_RATIO } from '@/domain/transit/color-resolver/contrast-thresholds';
-import {
-  getContrastAdjustedRouteColors,
-  resolveRouteColors,
-} from '@/domain/transit/color-resolver/route-colors';
-import { useThemeContrastAssessment } from '@/hooks/use-is-low-contrast-against-theme';
 import { minutesToDate } from '../domain/transit/calendar-utils';
 import { formatAbsoluteTime } from '../domain/transit/time';
-import type {
-  ContextualTimetableEntry,
-  TripInspectionTarget,
-  WithServiceDate,
-} from '../types/app/transit-composed';
+import type { TripInspectionTarget, WithServiceDate } from '../types/app/transit-composed';
+import { cn } from '../lib/utils';
 import { BaseLabel } from './label/base-label';
 import { RelativeTime } from './relative-time';
 import type { ExtendedDisplaySize } from './shared/display-size';
 
 /**
- * Proposed future props for `StopTimeTimeInfo` after caller migration.
+ * Public display-size alias for stop-time rendering.
  *
- * The current component still accepts `StopTimeTimeInfoProps` so existing call
- * sites remain unchanged. This interface captures the slimmer API direction:
- * render from schedule + service date + text appearance, and keep trip
- * inspection wiring as an explicit optional feature.
+ * `StopTimeTimeInfo` now renders from explicit schedule + service-date props
+ * rather than a full timetable entry object.
  */
 export type StopTimeTimeTextSize = ExtendedDisplaySize;
 
@@ -42,7 +31,7 @@ export interface StopTimeTimeTextAppearance {
   className?: string;
 }
 
-export interface StopTimeTimeInfoNextProps extends WithServiceDate {
+export interface StopTimeTimeInfoProps extends WithServiceDate {
   /** Arrival minutes from midnight of the service day. */
   arrivalMinutes: number;
   /** Departure minutes from midnight of the service day. */
@@ -50,7 +39,7 @@ export interface StopTimeTimeInfoNextProps extends WithServiceDate {
   /** Current wall-clock reference time for relative display. */
   now: Date;
   /** Visual size preset for rendered time text. */
-  size?: StopTimeTimeTextSize;
+  size: StopTimeTimeTextSize;
   /** Optional appearance overrides for rendered time text. */
   textAppearance?: StopTimeTimeTextAppearance;
   /** Whether to render the arrival absolute time. */
@@ -69,51 +58,36 @@ export interface StopTimeTimeInfoNextProps extends WithServiceDate {
   onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
-interface StopTimeTimeInfoProps {
-  entry: ContextualTimetableEntry;
-  now: Date;
-  size?: StopTimeTimeTextSize;
-  showArrivalTime: boolean;
-  showDepartureTime: boolean;
-  collapseArrivalWhenSameAsDeparture: boolean;
-  forceShowRelativeTime: boolean;
-  showVerbose: boolean;
-  onInspectTrip?: (entry: ContextualTimetableEntry) => void;
-}
-
 export function StopTimeTimeInfo({
-  entry,
+  arrivalMinutes,
+  departureMinutes,
+  serviceDate,
   now,
-  size = 'md',
+  size,
+  textAppearance,
   showArrivalTime,
   showDepartureTime,
   collapseArrivalWhenSameAsDeparture,
   forceShowRelativeTime,
   showVerbose,
+  inspectTarget,
   onInspectTrip,
 }: StopTimeTimeInfoProps) {
-  const primaryMinutes = showDepartureTime
-    ? entry.schedule.departureMinutes
-    : entry.schedule.arrivalMinutes;
-  const time = minutesToDate(entry.serviceDate, primaryMinutes);
+  const primaryMinutes = showDepartureTime ? departureMinutes : arrivalMinutes;
+  const time = minutesToDate(serviceDate, primaryMinutes);
   const diffMs = time.getTime() - now.getTime();
   const showRelativeTime = forceShowRelativeTime || diffMs <= 60 * 60 * 1000;
-  const dt = formatAbsoluteTime(minutesToDate(entry.serviceDate, entry.schedule.departureMinutes));
-  const at = formatAbsoluteTime(minutesToDate(entry.serviceDate, entry.schedule.arrivalMinutes));
+  const dt = formatAbsoluteTime(minutesToDate(serviceDate, departureMinutes));
+  const at = formatAbsoluteTime(minutesToDate(serviceDate, arrivalMinutes));
   const shouldCollapseArrival =
     collapseArrivalWhenSameAsDeparture && showArrivalTime && showDepartureTime && at === dt;
   const shouldShowArrivalAbsolute = showArrivalTime && !shouldCollapseArrival;
   const shouldShowDepartureAbsolute = showDepartureTime;
   const shouldShowDepartureMarker = shouldShowArrivalAbsolute && shouldShowDepartureAbsolute;
   const timeSize: ExtendedDisplaySize = size;
-
-  const { route } = entry.routeDirection;
-  const { routeColor } = resolveRouteColors(route, 'css-hex');
-  const routeColorAssessment = useThemeContrastAssessment(routeColor, LOW_CONTRAST_BADGE_MIN_RATIO);
-  const contrastAdjustedRouteColors = getContrastAdjustedRouteColors(
-    route,
-    routeColorAssessment.isLowContrast,
-    'css-hex',
+  const timeTextClassName = cn(
+    textAppearance?.weight === 'normal' ? 'font-normal' : 'font-bold',
+    textAppearance?.className,
   );
 
   const timeVariants = [
@@ -156,6 +130,7 @@ export function StopTimeTimeInfo({
           size={timeSize}
           showPastTime={true}
           hidePrefix={diffMs > 90 * 60 * 1000}
+          className={timeTextClassName}
         />
       )}
       {timeVariants.map((variant) => {
@@ -167,8 +142,10 @@ export function StopTimeTimeInfo({
           <AbsoluteStopTime
             key={variant.key}
             timeText={variant.timeText}
-            textColor={contrastAdjustedRouteColors.color}
+            textColor={textAppearance?.color}
             size={timeSize}
+            weight={textAppearance?.weight}
+            className={textAppearance?.className}
             showDepartureMarker={variant.showDepartureMarker}
             showArrivalMarker={variant.showArrivalMarker}
           />
@@ -177,7 +154,7 @@ export function StopTimeTimeInfo({
     </>
   );
 
-  if (onInspectTrip === undefined) {
+  if (onInspectTrip === undefined || inspectTarget === undefined) {
     return (
       <div className="flex min-h-8 w-14 shrink-0 flex-col justify-center text-right leading-none">
         {content}
@@ -191,7 +168,7 @@ export function StopTimeTimeInfo({
       className="flex min-h-8 w-14 shrink-0 cursor-pointer flex-col justify-center text-right leading-none"
       onClick={(e) => {
         e.stopPropagation();
-        onInspectTrip(entry);
+        onInspectTrip(inspectTarget);
       }}
     >
       {content}

--- a/src/components/stop-time-time-info.tsx
+++ b/src/components/stop-time-time-info.tsx
@@ -165,7 +165,7 @@ export function StopTimeTimeInfo({
   return (
     <button
       type="button"
-      className="flex min-h-8 w-14 shrink-0 cursor-pointer flex-col justify-center text-right leading-none"
+      className="flex min-h-8 w-14 shrink-0 cursor-pointer flex-col justify-center rounded-sm text-right leading-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       onClick={(e) => {
         e.stopPropagation();
         onInspectTrip(inspectTarget);

--- a/src/components/stop-times-item.tsx
+++ b/src/components/stop-times-item.tsx
@@ -130,7 +130,7 @@ export function StopTimesItem({
               <button
                 key={i}
                 type="button"
-                className="inline-flex cursor-pointer items-center gap-0.5 text-sm font-bold whitespace-nowrap text-[#757575] dark:text-gray-400"
+                className="inline-flex cursor-pointer items-center gap-0.5 rounded-sm text-sm font-bold whitespace-nowrap text-[#757575] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-gray-400"
                 onClick={(e) => {
                   e.stopPropagation();
                   onInspectTrip({

--- a/src/components/stop-times-item.tsx
+++ b/src/components/stop-times-item.tsx
@@ -7,7 +7,7 @@ import { getTimetableEntryAttributes } from '../domain/transit/timetable-entry-a
 import { getDisplayMinutes } from '../domain/transit/timetable-utils';
 import type { InfoLevel } from '../types/app/settings';
 import type { Agency } from '../types/app/transit';
-import type { ContextualTimetableEntry } from '../types/app/transit-composed';
+import type { ContextualTimetableEntry, TripInspectionTarget } from '../types/app/transit-composed';
 import { TimetableEntryAttributesLabels } from './label/timetable-entry-attributes-labels';
 import { RelativeTime } from './relative-time';
 import { TripInfo } from './trip-info';
@@ -37,7 +37,7 @@ interface StopTimesItemProps {
   maxDisplay?: number;
   onShowTimetable?: (routeId: string, headsign: string) => void;
   /** Optional callback for inspecting one concrete trip. */
-  onInspectTrip?: (entry: ContextualTimetableEntry) => void;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
 export function StopTimesItem({
@@ -133,7 +133,11 @@ export function StopTimesItem({
                 className="inline-flex cursor-pointer items-center gap-0.5 text-sm font-bold whitespace-nowrap text-[#757575] dark:text-gray-400"
                 onClick={(e) => {
                   e.stopPropagation();
-                  onInspectTrip(entry);
+                  onInspectTrip({
+                    serviceDate: entry.serviceDate,
+                    tripLocator: entry.tripLocator,
+                    stopIndex: entry.patternPosition.stopIndex,
+                  });
                 }}
               >
                 {content}

--- a/src/components/timetable/timetable-grid-entry.tsx
+++ b/src/components/timetable/timetable-grid-entry.tsx
@@ -30,8 +30,6 @@ interface TimetableGridEntryProps {
   /** Suppress verbose-only rendering (IdBadge, details dump).
    *  Use in non-interactive contexts like tooltips. */
   disableVerbose?: boolean;
-  /** Start with details expanded. @default false */
-  defaultOpen?: boolean;
   onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
@@ -52,7 +50,6 @@ export function TimetableGridEntry({
   isDisplayPickupUnavailable,
   isDisplayDropOffUnavailable,
   disableVerbose = false,
-  defaultOpen = false,
   onInspectTrip,
 }: TimetableGridEntryProps) {
   const { t } = useTranslation();
@@ -79,7 +76,7 @@ export function TimetableGridEntry({
           agencyLang={agencyLang}
           maxLength={headsignMaxLength}
           size="xs"
-          enableVerboseExtras={!disableVerbose}
+          enableVerboseExtras={false}
           showBorder={true}
         />
       )}
@@ -113,12 +110,14 @@ export function TimetableGridEntry({
           displayMinutes={displayMinutes}
           showHeadsign={showHeadsign}
           headsignMaxLength={headsignMaxLength}
+          dataLangs={dataLangs}
+          agencyLang={agencyLang}
           infoLevel={infoLevel}
           isDisplayTerminal={isDisplayTerminal}
           isDisplayOrigin={isDisplayOrigin}
           isDisplayPickupUnavailable={isDisplayPickupUnavailable}
           isDisplayDropOffUnavailable={isDisplayDropOffUnavailable}
-          defaultOpen={defaultOpen}
+          defaultOpen={false}
         />
       )}
     </span>

--- a/src/components/timetable/timetable-grid-entry.tsx
+++ b/src/components/timetable/timetable-grid-entry.tsx
@@ -1,5 +1,5 @@
 import type { InfoLevel } from '../../types/app/settings';
-import type { TimetableEntry } from '../../types/app/transit-composed';
+import type { TimetableEntry, TripInspectionTarget } from '../../types/app/transit-composed';
 import { useTranslation } from 'react-i18next';
 import { getDisplayMinutes } from '../../domain/transit/timetable-utils';
 import { getTimetableEntryAttributes } from '../../domain/transit/timetable-entry-attributes';
@@ -9,6 +9,7 @@ import { TimetableEntryAttributesLabels } from '../label/timetable-entry-attribu
 
 interface TimetableGridEntryProps {
   entry: TimetableEntry;
+  serviceDate: Date;
   /** Whether to show the headsign badge. */
   showHeadsign: boolean;
   /** Maximum characters for headsign truncation. */
@@ -31,6 +32,7 @@ interface TimetableGridEntryProps {
   disableVerbose?: boolean;
   /** Start with details expanded. @default false */
   defaultOpen?: boolean;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
 /**
@@ -39,6 +41,7 @@ interface TimetableGridEntryProps {
  */
 export function TimetableGridEntry({
   entry,
+  serviceDate,
   showHeadsign,
   headsignMaxLength,
   infoLevel,
@@ -50,22 +53,20 @@ export function TimetableGridEntry({
   isDisplayDropOffUnavailable,
   disableVerbose = false,
   defaultOpen = false,
+  onInspectTrip,
 }: TimetableGridEntryProps) {
   const { t } = useTranslation();
   const showVerbose = infoLevel === 'verbose' && !disableVerbose;
   const displayMinutes = getDisplayMinutes(entry);
-
-  return (
-    <span className="inline-flex items-baseline gap-0.5">
+  const inspectTarget: TripInspectionTarget = {
+    serviceDate,
+    tripLocator: entry.tripLocator,
+    stopIndex: entry.patternPosition.stopIndex,
+  };
+  const content = (
+    <>
       <span className="text-muted-foreground text-sm tabular-nums">
         {String(displayMinutes % 60).padStart(2, '0')}
-        {/*
-         * Compact inline arriving marker (e.g. "着" / "Arr") attached to the
-         * minute number for trips that terminate at this stop. This shares the
-         * `timetable.entry.*` namespace with the pill-style labels rendered by
-         * TimetableEntryAttributesLabels below, but serves a different purpose:
-         * the pill is a full-word label, whereas this is a short inline marker.
-         */}
         {entry.patternPosition.isTerminal && (
           <span className="text-[9px] opacity-70">{t('timetable.entry.arriving')}</span>
         )}
@@ -90,6 +91,22 @@ export function TimetableGridEntry({
         isDisplayPickupUnavailable={isDisplayPickupUnavailable}
         isDisplayDropOffUnavailable={isDisplayDropOffUnavailable}
       />
+    </>
+  );
+
+  return (
+    <span className="inline-flex items-baseline gap-0.5">
+      {onInspectTrip ? (
+        <button
+          type="button"
+          className="inline-flex cursor-pointer items-baseline gap-0.5 rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          onClick={() => onInspectTrip(inspectTarget)}
+        >
+          {content}
+        </button>
+      ) : (
+        content
+      )}
       {showVerbose && (
         <VerboseGridEntry
           entry={entry}

--- a/src/components/timetable/timetable-grid.tsx
+++ b/src/components/timetable/timetable-grid.tsx
@@ -140,6 +140,7 @@ export function TimetableGrid({
           {info.isVerboseEnabled && (
             <details className="mt-0.5 text-[9px] font-normal text-[#999] dark:text-gray-500">
               <summary
+                tabIndex={-1}
                 className="cursor-pointer select-none"
                 onClick={(event) => event.stopPropagation()}
               >

--- a/src/components/timetable/timetable-grid.tsx
+++ b/src/components/timetable/timetable-grid.tsx
@@ -132,7 +132,6 @@ export function TimetableGrid({
                   isDisplayPickupUnavailable={isDisplayPickupUnavailable}
                   isDisplayDropOffUnavailable={isDisplayDropOffUnavailable}
                   disableVerbose={true}
-                  defaultOpen={false}
                   onInspectTrip={onInspectTrip}
                 />
               ))}
@@ -168,7 +167,6 @@ export function TimetableGrid({
                     isDisplayOrigin={isDisplayOrigin}
                     isDisplayPickupUnavailable={isDisplayPickupUnavailable}
                     isDisplayDropOffUnavailable={isDisplayDropOffUnavailable}
-                    defaultOpen={false}
                     onInspectTrip={onInspectTrip}
                   />
                 ))}

--- a/src/components/timetable/timetable-grid.tsx
+++ b/src/components/timetable/timetable-grid.tsx
@@ -8,17 +8,19 @@ import { useInfoLevel } from '@/hooks/use-info-level';
 import type { TimetableOmitted } from '@/types/app/repository';
 import type { InfoLevel } from '@/types/app/settings';
 import type { Agency } from '@/types/app/transit';
-import type { TimetableEntry } from '@/types/app/transit-composed';
+import type { TimetableEntry, TripInspectionTarget } from '@/types/app/transit-composed';
 import { TimetableGridEntry } from './timetable-grid-entry';
 
 interface TimetableGridProps {
   timetableEntries: TimetableEntry[];
+  serviceDate: Date;
   showHeadsign: boolean;
   currentHour: number;
   infoLevel: InfoLevel;
   dataLangs: readonly string[];
   agencies: Agency[];
   omitted: TimetableOmitted;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
 function useCurrentHourScroll() {
@@ -39,12 +41,14 @@ function useCurrentHourScroll() {
  */
 export function TimetableGrid({
   timetableEntries,
+  serviceDate,
   showHeadsign,
   currentHour,
   infoLevel,
   dataLangs,
   agencies,
   omitted,
+  onInspectTrip,
 }: TimetableGridProps) {
   const scrollRef = useCurrentHourScroll();
   const { t, i18n } = useTranslation();
@@ -115,6 +119,7 @@ export function TimetableGrid({
                 <TimetableGridEntry
                   key={`${entry.routeDirection.route.route_id}__${getEffectiveHeadsign(entry.routeDirection)}__${entry.schedule.departureMinutes}_${entry.schedule.arrivalMinutes}_${index}`}
                   entry={entry}
+                  serviceDate={serviceDate}
                   showHeadsign={showHeadsign}
                   headsignMaxLength={headsignLengths.get(
                     getEffectiveHeadsign(entry.routeDirection),
@@ -128,6 +133,7 @@ export function TimetableGrid({
                   isDisplayDropOffUnavailable={isDisplayDropOffUnavailable}
                   disableVerbose={true}
                   defaultOpen={false}
+                  onInspectTrip={onInspectTrip}
                 />
               ))}
             </span>
@@ -150,6 +156,7 @@ export function TimetableGrid({
                   <TimetableGridEntry
                     key={`${entry.routeDirection.route.route_id}__${getEffectiveHeadsign(entry.routeDirection)}__${entry.schedule.departureMinutes}_${entry.schedule.arrivalMinutes}_${index}`}
                     entry={entry}
+                    serviceDate={serviceDate}
                     showHeadsign={showHeadsign}
                     headsignMaxLength={headsignLengths.get(
                       getEffectiveHeadsign(entry.routeDirection),
@@ -162,6 +169,7 @@ export function TimetableGrid({
                     isDisplayPickupUnavailable={isDisplayPickupUnavailable}
                     isDisplayDropOffUnavailable={isDisplayDropOffUnavailable}
                     defaultOpen={false}
+                    onInspectTrip={onInspectTrip}
                   />
                 ))}
               </div>

--- a/src/components/verbose/verbose-agencies.tsx
+++ b/src/components/verbose/verbose-agencies.tsx
@@ -24,7 +24,11 @@ export function VerboseAgencies({
 
   return (
     <details className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [Agencies ({agencies.length})]
       </summary>
       <div className="mt-0.5 space-y-0.5">

--- a/src/components/verbose/verbose-agency.tsx
+++ b/src/components/verbose/verbose-agency.tsx
@@ -19,7 +19,11 @@ export function VerboseAgency({
 }) {
   return (
     <details open={defaultOpen} className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [Agency]
       </summary>
       <div className="mt-0.5 space-y-0.5">

--- a/src/components/verbose/verbose-contextual-timetable-entry.tsx
+++ b/src/components/verbose/verbose-contextual-timetable-entry.tsx
@@ -32,7 +32,11 @@ export function VerboseContextualTimetableEntry({
 
   return (
     <details open={defaultOpen} className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [Departure]
       </summary>
       <div className="mt-0.5">
@@ -70,7 +74,11 @@ export function VerboseContextualTimetableEntries({
 
   return (
     <details className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [Departures ({entries.length})]
       </summary>
       <div className="mt-0.5 space-y-0.5">

--- a/src/components/verbose/verbose-contextual-timetable-entry.tsx
+++ b/src/components/verbose/verbose-contextual-timetable-entry.tsx
@@ -1,4 +1,6 @@
+import type { InfoLevel } from '../../types/app/settings';
 import type { ContextualTimetableEntry } from '../../types/app/transit-composed';
+import { DEFAULT_AGENCY_LANG } from '../../config/transit-defaults';
 import { formatDateKey } from '../../domain/transit/calendar-utils';
 import { VerboseTimetableEntry } from './verbose-timetable-entries';
 
@@ -6,6 +8,8 @@ interface VerboseContextualTimetableEntryProps {
   entry: ContextualTimetableEntry;
   /** Suppress verbose rendering. Use in non-interactive contexts like tooltips. */
   disableVerbose?: boolean;
+  /** Info level used when formatting route labels. @default 'verbose' */
+  infoLevel?: InfoLevel;
   /** Start with details expanded. @default false */
   defaultOpen?: boolean;
 }
@@ -19,6 +23,7 @@ interface VerboseContextualTimetableEntryProps {
 export function VerboseContextualTimetableEntry({
   entry,
   disableVerbose = false,
+  infoLevel = 'verbose',
   defaultOpen = false,
 }: VerboseContextualTimetableEntryProps) {
   if (disableVerbose) {
@@ -33,7 +38,12 @@ export function VerboseContextualTimetableEntry({
       <div className="mt-0.5">
         <span className="border-app-neutral block overflow-x-auto rounded border border-dashed p-1 text-[9px] whitespace-nowrap text-[#999] dark:text-gray-500">
           <span className="block">[serviceDate] {formatDateKey(entry.serviceDate)}</span>
-          <VerboseTimetableEntry entry={entry} />
+          <VerboseTimetableEntry
+            timetableEntry={entry}
+            dataLangs={DEFAULT_AGENCY_LANG}
+            infoLevel={infoLevel}
+            defaultOpen={true}
+          />
         </span>
       </div>
     </details>

--- a/src/components/verbose/verbose-headsign.tsx
+++ b/src/components/verbose/verbose-headsign.tsx
@@ -13,17 +13,20 @@ export function VerboseHeadsign({
   names,
   label,
   maxLength,
+  defaultOpen = false,
 }: {
   routeDirection: RouteDirection;
   names: HeadsignDisplayNames;
   label: string;
   maxLength?: number;
+  /** Start with details expanded. @default false */
+  defaultOpen?: boolean;
 }) {
   const { route, tripHeadsign, stopHeadsign, direction } = routeDirection;
   const isTruncated = label !== names.resolved.name;
 
   return (
-    <details className="text-[9px] font-normal text-[#999] dark:text-gray-500">
+    <details open={defaultOpen} className="text-[9px] font-normal text-[#999] dark:text-gray-500">
       <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
         [Headsign]
       </summary>

--- a/src/components/verbose/verbose-headsign.tsx
+++ b/src/components/verbose/verbose-headsign.tsx
@@ -27,7 +27,11 @@ export function VerboseHeadsign({
 
   return (
     <details open={defaultOpen} className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [Headsign]
       </summary>
       <div className="mt-0.5">

--- a/src/components/verbose/verbose-nearby-stop-summary.tsx
+++ b/src/components/verbose/verbose-nearby-stop-summary.tsx
@@ -34,7 +34,11 @@ export function VerboseNearbyStopSummary({
 
   return (
     <details className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [NearbyStop]
       </summary>
       <div className="mt-0.5">

--- a/src/components/verbose/verbose-route.tsx
+++ b/src/components/verbose/verbose-route.tsx
@@ -41,7 +41,11 @@ export function VerboseRoute({
 
   return (
     <details open={defaultOpen} className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [Route {summaryName}]
       </summary>
       <div className="mt-0.5 space-y-0.5">

--- a/src/components/verbose/verbose-routes.tsx
+++ b/src/components/verbose/verbose-routes.tsx
@@ -26,7 +26,11 @@ export function VerboseRoutes({
 
   return (
     <details className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [Routes ({routes.length})]
       </summary>
       <div className="mt-0.5 space-y-0.5">

--- a/src/components/verbose/verbose-stop-data.tsx
+++ b/src/components/verbose/verbose-stop-data.tsx
@@ -40,7 +40,11 @@ export function VerboseStopData({
 }) {
   return (
     <details className="mt-1 text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [StopData]
       </summary>
       <div className="mt-0.5 space-y-0.5">

--- a/src/components/verbose/verbose-stop-metrics.tsx
+++ b/src/components/verbose/verbose-stop-metrics.tsx
@@ -14,7 +14,11 @@ export function VerboseStopMetrics({
 }) {
   return (
     <details className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [Metrics]
       </summary>
       <div className="mt-0.5">

--- a/src/components/verbose/verbose-timetable-entries.tsx
+++ b/src/components/verbose/verbose-timetable-entries.tsx
@@ -81,7 +81,11 @@ export function VerboseTimetableEntry({
 
   return (
     <details open={defaultOpen} className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [TimetableEntry]
       </summary>
       <div className="border-app-neutral mt-0.5 rounded border border-dashed p-1">

--- a/src/components/verbose/verbose-timetable-entries.tsx
+++ b/src/components/verbose/verbose-timetable-entries.tsx
@@ -1,5 +1,5 @@
-import type { TimetableEntry } from '../../types/app/transit-composed';
 import { getEffectiveHeadsign } from '../../domain/transit/get-effective-headsign';
+import type { TimetableEntry } from '../../types/app/transit-composed';
 
 /**
  * Render a one-line visual indicator of the current stop position within
@@ -42,6 +42,9 @@ export function VerboseTimetableEntry({
     return null;
   }
 
+  const tripHeadsign = entry.routeDirection.tripHeadsign;
+  const stopHeadsign = entry.routeDirection.stopHeadsign;
+
   return (
     <>
       <span className="block">
@@ -53,27 +56,32 @@ export function VerboseTimetableEntry({
         {entry.routeDirection.direction !== undefined && ` dir=${entry.routeDirection.direction}`}
       </span>
       <span className="block">
-        [headsign] effective=&quot;{getEffectiveHeadsign(entry.routeDirection)}&quot; trip=&quot;
+        [Headsign] effective=&quot;{getEffectiveHeadsign(entry.routeDirection)}&quot; trip=&quot;
         {entry.routeDirection.tripHeadsign.name}&quot;
         {entry.routeDirection.stopHeadsign != null &&
           ` stop="${entry.routeDirection.stopHeadsign.name}"`}
       </span>
       <span className="block">
-        [headsign-names] trip=
-        {Object.keys(entry.routeDirection.tripHeadsign.names).length > 0
-          ? Object.entries(entry.routeDirection.tripHeadsign.names)
+        [TripHeadSign]{' '}
+        {Object.keys(tripHeadsign.names).length > 0
+          ? Object.entries(tripHeadsign.names)
               .map(([k, v]) => `${k}=${v}`)
               .join(' ')
           : '(none)'}
-        {entry.routeDirection.stopHeadsign != null &&
-          ` stop=${
-            Object.keys(entry.routeDirection.stopHeadsign.names).length > 0
-              ? Object.entries(entry.routeDirection.stopHeadsign.names)
-                  .map(([k, v]) => `${k}=${v}`)
-                  .join(' ')
-              : '(none)'
-          }`}
       </span>
+      <span className="block">
+        [StopHeadSign]{' '}
+        {stopHeadsign == null
+          ? '(undefined)'
+          : `${
+              Object.keys(stopHeadsign.names).length > 0
+                ? Object.entries(stopHeadsign.names)
+                    .map(([k, v]) => `${k}=${v}`)
+                    .join(' ')
+                : '(none)'
+            }`}
+      </span>
+
       <span className="block">
         [boarding] pt={entry.boarding.pickupType} dt={entry.boarding.dropOffType}
       </span>

--- a/src/components/verbose/verbose-timetable-entries.tsx
+++ b/src/components/verbose/verbose-timetable-entries.tsx
@@ -1,5 +1,10 @@
-import { getEffectiveHeadsign } from '../../domain/transit/get-effective-headsign';
+import { DEFAULT_AGENCY_LANG } from '../../config/transit-defaults';
+import { getHeadsignDisplayNames } from '../../domain/transit/get-headsign-display-names';
+import { getRouteDisplayNames } from '../../domain/transit/get-route-display-names';
+import type { InfoLevel } from '../../types/app/settings';
 import type { TimetableEntry } from '../../types/app/transit-composed';
+import { VerboseHeadsign } from './verbose-headsign';
+import { VerboseRoute } from './verbose-route';
 
 /**
  * Render a one-line visual indicator of the current stop position within
@@ -24,9 +29,19 @@ function renderPatternBar(stopIndex: number, totalStops: number): string {
 
 interface VerboseTimetableEntryProps {
   /** The timetable entry to dump. */
-  entry: TimetableEntry;
+  timetableEntry: TimetableEntry;
+  /** Display language chain for translated GTFS/ODPT data names. */
+  dataLangs: readonly string[];
+  /** Agency languages for subNames sort priority. */
+  agencyLang?: readonly string[];
+  /** Maximum characters for headsign truncation. */
+  headsignMaxLength?: number;
+  /** Info level used when formatting route labels. */
+  infoLevel: InfoLevel;
   /** Suppress verbose rendering. Use in non-interactive contexts like tooltips. */
   disableVerbose?: boolean;
+  /** Start with details expanded. @default false */
+  defaultOpen?: boolean;
 }
 
 /**
@@ -35,68 +50,87 @@ interface VerboseTimetableEntryProps {
  * Used as a building block by {@link VerboseContextualTimetableEntry}.
  */
 export function VerboseTimetableEntry({
-  entry,
+  timetableEntry,
+  dataLangs,
+  agencyLang = DEFAULT_AGENCY_LANG,
+  headsignMaxLength,
+  infoLevel,
   disableVerbose = false,
+  defaultOpen = false,
 }: VerboseTimetableEntryProps) {
   if (disableVerbose) {
     return null;
   }
 
-  const tripHeadsign = entry.routeDirection.tripHeadsign;
-  const stopHeadsign = entry.routeDirection.stopHeadsign;
+  const routeNames = getRouteDisplayNames(
+    timetableEntry.routeDirection.route,
+    dataLangs,
+    agencyLang,
+  );
+
+  const headsignNames = getHeadsignDisplayNames(
+    timetableEntry.routeDirection,
+    dataLangs,
+    agencyLang,
+    'stop',
+  );
+  const headsignLabel =
+    headsignMaxLength != null && headsignNames.resolved.name.length > headsignMaxLength
+      ? headsignNames.resolved.name.slice(0, headsignMaxLength)
+      : headsignNames.resolved.name;
 
   return (
-    <>
-      <span className="block">
-        [schedule] d={entry.schedule.departureMinutes} a={entry.schedule.arrivalMinutes}
-      </span>
-      <span className="block">
-        [route] id={entry.routeDirection.route.route_id} type=
-        {entry.routeDirection.route.route_type}
-        {entry.routeDirection.direction !== undefined && ` dir=${entry.routeDirection.direction}`}
-      </span>
-      <span className="block">
-        [Headsign] effective=&quot;{getEffectiveHeadsign(entry.routeDirection)}&quot; trip=&quot;
-        {entry.routeDirection.tripHeadsign.name}&quot;
-        {entry.routeDirection.stopHeadsign != null &&
-          ` stop="${entry.routeDirection.stopHeadsign.name}"`}
-      </span>
-      <span className="block">
-        [TripHeadSign]{' '}
-        {Object.keys(tripHeadsign.names).length > 0
-          ? Object.entries(tripHeadsign.names)
-              .map(([k, v]) => `${k}=${v}`)
-              .join(' ')
-          : '(none)'}
-      </span>
-      <span className="block">
-        [StopHeadSign]{' '}
-        {stopHeadsign == null
-          ? '(undefined)'
-          : `${
-              Object.keys(stopHeadsign.names).length > 0
-                ? Object.entries(stopHeadsign.names)
-                    .map(([k, v]) => `${k}=${v}`)
-                    .join(' ')
-                : '(none)'
-            }`}
-      </span>
+    <details open={defaultOpen} className="text-[9px] font-normal text-[#999] dark:text-gray-500">
+      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+        [TimetableEntry]
+      </summary>
+      <div className="border-app-neutral mt-0.5 rounded border border-dashed p-1">
+        <span className="border-app-neutral block overflow-x-auto rounded border border-dashed p-1 whitespace-nowrap">
+          <span className="block">
+            [schedule] d={timetableEntry.schedule.departureMinutes} a=
+            {timetableEntry.schedule.arrivalMinutes}
+          </span>
+          <span className="block">
+            [boarding] pt={timetableEntry.boarding.pickupType} dt=
+            {timetableEntry.boarding.dropOffType}
+          </span>
+          <span className="block">
+            [pattern] si={timetableEntry.patternPosition.stopIndex} [
+            {timetableEntry.patternPosition.stopIndex + 1}/
+            {timetableEntry.patternPosition.totalStops}]
+            {timetableEntry.patternPosition.isTerminal && ' TERM'}
+            {timetableEntry.patternPosition.isOrigin && ' ORIG'}
+          </span>
+          <span className="block pl-2 font-mono text-xs">
+            {renderPatternBar(
+              timetableEntry.patternPosition.stopIndex,
+              timetableEntry.patternPosition.totalStops,
+            )}
+          </span>
+          <span className="block">
+            [insights]{' '}
+            {timetableEntry.insights
+              ? `remainingMinutes=${timetableEntry.insights.remainingMinutes}`
+              : '(none)'}
+          </span>
+        </span>
 
-      <span className="block">
-        [boarding] pt={entry.boarding.pickupType} dt={entry.boarding.dropOffType}
-      </span>
-      <span className="block">
-        [pattern] si={entry.patternPosition.stopIndex} [{entry.patternPosition.stopIndex + 1}/
-        {entry.patternPosition.totalStops}]{entry.patternPosition.isTerminal && ' TERM'}
-        {entry.patternPosition.isOrigin && ' ORIG'}
-      </span>
-      <span className="block pl-2 font-mono text-xs">
-        {renderPatternBar(entry.patternPosition.stopIndex, entry.patternPosition.totalStops)}
-      </span>
-      <span className="block">
-        [insights]{' '}
-        {entry.insights ? `remainingMinutes=${entry.insights.remainingMinutes}` : '(none)'}
-      </span>
-    </>
+        <VerboseRoute
+          route={timetableEntry.routeDirection.route}
+          names={routeNames}
+          infoLevel={infoLevel}
+          defaultOpen={defaultOpen}
+        />
+
+        {/* Headsign  */}
+        <VerboseHeadsign
+          routeDirection={timetableEntry.routeDirection}
+          names={headsignNames}
+          label={headsignLabel}
+          maxLength={headsignMaxLength}
+          defaultOpen={defaultOpen}
+        />
+      </div>
+    </details>
   );
 }

--- a/src/components/verbose/verbose-timetable-grid-entry.tsx
+++ b/src/components/verbose/verbose-timetable-grid-entry.tsx
@@ -12,6 +12,8 @@ export function VerboseTimetableGridEntry({
   displayMinutes,
   showHeadsign,
   headsignMaxLength,
+  dataLangs,
+  agencyLang,
   infoLevel,
   isDisplayTerminal,
   isDisplayOrigin,
@@ -23,6 +25,8 @@ export function VerboseTimetableGridEntry({
   displayMinutes: number;
   showHeadsign: boolean;
   headsignMaxLength?: number;
+  dataLangs: readonly string[];
+  agencyLang?: readonly string[];
   infoLevel: InfoLevel;
   isDisplayTerminal: boolean;
   isDisplayOrigin: boolean;
@@ -49,9 +53,14 @@ export function VerboseTimetableGridEntry({
             {` dropOffUnavail=${String(isDisplayDropOffUnavailable)}`}
           </span>
         </span>
-        <span className="border-app-neutral block overflow-x-auto rounded border border-dashed p-1 whitespace-nowrap">
-          <VerboseTimetableEntry entry={entry} />
-        </span>
+        <VerboseTimetableEntry
+          timetableEntry={entry}
+          dataLangs={dataLangs}
+          agencyLang={agencyLang}
+          headsignMaxLength={headsignMaxLength}
+          infoLevel={infoLevel}
+          defaultOpen={true}
+        />
       </div>
     </details>
   );

--- a/src/components/verbose/verbose-timetable-grid-entry.tsx
+++ b/src/components/verbose/verbose-timetable-grid-entry.tsx
@@ -37,7 +37,11 @@ export function VerboseTimetableGridEntry({
 }) {
   return (
     <details open={defaultOpen} className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [GridEntry]
       </summary>
       <div className="mt-0.5 space-y-0.5">

--- a/src/components/verbose/verbose-timetable-summary.tsx
+++ b/src/components/verbose/verbose-timetable-summary.tsx
@@ -53,7 +53,11 @@ export function VerboseTimetableSummary({
 
   return (
     <details className="text-[9px] font-normal text-[#999] dark:text-gray-500">
-      <summary className="cursor-pointer select-none" onClick={(e) => e.stopPropagation()}>
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
         [TimetableSummary]
       </summary>
       <div className="mt-0.5">

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { createLogger } from '../lib/logger';
 import type { TransitRepository } from '../repositories/transit-repository';
-import type { ContextualTimetableEntry, SelectedTripSnapshot } from '../types/app/transit-composed';
+import type { SelectedTripSnapshot, TripInspectionTarget } from '../types/app/transit-composed';
 import {
   buildTripInspectionStopsLog,
   buildTripInspectionSummaryLog,
@@ -11,7 +11,7 @@ const logger = createLogger('TripInspection');
 
 interface UseTripInspectionReturn {
   tripInspectionSnapshot: SelectedTripSnapshot | null;
-  openTripInspection: (entry: ContextualTimetableEntry) => void;
+  openTripInspection: (target: TripInspectionTarget) => void;
   closeTripInspection: () => void;
 }
 
@@ -19,7 +19,7 @@ interface UseTripInspectionReturn {
  * Manage the currently selected trip inspection snapshot and expose handlers
  * to open or close the dialog from a timetable entry.
  *
- * @param repo - Repository used to reconstruct a full trip snapshot for the selected entry.
+ * @param repo - Repository used to reconstruct a full trip snapshot for the selected target.
  * @returns Current trip inspection snapshot state and open/close handlers.
  */
 export function useTripInspection(repo: TransitRepository): UseTripInspectionReturn {
@@ -32,26 +32,26 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
   }, []);
 
   const openTripInspection = useCallback(
-    (entry: ContextualTimetableEntry) => {
-      const trip = repo.getTripSnapshot(entry.tripLocator, entry.serviceDate);
+    (target: TripInspectionTarget) => {
+      const trip = repo.getTripSnapshot(target.tripLocator, target.serviceDate);
       if (!trip.success) {
         logger.warn('openTripInspection: failed to resolve trip snapshot', trip.error);
         return;
       }
 
       const selectedStop = trip.data.stopTimes.find(
-        (stop) => stop.timetableEntry.patternPosition.stopIndex === entry.patternPosition.stopIndex,
+        (stop) => stop.timetableEntry.patternPosition.stopIndex === target.stopIndex,
       );
       if (!selectedStop) {
         logger.warn(
-          `openTripInspection: selected stop index ${entry.patternPosition.stopIndex} is missing from reconstructed trip snapshot`,
+          `openTripInspection: selected stop index ${target.stopIndex} is missing from reconstructed trip snapshot`,
         );
         return;
       }
 
       const snapshot: SelectedTripSnapshot = {
         ...trip.data,
-        currentStopIndex: entry.patternPosition.stopIndex,
+        currentStopIndex: target.stopIndex,
         selectedStop,
       };
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -170,6 +170,7 @@
   },
   "tripInspection": {
     "title": "Trip info",
+    "titleWithNoHeadsign": "(No headsign)",
     "description": "Show the stop sequence and times for the selected trip",
     "sections": {
       "summary": "Summary",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -170,6 +170,7 @@
   },
   "tripInspection": {
     "title": "Trip info",
+    "titleWithNoHeadsign": "(行先情報なし)",
     "description": "選択した便の停車順と時刻を表示します",
     "sections": {
       "summary": "概要",

--- a/src/repositories/mock-repository/__tests__/mock-repository.test.ts
+++ b/src/repositories/mock-repository/__tests__/mock-repository.test.ts
@@ -67,6 +67,31 @@ describe('MockRepository i18n data', () => {
     );
     expect(tripDisplay.resolved.name).toBe('니지다리');
   });
+
+  it('prefers the raw Japanese headsign for ja before falling back to en', async () => {
+    const repository = new MockRepository();
+    const result = await repository.getFullDayTimetableEntries(
+      'sta_central',
+      new Date('2026-04-24T15:42:00+09:00'),
+    );
+
+    assertSuccess(result);
+
+    const tripHeadsignEntry = result.data.find(
+      (entry) =>
+        entry.routeDirection.route.route_id === 'subway_airport_sora' &&
+        entry.routeDirection.tripHeadsign.name === 'ホテル満月',
+    );
+    expect(tripHeadsignEntry).toBeDefined();
+
+    const tripDisplay = getHeadsignDisplayNames(
+      tripHeadsignEntry!.routeDirection,
+      ['ja', 'en'],
+      ['ja'],
+      'trip',
+    );
+    expect(tripDisplay.resolved.name).toBe('ホテル満月');
+  });
 });
 
 describe('MockRepository contract compatibility', () => {

--- a/src/repositories/mock-repository/mock-data.ts
+++ b/src/repositories/mock-repository/mock-data.ts
@@ -1684,7 +1684,13 @@ const HEADSIGN_TRANSLATIONS: Record<string, Record<string, string>> = {
 };
 
 function createMockTranslatableText(name: string): TranslatableText {
-  return { name, names: HEADSIGN_TRANSLATIONS[name] ?? {} };
+  return {
+    name,
+    names: {
+      ja: name,
+      ...(HEADSIGN_TRANSLATIONS[name] ?? {}),
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- refactor trip inspection callbacks to pass a shared `TripInspectionTarget`
- enable opening trip inspection from timetable entries as well as the bottom sheet
- add a fallback title for trips with no headsign and improve verbose headsign diagnostics
- restore Japanese headsigns in the mock repository and add a regression test
- show a pointer cursor on clickable pill buttons

## Validation
- `npm run format -- src/app.tsx src/components/dialog/timetable-modal.tsx src/components/dialog/trip-inspection-dialog.tsx src/components/timetable/timetable-grid-entry.tsx src/components/timetable/timetable-grid.tsx`
- `npx eslint src/app.tsx src/components/dialog/timetable-modal.tsx src/components/dialog/trip-inspection-dialog.tsx src/components/timetable/timetable-grid-entry.tsx src/components/timetable/timetable-grid.tsx`
- `npm run build`
- confirmed trip information opens from both the timetable and the bottom sheet

## Commits
- `d573ea9` refactor(stop-time): use explicit time props
- `69e832d` refactor(trip-inspection): use inspection target
- `75ae0c1` fix(mock-repository): restore ja headsigns
- `92dfafe` fix(ui): show pointer on pill buttons
- `1065903` fix(headsign): label missing headsign states
- `6addb0b` feat(timetable): open trip inspection