### PR TITLE
Add trip inspection target navigation and staged rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [CalVer](https://calver.org/).
 - `TripInspectionTarget` 型を追加 (`src/types/app/transit-composed.ts`)。trip inspection の入口を stop-time entry 由来に限定せず一般化。
 - `StopTimeDetailInfo` / `StopTimeTimeInfo` / `AbsoluteStopTime` コンポーネントを追加。`StopTimeItem` から building block を分離し、TripInspectionDialog の row layout と共有。
 - `TimetableGridEntry` / `TimetableModal` から trip inspection を起動する動線を追加。
+- `TripInspectionDialog` に「前 / 次の trip」ナビゲーションを追加。同一停留所の隣接 trip を巡回でき、`tripInspectionTargets` / `currentTripInspectionTargetIndex` / `onOpenPreviousTrip` / `onOpenNextTrip` props で外部から候補リストと現在位置を渡す。
+- `TransitRepository.getTripInspectionTargets(query)` を追加。同一停留所・同一 service day に存在する候補 trip を `TripInspectionTarget[]` で返す lightweight API (trip navigation の候補生成に使用)。
 - Display size primitive を共通化する alias を追加 (`src/components/shared/display-size.ts`)。
 - `time-style.ts` に explicit time band 定義を追加 (morning / daytime / evening / night band を明示)。
 - Pipeline: りんかい線 (東京臨海高速鉄道株式会社) の GTFS データソースを追加 (prefix `twrr`, route_type 2 rail)。8 駅 / 1 路線。`shapes.txt` は含まれないが MLIT 国土数値情報 (臨海副都心線) 経由で路線図に対応。`data-source-settings` の `routeTypes` は `[1, 2]` (subway + rail) — 実態として地下鉄区間を含むため将来の Source 選択 UI 用に両方を宣言。
@@ -30,6 +32,12 @@ and this project adheres to [CalVer](https://calver.org/).
 - `JourneyTimeBar` Storybook の args を実サイズ値に近づけて調整。
 - `VerboseTimetableEntries` / `VerboseTimetableGridEntry` / `VerboseContextualTimetableEntry` / `VerboseHeadsign` の構成を整理し、timetable entry の verbose 表示を共通の building block で組み立てるよう refactor。
 - verbose/debug 用 `<summary>` (stop-summary / timetable-grid / verbose-\* 全般) に `tabIndex={-1}` を付与し、キーボード tab 移動の焦点対象から除外。
+- `TransitRepository` interface の TSDoc を整理。`referenceDateTime` (任意日時、内部正規化) と `serviceDate` (pre-normalized service day) の 2 契約を method classification 表で明示。エラー文字列の parse 非推奨ポリシー、`getTripInspectionTargets` の sort 契約 (`sortTimetableEntriesByDepartureTime` 同等) を明記。
+- `getUpcomingTimetableEntries` の引数 `now` を `referenceDateTime` にリネーム (両 repo 実装と test を追従)。`?time=` 等の custom time を含む任意の日時を受け取る契約を引数名でも明示。
+- `resolveStopStats` / `resolveRouteFreq` / `getTripSnapshot` / `getTripInspectionTargets` を pre-normalized serviceDate 前提に統一。caller 側で `getServiceDay()` 正規化する責務を契約として固定し、impl 内の重複正規化を削除。
+- `AthenaiRepositoryV2.timetableByPattern` の型を `Map<string, PatternTimetableEntry[]>` に更新し、pattern→stop 列挙の型情報を強化。
+- `TripInspectionDialog` の stop 行レンダリングを 2-stage progressive render に変更。初回フレームは選択行 ±5 のみ描画し、次の `requestAnimationFrame` で全件に展開することで長い trip の first paint を高速化。
+- `TripInspectionDialog` の trip stop row レイアウトを normalize し、不要な fragment 等を整理。
 
 ### Fixed
 
@@ -40,6 +48,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - `MockRepository` の再構成 trip で停車時刻が進行しない問題を修正 (pattern stops の travel offset を upcoming / full-day / trip snapshot の各経路で適用)。併せて `r6-*` モック停留所の配置を東側に移動。`bus_yukkuri01` trip の timing 回帰テストを追加。
 - `MockRepository` の日本語 headsign 定義が欠落していた問題を修正。
 - `StopTimeTimeInfo` / `StopTimesItem` の trip inspect トリガーボタンに `focus-visible` ring を追加し、キーボード操作時のフォーカス可視性を確保 (a11y)。
+- `TripInspectionDialog` で sparse な trip stop rows (一部停留所の `stopMeta` が欠落するケース) を含む trip でも row レイアウトが崩れないよう修正。
 
 ## [2026.04.23]
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -118,8 +118,15 @@ export default function App({ loadResult }: AppProps) {
   const [searchModalOpen, setSearchModalOpen] = useState(false);
   const [infoDialogOpen, setInfoDialogOpen] = useState(false);
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
-  const { tripInspectionSnapshot, openTripInspection, closeTripInspection } =
-    useTripInspection(repo);
+  const {
+    tripInspectionSnapshot,
+    tripInspectionTargets,
+    currentTripInspectionTargetIndex,
+    openTripInspection,
+    openPreviousTripInspection,
+    openNextTripInspection,
+    closeTripInspection,
+  } = useTripInspection(repo);
 
   // Global keyboard shortcuts. Suppressed while any of the four primary
   // modals owned by app.tsx is open (search / info / help / timetable),
@@ -855,9 +862,13 @@ export default function App({ loadResult }: AppProps) {
       <TripInspectionDialog
         open={tripInspectionSnapshot !== null}
         snapshot={tripInspectionSnapshot}
+        tripInspectionTargets={tripInspectionTargets}
+        currentTripInspectionTargetIndex={currentTripInspectionTargetIndex}
         now={dateTime}
         infoLevel={settings.infoLevel}
         dataLangs={langChain}
+        onOpenPreviousTrip={openPreviousTripInspection}
+        onOpenNextTrip={openNextTripInspection}
         onOpenChange={(open) => {
           if (!open) {
             closeTripInspection();

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -91,6 +91,10 @@ interface RichStopSummaryProps {
   dataLangs: readonly string[];
 }
 
+// Initial frame renders the selected stop and +/- 5 neighbors so
+// long trips paint quickly before the full list is restored.
+const INITIAL_TRIP_STOP_RENDER_PADDING = 5;
+
 function resolveTripStopDisplay(stop: TripStopTime | undefined, dataLangs: readonly string[]) {
   const stopId = stop?.stopMeta?.stop.stop_id || '(unknown-stop)';
   const stopAgencyLangs = stop?.stopMeta
@@ -302,7 +306,11 @@ function TripInspectionStopRow({
   );
 }
 
-function TripInspectionSummary({ snapshot, infoLevel, dataLangs }: TripInspectionSummaryProps) {
+function TripInspectionSummary({
+  snapshot,
+  infoLevel,
+  dataLangs: _dataLangs,
+}: TripInspectionSummaryProps) {
   const infoLevelFlag = useInfoLevel(infoLevel);
   const route = snapshot.route;
   const selectedStop = snapshot.selectedStop;
@@ -447,8 +455,23 @@ export function TripInspectionDialog({
       : 'empty',
   );
   const selectedStopRowKey = snapshot
-    ? `${snapshot.currentStopIndex}:${snapshot.stopTimes.length}`
+    ? `${snapshot.locator.patternId}:${snapshot.locator.serviceId}:${snapshot.locator.tripIndex}:${snapshot.currentStopIndex}:${snapshot.stopTimes.length}`
     : 'empty';
+  const [renderedSnapshot, setRenderedSnapshot] = useState<SelectedTripSnapshot | null>(null);
+
+  useEffect(() => {
+    if (!open || !snapshot) {
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      setRenderedSnapshot(snapshot);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [open, snapshot]);
 
   useEffect(() => {
     if (!open || !snapshot || !contentContainerEl) {
@@ -543,6 +566,20 @@ export function TripInspectionDialog({
 
   // Selected TripStopTime
   const selectedStop = tripStopTimes[snapshot.currentStopIndex];
+  // Progressive render: paint a small window first, then switch to
+  // the full stop list on the next animation frame.
+  const initialRenderStart = Math.max(
+    0,
+    snapshot.currentStopIndex - INITIAL_TRIP_STOP_RENDER_PADDING,
+  );
+  const initialRenderEnd = Math.min(
+    tripStopTimes.length,
+    snapshot.currentStopIndex + INITIAL_TRIP_STOP_RENDER_PADDING + 1,
+  );
+  const renderAllStops = renderedSnapshot === snapshot;
+  const renderedTripStopTimes = renderAllStops
+    ? tripStopTimes
+    : tripStopTimes.slice(initialRenderStart, initialRenderEnd);
 
   // First TripStopTime
   const firstStop = tripStopTimes[0];
@@ -685,24 +722,22 @@ export function TripInspectionDialog({
           <div className="flex flex-col gap-4 pt-3 pb-4">
             <section className="flex flex-col gap-2">
               <div className="flex flex-col gap-2">
-                {snapshot.stopTimes.map((stop) => {
+                {renderedTripStopTimes.map((stop) => {
                   const stopId = stop.stopMeta?.stop.stop_id || '(unknown-stop)';
                   const stopIndex = stop.timetableEntry.patternPosition.stopIndex;
 
                   return (
-                    <>
-                      <TripInspectionStopRow
-                        key={`${stopId}:${stopIndex}`}
-                        stop={stop}
-                        currentStopIndex={snapshot.currentStopIndex}
-                        infoLevel={infoLevel}
-                        // infoLevel={'simple'}
-                        // infoLevel={'verbose'}
-                        dataLangs={dataLangs}
-                        serviceDate={snapshot.serviceDate}
-                        now={now}
-                      />
-                    </>
+                    <TripInspectionStopRow
+                      key={`${stopId}:${stopIndex}`}
+                      stop={stop}
+                      currentStopIndex={snapshot.currentStopIndex}
+                      infoLevel={infoLevel}
+                      // infoLevel={'simple'}
+                      // infoLevel={'verbose'}
+                      dataLangs={dataLangs}
+                      serviceDate={snapshot.serviceDate}
+                      now={now}
+                    />
                   );
                 })}
               </div>

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -600,6 +600,11 @@ export function TripInspectionDialog({
       <DialogContent className="flex max-h-[80dvh] max-w-120 flex-col gap-0 overflow-hidden">
         <DialogHeader className="border-border shrink-0 border-b pb-3 sm:text-center">
           {/* {now.toLocaleDateString()} */}
+          {/*
+            DialogTitle intentionally summarizes the selected stop.
+            The dialog content describes one concrete trip that passes
+            through that stop, including trip identity and stop sequence.
+          */}
           <DialogTitle className="flex flex-col items-center justify-center gap-2 text-base">
             <div>
               {/* Selected stop (RichStopSummary) */}
@@ -615,6 +620,11 @@ export function TripInspectionDialog({
             </div>
           </DialogTitle>
 
+          {/*
+            Trip identity stays below the title because the dialog is
+            centered on the selected stop, while the body renders the
+            matching trip that serves that stop.
+          */}
           <div className="flex items-center justify-center gap-2 pb-2">
             <Button
               className={!hasPreviousTrip ? 'pointer-events-none invisible' : undefined}

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -62,12 +62,23 @@ interface TripInspectionDialogProps {
 
 interface TripInspectionStopRowProps {
   stop: TripStopTime;
-  currentStopIndex: number;
+  currentPatternStopIndex: number;
   infoLevel: InfoLevel;
   serviceDate: Date;
   dataLangs: readonly string[];
   now: Date;
 }
+
+interface TripInspectionPlaceholderRowProps {
+  stopIndex: number;
+  totalStops: number;
+  currentPatternStopIndex: number;
+  infoLevel: InfoLevel;
+}
+
+type RenderedTripStopRow =
+  | { kind: 'stop'; stop: TripStopTime }
+  | { kind: 'placeholder'; stopIndex: number; totalStops: number };
 
 interface TripInspectionSummaryProps {
   snapshot: SelectedTripSnapshot;
@@ -126,6 +137,26 @@ function getSelectedRowScrollTop(container: HTMLDivElement, selectedRow: HTMLEle
   );
 }
 
+function buildRenderedTripStopRows(stopTimes: readonly TripStopTime[]): RenderedTripStopRow[] {
+  if (stopTimes.length === 0) {
+    return [];
+  }
+
+  const totalStops = stopTimes[0]?.timetableEntry.patternPosition.totalStops ?? 0;
+  const stopByIndex = new Map(
+    stopTimes.map((stop) => [stop.timetableEntry.patternPosition.stopIndex, stop]),
+  );
+
+  return Array.from({ length: totalStops }, (_, stopIndex) => {
+    const stop = stopByIndex.get(stopIndex);
+    if (stop) {
+      return { kind: 'stop', stop } satisfies RenderedTripStopRow;
+    }
+
+    return { kind: 'placeholder', stopIndex, totalStops } satisfies RenderedTripStopRow;
+  });
+}
+
 function SimpleStopSummary({ stopNames, stopName }: StopSummaryProps) {
   return (
     <div className="min-w-0 rounded-md border p-2">
@@ -175,7 +206,7 @@ function formatTargetDepartureTime(target: TripInspectionTarget | undefined): st
 
 function TripInspectionStopRow({
   stop,
-  currentStopIndex,
+  currentPatternStopIndex,
   infoLevel,
   dataLangs,
   serviceDate,
@@ -203,7 +234,7 @@ function TripInspectionStopRow({
     ? getStopDisplayNames(stop.stopMeta.stop, dataLangs, stopAgencyLangs)
     : null;
   const stopIndex = stop.timetableEntry.patternPosition.stopIndex;
-  const isCurrent = stopIndex === currentStopIndex;
+  const isCurrent = stopIndex === currentPatternStopIndex;
   const isTerminalStop = stop.timetableEntry.patternPosition.isTerminal;
   const isFirstStop = stop.timetableEntry.patternPosition.isOrigin;
   const showArrivalTime = isTerminalStop || !isFirstStop;
@@ -302,6 +333,38 @@ function TripInspectionStopRow({
           />
         </>
       )}
+    </div>
+  );
+}
+
+function TripInspectionPlaceholderRow({
+  stopIndex,
+  totalStops,
+  currentPatternStopIndex,
+  infoLevel,
+}: TripInspectionPlaceholderRowProps) {
+  const infoLevelFlag = useInfoLevel(infoLevel);
+  const isCurrent = stopIndex === currentPatternStopIndex;
+
+  return (
+    <div
+      data-trip-stop-index={stopIndex}
+      className={[
+        'rounded-md border border-dashed px-3 py-2',
+        isCurrent ? 'border-primary bg-primary/5' : 'border-border bg-muted/20',
+      ].join(' ')}
+    >
+      <div className="flex min-w-0 flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground text-xs">#{stopIndex}</span>
+          <span className="text-muted-foreground truncate font-medium">Stop-time unavailable</span>
+        </div>
+        {infoLevelFlag.isVerboseEnabled && (
+          <div className="text-muted-foreground truncate text-xs">
+            Pattern stop {stopIndex + 1} / {totalStops}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -412,18 +475,20 @@ function TripInspectionCurrentStop({ snapshot }: TripInspectionCurrentStopProps)
   const selectedStop: TripStopTime = snapshot.selectedStop;
   const selectedStopId = selectedStop.stopMeta?.stop.stop_id || '(unknown-stop)';
   const selectedStopName = selectedStop.stopMeta?.stop.stop_name || selectedStopId;
+  const selectedPatternPosition = selectedStop.timetableEntry.patternPosition;
 
   return (
-    <section className="flex flex-col gap-2">
-      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm">
-        <dt className="text-muted-foreground">Stop</dt>
-        <dd className="min-w-0">
-          <div className="truncate font-medium">
-            <IdBadge>{selectedStopId}</IdBadge>
-            {selectedStopName} ({snapshot.currentStopIndex + 1} / {snapshot.stopTimes.length})
-          </div>
-        </dd>
-      </dl>
+    <section className="flex items-center gap-3 overflow-x-auto text-xs whitespace-nowrap">
+      <div className="shrink-0 font-medium">
+        <IdBadge>{selectedStopId}</IdBadge>
+        {selectedStopName}
+      </div>
+      <div className="text-muted-foreground shrink-0">
+        Pattern stop {selectedPatternPosition.stopIndex + 1} / {selectedPatternPosition.totalStops}
+      </div>
+      <div className="text-muted-foreground shrink-0">
+        Reconstructed row {snapshot.currentStopIndex + 1} / {snapshot.stopTimes.length}
+      </div>
     </section>
   );
 }
@@ -448,14 +513,16 @@ export function TripInspectionDialog({
     contentContainerRef.current = node;
     setContentContainerEl(node);
   }, []);
+  const selectedPatternStopIndex =
+    snapshot?.selectedStop.timetableEntry.patternPosition.stopIndex ?? -1;
   const contentScroll = useScrollFades(
     contentContainerRef,
     snapshot
-      ? `${snapshot.locator.patternId}:${snapshot.locator.serviceId}:${snapshot.locator.tripIndex}:${snapshot.currentStopIndex}:${snapshot.stopTimes.length}`
+      ? `${snapshot.locator.patternId}:${snapshot.locator.serviceId}:${snapshot.locator.tripIndex}:${selectedPatternStopIndex}:${snapshot.stopTimes.length}`
       : 'empty',
   );
   const selectedStopRowKey = snapshot
-    ? `${snapshot.locator.patternId}:${snapshot.locator.serviceId}:${snapshot.locator.tripIndex}:${snapshot.currentStopIndex}:${snapshot.stopTimes.length}`
+    ? `${snapshot.locator.patternId}:${snapshot.locator.serviceId}:${snapshot.locator.tripIndex}:${selectedPatternStopIndex}:${snapshot.stopTimes.length}`
     : 'empty';
   const [renderedSnapshot, setRenderedSnapshot] = useState<SelectedTripSnapshot | null>(null);
 
@@ -485,7 +552,7 @@ export function TripInspectionDialog({
     const applyScrollToSelectedRow = (behavior: ScrollBehavior) => {
       const container = contentContainerEl;
       const selectedRow = container?.querySelector<HTMLElement>(
-        `[data-trip-stop-index="${snapshot.currentStopIndex}"]`,
+        `[data-trip-stop-index="${selectedPatternStopIndex}"]`,
       );
 
       if (!container || !selectedRow) {
@@ -532,7 +599,7 @@ export function TripInspectionDialog({
       window.cancelAnimationFrame(secondFrameId);
       window.cancelAnimationFrame(correctionFrameId);
     };
-  }, [contentContainerEl, open, selectedStopRowKey, snapshot]);
+  }, [contentContainerEl, open, selectedPatternStopIndex, selectedStopRowKey, snapshot]);
 
   if (!snapshot) {
     return <Dialog open={false} onOpenChange={onOpenChange} />;
@@ -564,22 +631,22 @@ export function TripInspectionDialog({
     'stop',
   ).resolved.name;
 
-  // Selected TripStopTime
-  const selectedStop = tripStopTimes[snapshot.currentStopIndex];
+  const selectedStop = snapshot.selectedStop;
+  const renderedTripStopRows = buildRenderedTripStopRows(tripStopTimes);
   // Progressive render: paint a small window first, then switch to
   // the full stop list on the next animation frame.
   const initialRenderStart = Math.max(
     0,
-    snapshot.currentStopIndex - INITIAL_TRIP_STOP_RENDER_PADDING,
+    selectedPatternStopIndex - INITIAL_TRIP_STOP_RENDER_PADDING,
   );
   const initialRenderEnd = Math.min(
-    tripStopTimes.length,
-    snapshot.currentStopIndex + INITIAL_TRIP_STOP_RENDER_PADDING + 1,
+    renderedTripStopRows.length,
+    selectedPatternStopIndex + INITIAL_TRIP_STOP_RENDER_PADDING + 1,
   );
   const renderAllStops = renderedSnapshot === snapshot;
-  const renderedTripStopTimes = renderAllStops
-    ? tripStopTimes
-    : tripStopTimes.slice(initialRenderStart, initialRenderEnd);
+  const visibleTripStopRows = renderAllStops
+    ? renderedTripStopRows
+    : renderedTripStopRows.slice(initialRenderStart, initialRenderEnd);
 
   // First TripStopTime
   const firstStop = tripStopTimes[0];
@@ -732,22 +799,45 @@ export function TripInspectionDialog({
           <div className="flex flex-col gap-4 pt-3 pb-4">
             <section className="flex flex-col gap-2">
               <div className="flex flex-col gap-2">
-                {renderedTripStopTimes.map((stop) => {
-                  const stopId = stop.stopMeta?.stop.stop_id || '(unknown-stop)';
-                  const stopIndex = stop.timetableEntry.patternPosition.stopIndex;
+                {visibleTripStopRows.map((row) => {
+                  if (row.kind === 'placeholder') {
+                    return (
+                      <div key={`placeholder:${row.stopIndex}`} className="flex flex-col gap-1">
+                        {infoLevelFlag.isVerboseEnabled && (
+                          <div className="text-muted-foreground px-1 text-xs">
+                            {row.stopIndex + 1} / {row.totalStops}
+                          </div>
+                        )}
+                        <TripInspectionPlaceholderRow
+                          stopIndex={row.stopIndex}
+                          totalStops={row.totalStops}
+                          currentPatternStopIndex={selectedPatternStopIndex}
+                          infoLevel={infoLevel}
+                        />
+                      </div>
+                    );
+                  }
+
+                  const stopId = row.stop.stopMeta?.stop.stop_id || '(unknown-stop)';
+                  const patternPosition = row.stop.timetableEntry.patternPosition;
+                  const stopIndex = patternPosition.stopIndex;
 
                   return (
-                    <TripInspectionStopRow
-                      key={`${stopId}:${stopIndex}`}
-                      stop={stop}
-                      currentStopIndex={snapshot.currentStopIndex}
-                      infoLevel={infoLevel}
-                      // infoLevel={'simple'}
-                      // infoLevel={'verbose'}
-                      dataLangs={dataLangs}
-                      serviceDate={snapshot.serviceDate}
-                      now={now}
-                    />
+                    <div key={`${stopId}:${stopIndex}`} className="flex flex-col gap-1">
+                      {infoLevelFlag.isVerboseEnabled && (
+                        <div className="text-muted-foreground px-1 text-xs">
+                          {patternPosition.stopIndex + 1} / {patternPosition.totalStops}
+                        </div>
+                      )}
+                      <TripInspectionStopRow
+                        stop={row.stop}
+                        currentPatternStopIndex={selectedPatternStopIndex}
+                        infoLevel={infoLevel}
+                        dataLangs={dataLangs}
+                        serviceDate={snapshot.serviceDate}
+                        now={now}
+                      />
+                    </div>
                   );
                 })}
               </div>

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { JourneyTimeBar } from '@/components/journey-time-bar';
 import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
 import { StopInfo } from '@/components/stop-info';
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -20,9 +21,11 @@ import {
   getContrastAdjustedRouteColors,
   resolveRouteColors,
 } from '@/domain/transit/color-resolver/route-colors';
+import { minutesToDate } from '@/domain/transit/calendar-utils';
 import { getHeadsignDisplayNames } from '@/domain/transit/get-headsign-display-names';
 import { getStopDisplayNames } from '@/domain/transit/get-stop-display-names';
 import { getTimetableEntryAttributes } from '@/domain/transit/timetable-entry-attributes';
+import { formatAbsoluteTime } from '@/domain/transit/time';
 import { useInfoLevel } from '@/hooks/use-info-level';
 import { useThemeContrastAssessment } from '@/hooks/use-is-low-contrast-against-theme';
 import { useScrollFades } from '@/hooks/use-scroll-fades';
@@ -31,6 +34,7 @@ import type { Agency, Route } from '@/types/app/transit';
 import type {
   ContextualTimetableEntry,
   SelectedTripSnapshot,
+  TripInspectionTarget,
   TripStopTime,
 } from '@/types/app/transit-composed';
 import { getContrastAwareAlphaSuffixes } from '@/utils/color/contrast-alpha-suffixes';
@@ -47,9 +51,13 @@ interface TripInspectionDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   snapshot: SelectedTripSnapshot | null;
+  tripInspectionTargets: TripInspectionTarget[];
+  currentTripInspectionTargetIndex: number;
   now: Date;
   infoLevel: InfoLevel;
   dataLangs: readonly string[];
+  onOpenPreviousTrip: () => void;
+  onOpenNextTrip: () => void;
 }
 
 interface TripInspectionStopRowProps {
@@ -151,6 +159,14 @@ function RichStopSummary({ stop, infoLevel, dataLangs }: RichStopSummaryProps) {
       />
     </div>
   );
+}
+
+function formatTargetDepartureTime(target: TripInspectionTarget | undefined): string | null {
+  if (!target) {
+    return null;
+  }
+
+  return formatAbsoluteTime(minutesToDate(target.serviceDate, target.departureMinutes));
 }
 
 function TripInspectionStopRow({
@@ -373,7 +389,13 @@ function TripInspectionSummary({ snapshot, infoLevel, dataLangs }: TripInspectio
       /> */}
 
       {/* Last stop */}
-      <RichStopSummary stop={lastStop} infoLevel={infoLevel} dataLangs={dataLangs} />
+      {/* <RichStopSummary
+        //
+        stop={lastStop}
+        // infoLevel={infoLevel}
+        infoLevel={'simple'}
+        dataLangs={dataLangs}
+      /> */}
     </section>
   );
 }
@@ -402,9 +424,13 @@ export function TripInspectionDialog({
   open,
   onOpenChange,
   snapshot,
+  tripInspectionTargets,
+  currentTripInspectionTargetIndex,
   infoLevel,
   dataLangs,
   now,
+  onOpenPreviousTrip,
+  onOpenNextTrip,
 }: TripInspectionDialogProps) {
   const infoLevelFlag = useInfoLevel(infoLevel);
   const { t } = useTranslation();
@@ -497,6 +523,16 @@ export function TripInspectionDialog({
   const routeAgencyLangs =
     agencies !== undefined ? resolveAgencyLang(agencies, route.agency_id) : DEFAULT_AGENCY_LANG;
   const routeAgency = agencies?.find((agency) => agency.agency_id === route.agency_id);
+  const hasPreviousTrip = currentTripInspectionTargetIndex > 0;
+  const hasNextTrip = currentTripInspectionTargetIndex < tripInspectionTargets.length - 1;
+  const previousTarget = hasPreviousTrip
+    ? tripInspectionTargets[currentTripInspectionTargetIndex - 1]
+    : undefined;
+  const nextTarget = hasNextTrip
+    ? tripInspectionTargets[currentTripInspectionTargetIndex + 1]
+    : undefined;
+  const previousDepartureTime = formatTargetDepartureTime(previousTarget);
+  const nextDepartureTime = formatTargetDepartureTime(nextTarget);
 
   const headsignTitle = getHeadsignDisplayNames(
     snapshot.selectedStop.timetableEntry.routeDirection,
@@ -504,6 +540,9 @@ export function TripInspectionDialog({
     routeAgencyLangs,
     'stop',
   ).resolved.name;
+
+  // Selected TripStopTime
+  const selectedStop = tripStopTimes[snapshot.currentStopIndex];
 
   // First TripStopTime
   const firstStop = tripStopTimes[0];
@@ -524,8 +563,68 @@ export function TripInspectionDialog({
       <DialogContent className="flex max-h-[80dvh] max-w-120 flex-col gap-0 overflow-hidden">
         <DialogHeader className="border-border shrink-0 border-b pb-3 sm:text-center">
           {/* {now.toLocaleDateString()} */}
-          <DialogTitle className="flex items-center justify-center gap-2 text-base">
+          <DialogTitle className="flex flex-col items-center justify-center gap-2 text-base">
+            <div>
+              {/* Selected stop (RichStopSummary) */}
+              <RichStopSummary
+                //
+                stop={selectedStop}
+                // infoLevel={infoLevel}
+                infoLevel={'simple'}
+                // infoLevel={'normal'}
+                // infoLevel={'detailed'}
+                dataLangs={dataLangs}
+              />
+            </div>
+          </DialogTitle>
+
+          <div className="flex items-center justify-center gap-2 pb-2">
+            <Button
+              className={!hasPreviousTrip ? 'pointer-events-none invisible' : undefined}
+              size="sm"
+              variant="outline"
+              disabled={!hasPreviousTrip}
+              onClick={onOpenPreviousTrip}
+            >
+              {previousDepartureTime ? `${previousDepartureTime}` : 'Prev'}
+            </Button>
+            <div className="flex min-w-16 flex-col items-center justify-center gap-1">
+              {/* departure time of selected stop or (arrival time (terminal)) */}
+              <StopTimeTimeInfo
+                arrivalMinutes={selectedStop.timetableEntry.schedule.arrivalMinutes}
+                departureMinutes={selectedStop.timetableEntry.schedule.departureMinutes}
+                serviceDate={snapshot.serviceDate}
+                now={now}
+                size="sm"
+                showArrivalTime={true}
+                showDepartureTime={true}
+                collapseArrivalWhenSameAsDeparture={true}
+                forceShowRelativeTime={false}
+                showVerbose={false}
+                // textAppearance={{ color: 'var(--muted-foreground)' }}
+              />
+            </div>
+            <Button
+              className={!hasNextTrip ? 'pointer-events-none invisible' : undefined}
+              size="sm"
+              variant="outline"
+              disabled={!hasNextTrip}
+              onClick={onOpenNextTrip}
+            >
+              {nextDepartureTime ? `${nextDepartureTime}` : 'Next'}
+            </Button>
+
+            <span className="text-muted-foreground text-center text-xs">
+              {tripInspectionTargets.length > 0
+                ? `${currentTripInspectionTargetIndex + 1} / ${tripInspectionTargets.length}`
+                : '0 / 0'}
+            </span>
+          </div>
+
+          {/* Trip info (simple) */}
+          <div className="flex flex-wrap items-center justify-center gap-2 text-center">
             {routeTypesEmoji([route.route_type])}
+
             {routeAgency && (
               <>
                 <AgencyBadge
@@ -551,7 +650,8 @@ export function TripInspectionDialog({
             ) : (
               t('tripInspection.titleWithNoHeadsign')
             )}
-          </DialogTitle>
+          </div>
+
           <DialogDescription asChild className="text-center sm:text-center">
             <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-x-2">
               <SimpleStopSummary stopNames={firstStopNames} stopName={firstStopName} />
@@ -590,15 +690,19 @@ export function TripInspectionDialog({
                   const stopIndex = stop.timetableEntry.patternPosition.stopIndex;
 
                   return (
-                    <TripInspectionStopRow
-                      key={`${stopId}:${stopIndex}`}
-                      stop={stop}
-                      currentStopIndex={snapshot.currentStopIndex}
-                      infoLevel={infoLevel}
-                      dataLangs={dataLangs}
-                      serviceDate={snapshot.serviceDate}
-                      now={now}
-                    />
+                    <>
+                      <TripInspectionStopRow
+                        key={`${stopId}:${stopIndex}`}
+                        stop={stop}
+                        currentStopIndex={snapshot.currentStopIndex}
+                        infoLevel={infoLevel}
+                        // infoLevel={'simple'}
+                        // infoLevel={'verbose'}
+                        dataLangs={dataLangs}
+                        serviceDate={snapshot.serviceDate}
+                        now={now}
+                      />
+                    </>
                   );
                 })}
               </div>

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -77,7 +77,7 @@ interface TripInspectionPlaceholderRowProps {
 }
 
 type RenderedTripStopRow =
-  | { kind: 'stop'; stop: TripStopTime }
+  | { kind: 'stop'; stop: TripStopTime; stopIndex: number; totalStops: number }
   | { kind: 'placeholder'; stopIndex: number; totalStops: number };
 
 interface TripInspectionSummaryProps {
@@ -150,7 +150,7 @@ function buildRenderedTripStopRows(stopTimes: readonly TripStopTime[]): Rendered
   return Array.from({ length: totalStops }, (_, stopIndex) => {
     const stop = stopByIndex.get(stopIndex);
     if (stop) {
-      return { kind: 'stop', stop } satisfies RenderedTripStopRow;
+      return { kind: 'stop', stop, stopIndex, totalStops } satisfies RenderedTripStopRow;
     }
 
     return { kind: 'placeholder', stopIndex, totalStops } satisfies RenderedTripStopRow;
@@ -800,35 +800,20 @@ export function TripInspectionDialog({
             <section className="flex flex-col gap-2">
               <div className="flex flex-col gap-2">
                 {visibleTripStopRows.map((row) => {
-                  if (row.kind === 'placeholder') {
-                    return (
-                      <div key={`placeholder:${row.stopIndex}`} className="flex flex-col gap-1">
-                        {infoLevelFlag.isVerboseEnabled && (
-                          <div className="text-muted-foreground px-1 text-xs">
-                            {row.stopIndex + 1} / {row.totalStops}
-                          </div>
-                        )}
-                        <TripInspectionPlaceholderRow
-                          stopIndex={row.stopIndex}
-                          totalStops={row.totalStops}
-                          currentPatternStopIndex={selectedPatternStopIndex}
-                          infoLevel={infoLevel}
-                        />
-                      </div>
-                    );
-                  }
+                  const rowKey =
+                    row.kind === 'placeholder'
+                      ? `placeholder:${row.stopIndex}`
+                      : `${row.stop.stopMeta?.stop.stop_id || '(unknown-stop)'}:${row.stopIndex}`;
 
-                  const stopId = row.stop.stopMeta?.stop.stop_id || '(unknown-stop)';
-                  const patternPosition = row.stop.timetableEntry.patternPosition;
-                  const stopIndex = patternPosition.stopIndex;
-
-                  return (
-                    <div key={`${stopId}:${stopIndex}`} className="flex flex-col gap-1">
-                      {infoLevelFlag.isVerboseEnabled && (
-                        <div className="text-muted-foreground px-1 text-xs">
-                          {patternPosition.stopIndex + 1} / {patternPosition.totalStops}
-                        </div>
-                      )}
+                  const rowContent =
+                    row.kind === 'placeholder' ? (
+                      <TripInspectionPlaceholderRow
+                        stopIndex={row.stopIndex}
+                        totalStops={row.totalStops}
+                        currentPatternStopIndex={selectedPatternStopIndex}
+                        infoLevel={infoLevel}
+                      />
+                    ) : (
                       <TripInspectionStopRow
                         stop={row.stop}
                         currentPatternStopIndex={selectedPatternStopIndex}
@@ -837,6 +822,16 @@ export function TripInspectionDialog({
                         serviceDate={snapshot.serviceDate}
                         now={now}
                       />
+                    );
+
+                  return (
+                    <div key={rowKey} className="flex flex-col gap-1">
+                      {infoLevelFlag.isVerboseEnabled && (
+                        <div className="text-muted-foreground px-1 text-xs">
+                          {row.stopIndex + 1} / {row.totalStops}
+                        </div>
+                      )}
+                      {rowContent}
                     </div>
                   );
                 })}

--- a/src/components/stop-time-item.tsx
+++ b/src/components/stop-time-item.tsx
@@ -99,6 +99,7 @@ export function StopTimeItem({
             serviceDate: entry.serviceDate,
             tripLocator: entry.tripLocator,
             stopIndex: entry.patternPosition.stopIndex,
+            departureMinutes: entry.schedule.departureMinutes,
           }}
           onInspectTrip={onInspectTrip}
         />

--- a/src/components/stop-times-item.tsx
+++ b/src/components/stop-times-item.tsx
@@ -137,6 +137,7 @@ export function StopTimesItem({
                     serviceDate: entry.serviceDate,
                     tripLocator: entry.tripLocator,
                     stopIndex: entry.patternPosition.stopIndex,
+                    departureMinutes: entry.schedule.departureMinutes,
                   });
                 }}
               >

--- a/src/components/timetable/timetable-grid-entry.tsx
+++ b/src/components/timetable/timetable-grid-entry.tsx
@@ -59,6 +59,7 @@ export function TimetableGridEntry({
     serviceDate,
     tripLocator: entry.tripLocator,
     stopIndex: entry.patternPosition.stopIndex,
+    departureMinutes: entry.schedule.departureMinutes,
   };
   const content = (
     <>

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -1,11 +1,8 @@
 import { useCallback, useRef, useState } from 'react';
+import { formatDateKey } from '../domain/transit/calendar-utils';
 import { createLogger } from '../lib/logger';
 import type { TransitRepository } from '../repositories/transit-repository';
 import type { SelectedTripSnapshot, TripInspectionTarget } from '../types/app/transit-composed';
-import {
-  buildTripInspectionStopsLog,
-  buildTripInspectionSummaryLog,
-} from '../utils/trip-inspection-log';
 
 const logger = createLogger('TripInspection');
 
@@ -32,6 +29,67 @@ function isSameTripInspectionTarget(
   );
 }
 
+function summarizeTripInspectionTarget(target: TripInspectionTarget) {
+  return {
+    patternId: target.tripLocator.patternId,
+    serviceId: target.tripLocator.serviceId,
+    tripIndex: target.tripLocator.tripIndex,
+    stopIndex: target.stopIndex,
+    departureMinutes: target.departureMinutes,
+    serviceDate: target.serviceDate.toISOString(),
+  };
+}
+
+function formatTripInspectionServiceDate(serviceDate: Date): string {
+  return formatDateKey(serviceDate);
+}
+
+function buildTripInspectionMatchDiagnostics(
+  target: TripInspectionTarget,
+  candidates: TripInspectionTarget[],
+) {
+  const samePattern = candidates.filter(
+    (candidate) => candidate.tripLocator.patternId === target.tripLocator.patternId,
+  );
+  const sameService = samePattern.filter(
+    (candidate) => candidate.tripLocator.serviceId === target.tripLocator.serviceId,
+  );
+  const sameTripIndex = sameService.filter(
+    (candidate) => candidate.tripLocator.tripIndex === target.tripLocator.tripIndex,
+  );
+  const sameStopIndex = sameTripIndex.filter(
+    (candidate) => candidate.stopIndex === target.stopIndex,
+  );
+  const sameServiceDate = sameStopIndex.filter(
+    (candidate) => candidate.serviceDate.getTime() === target.serviceDate.getTime(),
+  );
+  const sameDepartureMinutes = sameStopIndex.filter(
+    (candidate) => candidate.departureMinutes === target.departureMinutes,
+  );
+
+  return {
+    patternId: target.tripLocator.patternId,
+    serviceId: target.tripLocator.serviceId,
+    tripIndex: target.tripLocator.tripIndex,
+    stopIndex: target.stopIndex,
+    departureMinutes: target.departureMinutes,
+    serviceDate: target.serviceDate.toISOString(),
+    counts: {
+      total: candidates.length,
+      samePattern: samePattern.length,
+      sameService: sameService.length,
+      sameTripIndex: sameTripIndex.length,
+      sameStopIndex: sameStopIndex.length,
+      sameServiceDate: sameServiceDate.length,
+      sameDepartureMinutesAfterStopIndex: sameDepartureMinutes.length,
+    },
+    sampleSamePattern: samePattern.slice(0, 5).map(summarizeTripInspectionTarget),
+    sampleSameService: sameService.slice(0, 5).map(summarizeTripInspectionTarget),
+    sampleSameTripIndex: sameTripIndex.slice(0, 5).map(summarizeTripInspectionTarget),
+    sampleSameStopIndex: sameStopIndex.slice(0, 5).map(summarizeTripInspectionTarget),
+  };
+}
+
 /**
  * Manage the currently selected trip inspection snapshot and expose handlers
  * to open or close the dialog from a timetable entry.
@@ -45,14 +103,20 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
   );
   const [tripInspectionTargets, setTripInspectionTargets] = useState<TripInspectionTarget[]>([]);
   const [currentTripInspectionTargetIndex, setCurrentTripInspectionTargetIndex] = useState(-1);
+  const tripInspectionTargetsRef = useRef<TripInspectionTarget[]>([]);
   const lookupRequestIdRef = useRef(0);
+
+  const updateTripInspectionTargets = useCallback((targets: TripInspectionTarget[]) => {
+    tripInspectionTargetsRef.current = targets;
+    setTripInspectionTargets(targets);
+  }, []);
 
   const closeTripInspection = useCallback(() => {
     lookupRequestIdRef.current += 1;
     setTripInspectionSnapshot(null);
-    setTripInspectionTargets([]);
+    updateTripInspectionTargets([]);
     setCurrentTripInspectionTargetIndex(-1);
-  }, []);
+  }, [updateTripInspectionTargets]);
 
   const openTripInspectionInternal = useCallback(
     (target: TripInspectionTarget, refreshTargets: boolean) => {
@@ -81,13 +145,13 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         selectedStop,
       };
 
-      logger.debug(buildTripInspectionSummaryLog(snapshot), snapshot);
-      logger.debug(buildTripInspectionStopsLog(snapshot));
+      // logger.debug(buildTripInspectionSummaryLog(snapshot), snapshot);
+      // logger.debug(buildTripInspectionStopsLog(snapshot));
 
       setTripInspectionSnapshot(snapshot);
 
       if (!refreshTargets) {
-        const currentIndex = tripInspectionTargets.findIndex((candidate) =>
+        const currentIndex = tripInspectionTargetsRef.current.findIndex((candidate) =>
           isSameTripInspectionTarget(candidate, target),
         );
         if (currentIndex >= 0) {
@@ -97,11 +161,11 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
 
         logger.warn('openTripInspection: target missing from cached trip-inspection targets', {
           target,
-          tripInspectionTargets,
+          tripInspectionTargets: tripInspectionTargetsRef.current,
         });
       }
 
-      setTripInspectionTargets([target]);
+      updateTripInspectionTargets([target]);
       setCurrentTripInspectionTargetIndex(0);
 
       const selectedStopId = selectedStop.stopMeta?.stop.stop_id;
@@ -109,61 +173,88 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         logger.warn(
           'openTripInspection: selected stop metadata missing; skip trip-inspection target lookup',
         );
-      } else {
-        void repo
-          .getTripInspectionTargets({
-            tripLocator: target.tripLocator,
-            serviceDate: target.serviceDate,
-            stopId: selectedStopId,
-          })
-          .then((result) => {
-            if (lookupRequestIdRef.current !== lookupRequestId) {
-              return;
-            }
-
-            if (!result.success) {
-              logger.warn(
-                'openTripInspection: trip-inspection target lookup failed',
-                result.error,
-                target,
-              );
-              return;
-            }
-
-            if (result.data.length === 0) {
-              setTripInspectionTargets([]);
-              setCurrentTripInspectionTargetIndex(-1);
-              logger.debug('openTripInspection: trip-inspection target lookup returned no targets');
-              return;
-            }
-
-            const currentIndex = result.data.findIndex((candidate) =>
-              isSameTripInspectionTarget(candidate, target),
-            );
-            if (currentIndex < 0) {
-              setTripInspectionTargets([]);
-              setCurrentTripInspectionTargetIndex(-1);
-              logger.warn(
-                'openTripInspection: current target missing from trip-inspection targets',
-                {
-                  target,
-                  targets: result.data,
-                },
-              );
-              return;
-            }
-
-            setTripInspectionTargets(result.data);
-            setCurrentTripInspectionTargetIndex(currentIndex);
-
-            logger.debug(
-              `openTripInspection: trip-inspection targets=${result.data.length} currentIndex=${currentIndex} stopId=${selectedStopId}`,
-              result.data,
-            );
-          });
+        return;
       }
+
+      void repo
+        .getTripInspectionTargets({
+          tripLocator: target.tripLocator,
+          serviceDate: target.serviceDate,
+          stopId: selectedStopId,
+        })
+        .then((result) => {
+          if (lookupRequestIdRef.current !== lookupRequestId) {
+            return;
+          }
+
+          logger.debug(
+            `openTripInspection: getTripInspectionTargets result serviceDate=${formatTripInspectionServiceDate(target.serviceDate)} stopId=${selectedStopId}`,
+            result,
+          );
+
+          if (!result.success) {
+            logger.warn(
+              'openTripInspection: trip-inspection target lookup failed',
+              result.error,
+              target,
+            );
+            return;
+          }
+
+          if (result.data.length === 0) {
+            updateTripInspectionTargets([target]);
+            setCurrentTripInspectionTargetIndex(0);
+            logger.debug('openTripInspection: trip-inspection target lookup returned no targets');
+            return;
+          }
+
+          const currentIndex = result.data.findIndex((candidate) =>
+            isSameTripInspectionTarget(candidate, target),
+          );
+          if (currentIndex < 0) {
+            const diagnostics = buildTripInspectionMatchDiagnostics(target, result.data);
+            logger.debug('openTripInspection: target lookup mismatch', {
+              requestedStopId: selectedStopId,
+              target: summarizeTripInspectionTarget(target),
+              sampleCandidates: result.data.slice(0, 10).map(summarizeTripInspectionTarget),
+            });
+            logger.debug('openTripInspection: target lookup mismatch counts', diagnostics.counts);
+            logger.debug(
+              'openTripInspection: target lookup mismatch sampleSamePattern',
+              diagnostics.sampleSamePattern,
+            );
+            logger.debug(
+              'openTripInspection: target lookup mismatch sampleSameService',
+              diagnostics.sampleSameService,
+            );
+            logger.debug(
+              'openTripInspection: target lookup mismatch sampleSameTripIndex',
+              diagnostics.sampleSameTripIndex,
+            );
+            logger.debug(
+              'openTripInspection: target lookup mismatch sampleSameStopIndex',
+              diagnostics.sampleSameStopIndex,
+            );
+            logger.debug('openTripInspection: target lookup mismatch diagnostics', diagnostics);
+            updateTripInspectionTargets([target]);
+            setCurrentTripInspectionTargetIndex(0);
+            logger.warn('openTripInspection: current target missing from trip-inspection targets', {
+              target,
+              targets: result.data,
+            });
+            return;
+          }
+
+          updateTripInspectionTargets(result.data);
+          setCurrentTripInspectionTargetIndex(currentIndex);
+
+          logger.debug(
+            `openTripInspection: serviceDate=${formatTripInspectionServiceDate(target.serviceDate)} trip-inspection targets=${result.data.length} currentIndex=${currentIndex} stopId=${selectedStopId}`,
+            result.data,
+          );
+        });
     },
-    [repo, tripInspectionTargets],
+    [repo, updateTripInspectionTargets],
   );
 
   const openTripInspection = useCallback(

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -178,7 +178,6 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
 
       void repo
         .getTripInspectionTargets({
-          tripLocator: target.tripLocator,
           serviceDate: target.serviceDate,
           stopId: selectedStopId,
         })

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { createLogger } from '../lib/logger';
 import type { TransitRepository } from '../repositories/transit-repository';
 import type { SelectedTripSnapshot, TripInspectionTarget } from '../types/app/transit-composed';
@@ -11,8 +11,25 @@ const logger = createLogger('TripInspection');
 
 interface UseTripInspectionReturn {
   tripInspectionSnapshot: SelectedTripSnapshot | null;
+  tripInspectionTargets: TripInspectionTarget[];
+  currentTripInspectionTargetIndex: number;
   openTripInspection: (target: TripInspectionTarget) => void;
+  openPreviousTripInspection: () => void;
+  openNextTripInspection: () => void;
   closeTripInspection: () => void;
+}
+
+function isSameTripInspectionTarget(
+  left: TripInspectionTarget,
+  right: TripInspectionTarget,
+): boolean {
+  return (
+    left.tripLocator.patternId === right.tripLocator.patternId &&
+    left.tripLocator.serviceId === right.tripLocator.serviceId &&
+    left.tripLocator.tripIndex === right.tripLocator.tripIndex &&
+    left.stopIndex === right.stopIndex &&
+    left.serviceDate.getTime() === right.serviceDate.getTime()
+  );
 }
 
 /**
@@ -26,13 +43,22 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
   const [tripInspectionSnapshot, setTripInspectionSnapshot] = useState<SelectedTripSnapshot | null>(
     null,
   );
+  const [tripInspectionTargets, setTripInspectionTargets] = useState<TripInspectionTarget[]>([]);
+  const [currentTripInspectionTargetIndex, setCurrentTripInspectionTargetIndex] = useState(-1);
+  const lookupRequestIdRef = useRef(0);
 
   const closeTripInspection = useCallback(() => {
+    lookupRequestIdRef.current += 1;
     setTripInspectionSnapshot(null);
+    setTripInspectionTargets([]);
+    setCurrentTripInspectionTargetIndex(-1);
   }, []);
 
-  const openTripInspection = useCallback(
-    (target: TripInspectionTarget) => {
+  const openTripInspectionInternal = useCallback(
+    (target: TripInspectionTarget, refreshTargets: boolean) => {
+      const lookupRequestId = lookupRequestIdRef.current + 1;
+      lookupRequestIdRef.current = lookupRequestId;
+
       const trip = repo.getTripSnapshot(target.tripLocator, target.serviceDate);
       if (!trip.success) {
         logger.warn('openTripInspection: failed to resolve trip snapshot', trip.error);
@@ -57,14 +83,125 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
 
       logger.debug(buildTripInspectionSummaryLog(snapshot), snapshot);
       logger.debug(buildTripInspectionStopsLog(snapshot));
+
       setTripInspectionSnapshot(snapshot);
+
+      if (!refreshTargets) {
+        const currentIndex = tripInspectionTargets.findIndex((candidate) =>
+          isSameTripInspectionTarget(candidate, target),
+        );
+        if (currentIndex >= 0) {
+          setCurrentTripInspectionTargetIndex(currentIndex);
+          return;
+        }
+
+        logger.warn('openTripInspection: target missing from cached trip-inspection targets', {
+          target,
+          tripInspectionTargets,
+        });
+      }
+
+      setTripInspectionTargets([target]);
+      setCurrentTripInspectionTargetIndex(0);
+
+      const selectedStopId = selectedStop.stopMeta?.stop.stop_id;
+      if (selectedStopId === undefined) {
+        logger.warn(
+          'openTripInspection: selected stop metadata missing; skip trip-inspection target lookup',
+        );
+      } else {
+        void repo
+          .getTripInspectionTargets({
+            tripLocator: target.tripLocator,
+            serviceDate: target.serviceDate,
+            stopId: selectedStopId,
+          })
+          .then((result) => {
+            if (lookupRequestIdRef.current !== lookupRequestId) {
+              return;
+            }
+
+            if (!result.success) {
+              logger.warn(
+                'openTripInspection: trip-inspection target lookup failed',
+                result.error,
+                target,
+              );
+              return;
+            }
+
+            if (result.data.length === 0) {
+              setTripInspectionTargets([]);
+              setCurrentTripInspectionTargetIndex(-1);
+              logger.debug('openTripInspection: trip-inspection target lookup returned no targets');
+              return;
+            }
+
+            const currentIndex = result.data.findIndex((candidate) =>
+              isSameTripInspectionTarget(candidate, target),
+            );
+            if (currentIndex < 0) {
+              setTripInspectionTargets([]);
+              setCurrentTripInspectionTargetIndex(-1);
+              logger.warn(
+                'openTripInspection: current target missing from trip-inspection targets',
+                {
+                  target,
+                  targets: result.data,
+                },
+              );
+              return;
+            }
+
+            setTripInspectionTargets(result.data);
+            setCurrentTripInspectionTargetIndex(currentIndex);
+
+            logger.debug(
+              `openTripInspection: trip-inspection targets=${result.data.length} currentIndex=${currentIndex} stopId=${selectedStopId}`,
+              result.data,
+            );
+          });
+      }
     },
-    [repo],
+    [repo, tripInspectionTargets],
   );
+
+  const openTripInspection = useCallback(
+    (target: TripInspectionTarget) => {
+      openTripInspectionInternal(target, true);
+    },
+    [openTripInspectionInternal],
+  );
+
+  const openPreviousTripInspection = useCallback(() => {
+    if (currentTripInspectionTargetIndex <= 0) {
+      return;
+    }
+
+    const previousTarget = tripInspectionTargets[currentTripInspectionTargetIndex - 1];
+    if (previousTarget) {
+      openTripInspectionInternal(previousTarget, false);
+    }
+  }, [currentTripInspectionTargetIndex, openTripInspectionInternal, tripInspectionTargets]);
+
+  const openNextTripInspection = useCallback(() => {
+    if (currentTripInspectionTargetIndex < 0) {
+      return;
+    }
+
+    const nextTarget = tripInspectionTargets[currentTripInspectionTargetIndex + 1];
+    if (nextTarget) {
+      openTripInspectionInternal(nextTarget, false);
+    }
+  }, [currentTripInspectionTargetIndex, openTripInspectionInternal, tripInspectionTargets]);
 
   return {
     tripInspectionSnapshot,
+    tripInspectionTargets,
+    currentTripInspectionTargetIndex,
     openTripInspection,
+    openPreviousTripInspection,
+    openNextTripInspection,
     closeTripInspection,
   };
 }

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -129,19 +129,27 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         return;
       }
 
-      const selectedStop = trip.data.stopTimes.find(
+      const selectedStopIndex = trip.data.stopTimes.findIndex(
         (stop) => stop.timetableEntry.patternPosition.stopIndex === target.stopIndex,
       );
-      if (!selectedStop) {
+      if (selectedStopIndex < 0) {
         logger.warn(
           `openTripInspection: selected stop index ${target.stopIndex} is missing from reconstructed trip snapshot`,
         );
         return;
       }
 
+      const selectedStop = trip.data.stopTimes[selectedStopIndex];
+      if (!selectedStop) {
+        logger.warn(
+          `openTripInspection: selected stop array index ${selectedStopIndex} is missing from reconstructed trip snapshot`,
+        );
+        return;
+      }
+
       const snapshot: SelectedTripSnapshot = {
         ...trip.data,
-        currentStopIndex: target.stopIndex,
+        currentStopIndex: selectedStopIndex,
         selectedStop,
       };
 

--- a/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
@@ -638,6 +638,60 @@ describe('getTripSnapshot', () => {
 });
 
 // ---------------------------------------------------------------------------
+// getTripInspectionTargets
+// ---------------------------------------------------------------------------
+
+describe('getTripInspectionTargets', () => {
+  it('returns trip-inspection targets at the queried stop in timetable order', async () => {
+    const fixture = createFixtureV2();
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    const result = await repository.getTripInspectionTargets({
+      tripLocator: { patternId: 'tp_bus_o', serviceId: 'svc_weekday', tripIndex: 0 },
+      serviceDate: WEEKDAY,
+      stopId: 'bus_01',
+    });
+    const timetable = await repository.getFullDayTimetableEntries('bus_01', WEEKDAY);
+
+    assertSuccess(result);
+    assertSuccess(timetable);
+    expect(result.data).toEqual(
+      timetable.data.map((entry) => ({
+        tripLocator: entry.tripLocator,
+        serviceDate: WEEKDAY,
+        stopIndex: entry.patternPosition.stopIndex,
+        departureMinutes: entry.schedule.departureMinutes,
+      })),
+    );
+  });
+
+  it('does not require the current trip pattern to exist', async () => {
+    const fixture = createFixtureV2();
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    const result = await repository.getTripInspectionTargets({
+      tripLocator: { patternId: 'missing_pattern', serviceId: 'svc_weekday', tripIndex: 0 },
+      serviceDate: WEEKDAY,
+      stopId: 'bus_01',
+    });
+    const timetable = await repository.getFullDayTimetableEntries('bus_01', WEEKDAY);
+
+    assertSuccess(result);
+    assertSuccess(timetable);
+    expect(result.data).toEqual(
+      timetable.data.map((entry) => ({
+        tripLocator: entry.tripLocator,
+        serviceDate: WEEKDAY,
+        stopIndex: entry.patternPosition.stopIndex,
+        departureMinutes: entry.schedule.departureMinutes,
+      })),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // getRouteShapes (background loading)
 // ---------------------------------------------------------------------------
 

--- a/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { AthenaiRepositoryV2 } from '..';
 import { getEffectiveHeadsign } from '../../../domain/transit/get-effective-headsign';
+import { getServiceDay } from '../../../domain/transit/service-day';
 import {
   TestDataSourceV2,
   createFixtureV2,
@@ -635,6 +636,21 @@ describe('getTripSnapshot', () => {
       firstStop?.timetableEntry.schedule.departureMinutes,
     );
   });
+
+  it('passes through the provided serviceDate on trip snapshots', async () => {
+    const fixture = createFixtureV2();
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+    const serviceDate = new Date('2026-03-11T00:00:00+09:00');
+
+    const result = repository.getTripSnapshot(
+      { patternId: 'tp_sub_n', serviceId: 'svc_weekday', tripIndex: 0 },
+      serviceDate,
+    );
+
+    assertSuccess(result);
+    expect(result.data.serviceDate).toBe(serviceDate);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -666,6 +682,39 @@ describe('getTripInspectionTargets', () => {
     );
   });
 
+  it('sorts same-minute duplicate-stop occurrences by stopIndex', async () => {
+    const fixture = createFixtureV2();
+    const circularTerminalGroup = fixture.data.timetable.data['bus_01']?.find(
+      (group) => group.tp === 'tp_bus_c' && group.si === 3,
+    );
+    if (!circularTerminalGroup) {
+      throw new Error('Expected bus_01 circular terminal timetable fixture');
+    }
+    circularTerminalGroup.d = { svc_weekday: [620] };
+    circularTerminalGroup.a = { svc_weekday: [620] };
+
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    const result = await repository.getTripInspectionTargets({
+      tripLocator: { patternId: 'tp_bus_c', serviceId: 'svc_weekday', tripIndex: 0 },
+      serviceDate: WEEKDAY,
+      stopId: 'bus_01',
+    });
+
+    assertSuccess(result);
+    expect(
+      result.data
+        .filter(
+          (target) =>
+            target.tripLocator.patternId === 'tp_bus_c' &&
+            target.tripLocator.tripIndex === 0 &&
+            target.departureMinutes === 620,
+        )
+        .map((target) => target.stopIndex),
+    ).toEqual([0, 3]);
+  });
+
   it('does not require the current trip pattern to exist', async () => {
     const fixture = createFixtureV2();
     const ds = new TestDataSourceV2({ test: fixture });
@@ -687,6 +736,34 @@ describe('getTripInspectionTargets', () => {
         stopIndex: entry.patternPosition.stopIndex,
         departureMinutes: entry.schedule.departureMinutes,
       })),
+    );
+  });
+
+  it('uses the provided service day without re-normalizing it again', async () => {
+    const fixture = createFixtureV2();
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    const serviceDate = getServiceDay(EXCEPTION_HOLIDAY);
+    const result = await repository.getTripInspectionTargets({
+      tripLocator: { patternId: 'tp_sub_n', serviceId: 'svc_holiday', tripIndex: 0 },
+      serviceDate,
+      stopId: 'sub_01',
+    });
+    const timetable = await repository.getFullDayTimetableEntries('sub_01', EXCEPTION_HOLIDAY);
+
+    assertSuccess(result);
+    assertSuccess(timetable);
+    expect(result.data).toEqual(
+      timetable.data.map((entry) => ({
+        tripLocator: entry.tripLocator,
+        serviceDate,
+        stopIndex: entry.patternPosition.stopIndex,
+        departureMinutes: entry.schedule.departureMinutes,
+      })),
+    );
+    expect(new Set(result.data.map((target) => target.tripLocator.serviceId))).toEqual(
+      new Set(['svc_holiday']),
     );
   });
 });

--- a/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
@@ -591,7 +591,7 @@ describe('getTripSnapshot', () => {
     expect(result.success).toBe(false);
   });
 
-  it('returns failure when no rows match the requested service or trip index', async () => {
+  it('returns success with an empty stopTimes when no rows match the requested service or trip index', async () => {
     const fixture = createFixtureV2();
     const ds = new TestDataSourceV2({ test: fixture });
     const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
@@ -605,36 +605,13 @@ describe('getTripSnapshot', () => {
       WEEKDAY,
     );
 
-    expect(missingService.success).toBe(false);
-    expect(missingTripIndex.success).toBe(false);
-  });
-
-  it('falls back to departure time when arrivals are unavailable', async () => {
-    const fixture = createFixtureV2();
-    const timetableGroup = fixture.data.timetable.data['sub_01']?.[0] as
-      | { a?: Record<string, number[]> }
-      | undefined;
-    if (!timetableGroup) {
-      throw new Error('Expected sub_01 timetable fixture');
-    }
-    delete timetableGroup.a;
-
-    const ds = new TestDataSourceV2({ test: fixture });
-    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
-
-    const result = repository.getTripSnapshot(
-      { patternId: 'tp_sub_n', serviceId: 'svc_weekday', tripIndex: 0 },
-      WEEKDAY,
-    );
-    assertSuccess(result);
-
-    const firstStop = result.data.stopTimes.find(
-      (stopTime) => stopTime.timetableEntry.patternPosition.stopIndex === 0,
-    );
-    expect(firstStop).toBeDefined();
-    expect(firstStop?.timetableEntry.schedule.arrivalMinutes).toBe(
-      firstStop?.timetableEntry.schedule.departureMinutes,
-    );
+    // The pattern itself resolves, so getTripSnapshot returns a valid
+    // snapshot even when no individual stop rows can be reconstructed.
+    // Callers observe the empty stop list rather than a failure.
+    assertSuccess(missingService);
+    expect(missingService.data.stopTimes).toEqual([]);
+    assertSuccess(missingTripIndex);
+    expect(missingTripIndex.data.stopTimes).toEqual([]);
   });
 
   it('passes through the provided serviceDate on trip snapshots', async () => {
@@ -651,6 +628,66 @@ describe('getTripSnapshot', () => {
     assertSuccess(result);
     expect(result.data.serviceDate).toBe(serviceDate);
   });
+
+  it('returns failure when the pattern resolves but its route_id does not', async () => {
+    // Inject a pattern that points to a non-existent route. This is a
+    // contract violation between TripPattern and Route maps, so the
+    // repository should fail fast rather than fabricate a snapshot.
+    const fixture = createFixtureV2();
+    fixture.data.tripPatterns.data['tp_orphan'] = {
+      v: 2,
+      r: 'route_does_not_exist',
+      h: 'Orphan',
+      stops: [{ id: 'bus_01' }, { id: 'bus_02' }],
+    };
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    const result = repository.getTripSnapshot(
+      { patternId: 'tp_orphan', serviceId: 'svc_weekday', tripIndex: 0 },
+      WEEKDAY,
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it('populates the snapshot with locator, route, headsign, and stop sequence', async () => {
+    const fixture = createFixtureV2();
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    const locator = { patternId: 'tp_bus_o', serviceId: 'svc_weekday', tripIndex: 0 };
+    const result = repository.getTripSnapshot(locator, WEEKDAY);
+    assertSuccess(result);
+
+    expect(result.data.locator).toBe(locator);
+    expect(result.data.route.route_id).toBe('route_bus');
+    expect(result.data.tripHeadsign.name).toBe('Oji-eki');
+    // The fixture pattern does not specify a direction.
+    expect(result.data.direction).toBeUndefined();
+    expect(result.data.stopTimes.length).toBeGreaterThan(0);
+  });
+
+  it('orders stopTimes by ascending patternPosition.stopIndex', async () => {
+    // The repository's internal timetable is keyed by stopId, so stop rows
+    // arrive in source iteration order rather than pattern order.
+    // getTripSnapshot must sort them into the canonical pattern sequence.
+    const fixture = createFixtureV2();
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    const result = repository.getTripSnapshot(
+      { patternId: 'tp_bus_c', serviceId: 'svc_weekday', tripIndex: 0 },
+      WEEKDAY,
+    );
+    assertSuccess(result);
+
+    const stopIndexes = result.data.stopTimes.map(
+      (stopTime) => stopTime.timetableEntry.patternPosition.stopIndex,
+    );
+    const sorted = [...stopIndexes].sort((a, b) => a - b);
+    expect(stopIndexes).toEqual(sorted);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -664,7 +701,6 @@ describe('getTripInspectionTargets', () => {
     const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
 
     const result = await repository.getTripInspectionTargets({
-      tripLocator: { patternId: 'tp_bus_o', serviceId: 'svc_weekday', tripIndex: 0 },
       serviceDate: WEEKDAY,
       stopId: 'bus_01',
     });
@@ -697,7 +733,6 @@ describe('getTripInspectionTargets', () => {
     const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
 
     const result = await repository.getTripInspectionTargets({
-      tripLocator: { patternId: 'tp_bus_c', serviceId: 'svc_weekday', tripIndex: 0 },
       serviceDate: WEEKDAY,
       stopId: 'bus_01',
     });
@@ -721,7 +756,6 @@ describe('getTripInspectionTargets', () => {
     const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
 
     const result = await repository.getTripInspectionTargets({
-      tripLocator: { patternId: 'missing_pattern', serviceId: 'svc_weekday', tripIndex: 0 },
       serviceDate: WEEKDAY,
       stopId: 'bus_01',
     });
@@ -746,7 +780,6 @@ describe('getTripInspectionTargets', () => {
 
     const serviceDate = getServiceDay(EXCEPTION_HOLIDAY);
     const result = await repository.getTripInspectionTargets({
-      tripLocator: { patternId: 'tp_sub_n', serviceId: 'svc_holiday', tripIndex: 0 },
       serviceDate,
       stopId: 'sub_01',
     });

--- a/src/repositories/athenai-repository/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository/athenai-repository-v2.ts
@@ -111,7 +111,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
   private readonly patternStatsMap = new Map<string, PatternStatsEntry>();
 
   // Mutable caches and lazy-load state.
-  private activeServiceCache: { key: string; ids: Set<string> } | null = null;
+  private activeServiceCache = new Map<string, Set<string>>();
   private routeStopsCache: Map<string, Set<string>> | null = null;
   private shapesPromise: Promise<RouteShape[]> = Promise.resolve([]);
   private shapesCache: RouteShape[] | null = null;
@@ -307,6 +307,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return shapes;
   }
 
+  /** {@inheritDoc TransitRepository.getStopsInBounds} */
   getStopsInBounds(bounds: Bounds, limit: number): Promise<CollectionResult<StopWithMeta>> {
     const t0 = performance.now();
     const effectiveLimit = normalizeStopQueryLimit(limit);
@@ -341,6 +342,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return Promise.resolve({ success: true, data, truncated });
   }
 
+  /** {@inheritDoc TransitRepository.getStopsNearby} */
   getStopsNearby(
     center: LatLng,
     radiusM: number,
@@ -378,9 +380,10 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return Promise.resolve({ success: true, data, truncated });
   }
 
+  /** {@inheritDoc TransitRepository.getUpcomingTimetableEntries} */
   getUpcomingTimetableEntries(
     stopId: string,
-    now: Date,
+    referenceDateTime: Date,
     limit?: number,
   ): Promise<UpcomingTimetableResult> {
     const t0 = performance.now();
@@ -390,7 +393,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       return Promise.resolve({ success: false, error: `No stop time data for stop: ${stopId}` });
     }
 
-    const serviceDay = getServiceDay(now);
+    const serviceDay = getServiceDay(referenceDateTime);
     const todayServiceIds = this.getActiveServiceIds(serviceDay);
 
     let fullDayCount = 0;
@@ -400,7 +403,8 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     prevServiceDay.setDate(prevServiceDay.getDate() - 1);
     const yesterdayServiceIds = this.getActiveServiceIds(prevServiceDay);
 
-    const nowMinutes = getServiceDayMinutes(now);
+    const nowMinutes = getServiceDayMinutes(referenceDateTime);
+    const overnightTarget = nowMinutes + 1440;
 
     const entries: ContextualTimetableEntry[] = [];
 
@@ -416,6 +420,9 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       const totalStops = pattern.stops.length;
       const stopIndex = group.si;
       const isTerminalPosition = stopIndex === totalStops - 1;
+      const routeDirection = this.resolveRouteDirection(route, pattern, stopIndex);
+      const todayTripInsights = this.resolveTripInsights(group.tp, stopIndex, serviceDay);
+      const yesterdayTripInsights = this.resolveTripInsights(group.tp, stopIndex, prevServiceDay);
 
       for (const [serviceId, times] of Object.entries(group.d)) {
         if (!todayServiceIds.has(serviceId)) {
@@ -436,7 +443,6 @@ export class AthenaiRepositoryV2 implements TransitRepository {
         }
 
         const startIdx = binarySearchFirstGte(times, nowMinutes);
-        const tripInsights = this.resolveTripInsights(group.tp, stopIndex, serviceDay);
         for (let i = startIdx; i < times.length; i++) {
           const pickupType = (pickupTypes?.[i] ?? 0) as StopServiceType;
           const dropOffType = (dropOffTypes?.[i] ?? 0) as StopServiceType;
@@ -446,7 +452,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
               departureMinutes: times[i],
               arrivalMinutes: arrivals?.[i] ?? times[i],
             },
-            routeDirection: this.resolveRouteDirection(route, pattern, stopIndex),
+            routeDirection,
             boarding: { pickupType, dropOffType },
             patternPosition: {
               stopIndex,
@@ -455,7 +461,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
               isOrigin: stopIndex === 0,
             },
             serviceDate: serviceDay,
-            ...(tripInsights !== undefined ? { insights: tripInsights } : {}),
+            ...(todayTripInsights !== undefined ? { insights: todayTripInsights } : {}),
           });
         }
       }
@@ -480,10 +486,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
             }
           }
         }
-
-        const overnightTarget = nowMinutes + 1440;
         const startIdx = binarySearchFirstGte(times, overnightTarget);
-        const tripInsights = this.resolveTripInsights(group.tp, stopIndex, prevServiceDay);
         for (let i = startIdx; i < times.length; i++) {
           const pickupType = (pickupTypes?.[i] ?? 0) as StopServiceType;
           const dropOffType = (dropOffTypes?.[i] ?? 0) as StopServiceType;
@@ -493,7 +496,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
               departureMinutes: times[i],
               arrivalMinutes: arrivals?.[i] ?? times[i],
             },
-            routeDirection: this.resolveRouteDirection(route, pattern, stopIndex),
+            routeDirection,
             boarding: { pickupType, dropOffType },
             patternPosition: {
               stopIndex,
@@ -502,7 +505,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
               isOrigin: stopIndex === 0,
             },
             serviceDate: prevServiceDay,
-            ...(tripInsights !== undefined ? { insights: tripInsights } : {}),
+            ...(yesterdayTripInsights !== undefined ? { insights: yesterdayTripInsights } : {}),
           });
         }
       }
@@ -528,6 +531,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return Promise.resolve({ success: true, data: result, truncated, meta });
   }
 
+  /** {@inheritDoc TransitRepository.getFullDayTimetableEntries} */
   getFullDayTimetableEntries(stopId: string, dateTime: Date): Promise<TimetableResult> {
     const t0 = performance.now();
     const emptyMeta: TimetableQueryMeta = {
@@ -555,6 +559,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       const totalStops = pattern.stops.length;
       const stopIndex = group.si;
       const isTerminalPosition = stopIndex === totalStops - 1;
+      const routeDirection = this.resolveRouteDirection(route, pattern, stopIndex);
 
       const tripInsights = this.resolveTripInsights(group.tp, stopIndex, serviceDate);
       for (const [serviceId, times] of Object.entries(group.d)) {
@@ -572,7 +577,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
               departureMinutes: times[i],
               arrivalMinutes: arrivals?.[i] ?? times[i],
             },
-            routeDirection: this.resolveRouteDirection(route, pattern, stopIndex),
+            routeDirection,
             boarding: { pickupType, dropOffType },
             patternPosition: {
               stopIndex,
@@ -599,6 +604,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return Promise.resolve({ success: true, data: entries, truncated: false, meta });
   }
 
+  /** {@inheritDoc TransitRepository.getTripSnapshot} */
   getTripSnapshot(locator: TripLocator, serviceDate: Date): TripSnapshotResult {
     const pattern = this.tripPatterns.get(locator.patternId);
     if (!pattern) {
@@ -612,13 +618,23 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     const stopTimes: TripStopTime[] = [];
     for (const { stopId, group } of this.timetableByPattern.get(locator.patternId) ?? []) {
       const departures = group.d[locator.serviceId];
-      if (!departures || locator.tripIndex >= departures.length) {
+      if (!departures) {
+        logger.warn(
+          `getTripSnapshot: missing departures for pattern=${locator.patternId} service=${locator.serviceId} stop=${stopId} stopIndex=${group.si}`,
+        );
+        continue;
+      }
+      if (locator.tripIndex >= departures.length) {
+        logger.warn(
+          `getTripSnapshot: missing trip index for pattern=${locator.patternId} service=${locator.serviceId} index=${locator.tripIndex} stop=${stopId} stopIndex=${group.si} departures=${departures.length}`,
+        );
         continue;
       }
 
       const arrivals = group.a?.[locator.serviceId];
       const pickupTypes = group.pt?.[locator.serviceId];
       const dropOffTypes = group.dt?.[locator.serviceId];
+      const routeDirection = this.resolveRouteDirection(route, pattern, group.si);
       stopTimes.push({
         stopMeta: this.stopsMetaMap.get(stopId),
         routeTypes: this.stopRouteTypeMap.get(stopId) ?? [],
@@ -628,7 +644,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
             departureMinutes: departures[locator.tripIndex],
             arrivalMinutes: arrivals?.[locator.tripIndex] ?? departures[locator.tripIndex],
           },
-          routeDirection: this.resolveRouteDirection(route, pattern, group.si),
+          routeDirection,
           boarding: {
             pickupType: (pickupTypes?.[locator.tripIndex] ?? 0) as StopServiceType,
             dropOffType: (dropOffTypes?.[locator.tripIndex] ?? 0) as StopServiceType,
@@ -665,24 +681,62 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return { success: true, data: snapshot };
   }
 
-  async getTripInspectionTargets(
+  /** {@inheritDoc TransitRepository.getTripInspectionTargets} */
+  getTripInspectionTargets(
     query: TripInspectionGroupQuery,
   ): Promise<Result<TripInspectionTarget[]>> {
-    const timetable = await this.getFullDayTimetableEntries(query.stopId, query.serviceDate);
-    if (!timetable.success) {
-      return timetable;
+    const timetableGroups = this.timetable[query.stopId];
+    if (!timetableGroups) {
+      return Promise.resolve({ success: true, data: [] });
     }
 
-    const targets = timetable.data.map<TripInspectionTarget>((entry) => ({
-      tripLocator: entry.tripLocator,
-      serviceDate: query.serviceDate,
-      stopIndex: entry.patternPosition.stopIndex,
-      departureMinutes: entry.schedule.departureMinutes,
-    }));
+    const activeServiceIds = this.getActiveServiceIds(query.serviceDate);
+    const targets: Array<TripInspectionTarget & { routeId: string }> = [];
 
-    return { success: true, data: targets };
+    for (const group of timetableGroups) {
+      const pattern = this.tripPatterns.get(group.tp);
+      if (!pattern) {
+        continue;
+      }
+
+      for (const [serviceId, times] of Object.entries(group.d)) {
+        if (!activeServiceIds.has(serviceId)) {
+          continue;
+        }
+
+        for (let i = 0; i < times.length; i++) {
+          targets.push({
+            tripLocator: { patternId: group.tp, serviceId, tripIndex: i },
+            serviceDate: query.serviceDate,
+            stopIndex: group.si,
+            departureMinutes: times[i],
+            routeId: pattern.route_id,
+          });
+        }
+      }
+    }
+
+    targets.sort((left, right) => {
+      const departureDiff = left.departureMinutes - right.departureMinutes;
+      if (departureDiff !== 0) {
+        return departureDiff;
+      }
+
+      const stopIndexDiff = left.stopIndex - right.stopIndex;
+      if (stopIndexDiff !== 0) {
+        return stopIndexDiff;
+      }
+
+      return left.routeId.localeCompare(right.routeId);
+    });
+
+    return Promise.resolve({
+      success: true,
+      data: targets.map(({ routeId: _routeId, ...target }) => target),
+    });
   }
 
+  /** {@inheritDoc TransitRepository.getRouteTypesForStop} */
   getRouteTypesForStop(stopId: string): Promise<Result<AppRouteTypeValue[]>> {
     const routeTypes = this.stopRouteTypeMap.get(stopId);
     if (routeTypes === undefined) {
@@ -693,6 +747,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return Promise.resolve({ success: true, data: routeTypes });
   }
 
+  /** {@inheritDoc TransitRepository.getStopMetaById} */
   getStopMetaById(stopId: string): Promise<Result<StopWithMeta>> {
     const meta = this.stopsMetaMap.get(stopId);
     if (meta) {
@@ -701,6 +756,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return Promise.resolve({ success: false, error: `Stop not found: ${stopId}` });
   }
 
+  /** {@inheritDoc TransitRepository.getStopMetaByIds} */
   getStopMetaByIds(stopIds: Set<string>): StopWithMeta[] {
     const result: StopWithMeta[] = [];
     for (const stopId of stopIds) {
@@ -712,6 +768,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return result;
   }
 
+  /** {@inheritDoc TransitRepository.getStopsForRoutes} */
   getStopsForRoutes(routeIds: Set<string>): Set<string> {
     const cache = this.getRouteStopsMap();
     const stopIds = new Set<string>();
@@ -750,13 +807,13 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return map;
   }
 
+  /** {@inheritDoc TransitRepository.getAllStops} */
   getAllStops(): Promise<CollectionResult<Stop>> {
-    const t0 = performance.now();
-    const elapsed = Math.round(performance.now() - t0);
-    logger.debug(`getAllStops: ${this.stops.length} stops in ${elapsed}ms`);
+    logger.debug(`getAllStops: ${this.stops.length} stops`);
     return Promise.resolve({ success: true, data: this.stops, truncated: false });
   }
 
+  /** {@inheritDoc TransitRepository.getRouteShapes} */
   async getRouteShapes(): Promise<CollectionResult<RouteShape>> {
     if (this.shapesCache) {
       logger.debug(`getRouteShapes: ${this.shapesCache.length} shapes (cached)`);
@@ -767,6 +824,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return { success: true, data: this.shapesCache, truncated: false };
   }
 
+  /** {@inheritDoc TransitRepository.getAgency} */
   getAgency(agencyId: string): Promise<Result<Agency>> {
     const agency = this.agencyMap.get(agencyId);
     if (!agency) {
@@ -775,16 +833,18 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return Promise.resolve({ success: true, data: agency });
   }
 
+  /** {@inheritDoc TransitRepository.getAllSourceMeta} */
   getAllSourceMeta(): Promise<CollectionResult<SourceMeta>> {
     return Promise.resolve({ success: true, data: this.sourceMetas, truncated: false });
   }
 
+  /** {@inheritDoc TransitRepository.resolveStopStats} */
   resolveStopStats(stopId: string, serviceDate: Date): StopWithMeta['stats'] | undefined {
     const entry = this.stopInsightsMap.get(stopId);
     if (!entry) {
       return undefined;
     }
-    const activeIds = this.getActiveServiceIds(getServiceDay(serviceDate));
+    const activeIds = this.getActiveServiceIds(serviceDate);
     const groupKey = selectServiceGroup(entry.groups, activeIds);
     if (!groupKey) {
       return undefined;
@@ -792,12 +852,13 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     return entry.stats[groupKey];
   }
 
+  /** {@inheritDoc TransitRepository.resolveRouteFreq} */
   resolveRouteFreq(routeId: string, serviceDate: Date): number | undefined {
     const entry = this.routeFreqMap.get(routeId);
     if (!entry) {
       return undefined;
     }
-    const activeIds = this.getActiveServiceIds(getServiceDay(serviceDate));
+    const activeIds = this.getActiveServiceIds(serviceDate);
     const groupKey = selectServiceGroup(entry.groups, activeIds);
     if (!groupKey) {
       return undefined;
@@ -866,11 +927,25 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     };
   }
 
+  /**
+   * Returns active GTFS service IDs for a pre-normalized service day.
+   *
+   * The input must already be normalized with `getServiceDay(...)` or come
+   * from another repository API that exposes a service-day value. Passing a
+   * raw reference datetime here produces silently wrong calendar matching,
+   * because `formatDateKey()` / `getDayIndex()` interpret the date as-is.
+   *
+   * Results are cached by `YYYYMMDD` key.
+   *
+   * @param serviceDate - Pre-normalized GTFS service day.
+   * @returns Active service IDs for that service day.
+   */
   private getActiveServiceIds(serviceDate: Date): Set<string> {
     const key = formatDateKey(serviceDate);
 
-    if (this.activeServiceCache?.key === key) {
-      return this.activeServiceCache.ids;
+    const cached = this.activeServiceCache.get(key);
+    if (cached) {
+      return cached;
     }
 
     const ids = computeActiveServiceIds(
@@ -879,7 +954,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       this.calendarExceptions,
     );
 
-    this.activeServiceCache = { key, ids };
+    this.activeServiceCache.set(key, ids);
     return ids;
   }
 }

--- a/src/repositories/athenai-repository/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository/athenai-repository-v2.ts
@@ -30,7 +30,6 @@ import type {
   TripInspectionGroupQuery,
   TripInspectionTarget,
   TripLocator,
-  TripStopTime,
   TripPattern,
   TripSnapshot,
 } from '../../types/app/transit-composed';
@@ -63,6 +62,9 @@ import { extractPrefix } from '../../domain/transit/prefixed-id';
 import { mergeSourcesV2 } from './merge-sources-v2';
 import { fetchSourcesV2 } from './fetch-sources-v2';
 import { enrichStopInsights } from './enrich-stop-insights';
+import { buildTripStopTimes } from './lib/build-trip-stop-times';
+import { buildTranslatableText } from './lib/build-translatable-text';
+import { sortTripStopTimesByStopIndex } from './lib/sort-trip-stop-times';
 import type {
   HeadsignTranslationsByPrefix,
   LoadResult,
@@ -616,66 +618,30 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       return { success: false, error: `Unknown route for trip pattern: ${locator.patternId}` };
     }
 
-    const stopTimes: TripStopTime[] = [];
-    for (const { stopId, group } of this.timetableByPattern.get(locator.patternId) ?? []) {
-      const departures = group.d[locator.serviceId];
-      if (!departures) {
-        logger.warn(
-          `getTripSnapshot: missing departures for pattern=${locator.patternId} service=${locator.serviceId} stop=${stopId} stopIndex=${group.si}`,
-        );
-        continue;
-      }
-      if (locator.tripIndex >= departures.length) {
-        logger.warn(
-          `getTripSnapshot: missing trip index for pattern=${locator.patternId} service=${locator.serviceId} index=${locator.tripIndex} stop=${stopId} stopIndex=${group.si} departures=${departures.length}`,
-        );
-        continue;
-      }
+    const timetableEntries = this.timetableByPattern.get(locator.patternId);
+    const stopTimes = buildTripStopTimes(locator, pattern.stops.length, timetableEntries, {
+      getStopMeta: (stopId) => this.stopsMetaMap.get(stopId),
+      getStopRouteTypes: (stopId) => this.stopRouteTypeMap.get(stopId) ?? [],
+      resolveRouteDirection: (stopIndex) => this.resolveRouteDirection(route, pattern, stopIndex),
+    });
+    sortTripStopTimesByStopIndex(stopTimes);
 
-      const arrivals = group.a?.[locator.serviceId];
-      const pickupTypes = group.pt?.[locator.serviceId];
-      const dropOffTypes = group.dt?.[locator.serviceId];
-      const routeDirection = this.resolveRouteDirection(route, pattern, group.si);
-      stopTimes.push({
-        stopMeta: this.stopsMetaMap.get(stopId),
-        routeTypes: this.stopRouteTypeMap.get(stopId) ?? [],
-        timetableEntry: {
-          tripLocator: locator,
-          schedule: {
-            departureMinutes: departures[locator.tripIndex],
-            arrivalMinutes: arrivals?.[locator.tripIndex] ?? departures[locator.tripIndex],
-          },
-          routeDirection,
-          boarding: {
-            pickupType: (pickupTypes?.[locator.tripIndex] ?? 0) as StopServiceType,
-            dropOffType: (dropOffTypes?.[locator.tripIndex] ?? 0) as StopServiceType,
-          },
-          patternPosition: {
-            stopIndex: group.si,
-            totalStops: pattern.stops.length,
-            isTerminal: group.si === pattern.stops.length - 1,
-            isOrigin: group.si === 0,
-          },
-        },
-      });
-    }
-
-    stopTimes.sort(
-      (a, b) =>
-        a.timetableEntry.patternPosition.stopIndex - b.timetableEntry.patternPosition.stopIndex,
+    // Trip-level headsign as defined by the v2 contract (TripSnapshot
+    // exposes whatever the source provides for the entire trip). Some
+    // agencies — Keio Bus is one — do not provide trip_headsign at all
+    // and instead carry per-stop stop_headsigns; for those sources this
+    // value is intentionally an empty TranslatableText.
+    const headsignTranslations = this.headsignTranslations.get(extractPrefix(route.agency_id));
+    const tripHeadsign = buildTranslatableText(
+      pattern.headsign,
+      headsignTranslations?.trip_headsigns,
     );
-    if (stopTimes.length === 0) {
-      return {
-        success: false,
-        error: `No trip snapshot rows for pattern=${locator.patternId} service=${locator.serviceId} index=${locator.tripIndex}`,
-      };
-    }
 
     const snapshot: TripSnapshot = {
       locator,
       serviceDate,
       route,
-      tripHeadsign: this.resolveRouteDirection(route, pattern, 0).tripHeadsign,
+      tripHeadsign,
       direction: pattern.direction,
       stopTimes,
     };
@@ -913,16 +879,10 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     const src = this.headsignTranslations.get(extractPrefix(route.agency_id));
     return {
       route,
-      tripHeadsign: {
-        name: pattern.headsign,
-        names: src?.trip_headsigns[pattern.headsign] ?? {},
-      },
+      tripHeadsign: buildTranslatableText(pattern.headsign, src?.trip_headsigns),
       stopHeadsign:
         stop.headsign != null
-          ? {
-              name: stop.headsign,
-              names: src?.stop_headsigns[stop.headsign] ?? {},
-            }
+          ? buildTranslatableText(stop.headsign, src?.stop_headsigns)
           : undefined,
       direction: pattern.direction,
     };

--- a/src/repositories/athenai-repository/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository/athenai-repository-v2.ts
@@ -27,6 +27,8 @@ import type {
   StopServiceType,
   StopWithMeta,
   TimetableEntry,
+  TripInspectionGroupQuery,
+  TripInspectionTarget,
   TripLocator,
   TripStopTime,
   TripPattern,
@@ -661,6 +663,24 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       stopTimes,
     };
     return { success: true, data: snapshot };
+  }
+
+  async getTripInspectionTargets(
+    query: TripInspectionGroupQuery,
+  ): Promise<Result<TripInspectionTarget[]>> {
+    const timetable = await this.getFullDayTimetableEntries(query.stopId, query.serviceDate);
+    if (!timetable.success) {
+      return timetable;
+    }
+
+    const targets = timetable.data.map<TripInspectionTarget>((entry) => ({
+      tripLocator: entry.tripLocator,
+      serviceDate: query.serviceDate,
+      stopIndex: entry.patternPosition.stopIndex,
+      departureMinutes: entry.schedule.departureMinutes,
+    }));
+
+    return { success: true, data: targets };
   }
 
   getRouteTypesForStop(stopId: string): Promise<Result<AppRouteTypeValue[]>> {

--- a/src/repositories/athenai-repository/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository/athenai-repository-v2.ts
@@ -68,6 +68,7 @@ import type {
   LoadResult,
   MergedDataV2,
   PatternStatsEntry,
+  PatternTimetableEntry,
   RouteFreqEntry,
   StopInsightsEntry,
 } from './types';
@@ -101,7 +102,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
   private readonly calendarServices: CalendarServiceJson[];
   private readonly calendarExceptions: Map<string, CalendarExceptionJson[]>;
   private readonly timetable: Record<string, TimetableGroupV2Json[]>;
-  private readonly timetableByPattern: MergedDataV2['timetableByPattern'];
+  private readonly timetableByPattern: Map<string, PatternTimetableEntry[]>;
   private readonly headsignTranslations: HeadsignTranslationsByPrefix;
   private readonly sourceMetas: SourceMeta[];
 

--- a/src/repositories/athenai-repository/lib/__tests__/build-translatable-text.test.ts
+++ b/src/repositories/athenai-repository/lib/__tests__/build-translatable-text.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildTranslatableText } from '../build-translatable-text';
+
+describe('buildTranslatableText', () => {
+  it('returns the name verbatim and the translations entry for that name', () => {
+    const translations = {
+      'Oji Station': { en: 'Oji Sta.', ja: '王子駅' },
+      Other: { en: 'Other', ja: 'その他' },
+    };
+
+    const result = buildTranslatableText('Oji Station', translations);
+
+    expect(result).toEqual({
+      name: 'Oji Station',
+      names: { en: 'Oji Sta.', ja: '王子駅' },
+    });
+  });
+
+  it('returns an empty names object when the name has no translation entry', () => {
+    const translations = {
+      Other: { en: 'Other' },
+    };
+
+    const result = buildTranslatableText('Missing', translations);
+
+    expect(result).toEqual({
+      name: 'Missing',
+      names: {},
+    });
+  });
+
+  it('returns an empty names object when the translations table is undefined', () => {
+    const result = buildTranslatableText('Some name', undefined);
+
+    expect(result).toEqual({
+      name: 'Some name',
+      names: {},
+    });
+  });
+
+  it('returns an empty names object when both name and translations are absent', () => {
+    // Empty name is still wrapped, mirroring agencies that omit trip_headsign.
+    const result = buildTranslatableText('', undefined);
+
+    expect(result).toEqual({
+      name: '',
+      names: {},
+    });
+  });
+
+  it('does not mutate the supplied translations table', () => {
+    const translations = {
+      A: { en: 'A' },
+    };
+    const snapshot = JSON.parse(JSON.stringify(translations)) as typeof translations;
+
+    buildTranslatableText('A', translations);
+
+    expect(translations).toEqual(snapshot);
+  });
+
+  it('returns the translations entry by reference (no defensive copy)', () => {
+    // This is observable behaviour worth pinning: callers receive the same
+    // object stored in the translations table. Future changes that defensively
+    // copy would change the reference identity here.
+    const translatedNames = { en: 'A' };
+    const translations = { A: translatedNames };
+
+    const result = buildTranslatableText('A', translations);
+
+    expect(result.names).toBe(translatedNames);
+  });
+});

--- a/src/repositories/athenai-repository/lib/__tests__/build-trip-stop-times.test.ts
+++ b/src/repositories/athenai-repository/lib/__tests__/build-trip-stop-times.test.ts
@@ -1,0 +1,636 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AppRouteTypeValue } from '@/types/app/transit';
+import type { RouteDirection, StopWithMeta, TripLocator } from '@/types/app/transit-composed';
+import type { TimetableGroupV2Json } from '@/types/data/transit-v2-json';
+
+import { buildTripStopTimeFromGroup, buildTripStopTimes } from '../build-trip-stop-times';
+import type { BuildTripStopTimesLookups } from '../build-trip-stop-times';
+import type { PatternTimetableEntry } from '../../types';
+
+interface CreateEntryArgs {
+  stopId: string;
+  si: number;
+  d: Record<string, number[]>;
+  a?: Record<string, number[]>;
+  pt?: Record<string, (0 | 1 | 2 | 3)[]>;
+  dt?: Record<string, (0 | 1 | 2 | 3)[]>;
+}
+
+function createEntry({ stopId, si, d, a, pt, dt }: CreateEntryArgs): PatternTimetableEntry {
+  const group: TimetableGroupV2Json = {
+    v: 2,
+    tp: 'test:p1',
+    si,
+    d,
+    a: a ?? d,
+  };
+  if (pt !== undefined) {
+    group.pt = pt;
+  }
+  if (dt !== undefined) {
+    group.dt = dt;
+  }
+  return { stopId, group };
+}
+
+function getStopIndexes(result: ReturnType<typeof buildTripStopTimes>): number[] {
+  return result.map((row) => row.timetableEntry.patternPosition.stopIndex);
+}
+
+function createLocator(overrides: Partial<TripLocator> = {}): TripLocator {
+  return {
+    patternId: 'test:p1',
+    serviceId: 'test:weekday',
+    tripIndex: 0,
+    ...overrides,
+  };
+}
+
+function createLookups(
+  overrides: Partial<BuildTripStopTimesLookups> = {},
+): BuildTripStopTimesLookups {
+  return {
+    getStopMeta: vi.fn((_stopId: string): StopWithMeta | undefined => undefined),
+    getStopRouteTypes: vi.fn((_stopId: string): AppRouteTypeValue[] => []),
+    resolveRouteDirection: vi.fn(
+      (_stopIndex: number): RouteDirection => ({
+        route: {
+          route_id: 'test:r1',
+          route_type: 3,
+          agency_id: 'test:a1',
+          route_short_name: 'R1',
+          route_short_names: {},
+          route_long_name: '',
+          route_long_names: {},
+          route_color: '',
+          route_text_color: '',
+        },
+        tripHeadsign: { name: '', names: {} },
+      }),
+    ),
+    ...overrides,
+  };
+}
+
+describe('buildTripStopTimes', () => {
+  describe('when timetableEntries is empty or undefined', () => {
+    it('returns an empty array when timetableEntries is undefined', () => {
+      const result = buildTripStopTimes(createLocator(), 4, undefined, createLookups());
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns an empty array when timetableEntries is an empty array', () => {
+      const result = buildTripStopTimes(createLocator(), 4, [], createLookups());
+
+      expect(result).toEqual([]);
+    });
+
+    it('does not invoke any lookup callbacks when timetableEntries is undefined', () => {
+      const lookups = createLookups();
+
+      buildTripStopTimes(createLocator(), 4, undefined, lookups);
+
+      expect(lookups.getStopMeta).not.toHaveBeenCalled();
+      expect(lookups.getStopRouteTypes).not.toHaveBeenCalled();
+      expect(lookups.resolveRouteDirection).not.toHaveBeenCalled();
+    });
+
+    it('does not invoke any lookup callbacks when timetableEntries is empty', () => {
+      const lookups = createLookups();
+
+      buildTripStopTimes(createLocator(), 4, [], lookups);
+
+      expect(lookups.getStopMeta).not.toHaveBeenCalled();
+      expect(lookups.getStopRouteTypes).not.toHaveBeenCalled();
+      expect(lookups.resolveRouteDirection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when an entry has no departures column for the requested serviceId', () => {
+    // Skip rule #1: `group.d[locator.serviceId]` is undefined.
+    it('omits the entry from the output', () => {
+      const entries: PatternTimetableEntry[] = [
+        createEntry({ stopId: 'A', si: 0, d: { 'test:weekday': [600, 720] } }),
+        // stopB has no `test:weekday` key — only `test:saturday`.
+        createEntry({ stopId: 'B', si: 1, d: { 'test:saturday': [605, 725] } }),
+        createEntry({ stopId: 'C', si: 2, d: { 'test:weekday': [610, 730] } }),
+      ];
+
+      const result = buildTripStopTimes(
+        createLocator({ tripIndex: 0 }),
+        3,
+        entries,
+        createLookups(),
+      );
+
+      expect(result).toHaveLength(2);
+      expect(getStopIndexes(result)).toEqual([0, 2]);
+    });
+
+    it('does not invoke any lookups for the omitted entry', () => {
+      const entries: PatternTimetableEntry[] = [
+        createEntry({ stopId: 'A', si: 0, d: { 'test:weekday': [600] } }),
+        createEntry({ stopId: 'B', si: 1, d: { 'test:saturday': [605] } }),
+      ];
+      const lookups = createLookups();
+
+      buildTripStopTimes(createLocator({ tripIndex: 0 }), 2, entries, lookups);
+
+      // stopMeta / routeTypes are looked up keyed by stopId; verify B was never used.
+      expect(lookups.getStopMeta).toHaveBeenCalledWith('A');
+      expect(lookups.getStopMeta).not.toHaveBeenCalledWith('B');
+      expect(lookups.getStopRouteTypes).toHaveBeenCalledWith('A');
+      expect(lookups.getStopRouteTypes).not.toHaveBeenCalledWith('B');
+      // resolveRouteDirection is keyed by stopIndex; verify si=1 was never used.
+      expect(lookups.resolveRouteDirection).toHaveBeenCalledWith(0);
+      expect(lookups.resolveRouteDirection).not.toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('when departures[locator.tripIndex] does not yield a value', () => {
+    // Skip rule #2: `departures[locator.tripIndex] === undefined`.
+
+    it('omits the entry when tripIndex is past the end of departures', () => {
+      const entries: PatternTimetableEntry[] = [
+        createEntry({ stopId: 'A', si: 0, d: { 'test:weekday': [600, 720, 840] } }),
+        // stopB has only 2 departures; tripIndex=2 is out of range.
+        createEntry({ stopId: 'B', si: 1, d: { 'test:weekday': [605, 725] } }),
+        createEntry({ stopId: 'C', si: 2, d: { 'test:weekday': [610, 730, 850] } }),
+      ];
+
+      const result = buildTripStopTimes(
+        createLocator({ tripIndex: 2 }),
+        3,
+        entries,
+        createLookups(),
+      );
+
+      expect(result).toHaveLength(2);
+      expect(getStopIndexes(result)).toEqual([0, 2]);
+    });
+
+    it('omits the entry when departures is an empty array', () => {
+      const entries: PatternTimetableEntry[] = [
+        createEntry({ stopId: 'A', si: 0, d: { 'test:weekday': [600] } }),
+        createEntry({ stopId: 'B', si: 1, d: { 'test:weekday': [] } }),
+        createEntry({ stopId: 'C', si: 2, d: { 'test:weekday': [610] } }),
+      ];
+
+      const result = buildTripStopTimes(
+        createLocator({ tripIndex: 0 }),
+        3,
+        entries,
+        createLookups(),
+      );
+
+      expect(result).toHaveLength(2);
+      expect(getStopIndexes(result)).toEqual([0, 2]);
+    });
+
+    it('omits all entries when tripIndex is negative', () => {
+      const entries: PatternTimetableEntry[] = [
+        createEntry({ stopId: 'A', si: 0, d: { 'test:weekday': [600] } }),
+        createEntry({ stopId: 'B', si: 1, d: { 'test:weekday': [605] } }),
+      ];
+
+      const result = buildTripStopTimes(
+        createLocator({ tripIndex: -1 }),
+        2,
+        entries,
+        createLookups(),
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('omits all entries when tripIndex is non-integer', () => {
+      const entries: PatternTimetableEntry[] = [
+        createEntry({ stopId: 'A', si: 0, d: { 'test:weekday': [600, 720] } }),
+        createEntry({ stopId: 'B', si: 1, d: { 'test:weekday': [605, 725] } }),
+      ];
+
+      const result = buildTripStopTimes(
+        createLocator({ tripIndex: 0.5 }),
+        2,
+        entries,
+        createLookups(),
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('omits all entries when tripIndex is NaN', () => {
+      const entries: PatternTimetableEntry[] = [
+        createEntry({ stopId: 'A', si: 0, d: { 'test:weekday': [600] } }),
+        createEntry({ stopId: 'B', si: 1, d: { 'test:weekday': [605] } }),
+      ];
+
+      const result = buildTripStopTimes(
+        createLocator({ tripIndex: NaN }),
+        2,
+        entries,
+        createLookups(),
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('when an entry has no arrivals column for the requested serviceId', () => {
+    // Skip rule #3: `group.a[locator.serviceId]` is undefined despite the
+    // departures column being present. Treated like a missing departures
+    // column — the entry is dropped, not silently filled.
+    it('omits the entry from the output', () => {
+      const entries: PatternTimetableEntry[] = [
+        createEntry({ stopId: 'A', si: 0, d: { 'test:weekday': [600, 720] } }),
+        // stopB has departures for `test:weekday`, but arrivals only for
+        // `test:saturday` — i.e. `a[test:weekday]` is absent.
+        createEntry({
+          stopId: 'B',
+          si: 1,
+          d: { 'test:weekday': [605, 725] },
+          a: { 'test:saturday': [605, 725] },
+        }),
+        createEntry({ stopId: 'C', si: 2, d: { 'test:weekday': [610, 730] } }),
+      ];
+
+      const result = buildTripStopTimes(
+        createLocator({ tripIndex: 0 }),
+        3,
+        entries,
+        createLookups(),
+      );
+
+      expect(result).toHaveLength(2);
+      expect(getStopIndexes(result)).toEqual([0, 2]);
+    });
+
+    it('does not invoke any lookups for the omitted entry', () => {
+      const entries: PatternTimetableEntry[] = [
+        createEntry({ stopId: 'A', si: 0, d: { 'test:weekday': [600] } }),
+        createEntry({
+          stopId: 'B',
+          si: 1,
+          d: { 'test:weekday': [605] },
+          a: { 'test:saturday': [605] },
+        }),
+      ];
+      const lookups = createLookups();
+
+      buildTripStopTimes(createLocator({ tripIndex: 0 }), 2, entries, lookups);
+
+      expect(lookups.getStopMeta).toHaveBeenCalledWith('A');
+      expect(lookups.getStopMeta).not.toHaveBeenCalledWith('B');
+      expect(lookups.resolveRouteDirection).toHaveBeenCalledWith(0);
+      expect(lookups.resolveRouteDirection).not.toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('when arrivals[locator.tripIndex] does not yield a value', () => {
+    // Skip rule #4: `group.a[serviceId][tripIndex]` is undefined although
+    // the column itself exists (length mismatch with `d` — contract C3
+    // violation). Treated symmetrically with the departures-side check.
+
+    it('omits the entry when arrivals is shorter than departures', () => {
+      const entries: PatternTimetableEntry[] = [
+        createEntry({ stopId: 'A', si: 0, d: { 'test:weekday': [600, 720] } }),
+        // stopB has 2 departures but only 1 arrival; tripIndex=1 falls
+        // off the end of arrivals.
+        createEntry({
+          stopId: 'B',
+          si: 1,
+          d: { 'test:weekday': [605, 725] },
+          a: { 'test:weekday': [605] },
+        }),
+        createEntry({ stopId: 'C', si: 2, d: { 'test:weekday': [610, 730] } }),
+      ];
+
+      const result = buildTripStopTimes(
+        createLocator({ tripIndex: 1 }),
+        3,
+        entries,
+        createLookups(),
+      );
+
+      expect(result).toHaveLength(2);
+      expect(getStopIndexes(result)).toEqual([0, 2]);
+    });
+
+    it('omits the entry when arrivals is an empty array', () => {
+      const entries: PatternTimetableEntry[] = [
+        createEntry({ stopId: 'A', si: 0, d: { 'test:weekday': [600] } }),
+        createEntry({
+          stopId: 'B',
+          si: 1,
+          d: { 'test:weekday': [605] },
+          a: { 'test:weekday': [] },
+        }),
+        createEntry({ stopId: 'C', si: 2, d: { 'test:weekday': [610] } }),
+      ];
+
+      const result = buildTripStopTimes(
+        createLocator({ tripIndex: 0 }),
+        3,
+        entries,
+        createLookups(),
+      );
+
+      expect(result).toHaveLength(2);
+      expect(getStopIndexes(result)).toEqual([0, 2]);
+    });
+  });
+});
+
+describe('buildTripStopTimeFromGroup', () => {
+  function makeGroup(args: Omit<CreateEntryArgs, 'stopId'>): TimetableGroupV2Json {
+    return createEntry({ stopId: 'unused', ...args }).group;
+  }
+
+  describe('schedule', () => {
+    it('uses the caller-supplied departureMinutes and arrivalMinutes verbatim', () => {
+      const group = makeGroup({
+        si: 1,
+        // Source-side d/a values are NOT consulted by the function — the
+        // caller-supplied numbers must win.
+        d: { 'test:weekday': [9999] },
+        a: { 'test:weekday': [9999] },
+      });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator({ tripIndex: 0 }),
+        3,
+        'stop-A',
+        group,
+        720,
+        725,
+        createLookups(),
+      );
+
+      expect(result.timetableEntry.schedule).toEqual({
+        departureMinutes: 720,
+        arrivalMinutes: 725,
+      });
+    });
+  });
+
+  describe('boarding (pickupType / dropOffType)', () => {
+    it('defaults pickupType and dropOffType to 0 when group.pt and group.dt are absent', () => {
+      const group = makeGroup({ si: 0, d: { 'test:weekday': [600] } });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator({ tripIndex: 0 }),
+        3,
+        'stop-A',
+        group,
+        600,
+        600,
+        createLookups(),
+      );
+
+      expect(result.timetableEntry.boarding).toEqual({ pickupType: 0, dropOffType: 0 });
+    });
+
+    it('defaults to 0 when pt/dt exist but lack the requested serviceId', () => {
+      const group = makeGroup({
+        si: 0,
+        d: { 'test:weekday': [600] },
+        pt: { 'test:saturday': [1] },
+        dt: { 'test:saturday': [2] },
+      });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator({ tripIndex: 0 }),
+        3,
+        'stop-A',
+        group,
+        600,
+        600,
+        createLookups(),
+      );
+
+      expect(result.timetableEntry.boarding).toEqual({ pickupType: 0, dropOffType: 0 });
+    });
+
+    it('defaults to 0 when pt/dt arrays do not cover tripIndex', () => {
+      const group = makeGroup({
+        si: 0,
+        d: { 'test:weekday': [600, 720] },
+        pt: { 'test:weekday': [1] },
+        dt: { 'test:weekday': [2] },
+      });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator({ tripIndex: 1 }),
+        3,
+        'stop-A',
+        group,
+        720,
+        720,
+        createLookups(),
+      );
+
+      expect(result.timetableEntry.boarding).toEqual({ pickupType: 0, dropOffType: 0 });
+    });
+
+    it('returns the source-provided pickupType and dropOffType values', () => {
+      const group = makeGroup({
+        si: 0,
+        d: { 'test:weekday': [600, 720] },
+        pt: { 'test:weekday': [0, 1] },
+        dt: { 'test:weekday': [2, 3] },
+      });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator({ tripIndex: 1 }),
+        3,
+        'stop-A',
+        group,
+        720,
+        720,
+        createLookups(),
+      );
+
+      expect(result.timetableEntry.boarding).toEqual({ pickupType: 1, dropOffType: 3 });
+    });
+  });
+
+  describe('patternPosition', () => {
+    it('marks the first stop (si=0) as origin and not terminal', () => {
+      const group = makeGroup({ si: 0, d: { 'test:weekday': [600] } });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator(),
+        3,
+        'stop-A',
+        group,
+        600,
+        600,
+        createLookups(),
+      );
+
+      expect(result.timetableEntry.patternPosition).toEqual({
+        stopIndex: 0,
+        totalStops: 3,
+        isOrigin: true,
+        isTerminal: false,
+      });
+    });
+
+    it('marks the last stop (si=totalStops-1) as terminal and not origin', () => {
+      const group = makeGroup({ si: 2, d: { 'test:weekday': [610] } });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator(),
+        3,
+        'stop-C',
+        group,
+        610,
+        610,
+        createLookups(),
+      );
+
+      expect(result.timetableEntry.patternPosition).toEqual({
+        stopIndex: 2,
+        totalStops: 3,
+        isOrigin: false,
+        isTerminal: true,
+      });
+    });
+
+    it('marks a middle stop as neither origin nor terminal', () => {
+      const group = makeGroup({ si: 1, d: { 'test:weekday': [605] } });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator(),
+        3,
+        'stop-B',
+        group,
+        605,
+        605,
+        createLookups(),
+      );
+
+      expect(result.timetableEntry.patternPosition).toEqual({
+        stopIndex: 1,
+        totalStops: 3,
+        isOrigin: false,
+        isTerminal: false,
+      });
+    });
+
+    it('uses the caller-supplied totalStops verbatim, even when out of natural range', () => {
+      const group = makeGroup({ si: 7, d: { 'test:weekday': [600] } });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator(),
+        10,
+        'stop-X',
+        group,
+        600,
+        600,
+        createLookups(),
+      );
+
+      expect(result.timetableEntry.patternPosition.totalStops).toBe(10);
+      expect(result.timetableEntry.patternPosition.stopIndex).toBe(7);
+    });
+  });
+
+  describe('lookups', () => {
+    it('invokes getStopMeta with the provided stopId and stores the result', () => {
+      const group = makeGroup({ si: 0, d: { 'test:weekday': [600] } });
+      const stopMeta = { stop: { stop_id: 'stop-A' } } as unknown as StopWithMeta;
+      const lookups = createLookups({
+        getStopMeta: vi.fn(() => stopMeta),
+      });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator(),
+        3,
+        'stop-A',
+        group,
+        600,
+        600,
+        lookups,
+      );
+
+      expect(lookups.getStopMeta).toHaveBeenCalledWith('stop-A');
+      expect(result.stopMeta).toBe(stopMeta);
+    });
+
+    it('invokes getStopRouteTypes with the provided stopId and stores the result', () => {
+      const group = makeGroup({ si: 0, d: { 'test:weekday': [600] } });
+      const lookups = createLookups({
+        getStopRouteTypes: vi.fn(() => [3, 1] as AppRouteTypeValue[]),
+      });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator(),
+        3,
+        'stop-A',
+        group,
+        600,
+        600,
+        lookups,
+      );
+
+      expect(lookups.getStopRouteTypes).toHaveBeenCalledWith('stop-A');
+      expect(result.routeTypes).toEqual([3, 1]);
+    });
+
+    it('invokes resolveRouteDirection keyed by group.si and stores the result', () => {
+      const group = makeGroup({ si: 5, d: { 'test:weekday': [600] } });
+      const routeDirection: RouteDirection = {
+        route: {
+          route_id: 'r-x',
+          route_type: 3,
+          agency_id: 'a-x',
+          route_short_name: 'X',
+          route_short_names: {},
+          route_long_name: '',
+          route_long_names: {},
+          route_color: '',
+          route_text_color: '',
+        },
+        tripHeadsign: { name: 'sentinel', names: {} },
+      };
+      const lookups = createLookups({
+        resolveRouteDirection: vi.fn(() => routeDirection),
+      });
+
+      const result = buildTripStopTimeFromGroup(
+        createLocator(),
+        10,
+        'stop-A',
+        group,
+        600,
+        600,
+        lookups,
+      );
+
+      expect(lookups.resolveRouteDirection).toHaveBeenCalledWith(5);
+      expect(result.timetableEntry.routeDirection).toBe(routeDirection);
+    });
+  });
+
+  describe('tripLocator propagation', () => {
+    it('passes the supplied locator through unchanged', () => {
+      const group = makeGroup({ si: 0, d: { 'test:weekday': [600, 720] } });
+      const locator = createLocator({ tripIndex: 1 });
+
+      const result = buildTripStopTimeFromGroup(
+        locator,
+        3,
+        'stop-A',
+        group,
+        720,
+        720,
+        createLookups(),
+      );
+
+      expect(result.timetableEntry.tripLocator).toBe(locator);
+    });
+  });
+});

--- a/src/repositories/athenai-repository/lib/__tests__/sort-trip-stop-times.test.ts
+++ b/src/repositories/athenai-repository/lib/__tests__/sort-trip-stop-times.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TripStopTime } from '@/types/app/transit-composed';
+
+import { sortTripStopTimesByStopIndex } from '../sort-trip-stop-times';
+
+interface CreateRowArgs {
+  stopIndex: number;
+  marker?: string;
+}
+
+function createRow({ stopIndex, marker }: CreateRowArgs): TripStopTime {
+  // Only the fields exercised by the sort implementation are populated.
+  // Other fields are set to harmless minimal stand-ins, since this test
+  // only inspects identity and patternPosition.stopIndex ordering.
+  return {
+    stopMeta: undefined,
+    routeTypes: [],
+    timetableEntry: {
+      tripLocator: { patternId: 'p', serviceId: 's', tripIndex: 0 },
+      schedule: { departureMinutes: 0, arrivalMinutes: 0 },
+      routeDirection: {
+        route: {
+          route_id: 'r',
+          route_type: 3,
+          agency_id: 'a',
+          route_short_name: '',
+          route_short_names: {},
+          route_long_name: '',
+          route_long_names: {},
+          route_color: '',
+          route_text_color: '',
+        },
+        tripHeadsign: { name: marker ?? '', names: {} },
+      },
+      boarding: { pickupType: 0, dropOffType: 0 },
+      patternPosition: {
+        stopIndex,
+        totalStops: 100,
+        isOrigin: false,
+        isTerminal: false,
+      },
+    },
+  };
+}
+
+function getStopIndexes(rows: readonly TripStopTime[]): number[] {
+  return rows.map((row) => row.timetableEntry.patternPosition.stopIndex);
+}
+
+function getMarkers(rows: readonly TripStopTime[]): string[] {
+  return rows.map((row) => row.timetableEntry.routeDirection.tripHeadsign.name);
+}
+
+describe('sortTripStopTimesByStopIndex', () => {
+  describe('mutation behaviour', () => {
+    it('mutates the input array in place and returns nothing', () => {
+      const rows: TripStopTime[] = [createRow({ stopIndex: 2 }), createRow({ stopIndex: 0 })];
+      const sameRef = rows;
+
+      const result = sortTripStopTimesByStopIndex(rows);
+
+      expect(result).toBeUndefined();
+      // The function mutates the original array.
+      expect(sameRef).toBe(rows);
+      expect(getStopIndexes(rows)).toEqual([0, 2]);
+    });
+  });
+
+  describe('basic ordering', () => {
+    it('sorts a reversed array into ascending stopIndex order', () => {
+      const rows: TripStopTime[] = [
+        createRow({ stopIndex: 3 }),
+        createRow({ stopIndex: 2 }),
+        createRow({ stopIndex: 1 }),
+        createRow({ stopIndex: 0 }),
+      ];
+
+      sortTripStopTimesByStopIndex(rows);
+
+      expect(getStopIndexes(rows)).toEqual([0, 1, 2, 3]);
+    });
+
+    it('leaves an already-sorted array unchanged in stopIndex order', () => {
+      const rows: TripStopTime[] = [
+        createRow({ stopIndex: 0 }),
+        createRow({ stopIndex: 1 }),
+        createRow({ stopIndex: 2 }),
+      ];
+
+      sortTripStopTimesByStopIndex(rows);
+
+      expect(getStopIndexes(rows)).toEqual([0, 1, 2]);
+    });
+
+    it('handles a randomly ordered array', () => {
+      const rows: TripStopTime[] = [
+        createRow({ stopIndex: 5 }),
+        createRow({ stopIndex: 1 }),
+        createRow({ stopIndex: 9 }),
+        createRow({ stopIndex: 3 }),
+        createRow({ stopIndex: 7 }),
+      ];
+
+      sortTripStopTimesByStopIndex(rows);
+
+      expect(getStopIndexes(rows)).toEqual([1, 3, 5, 7, 9]);
+    });
+  });
+
+  describe('preserves gaps when the input has missing stopIndexes', () => {
+    it('keeps non-contiguous stopIndex values after sorting', () => {
+      // Simulates the output of buildTripStopTimes when some pattern
+      // entries were dropped: the surviving stopIndex values are not
+      // contiguous, and sortTripStopTimesByStopIndex must not invent or
+      // remove any rows.
+      const rows: TripStopTime[] = [
+        createRow({ stopIndex: 3 }),
+        createRow({ stopIndex: 0 }),
+        createRow({ stopIndex: 2 }),
+      ];
+
+      sortTripStopTimesByStopIndex(rows);
+
+      expect(getStopIndexes(rows)).toEqual([0, 2, 3]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('does nothing for an empty array', () => {
+      const rows: TripStopTime[] = [];
+
+      sortTripStopTimesByStopIndex(rows);
+
+      expect(rows).toEqual([]);
+    });
+
+    it('does nothing for a single-element array', () => {
+      const rows: TripStopTime[] = [createRow({ stopIndex: 5 })];
+      const original = rows[0];
+
+      sortTripStopTimesByStopIndex(rows);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toBe(original);
+      expect(getStopIndexes(rows)).toEqual([5]);
+    });
+  });
+
+  describe('stability', () => {
+    // Documented behaviour for the (unexpected) case of duplicate
+    // stopIndex values: the relative order of the duplicates must be
+    // preserved. Verifying this also guards against a future
+    // implementation switch to a non-stable sort.
+    it('preserves the relative order of elements with the same stopIndex', () => {
+      const rows: TripStopTime[] = [
+        createRow({ stopIndex: 2, marker: 'first-of-two' }),
+        createRow({ stopIndex: 0, marker: 'origin' }),
+        createRow({ stopIndex: 2, marker: 'second-of-two' }),
+        createRow({ stopIndex: 1, marker: 'middle' }),
+        createRow({ stopIndex: 2, marker: 'third-of-two' }),
+      ];
+
+      sortTripStopTimesByStopIndex(rows);
+
+      expect(getStopIndexes(rows)).toEqual([0, 1, 2, 2, 2]);
+      expect(getMarkers(rows)).toEqual([
+        'origin',
+        'middle',
+        'first-of-two',
+        'second-of-two',
+        'third-of-two',
+      ]);
+    });
+  });
+});

--- a/src/repositories/athenai-repository/lib/build-translatable-text.ts
+++ b/src/repositories/athenai-repository/lib/build-translatable-text.ts
@@ -1,0 +1,23 @@
+import type { TranslatableText } from '@/types/app/transit-composed';
+
+/**
+ * Build a {@link TranslatableText} from a base name and an optional
+ * translation table.
+ *
+ * `translations` is keyed by the base name and yields a per-language
+ * record of translated values. When the base name has no entry (or the
+ * translations table itself is unavailable), an empty `names` object is
+ * returned, so callers can always read `result.names` safely.
+ *
+ * Used to wrap GTFS-derived strings (trip_headsign, stop_headsign, etc.)
+ * with their multilingual variants from the merged translations table.
+ */
+export function buildTranslatableText(
+  name: string,
+  translations: Record<string, Record<string, string>> | undefined,
+): TranslatableText {
+  return {
+    name,
+    names: translations?.[name] ?? {},
+  };
+}

--- a/src/repositories/athenai-repository/lib/build-trip-stop-times.ts
+++ b/src/repositories/athenai-repository/lib/build-trip-stop-times.ts
@@ -1,0 +1,190 @@
+import type { AppRouteTypeValue } from '@/types/app/transit';
+import type {
+  RouteDirection,
+  StopServiceType,
+  StopWithMeta,
+  TripLocator,
+  TripStopTime,
+} from '@/types/app/transit-composed';
+import type { TimetableGroupV2Json } from '@/types/data/transit-v2-json';
+
+import type { PatternTimetableEntry } from '../types';
+
+/** Lookups supplied by the repository. */
+export interface BuildTripStopTimesLookups {
+  getStopMeta: (stopId: string) => StopWithMeta | undefined;
+  getStopRouteTypes: (stopId: string) => AppRouteTypeValue[];
+  resolveRouteDirection: (stopIndex: number) => RouteDirection;
+}
+
+/**
+ * Build the per-stop schedule rows for a single trip (locator) by walking
+ * the pattern's timetable entries.
+ *
+ * Output shape and order:
+ * - The returned array preserves the iteration order of
+ *   `timetableEntries`, which is grouped by source stopId rather than by
+ *   pattern position. To obtain a valid stop sequence, pass the result
+ *   through {@link sortTripStopTimesByStopIndex}
+ *   (see `./sort-trip-stop-times`).
+ * - When `timetableEntries` is `undefined` or empty, an empty array is
+ *   returned and no lookup callback is invoked.
+ *
+ * Inclusion rules:
+ *   A pattern entry is included in the output only when all of the
+ *   following resolve to a defined number:
+ *     1. `group.d[locator.serviceId]`
+ *     2. `group.d[locator.serviceId][locator.tripIndex]`
+ *     3. `group.a[locator.serviceId]`
+ *     4. `group.a[locator.serviceId][locator.tripIndex]`
+ *
+ *   Entries that fail any of these conditions are dropped silently;
+ *   their lookups (`getStopMeta`, `getStopRouteTypes`,
+ *   `resolveRouteDirection`) are not invoked. Rule (2) also catches
+ *   negative, non-integer, and `NaN` `tripIndex` values that bypass a
+ *   plain length comparison.
+ *
+ *   Rules (1) and (2) treat the source-of-truth `d` column;
+ *   rules (3) and (4) apply the same strictness to `a`. The v2 contract
+ *   states `a` is required and positionally aligned with `d`, but this
+ *   function does not assume contract compliance and therefore will not
+ *   substitute departure values for missing arrivals.
+ *
+ * Properties of the output:
+ * - The output may be shorter than the pattern's stop count when any
+ *   entry is dropped. The `patternPosition.stopIndex` values among the
+ *   returned elements are then not contiguous.
+ * - The output is self-describing: each element carries
+ *   `patternPosition.stopIndex` and `patternPosition.totalStops`, so
+ *   callers can detect missing positions by comparing the set of
+ *   returned `stopIndex` values against `[0..totalStops - 1]`.
+ *
+ * Callers must not treat an output array index as interchangeable with
+ * a pattern stopIndex.
+ */
+export function buildTripStopTimes(
+  locator: TripLocator,
+  totalStops: number,
+  timetableEntries: readonly PatternTimetableEntry[] | undefined,
+  lookups: BuildTripStopTimesLookups,
+): TripStopTime[] {
+  const stopTimes: TripStopTime[] = [];
+  // No timetable entries for the pattern: nothing to reconstruct.
+  if (!timetableEntries) {
+    return stopTimes;
+  }
+
+  // Walk every (stopId, group) pair belonging to this pattern. Order is
+  // not the pattern's stop sequence — the caller sorts later.
+  for (const { stopId, group } of timetableEntries) {
+    // Pull the departure column for the requested service. Each element
+    // d[serviceId][i] is the i-th trip's departure at this stop.
+    const departures = group.d[locator.serviceId];
+
+    // Skip when `group.d` has no entry for the requested serviceId
+    // (key absent). Without a column there is nothing to index into.
+    if (departures === undefined) {
+      continue;
+    }
+
+    // Skip when `departures[locator.tripIndex]` does not yield a value.
+    // Covers out-of-range indices, the empty-array case, and any
+    // non-integer / negative / NaN tripIndex that bypasses a length
+    // comparison.
+    const departureMinutes = departures[locator.tripIndex];
+    if (departureMinutes === undefined) {
+      continue;
+    }
+
+    // Arrival is resolved with the same strictness as departure.
+    // Although the v2 contract says `a` exists and is positionally
+    // aligned with `d` (ODPT sources copy departure into `a` at the
+    // pipeline stage), this code does not assume contract compliance.
+    const arrivals = group.a[locator.serviceId];
+    if (arrivals === undefined) {
+      continue;
+    }
+    const arrivalMinutes = arrivals[locator.tripIndex];
+    if (arrivalMinutes === undefined) {
+      continue;
+    }
+
+    stopTimes.push(
+      buildTripStopTimeFromGroup(
+        locator,
+        totalStops,
+        stopId,
+        group,
+        departureMinutes,
+        arrivalMinutes,
+        lookups,
+      ),
+    );
+  }
+
+  return stopTimes;
+}
+
+/**
+ * Build a single {@link TripStopTime} for the trip identified by `locator`
+ * at the (stop, group) pair indicated by `stopId` / `group`.
+ *
+ * `departureMinutes` / `arrivalMinutes` are resolved from `group.d` /
+ * `group.a` by the caller (see {@link buildTripStopTimes}). This function
+ * does not re-read those columns and does not validate the passed-in
+ * numbers.
+ */
+export function buildTripStopTimeFromGroup(
+  locator: TripLocator,
+  totalStops: number,
+  stopId: string,
+  group: TimetableGroupV2Json,
+  departureMinutes: number,
+  arrivalMinutes: number,
+  lookups: BuildTripStopTimesLookups,
+): TripStopTime {
+  // Resolve pickup_type. `group.pt` is optional at the source level
+  // (e.g. ODPT omits it entirely); within a present `pt`, individual
+  // entries may also be missing. Default to 0 (regular) for any of
+  // these absences.
+  const pickupType: StopServiceType = (group.pt?.[locator.serviceId]?.[locator.tripIndex] ??
+    0) as StopServiceType;
+
+  // Resolve drop_off_type with the same shape and default as pickup.
+  const dropOffType: StopServiceType = (group.dt?.[locator.serviceId]?.[locator.tripIndex] ??
+    0) as StopServiceType;
+
+  // Resolve the per-stop route direction (route + headsigns) from the
+  // repository lookup. The lookup is keyed by stopIndex because
+  // stop-level headsigns can differ along the same pattern.
+  const routeDirection = lookups.resolveRouteDirection(group.si);
+
+  // Derive pattern position from `group.si` and the caller-supplied
+  // `totalStops`. `totalStops` stays at the pattern's full length even
+  // when sibling rows are dropped upstream, so callers can still report
+  // "stop k of N".
+  const patternPosition = {
+    stopIndex: group.si,
+    totalStops,
+    isOrigin: group.si === 0,
+    isTerminal: group.si === totalStops - 1,
+  };
+
+  return {
+    stopMeta: lookups.getStopMeta(stopId),
+    routeTypes: lookups.getStopRouteTypes(stopId),
+    timetableEntry: {
+      tripLocator: locator,
+      schedule: {
+        departureMinutes,
+        arrivalMinutes,
+      },
+      routeDirection,
+      boarding: {
+        pickupType,
+        dropOffType,
+      },
+      patternPosition,
+    },
+  };
+}

--- a/src/repositories/athenai-repository/lib/sort-trip-stop-times.ts
+++ b/src/repositories/athenai-repository/lib/sort-trip-stop-times.ts
@@ -1,0 +1,26 @@
+import type { TripStopTime } from '@/types/app/transit-composed';
+
+/**
+ * Sort `stopTimes` in place by ascending
+ * `timetableEntry.patternPosition.stopIndex`, mutating the input array.
+ * Returns nothing.
+ *
+ * The result is the canonical stop sequence order for a single trip:
+ * the order in which the trip visits stops in its pattern. Apply this
+ * after `buildTripStopTimes` (see `./build-trip-stop-times`), which
+ * returns rows in source iteration order rather than pattern order.
+ *
+ * Properties:
+ * - Ascending stopIndex order does not imply a contiguous sequence: if
+ *   `buildTripStopTimes` dropped any pattern entry, the sorted array
+ *   still has gaps in stopIndex.
+ * - The sort is stable. If two elements share the same stopIndex (a
+ *   contract C1 violation; not expected from valid v2 data), their
+ *   original relative order is preserved.
+ */
+export function sortTripStopTimesByStopIndex(stopTimes: TripStopTime[]): void {
+  stopTimes.sort(
+    (a, b) =>
+      a.timetableEntry.patternPosition.stopIndex - b.timetableEntry.patternPosition.stopIndex,
+  );
+}

--- a/src/repositories/mock-repository/__tests__/mock-repository.test.ts
+++ b/src/repositories/mock-repository/__tests__/mock-repository.test.ts
@@ -101,11 +101,6 @@ describe('MockRepository contract compatibility', () => {
 
     const timetable = await repository.getFullDayTimetableEntries('bus_library', serviceDate);
     const result = await repository.getTripInspectionTargets({
-      tripLocator: {
-        patternId: 'bus_aoba01__にじ橋',
-        serviceId: 'mock:default',
-        tripIndex: 0,
-      },
       serviceDate,
       stopId: 'bus_library',
     });

--- a/src/repositories/mock-repository/__tests__/mock-repository.test.ts
+++ b/src/repositories/mock-repository/__tests__/mock-repository.test.ts
@@ -95,6 +95,33 @@ describe('MockRepository i18n data', () => {
 });
 
 describe('MockRepository contract compatibility', () => {
+  it('returns trip-inspection targets derived from the stop timetable', async () => {
+    const repository = new MockRepository();
+    const serviceDate = new Date('2026-04-07T12:00:00+09:00');
+
+    const timetable = await repository.getFullDayTimetableEntries('bus_library', serviceDate);
+    const result = await repository.getTripInspectionTargets({
+      tripLocator: {
+        patternId: 'bus_aoba01__にじ橋',
+        serviceId: 'mock:default',
+        tripIndex: 0,
+      },
+      serviceDate,
+      stopId: 'bus_library',
+    });
+
+    assertSuccess(timetable);
+    assertSuccess(result);
+    expect(result.data).toEqual(
+      timetable.data.map((entry) => ({
+        tripLocator: entry.tripLocator,
+        serviceDate,
+        stopIndex: entry.patternPosition.stopIndex,
+        departureMinutes: entry.schedule.departureMinutes,
+      })),
+    );
+  });
+
   it('returns all upcoming entries when limit is omitted', async () => {
     const repository = new MockRepository();
     const now = new Date('2026-04-07T05:00:00+09:00');

--- a/src/repositories/mock-repository/__tests__/mock-repository.test.ts
+++ b/src/repositories/mock-repository/__tests__/mock-repository.test.ts
@@ -191,6 +191,23 @@ describe('MockRepository contract compatibility', () => {
     expect(departures[2]).toBeLessThan(departures[3]);
     expect(arrivals.map((minutes, index) => departures[index] - minutes)).toEqual([3, 3, 3, 3]);
   });
+
+  it('passes through the provided serviceDate on trip snapshots', () => {
+    const repository = new MockRepository();
+    const serviceDate = new Date('2026-04-07T00:00:00+09:00');
+
+    const snapshot = repository.getTripSnapshot(
+      {
+        patternId: 'bus_yukkuri01__もり公園前',
+        serviceId: 'mock:default',
+        tripIndex: 0,
+      },
+      serviceDate,
+    );
+
+    assertSuccess(snapshot);
+    expect(snapshot.data.serviceDate).toBe(serviceDate);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/repositories/mock-repository/mock-repository.ts
+++ b/src/repositories/mock-repository/mock-repository.ts
@@ -22,6 +22,8 @@ import type {
   SourceMeta,
   StopWithMeta,
   TimetableEntry,
+  TripInspectionGroupQuery,
+  TripInspectionTarget,
   TripLocator,
   TripStopTime,
   TripSnapshot,
@@ -381,6 +383,26 @@ export class MockRepository implements TransitRepository {
       stopTimes,
     };
     return { success: true, data: snapshot };
+  }
+
+  getTripInspectionTargets(
+    query: TripInspectionGroupQuery,
+  ): Promise<Result<TripInspectionTarget[]>> {
+    return this.getFullDayTimetableEntries(query.stopId, query.serviceDate).then((result) => {
+      if (!result.success) {
+        return result;
+      }
+
+      return {
+        success: true,
+        data: result.data.map((entry) => ({
+          tripLocator: entry.tripLocator,
+          serviceDate: query.serviceDate,
+          stopIndex: entry.patternPosition.stopIndex,
+          departureMinutes: entry.schedule.departureMinutes,
+        })),
+      };
+    });
   }
 
   /** {@inheritDoc TransitRepository.getStopMetaById} */

--- a/src/repositories/mock-repository/mock-repository.ts
+++ b/src/repositories/mock-repository/mock-repository.ts
@@ -68,7 +68,55 @@ import {
   simpleHash,
 } from './mock-data';
 
+const MOCK_DEFAULT_SERVICE_ID = 'mock:default';
+
 export class MockRepository implements TransitRepository {
+  private buildFullDayTimetableEntries(stopId: string): TimetableEntry[] {
+    const stopRoutes = STOP_ROUTES[stopId] ?? [];
+    const entries: TimetableEntry[] = [];
+
+    for (const { routeId, headsign, stopHeadsign } of stopRoutes) {
+      const route = ROUTES.find((r) => r.route_id === routeId);
+      if (!route) {
+        continue;
+      }
+      // Issue #47: emit one set of entries per occurrence (6-shape / circular).
+      const occurrences = Math.max(1, countStopOccurrences(routeId, headsign, stopId));
+
+      for (let occ = 0; occ < occurrences; occ++) {
+        const position = getPatternPosition(routeId, headsign, stopId, occ);
+        const occOffset = computeOccOffset(routeId, occ);
+        const travelOffset = computePatternTravelOffset(routeId, headsign, position.stopIndex);
+        const { pickupType, dropOffType } = getBoardingTypes(routeId, headsign, stopId, occ);
+        const baseSchedule = generateFixedMinutes(routeId, headsign);
+        for (const [tripIndex, baseMinutes] of baseSchedule.entries()) {
+          const minutes = baseMinutes + travelOffset + occOffset;
+          const arrivalMinutes = computeArrivalMinutes(routeId, occ, minutes);
+          entries.push({
+            schedule: { departureMinutes: minutes, arrivalMinutes },
+            routeDirection: {
+              route,
+              tripHeadsign: createMockTranslatableText(headsign),
+              ...(stopHeadsign != null
+                ? { stopHeadsign: createMockTranslatableText(stopHeadsign) }
+                : {}),
+            },
+            boarding: { pickupType, dropOffType },
+            patternPosition: position,
+            tripLocator: {
+              patternId: createMockTripPatternId(routeId, headsign),
+              serviceId: MOCK_DEFAULT_SERVICE_ID,
+              tripIndex,
+            },
+          });
+        }
+      }
+    }
+
+    sortTimetableEntriesByDepartureTime(entries);
+    return entries;
+  }
+
   /** {@inheritDoc TransitRepository.getStopsInBounds} */
   getStopsInBounds(bounds: Bounds, limit: number): Promise<CollectionResult<StopWithMeta>> {
     const effectiveLimit = normalizeStopQueryLimit(limit);
@@ -104,7 +152,7 @@ export class MockRepository implements TransitRepository {
   /** {@inheritDoc TransitRepository.getUpcomingTimetableEntries} */
   getUpcomingTimetableEntries(
     stopId: string,
-    now: Date,
+    referenceDateTime: Date,
     limit?: number,
   ): Promise<UpcomingTimetableResult> {
     const normalizedLimit = normalizeOptionalResultLimit(limit);
@@ -118,8 +166,8 @@ export class MockRepository implements TransitRepository {
     let fullDayCount = 0;
     let hasBoardable = false;
 
-    const serviceDate = getServiceDay(now);
-    const nowMinutes = getServiceDayMinutes(now);
+    const serviceDate = getServiceDay(referenceDateTime);
+    const nowMinutes = getServiceDayMinutes(referenceDateTime);
     for (const { routeId, headsign, stopHeadsign } of stopRoutes) {
       const route = ROUTES.find((r) => r.route_id === routeId);
       if (!route) {
@@ -182,7 +230,7 @@ export class MockRepository implements TransitRepository {
             patternPosition: position,
             tripLocator: {
               patternId: createMockTripPatternId(routeId, headsign),
-              serviceId: 'mock:default',
+              serviceId: MOCK_DEFAULT_SERVICE_ID,
               tripIndex,
             },
             serviceDate,
@@ -253,54 +301,8 @@ export class MockRepository implements TransitRepository {
   }
 
   /** {@inheritDoc TransitRepository.getFullDayTimetableEntries} */
-  getFullDayTimetableEntries(
-    stopId: string,
-    ...[
-      /* dateTime */
-    ]: [Date]
-  ): Promise<TimetableResult> {
-    const stopRoutes = STOP_ROUTES[stopId] ?? [];
-    const entries: TimetableEntry[] = [];
-
-    for (const { routeId, headsign, stopHeadsign } of stopRoutes) {
-      const route = ROUTES.find((r) => r.route_id === routeId);
-      if (!route) {
-        continue;
-      }
-      // Issue #47: emit one set of entries per occurrence (6-shape / circular).
-      const occurrences = Math.max(1, countStopOccurrences(routeId, headsign, stopId));
-
-      for (let occ = 0; occ < occurrences; occ++) {
-        const position = getPatternPosition(routeId, headsign, stopId, occ);
-        const occOffset = computeOccOffset(routeId, occ);
-        const travelOffset = computePatternTravelOffset(routeId, headsign, position.stopIndex);
-        const { pickupType, dropOffType } = getBoardingTypes(routeId, headsign, stopId, occ);
-        const baseSchedule = generateFixedMinutes(routeId, headsign);
-        for (const [tripIndex, baseMinutes] of baseSchedule.entries()) {
-          const minutes = baseMinutes + travelOffset + occOffset;
-          const arrivalMinutes = computeArrivalMinutes(routeId, occ, minutes);
-          entries.push({
-            schedule: { departureMinutes: minutes, arrivalMinutes },
-            routeDirection: {
-              route,
-              tripHeadsign: createMockTranslatableText(headsign),
-              ...(stopHeadsign != null
-                ? { stopHeadsign: createMockTranslatableText(stopHeadsign) }
-                : {}),
-            },
-            boarding: { pickupType, dropOffType },
-            patternPosition: position,
-            tripLocator: {
-              patternId: createMockTripPatternId(routeId, headsign),
-              serviceId: 'mock:default',
-              tripIndex,
-            },
-          });
-        }
-      }
-    }
-
-    sortTimetableEntriesByDepartureTime(entries);
+  getFullDayTimetableEntries(stopId: string, _dateTime: Date): Promise<TimetableResult> {
+    const entries = this.buildFullDayTimetableEntries(stopId);
     const meta: TimetableQueryMeta = {
       isBoardableOnServiceDay: getTimetableEntriesState(entries) === 'boardable',
       totalEntries: entries.length,
@@ -388,20 +390,16 @@ export class MockRepository implements TransitRepository {
   getTripInspectionTargets(
     query: TripInspectionGroupQuery,
   ): Promise<Result<TripInspectionTarget[]>> {
-    return this.getFullDayTimetableEntries(query.stopId, query.serviceDate).then((result) => {
-      if (!result.success) {
-        return result;
-      }
+    const entries = this.buildFullDayTimetableEntries(query.stopId);
 
-      return {
-        success: true,
-        data: result.data.map((entry) => ({
-          tripLocator: entry.tripLocator,
-          serviceDate: query.serviceDate,
-          stopIndex: entry.patternPosition.stopIndex,
-          departureMinutes: entry.schedule.departureMinutes,
-        })),
-      };
+    return Promise.resolve({
+      success: true,
+      data: entries.map((entry) => ({
+        tripLocator: entry.tripLocator,
+        serviceDate: query.serviceDate,
+        stopIndex: entry.patternPosition.stopIndex,
+        departureMinutes: entry.schedule.departureMinutes,
+      })),
     });
   }
 
@@ -475,7 +473,7 @@ export class MockRepository implements TransitRepository {
   resolveRouteFreq(routeId: string, serviceDate: Date): number | undefined {
     // Return exaggerated weekday/weekend freq difference for visual testing.
     // Weekday: high freq (thick lines), Weekend: low freq (thin lines).
-    const day = getServiceDay(serviceDate).getDay(); // 0=Sun, 6=Sat
+    const day = serviceDate.getDay(); // 0=Sun, 6=Sat
     const isWeekend = day === 0 || day === 6;
     const route = ROUTE_MAP.get(routeId);
     if (!route || route.route_type !== 3) {

--- a/src/repositories/transit-repository.ts
+++ b/src/repositories/transit-repository.ts
@@ -320,9 +320,35 @@ export interface TransitRepository {
   /**
    * Reconstructs a whole trip from the minimal repository-side locator.
    *
-   * This method returns only trip-level data and the full stop list.
-   * Callers that need a current stop can resolve it afterward using
-   * their own selection context.
+   * This method returns only trip-level data and the per-stop schedule
+   * rows that could be reconstructed for `locator`. Callers that need a
+   * current stop can resolve it afterward using their own selection
+   * context.
+   *
+   * ### Outcome model
+   * - **Success** when `locator.patternId` resolves to a known
+   *   {@link TripPattern} and that pattern's route is also known. The
+   *   returned `data.stopTimes` may be empty: that signals the trip
+   *   simply has no schedulable rows for `locator` (e.g. the requested
+   *   `serviceId` is not active in any of the pattern's groups, or
+   *   `tripIndex` is out of range), not an error condition. It may
+   *   also be sparse — see "Sparse stopTimes" below.
+   * - **Failure** is reserved for cases where the locator cannot be
+   *   bound to repository state at all: the pattern is unknown, or the
+   *   pattern's route is unknown.
+   *
+   * Consumers should therefore branch on `result.success` first, and
+   * treat `result.data.stopTimes.length === 0` as a normal observable
+   * outcome rather than a separate error path.
+   *
+   * ### Sparse stopTimes
+   * `data.stopTimes` is the set of rows the implementation managed to
+   * reconstruct. When some pattern entries cannot be resolved against
+   * the requested `(serviceId, tripIndex)`, those positions are
+   * silently dropped. The remaining rows still carry their
+   * `patternPosition.stopIndex` and `patternPosition.totalStops`, so
+   * callers can detect missing positions by comparing the set of
+   * returned `stopIndex` values against `[0..totalStops - 1]`.
    *
    * `serviceDate` is attached to the returned snapshot as caller-owned context.
    * Implementations do not re-derive a service day from it and do not use it
@@ -333,13 +359,17 @@ export interface TransitRepository {
    *                      returned snapshot. Implementations treat this as
    *                      caller-owned context and pass it through without
    *                      additional normalization.
-   * @returns Whole-trip payload, or an error when reconstruction is unavailable.
+   * @returns Whole-trip payload — possibly with an empty or sparse
+   *          `stopTimes` — or an error when the locator cannot be
+   *          bound to a known pattern/route.
    */
   getTripSnapshot(locator: TripLocator, serviceDate: Date): TripSnapshotResult;
 
   /**
-   * Returns trip-inspection targets for departures at the same stop on the
-   * provided service day.
+   * Returns every trip-inspection target for departures at the queried
+   * stop on the provided service day. The result is not filtered by any
+   * particular trip: callers are expected to identify the currently
+   * selected target (and any neighbors of interest) themselves.
    *
    * Each target carries only the minimal fields needed for trip inspection and
    * candidate comparison. In particular, `departureMinutes` is included so
@@ -355,9 +385,8 @@ export interface TransitRepository {
    * Implementations use it as the service-day context for calendar filtering;
    * callers should not pass a raw real-world datetime here.
    *
-   * @param query - Minimal trip + stop context for grouping neighboring departures.
-   *                `query.serviceDate` is a pre-normalized service day, not a
-   *                reference datetime.
+   * @param query - Stop and service-day context. `query.serviceDate` is a
+   *                pre-normalized service day, not a reference datetime.
    * @returns Trip-inspection targets with lightweight comparison data.
    */
   getTripInspectionTargets(

--- a/src/repositories/transit-repository.ts
+++ b/src/repositories/transit-repository.ts
@@ -99,6 +99,29 @@ export function normalizeOptionalResultLimit(limit?: number): number | undefined
  * {@link Result} or {@link CollectionResult} to communicate domain-level
  * errors without throwing, while others return plain collections or
  * derived values directly.
+ *
+ * ### Date/time parameters
+ * Methods that accept a `Date` may be called with any user-selected
+ * date/time, not just the current wall-clock time. This includes real-time
+ * values from `new Date()` as well as custom time values from `?time=` or
+ * the app's time-setting UI.
+ *
+ * There are two distinct contracts:
+ * - Reference datetime parameters such as `referenceDateTime` / `dateTime` accept an
+ *   arbitrary real-world date/time and are normalized internally to the
+ *   GTFS service day when needed.
+ * - `serviceDate` parameters are already normalized to the GTFS service day
+ *   by the caller and must not be treated as raw reference datetimes.
+ *
+ * Method classification:
+ * - Reference datetime (arbitrary date/time, normalized internally):
+ *   `getUpcomingTimetableEntries(referenceDateTime)`,
+ *   `getFullDayTimetableEntries(dateTime)`
+ * - Pre-normalized service day (caller passes `getServiceDay(...)` result):
+ *   `getTripSnapshot(serviceDate)`,
+ *   `getTripInspectionTargets(query.serviceDate)`,
+ *   `resolveStopStats(serviceDate)`,
+ *   `resolveRouteFreq(serviceDate)`
  */
 export interface TransitRepository {
   /**
@@ -146,7 +169,7 @@ export interface TransitRepository {
    *
    * ### Service day boundary
    * The GTFS service day does not change at midnight but at 03:00.
-   * Before 03:00, `now` is treated as part of the previous calendar
+   * Before 03:00, `referenceDateTime` is treated as part of the previous calendar
    * day's service. This is handled internally via `getServiceDay()`.
    *
    * ### Overnight handling
@@ -168,8 +191,11 @@ export interface TransitRepository {
    *   `{ success: false, error: "No stop time data for stop: {stopId}" }`
    *
    * @param stopId - GTFS `stop_id` of the target stop.
-   * @param now    - Real-world reference time. The service day is
-   *                 determined internally (03:00 boundary).
+   * @param referenceDateTime - Reference date/time for the query. This may be
+   *                            the live current time or an arbitrary custom
+   *                            time selected by the user. The repository
+   *                            determines the GTFS service day internally
+   *                            (03:00 boundary).
    * @param limit  - Maximum number of entries to return.
    *                 When omitted, all upcoming entries are returned.
    *                 Negative and non-finite values are treated as `0`.
@@ -178,7 +204,7 @@ export interface TransitRepository {
    */
   getUpcomingTimetableEntries(
     stopId: string,
-    now: Date,
+    referenceDateTime: Date,
     limit?: number,
   ): Promise<UpcomingTimetableResult>;
 
@@ -267,14 +293,18 @@ export interface TransitRepository {
    *
    * ### Calendar filtering
    * Only service IDs active on the GTFS service day are included.
+   * Implementations are expected to derive that service day from `dateTime`
+   * internally rather than requiring callers to pre-normalize it.
    *
    * ### Error conditions
    * - No stop time data for `stopId`:
    *   `{ success: true, data: [], truncated: false }` (not an error).
    *
    * @param stopId   - GTFS stop_id.
-   * @param dateTime - Reference real-world time. The repository converts
-   *                   this to the GTFS service day internally (03:00 boundary).
+   * @param dateTime - Reference date/time for the query. This may be the live
+   *                   current time or an arbitrary custom time selected by the
+   *                   user. The repository converts it to the GTFS service day
+   *                   internally (03:00 boundary).
    * @returns All timetable entries at the stop for the service day.
    */
   getFullDayTimetableEntries(stopId: string, dateTime: Date): Promise<TimetableResult>;
@@ -286,22 +316,40 @@ export interface TransitRepository {
    * Callers that need a current stop can resolve it afterward using
    * their own selection context.
    *
+   * `serviceDate` is attached to the returned snapshot as caller-owned context.
+   * Implementations do not re-derive a service day from it and do not use it
+   * to recompute departure or arrival minutes.
+   *
    * @param locator - Repository-specific trip locator.
-   * @param serviceDate - Service day context for accurate time interpretation.
+   * @param serviceDate - Pre-normalized GTFS service day to attach to the
+   *                      returned snapshot. Implementations treat this as
+   *                      caller-owned context and pass it through without
+   *                      additional normalization.
    * @returns Whole-trip payload, or an error when reconstruction is unavailable.
    */
   getTripSnapshot(locator: TripLocator, serviceDate: Date): TripSnapshotResult;
 
   /**
    * Returns trip-inspection targets for departures at the same stop on the
-   * current service day.
+   * provided service day.
    *
    * Each target carries only the minimal fields needed for trip inspection and
    * candidate comparison. In particular, `departureMinutes` is included so
    * callers can compare or reorder candidates without reloading full timetable
    * entries.
    *
+   * ### Sorting
+   * Results are sorted with the same ordering as
+   * `sortTimetableEntriesByDepartureTime`: `departureMinutes` ascending,
+   * then `stopIndex` ascending, then route ID ascending.
+   *
+   * `query.serviceDate` must already be normalized to the GTFS service day.
+   * Implementations use it as the service-day context for calendar filtering;
+   * callers should not pass a raw real-world datetime here.
+   *
    * @param query - Minimal trip + stop context for grouping neighboring departures.
+   *                `query.serviceDate` is a pre-normalized service day, not a
+   *                reference datetime.
    * @returns Trip-inspection targets with lightweight comparison data.
    */
   getTripInspectionTargets(
@@ -414,13 +462,14 @@ export interface TransitRepository {
   /**
    * Resolves per-stop stats for the service group matching the given service day.
    *
-   * Uses active service IDs for the normalized service day to select the best
+   * Uses active service IDs for the provided service day to select the best
    * matching service group from InsightsBundle data. Returns undefined if
    * insights are not loaded or no group matches.
    *
    * @param stopId - GTFS stop_id.
-   * @param serviceDate - Reference date/time or precomputed service day.
-   *   Implementations normalize this via `getServiceDay(serviceDate)` before lookup.
+   * @param serviceDate - Pre-normalized GTFS service day.
+   *   Callers should pass the result of `getServiceDay(dateTime)` or an
+   *   equivalent repository-provided `serviceDate` value.
    * @returns Stats for the matched service group, or undefined.
    */
   resolveStopStats(stopId: string, serviceDate: Date): StopWithMeta['stats'] | undefined;
@@ -438,8 +487,9 @@ export interface TransitRepository {
    * Returns undefined if insights are not loaded or no group matches.
    *
    * @param routeId - GTFS route_id.
-   * @param serviceDate - Reference date/time or precomputed service day.
-   *   Implementations normalize this via `getServiceDay(serviceDate)` before lookup.
+   * @param serviceDate - Pre-normalized GTFS service day.
+   *   Callers should pass the result of `getServiceDay(dateTime)` or an
+   *   equivalent repository-provided `serviceDate` value.
    * @returns Number of trips in the matched service day, or undefined.
    */
   resolveRouteFreq(routeId: string, serviceDate: Date): number | undefined;

--- a/src/repositories/transit-repository.ts
+++ b/src/repositories/transit-repository.ts
@@ -30,7 +30,7 @@ import type { TripLocator } from '../types/app/transit-composed';
  * `limit` with {@link normalizeStopQueryLimit}. Even if the underlying
  * dataset contains more matching stops, those methods MUST NOT return
  * more than this number. When results are truncated to this limit, the
- * {@link CollectionResult.truncated} flag MUST be set to `true`.
+ * `truncated` flag on {@link CollectionResult} MUST be set to `true`.
  */
 export const MAX_STOP_QUERY_RESULT = 50_000; // FOR TESTING WITH LARGE DATASETS
 
@@ -100,6 +100,14 @@ export function normalizeOptionalResultLimit(limit?: number): number | undefined
  * errors without throwing, while others return plain collections or
  * derived values directly.
  *
+ * ### Error messages
+ * `error` strings on failure {@link Result} values are human-readable and
+ * implementation-specific. Consumers MUST NOT parse them or rely on their
+ * exact wording. Use the per-method `### Error conditions` documentation
+ * (and, where applicable, additional fields on the result) to distinguish
+ * error categories programmatically. The example strings shown in method
+ * TSDocs are illustrative only.
+ *
  * ### Date/time parameters
  * Methods that accept a `Date` may be called with any user-selected
  * date/time, not just the current wall-clock time. This includes real-time
@@ -163,14 +171,14 @@ export interface TransitRepository {
    * entries) and grouping (e.g. by route+headsign for display).
    *
    * ### Sorting
-   * Results are sorted by `sortTimetableEntriesChronologically`
+   * Results are sorted by {@link sortTimetableEntriesChronologically}
    * (defined in `src/domain/transit/sort-timetable-entries.ts`).
    * See that function's TSDoc for the canonical sort order spec.
    *
    * ### Service day boundary
    * The GTFS service day does not change at midnight but at 03:00.
    * Before 03:00, `referenceDateTime` is treated as part of the previous calendar
-   * day's service. This is handled internally via `getServiceDay()`.
+   * day's service. This is handled internally via {@link getServiceDay}.
    *
    * ### Overnight handling
    * Departures with times >= 24:00 (1440 minutes) on the current
@@ -200,7 +208,7 @@ export interface TransitRepository {
    *                 When omitted, all upcoming entries are returned.
    *                 Negative and non-finite values are treated as `0`.
    *                 Fractional values are truncated toward zero.
-   * @returns ContextualTimetableEntry items sorted chronologically.
+   * @returns {@link ContextualTimetableEntry} items sorted chronologically.
    */
   getUpcomingTimetableEntries(
     stopId: string,
@@ -287,7 +295,7 @@ export interface TransitRepository {
    * headsign, boarding availability, and pattern position.
    *
    * ### Sorting
-   * Results are sorted by `sortTimetableEntriesByDepartureTime`
+   * Results are sorted by {@link sortTimetableEntriesByDepartureTime}
    * (defined in `src/domain/transit/sort-timetable-entries.ts`).
    * See that function's TSDoc for the canonical sort order spec.
    *
@@ -340,7 +348,7 @@ export interface TransitRepository {
    *
    * ### Sorting
    * Results are sorted with the same ordering as
-   * `sortTimetableEntriesByDepartureTime`: `departureMinutes` ascending,
+   * {@link sortTimetableEntriesByDepartureTime}: `departureMinutes` ascending,
    * then `stopIndex` ascending, then route ID ascending.
    *
    * `query.serviceDate` must already be normalized to the GTFS service day.
@@ -372,12 +380,13 @@ export interface TransitRepository {
    *   `{ success: false, error: "Stop not found: {stopId}" }`
    *
    * @param stopId - GTFS `stop_id` to look up.
-   * @returns The StopWithMeta if found, or a failure Result if not found.
+   * @returns The {@link StopWithMeta} if found, or a failure {@link Result}
+   *   if not found.
    */
   getStopMetaById(stopId: string): Promise<Result<StopWithMeta>>;
 
   /**
-   * Returns StopWithMeta for each of the given stop IDs against the
+   * Returns {@link StopWithMeta} for each of the given stop IDs against the
    * **full loaded dataset**, not just the current viewport.
    *
    * "Full dataset" describes the search scope: any stop loaded into the
@@ -397,26 +406,32 @@ export interface TransitRepository {
    *
    * @param stopIds - Set of stop IDs to look up. Can include IDs
    *                  from any data source loaded into the repository.
-   * @returns Array of StopWithMeta for found stops, in unspecified order.
+   * @returns Array of {@link StopWithMeta} for found stops, in unspecified order.
    */
   getStopMetaByIds(stopIds: Set<string>): StopWithMeta[];
 
   /**
-   * Returns all stops in the dataset.
+   * Returns all stops that the repository treats as addressable stop entries.
    *
    * Used for stop name search functionality.
+   *
+   * This is not necessarily identical to every raw stop record present in the
+   * underlying dataset. Implementations may exclude stops that are not yet
+   * surfaced as user-selectable entries in the current UI. For example,
+   * parent stations (`location_type=1`) may be omitted until station-grouping
+   * support exists.
    *
    * ### Sorting
    * No specific ordering is guaranteed.
    *
    * ### Truncation
-   * Returns the full loaded stop set. `truncated` is always `false`.
+   * Returns the full loaded addressable stop set. `truncated` is always `false`.
    *
    * ### Error conditions
    * Always succeeds. An empty dataset returns
    * `{ success: true, data: [], truncated: false }`.
    *
-   * @returns All stops in the dataset.
+   * @returns All addressable stops exposed by the repository.
    */
   getAllStops(): Promise<CollectionResult<Stop>>;
 
@@ -440,7 +455,8 @@ export interface TransitRepository {
    *   `{ success: false, error: "Agency not found: {agencyId}" }`
    *
    * @param agencyId - The agency_id to look up.
-   * @returns The Agency if found, or a failure Result if not found.
+   * @returns The {@link Agency} if found, or a failure {@link Result}
+   *   if not found.
    */
   getAgency(agencyId: string): Promise<Result<Agency>>;
 
@@ -468,7 +484,7 @@ export interface TransitRepository {
    *
    * @param stopId - GTFS stop_id.
    * @param serviceDate - Pre-normalized GTFS service day.
-   *   Callers should pass the result of `getServiceDay(dateTime)` or an
+   *   Callers should pass the result of {@link getServiceDay} or an
    *   equivalent repository-provided `serviceDate` value.
    * @returns Stats for the matched service group, or undefined.
    */
@@ -488,7 +504,7 @@ export interface TransitRepository {
    *
    * @param routeId - GTFS route_id.
    * @param serviceDate - Pre-normalized GTFS service day.
-   *   Callers should pass the result of `getServiceDay(dateTime)` or an
+   *   Callers should pass the result of {@link getServiceDay} or an
    *   equivalent repository-provided `serviceDate` value.
    * @returns Number of trips in the matched service day, or undefined.
    */

--- a/src/repositories/transit-repository.ts
+++ b/src/repositories/transit-repository.ts
@@ -8,7 +8,12 @@
 
 import type { Bounds, LatLng, RouteShape } from '../types/app/map';
 import type { Agency, AppRouteTypeValue, Stop } from '../types/app/transit';
-import type { SourceMeta, StopWithMeta } from '../types/app/transit-composed';
+import type {
+  SourceMeta,
+  StopWithMeta,
+  TripInspectionGroupQuery,
+  TripInspectionTarget,
+} from '../types/app/transit-composed';
 import type {
   CollectionResult,
   Result,
@@ -286,6 +291,22 @@ export interface TransitRepository {
    * @returns Whole-trip payload, or an error when reconstruction is unavailable.
    */
   getTripSnapshot(locator: TripLocator, serviceDate: Date): TripSnapshotResult;
+
+  /**
+   * Returns trip-inspection targets for departures at the same stop on the
+   * current service day.
+   *
+   * Each target carries only the minimal fields needed for trip inspection and
+   * candidate comparison. In particular, `departureMinutes` is included so
+   * callers can compare or reorder candidates without reloading full timetable
+   * entries.
+   *
+   * @param query - Minimal trip + stop context for grouping neighboring departures.
+   * @returns Trip-inspection targets with lightweight comparison data.
+   */
+  getTripInspectionTargets(
+    query: TripInspectionGroupQuery,
+  ): Promise<Result<TripInspectionTarget[]>>;
 
   /**
    * Returns a single stop with metadata by its GTFS stop_id, against

--- a/src/types/app/transit-composed.ts
+++ b/src/types/app/transit-composed.ts
@@ -352,8 +352,12 @@ export interface TripStopTime {
  *   minutes-from-midnight values, including overnight trips.
  * - `route`, `tripHeadsign`, and `direction` provide trip-level metadata
  *   derived from the merged route/trip-pattern model.
- * - `stopTimes` contains the full stop sequence reconstructed from timetable
- *   rows and trip pattern positions, with optional stop metadata enrichment.
+ * - `stopTimes` contains the per-stop schedule rows reconstructed from
+ *   timetable rows and trip pattern positions, with optional stop metadata
+ *   enrichment. Rows may be omitted when the repository cannot bind a
+ *   pattern entry to the requested `(serviceId, tripIndex)`, so the array
+ *   may be empty or sparse — see {@link TripStopTime.timetableEntry}'s
+ *   `patternPosition` for the originating stop index.
  *
  * Because this type is reconstructed for app use, it must not be treated as a
  * mirror of GTFS `trips.txt`. Fields that exist in raw GTFS but are not
@@ -370,6 +374,17 @@ export interface TripSnapshot extends WithServiceDate {
   /** Direction ID when the source provides one. */
   direction?: 0 | 1;
 
+  /**
+   * Per-stop schedule rows reconstructed for this trip.
+   *
+   * The array is sorted by `timetableEntry.patternPosition.stopIndex`,
+   * but it may be empty or sparse: when the repository cannot resolve a
+   * pattern entry against the requested `(serviceId, tripIndex)` (no
+   * matching service column, out-of-range trip index, etc.), that entry
+   * is dropped. Callers must therefore not treat `stopTimes.length` as
+   * the pattern's stop count, and should not assume `stopTimes[i]`
+   * corresponds to `stopIndex === i`.
+   */
   stopTimes: TripStopTime[];
 }
 
@@ -397,13 +412,13 @@ export interface TripInspectionTarget extends WithServiceDate {
 }
 
 /**
- * Minimal query required to list trip-inspection targets at the same stop on
- * the current service day.
+ * Minimal query required to list trip-inspection targets at a stop on
+ * the current service day. The result is unfiltered: every active trip
+ * stopping at `stopId` on `serviceDate` is returned, and the caller is
+ * expected to identify the currently selected trip.
  */
 export interface TripInspectionGroupQuery extends WithServiceDate {
-  /** Locator used to reconstruct the current concrete trip instance. */
-  tripLocator: TripLocator;
-  /** Physical stop where neighboring departures should be searched. */
+  /** Physical stop whose departures (across all trips) should be listed. */
   stopId: string;
 }
 

--- a/src/types/app/transit-composed.ts
+++ b/src/types/app/transit-composed.ts
@@ -390,7 +390,7 @@ export interface TripSnapshot extends WithServiceDate {
 
 /** Reconstructed whole-trip payload enriched with the currently selected stop event. */
 export interface SelectedTripSnapshot extends TripSnapshot {
-  /** Current stop index of the selected entry. */
+  /** Array index of the selected entry within `stopTimes`. */
   currentStopIndex: number;
   /** Stop-level record corresponding to the clicked entry. */
   selectedStop: TripStopTime;

--- a/src/types/app/transit-composed.ts
+++ b/src/types/app/transit-composed.ts
@@ -387,6 +387,24 @@ export interface TripInspectionTarget extends WithServiceDate {
   tripLocator: TripLocator;
   /** Pattern position of the selected stop within the reconstructed trip. */
   stopIndex: number;
+  /**
+   * Departure minutes at the selected stop.
+   *
+   * Added so trip-inspection candidates can be compared and ordered without
+   * reloading the source timetable entries.
+   */
+  departureMinutes: number;
+}
+
+/**
+ * Minimal query required to list trip-inspection targets at the same stop on
+ * the current service day.
+ */
+export interface TripInspectionGroupQuery extends WithServiceDate {
+  /** Locator used to reconstruct the current concrete trip instance. */
+  tripLocator: TripLocator;
+  /** Physical stop where neighboring departures should be searched. */
+  stopId: string;
 }
 
 /**

--- a/src/utils/trip-inspection-log.ts
+++ b/src/utils/trip-inspection-log.ts
@@ -1,6 +1,10 @@
-import { minutesToDate } from '../domain/transit/calendar-utils';
+import { formatDateKey, minutesToDate } from '../domain/transit/calendar-utils';
 import { formatAbsoluteTime } from '../domain/transit/time';
 import type { SelectedTripSnapshot } from '../types/app/transit-composed';
+
+function formatInspectionServiceDate(serviceDate: Date): string {
+  return formatDateKey(serviceDate);
+}
 
 /**
  * Format inspection minutes as `minutes(HH:mm)` when serviceDate is available.
@@ -59,10 +63,11 @@ export function buildTripInspectionSummaryLog(snapshot: SelectedTripSnapshot): s
   const boarding = snapshot.selectedStop.timetableEntry.boarding;
   const selectedStopId = snapshot.selectedStop.stopMeta?.stop.stop_id ?? '(unknown-stop)';
   const selectedStopName = snapshot.selectedStop.stopMeta?.stop.stop_name ?? selectedStopId;
+  const serviceDateText = formatInspectionServiceDate(snapshot.serviceDate);
   const departureText = formatInspectionMinutes(schedule.departureMinutes, snapshot.serviceDate);
   const arrivalText = formatInspectionMinutes(schedule.arrivalMinutes, snapshot.serviceDate);
 
-  return `handleInspectTrip: pattern=${snapshot.locator.patternId} service=${snapshot.locator.serviceId} tripIndex=${snapshot.locator.tripIndex} selectedStop=${selectedStopId}(${selectedStopName}) stopIndex=${snapshot.currentStopIndex}/${snapshot.stopTimes.length - 1} dep=${departureText} arr=${arrivalText} pickup=${boarding.pickupType} dropOff=${boarding.dropOffType}`;
+  return `handleInspectTrip: serviceDate=${serviceDateText} pattern=${snapshot.locator.patternId} service=${snapshot.locator.serviceId} tripIndex=${snapshot.locator.tripIndex} selectedStop=${selectedStopId}(${selectedStopName}) stopIndex=${snapshot.currentStopIndex}/${snapshot.stopTimes.length - 1} dep=${departureText} arr=${arrivalText} pickup=${boarding.pickupType} dropOff=${boarding.dropOffType}`;
 }
 
 /**
@@ -72,6 +77,7 @@ export function buildTripInspectionSummaryLog(snapshot: SelectedTripSnapshot): s
  * @returns One-line listing of the route, headsign, span, and all stops.
  */
 export function buildTripInspectionStopsLog(snapshot: SelectedTripSnapshot): string {
+  const serviceDateText = formatInspectionServiceDate(snapshot.serviceDate);
   const routeInfo = `[${snapshot.route.route_short_name || snapshot.route.route_long_name}]`;
   const effectiveHeadsign =
     snapshot.selectedStop.timetableEntry.routeDirection.stopHeadsign?.name ??
@@ -95,5 +101,5 @@ export function buildTripInspectionStopsLog(snapshot: SelectedTripSnapshot): str
     })
     .join(', ');
 
-  return `handleInspectTrip.stops: ${routeInfo} ${headsign} (${snapshot.stopTimes.length} stops) ${tripSpan} ${stops}`;
+  return `handleInspectTrip.stops: serviceDate=${serviceDateText} ${routeInfo} ${headsign} (${snapshot.stopTimes.length} stops) ${tripSpan} ${stops}`;
 }


### PR DESCRIPTION
## Summary
Add trip inspection target lookup and prev/next navigation so the dialog can move across matching trips at the same stop.

## Changes
- add repository support for trip inspection targets and trip snapshot reconstruction metadata
- align repository service-day contracts and update related tests/docs
- move trip-inspection target filtering/navigation flow into the hook layer
- fix selected-stop handling so sparse `stopTimes` snapshots no longer treat pattern `stopIndex` as an array index
- update the trip inspection dialog to show prev/next navigation, placeholder rows for missing stop-times, and clearer sparse-trip position handling
- reduce initial dialog render cost by staging the stop-list render around the selected stop
- normalize dialog-side rendered trip-stop row data so real rows and placeholder rows share common `stopIndex` / `totalStops` fields

## Validation
- npm run format
- npm run lint
- npm run build