### PR TITLE
fix(trip-inspection): catch target lookup rejection

### DIFF
--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -259,6 +259,12 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
             `openTripInspection: serviceDate=${formatTripInspectionServiceDate(target.serviceDate)} trip-inspection targets=${result.data.length} currentIndex=${currentIndex} stopId=${selectedStopId}`,
             result.data,
           );
+        })
+        .catch((error: unknown) => {
+          if (lookupRequestIdRef.current !== lookupRequestId) {
+            return;
+          }
+          logger.warn('openTripInspection: trip-inspection target lookup threw', error, target);
         });
     },
     [repo, updateTripInspectionTargets],


### PR DESCRIPTION
## Summary
- Add a `.catch()` to the `repo.getTripInspectionTargets(...)` chain in `useTripInspection` so that an unexpected rejection is logged instead of becoming an unhandled promise rejection.
- The handler bails out early for stale lookups (consistent with the existing `lookupRequestIdRef` race-guard).

## Context
This addresses Copilot review feedback on PR #150 that was committed locally but did not make it into the merged branch (commit was made shortly before the merge and not pushed in time).

## Test plan
- [x] \`npm run format\` (no changes)
- [x] \`npm run lint\` (clean)
- [x] \`npm run build\` (typecheck via tsc)
- [x] Manual: open trip-inspection dialog and confirm normal flow still works (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)