### PR TITLE
fix(pipeline): split GTFS trip patterns by served stops (#154)

### DIFF
--- a/pipeline/src/lib/pipeline/app-data-v2/gtfs/__tests__/extract-timetable.test.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/gtfs/__tests__/extract-timetable.test.ts
@@ -5,7 +5,7 @@
  */
 
 import Database from 'better-sqlite3';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { extractTripPatternsAndTimetable } from '../extract-timetable';
 
@@ -244,7 +244,10 @@ describe('extractTripPatternsAndTimetable', () => {
     expect(g.dt!['test:WD']).toEqual([0]);
   });
 
-  it('NULL departure stop is in pattern.stops but not in timetable', () => {
+  it('pure pass-through stop (NULL dep AND NULL arr) is excluded from pattern.stops and timetable', () => {
+    // Pre-#154 behavior kept S002 in pattern.stops but skipped it from
+    // timetable, leaving the two arrays misaligned. Post-#154 the pattern
+    // key is built from served stops only, so S002 is excluded from both.
     db.exec(`
       INSERT INTO trips VALUES ('T001', 'R001', 'WD', '渋谷', 0);
       INSERT INTO stop_times VALUES ('T001', 'S001', 1, '08:00:00', '08:00:00', 0, 0, NULL);
@@ -253,17 +256,17 @@ describe('extractTripPatternsAndTimetable', () => {
     `);
 
     const { tripPatterns, timetable } = extractTripPatternsAndTimetable(db, 'test');
-    // Pattern includes all 3 stops (including pass-through)
-    expect(tripPatterns['test:p1'].stops).toEqual([
-      { id: 'test:S001' },
-      { id: 'test:S002' },
-      { id: 'test:S003' },
-    ]);
-    // But timetable has no entry for S002
+    expect(tripPatterns['test:p1'].stops).toEqual([{ id: 'test:S001' }, { id: 'test:S003' }]);
     expect(timetable['test:S002']).toBeUndefined();
+    // si values reflect the served-only positions: S001=0, S003=1.
+    expect(timetable['test:S001'][0].si).toBe(0);
+    expect(timetable['test:S003'][0].si).toBe(1);
   });
 
-  it('skips stop_times with NULL departure_time', () => {
+  it('NULL departure_time stop is excluded from both pattern.stops and timetable', () => {
+    // Same shape as the pure pass-through case, but S002 keeps an arrival_time.
+    // Per Issue #154 we use `departure_time != null` as the served signal,
+    // so S002 is still excluded (pattern.stops index must match timetable.si).
     db.exec(`
       INSERT INTO trips VALUES ('T001', 'R001', 'WD', '渋谷', 0);
       INSERT INTO stop_times VALUES ('T001', 'S001', 1, '08:00:00', '08:00:00', 0, 0, NULL);
@@ -271,12 +274,36 @@ describe('extractTripPatternsAndTimetable', () => {
       INSERT INTO stop_times VALUES ('T001', 'S003', 3, '08:10:00', '08:10:00', 0, 0, NULL);
     `);
 
-    const { timetable } = extractTripPatternsAndTimetable(db, 'test');
-    // S002 should have no timetable entry (departure is NULL)
+    const { tripPatterns, timetable } = extractTripPatternsAndTimetable(db, 'test');
+    expect(tripPatterns['test:p1'].stops).toEqual([{ id: 'test:S001' }, { id: 'test:S003' }]);
     expect(timetable['test:S002']).toBeUndefined();
-    // S001 and S003 should have entries
     expect(timetable['test:S001']).toHaveLength(1);
     expect(timetable['test:S003']).toHaveLength(1);
+  });
+
+  it('terminal arr-only stop (last stop has NULL dep but valid arr) is excluded from pattern.stops', () => {
+    // Edge case noted in the Issue #154 plan: when the *terminal* stop has
+    // departure_time = NULL but arrival_time set (drop-off only), the served
+    // filter (`departure_time != null`) excludes it from pattern.stops, so
+    // the trip's nominal terminus does not appear in the trip stops list.
+    // Real GTFS feeds usually populate dep == arr at terminals, so this
+    // should be rare; this test pins the contract anyway to catch regressions.
+    db.exec(`
+      INSERT INTO trips VALUES ('T001', 'R001', 'WD', '渋谷', 0);
+      INSERT INTO stop_times VALUES ('T001', 'S001', 1, '08:00:00', '08:00:00', 0, 0, NULL);
+      INSERT INTO stop_times VALUES ('T001', 'S002', 2, '08:05:00', '08:05:00', 0, 0, NULL);
+      INSERT INTO stop_times VALUES ('T001', 'S003', 3, NULL, '08:10:00', 0, 0, NULL);
+    `);
+
+    const { tripPatterns, timetable } = extractTripPatternsAndTimetable(db, 'test');
+    expect(tripPatterns['test:p1'].stops).toEqual([{ id: 'test:S001' }, { id: 'test:S002' }]);
+    expect(timetable['test:S003']).toBeUndefined();
+    expect(timetable['test:S001']).toHaveLength(1);
+    expect(timetable['test:S002']).toHaveLength(1);
+    // The included stops sit at si=0 and si=1 — the served-only sequence,
+    // not the raw stop_sequence (which would have made S002 si=1, S003 si=2).
+    expect(timetable['test:S001'][0].si).toBe(0);
+    expect(timetable['test:S002'][0].si).toBe(1);
   });
 
   it('d/a/pt/dt array lengths are equal for each service_id', () => {
@@ -735,5 +762,183 @@ describe('extractTripPatternsAndTimetable', () => {
     const p = tripPatterns[patternIds[0]];
     expect(p.stops[0].sh).toBe('渋谷駅');
     expect(p.stops[1].sh).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #154: served-only pattern key tests
+  // -------------------------------------------------------------------------
+
+  describe('served-only pattern key (Issue #154)', () => {
+    it('splits express vs local trips with same raw stop sequence into separate patterns', () => {
+      // Both trips list S1..S5 in stop_times, but the express trip skips S2
+      // and S4 (NULL departure_time). Pre-#154 they shared a pattern and the
+      // per-stop d[serviceId] arrays became inconsistent across stops.
+      // Post-#154 they form two patterns with served stops [S1,S3,S5] and
+      // [S1,S2,S3,S4,S5] respectively.
+      db.exec(`
+        INSERT INTO trips VALUES ('EXP', 'R001', 'WD', '快速', 0);
+        INSERT INTO trips VALUES ('LOC', 'R001', 'WD', '快速', 0);
+        INSERT INTO stop_times VALUES ('EXP', 'S1', 1, '08:00:00', '08:00:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('EXP', 'S2', 2, NULL, NULL, 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('EXP', 'S3', 3, '08:05:00', '08:05:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('EXP', 'S4', 4, NULL, NULL, 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('EXP', 'S5', 5, '08:10:00', '08:10:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('LOC', 'S1', 1, '09:00:00', '09:00:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('LOC', 'S2', 2, '09:02:00', '09:02:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('LOC', 'S3', 3, '09:04:00', '09:04:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('LOC', 'S4', 4, '09:06:00', '09:06:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('LOC', 'S5', 5, '09:08:00', '09:08:00', 0, 0, NULL);
+      `);
+
+      const { tripPatterns, timetable } = extractTripPatternsAndTimetable(db, 'test');
+
+      expect(Object.keys(tripPatterns)).toHaveLength(2);
+      const patterns = Object.values(tripPatterns);
+      const expressPattern = patterns.find((p) => p.stops.length === 3)!;
+      const localPattern = patterns.find((p) => p.stops.length === 5)!;
+      expect(expressPattern).toBeDefined();
+      expect(localPattern).toBeDefined();
+      expect(expressPattern.stops.map((s) => s.id)).toEqual(['test:S1', 'test:S3', 'test:S5']);
+      expect(localPattern.stops.map((s) => s.id)).toEqual([
+        'test:S1',
+        'test:S2',
+        'test:S3',
+        'test:S4',
+        'test:S5',
+      ]);
+
+      // S1 sits in both patterns -> 2 timetable groups, each with 1 trip.
+      const s1Groups = timetable['test:S1'];
+      expect(s1Groups).toHaveLength(2);
+      for (const g of s1Groups) {
+        expect(g.d['test:WD']).toHaveLength(1);
+      }
+      // S2 only sits in the local pattern.
+      expect(timetable['test:S2']).toHaveLength(1);
+      expect(timetable['test:S2'][0].d['test:WD']).toHaveLength(1);
+    });
+
+    it('through-running mid-pattern skip splits into separate patterns', () => {
+      // Same route/headsign/direction; trip B skips S3. Approximates the
+      // toaran case where express services through-run and skip Asakusa-line
+      // stations that local services serve.
+      db.exec(`
+        INSERT INTO trips VALUES ('TA', 'R001', 'WD', '成田空港', 0);
+        INSERT INTO trips VALUES ('TB', 'R001', 'WD', '成田空港', 0);
+        INSERT INTO stop_times VALUES ('TA', 'S1', 1, '08:00:00', '08:00:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('TA', 'S2', 2, '08:05:00', '08:05:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('TA', 'S3', 3, '08:10:00', '08:10:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('TA', 'S4', 4, '08:15:00', '08:15:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('TB', 'S1', 1, '09:00:00', '09:00:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('TB', 'S2', 2, '09:05:00', '09:05:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('TB', 'S3', 3, NULL, NULL, 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('TB', 'S4', 4, '09:13:00', '09:13:00', 0, 0, NULL);
+      `);
+
+      const { tripPatterns, timetable } = extractTripPatternsAndTimetable(db, 'test');
+      expect(Object.keys(tripPatterns)).toHaveLength(2);
+      // Within each (patId, serviceId), every stop in the pattern has the
+      // same d[serviceId].length.
+      for (const [patId, pattern] of Object.entries(tripPatterns)) {
+        const lengths: number[] = [];
+        for (const stop of pattern.stops) {
+          const groups = timetable[stop.id];
+          const group = groups.find((g) => g.tp === patId);
+          expect(group).toBeDefined();
+          lengths.push(group!.d['test:WD'].length);
+        }
+        const unique = [...new Set(lengths)];
+        expect(unique).toHaveLength(1);
+      }
+    });
+
+    it('cross-stop d/a length consistency within (patternId, serviceId)', () => {
+      // Re-use the express + local fixture from the first test and assert
+      // that for each pattern, every stop has the same d/a length. This is
+      // the structural invariant Issue #154 directly targets.
+      db.exec(`
+        INSERT INTO trips VALUES ('EXP', 'R001', 'WD', '快速', 0);
+        INSERT INTO trips VALUES ('LOC', 'R001', 'WD', '快速', 0);
+        INSERT INTO stop_times VALUES ('EXP', 'S1', 1, '08:00:00', '08:00:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('EXP', 'S2', 2, NULL, NULL, 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('EXP', 'S3', 3, '08:05:00', '08:05:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('EXP', 'S4', 4, NULL, NULL, 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('EXP', 'S5', 5, '08:10:00', '08:10:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('LOC', 'S1', 1, '09:00:00', '09:00:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('LOC', 'S2', 2, '09:02:00', '09:02:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('LOC', 'S3', 3, '09:04:00', '09:04:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('LOC', 'S4', 4, '09:06:00', '09:06:00', 0, 0, NULL);
+        INSERT INTO stop_times VALUES ('LOC', 'S5', 5, '09:08:00', '09:08:00', 0, 0, NULL);
+      `);
+
+      const { tripPatterns, timetable } = extractTripPatternsAndTimetable(db, 'test');
+      for (const [patId, pattern] of Object.entries(tripPatterns)) {
+        const dLengths: number[] = [];
+        const aLengths: number[] = [];
+        for (const stop of pattern.stops) {
+          const group = timetable[stop.id].find((g) => g.tp === patId)!;
+          dLengths.push(group.d['test:WD'].length);
+          aLengths.push(group.a['test:WD'].length);
+        }
+        expect([...new Set(dLengths)]).toHaveLength(1);
+        expect([...new Set(aLengths)]).toHaveLength(1);
+        expect(dLengths[0]).toBe(aLengths[0]);
+      }
+    });
+
+    it('served-only filter keeps stop_headsign attached to the correct stop (regression guard)', () => {
+      // The pre-#154 code read sh from refTrip.stopHeadsigns indexed by raw
+      // position. Once pattern.stops becomes served-only, that raw index
+      // misaligns and sh would attach to the wrong stop. This test pins the
+      // fix that step 5 reads sh from the served-only group field instead.
+      db.exec(`
+        INSERT INTO trips VALUES ('T001', 'R001', 'WD', '', 0);
+        INSERT INTO stop_times VALUES ('T001', 'S1', 1, '08:00:00', '08:00:00', 0, 0, 'A');
+        INSERT INTO stop_times VALUES ('T001', 'S2', 2, NULL, NULL, 0, 0, 'X');
+        INSERT INTO stop_times VALUES ('T001', 'S3', 3, '08:10:00', '08:10:00', 0, 0, 'C');
+      `);
+
+      const { tripPatterns } = extractTripPatternsAndTimetable(db, 'test');
+      const p = tripPatterns['test:p1'];
+      expect(p.stops).toEqual([
+        { id: 'test:S1', sh: 'A' },
+        { id: 'test:S3', sh: 'C' },
+      ]);
+      // Specifically: S3's sh must be 'C' (its own value), not 'X' (the
+      // pass-through stop's value that would leak in if raw index was used).
+      expect(p.stops[1].sh).toBe('C');
+    });
+
+    it('skips trips where all stops have NULL departure_time and emits a warning', () => {
+      // A trip with no served stops would otherwise produce a zero-length
+      // pattern.stops, which downstream consumers cannot meaningfully use.
+      // Check both behaviors: the trip is dropped and the warning is emitted.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        db.exec(`
+          INSERT INTO trips VALUES ('EMPTY', 'R001', 'WD', '回送', 0);
+          INSERT INTO trips VALUES ('NORMAL', 'R001', 'WD', '渋谷', 0);
+          INSERT INTO stop_times VALUES ('EMPTY', 'S1', 1, NULL, NULL, 0, 0, NULL);
+          INSERT INTO stop_times VALUES ('EMPTY', 'S2', 2, NULL, NULL, 0, 0, NULL);
+          INSERT INTO stop_times VALUES ('EMPTY', 'S3', 3, NULL, NULL, 0, 0, NULL);
+          INSERT INTO stop_times VALUES ('NORMAL', 'S1', 1, '09:00:00', '09:00:00', 0, 0, NULL);
+          INSERT INTO stop_times VALUES ('NORMAL', 'S2', 2, '09:05:00', '09:05:00', 0, 0, NULL);
+        `);
+
+        const { tripPatterns } = extractTripPatternsAndTimetable(db, 'test');
+        // Only the normal trip's pattern is emitted.
+        expect(Object.keys(tripPatterns)).toHaveLength(1);
+        expect(tripPatterns['test:p1'].stops).toEqual([{ id: 'test:S1' }, { id: 'test:S2' }]);
+
+        // Warning fires once with the skipped count.
+        const warnings = warnSpy.mock.calls
+          .map((args) => String(args[0]))
+          .filter((msg) => msg.includes('trips skipped (all stops have NULL departure_time)'));
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain('1 trips skipped');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 });

--- a/pipeline/src/lib/pipeline/app-data-v2/gtfs/extract-timetable.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/gtfs/extract-timetable.ts
@@ -174,11 +174,31 @@ export function extractTripPatternsAndTimetable(
     console.warn(`  [${prefix}] WARN: ${skipped} stop_times skipped (trip not found)`);
   }
 
-  // 4. Group trips by pattern (route + headsign + direction + stop sequence + stop headsigns)
-  // stop_headsign is included in the key so that trips with the same stop
-  // sequence but different stop_headsign values form separate patterns.
-  const patternKey = (t: TripStopTimes): string =>
-    `${t.routeId}\0${t.headsign}\0${t.directionId ?? ''}\0${JSON.stringify(t.stops)}\0${JSON.stringify(t.stopHeadsigns)}`;
+  // 4. Group trips by pattern.
+  //
+  // Pattern key = (route, headsign, direction, served stop sequence, served stop headsigns).
+  // "Served" means the trip has a non-null departure_time at that stop_times row.
+  //
+  // Pass-through stops (NULL departure_time, e.g. express trains skipping a
+  // station while local trains stop there) MUST NOT participate in the key.
+  // Including them would merge express and local trips into a single pattern
+  // even though they actually stop at different sets of stations, and the
+  // per-stop d[serviceId] arrays would then have inconsistent lengths across
+  // stops within one (patternId, serviceId) — see Issue #154.
+  //
+  // The set of stops emitted in pattern.stops, the set walked in step 6 to
+  // build the timetable, and the timetable inclusion rule (`dep != null`)
+  // must all agree. Otherwise pattern.stops[si] and the timetable's si lose
+  // alignment.
+  //
+  // stop_headsign is also part of the key so that trips with the same served
+  // stop sequence but different stop_headsign values form separate patterns
+  // (see #92).
+  const patternKey = (t: TripStopTimes, servedIdx: number[]): string => {
+    const servedStops = servedIdx.map((i) => t.stops[i]);
+    const servedHeadsigns = servedIdx.map((i) => t.stopHeadsigns[i]);
+    return `${t.routeId}\0${t.headsign}\0${t.directionId ?? ''}\0${JSON.stringify(servedStops)}\0${JSON.stringify(servedHeadsigns)}`;
+  };
 
   const patternGroups = new Map<
     string,
@@ -188,31 +208,57 @@ export function extractTripPatternsAndTimetable(
       directionId: number | null;
       stops: string[];
       stopHeadsigns: (string | null)[];
-      trips: TripStopTimes[];
+      trips: { trip: TripStopTimes; servedIdx: number[] }[];
     }
   >();
 
+  let skippedEmptyTrips = 0;
+
   for (const [, trip] of tripStopTimesMap) {
-    const key = patternKey(trip);
+    const servedIdx: number[] = [];
+    for (let i = 0; i < trip.departures.length; i++) {
+      if (trip.departures[i] != null) {
+        servedIdx.push(i);
+      }
+    }
+    if (servedIdx.length === 0) {
+      // A trip with no served stops cannot be located on a pattern and would
+      // produce a zero-length pattern.stops. Downstream consumers
+      // (build-trip-pattern-stats, build-trip-pattern-geo) defensively handle
+      // stops.length === 0 but would emit invalid placeholders. Skip the trip
+      // entirely instead.
+      skippedEmptyTrips++;
+      continue;
+    }
+
+    const servedStops = servedIdx.map((i) => trip.stops[i]);
+    const servedHeadsigns = servedIdx.map((i) => trip.stopHeadsigns[i]);
+    const key = patternKey(trip, servedIdx);
     let group = patternGroups.get(key);
     if (!group) {
       group = {
         routeId: trip.routeId,
         headsign: trip.headsign,
         directionId: trip.directionId,
-        stops: trip.stops,
-        stopHeadsigns: trip.stopHeadsigns,
+        stops: servedStops,
+        stopHeadsigns: servedHeadsigns,
         trips: [],
       };
       patternGroups.set(key, group);
     }
-    group.trips.push(trip);
+    group.trips.push({ trip, servedIdx });
+  }
+
+  if (skippedEmptyTrips > 0) {
+    console.warn(
+      `  [${prefix}] WARN: ${skippedEmptyTrips} trips skipped (all stops have NULL departure_time)`,
+    );
   }
 
   // 5. Sort patterns deterministically and assign IDs
   // Use code-unit comparison (< / >) instead of localeCompare to avoid
   // locale-dependent collation differences across environments.
-  const sortedPatterns = [...patternGroups.values()].sort((a, b) => {
+  const patternEntries = [...patternGroups.entries()].sort(([, a], [, b]) => {
     const ka = patternSortKey(a);
     const kb = patternSortKey(b);
     return ka < kb ? -1 : ka > kb ? 1 : 0;
@@ -222,17 +268,16 @@ export function extractTripPatternsAndTimetable(
   // Map from pattern key -> pattern ID for timetable building
   const patternIdByKey = new Map<string, string>();
 
-  for (let i = 0; i < sortedPatterns.length; i++) {
-    const p = sortedPatterns[i];
+  for (let i = 0; i < patternEntries.length; i++) {
+    const [key, p] = patternEntries[i];
     const patternId = `${prefix}:p${i + 1}`;
-    const key = patternKey(p.trips[0]);
     patternIdByKey.set(key, patternId);
 
-    // Use the first trip's stopHeadsigns as the representative values.
-    // All trips in the same pattern share the same stop_headsign at each
-    // stop — guaranteed by patternKey including stopHeadsigns.
-    const refTrip = p.trips[0];
-
+    // p.stops and p.stopHeadsigns are both already served-only (built in step
+    // 4 from the same servedIdx), so they are positionally aligned. Reading
+    // sh from p.stopHeadsigns[idx] — NOT from refTrip.stopHeadsigns[idx] —
+    // is required: refTrip.stopHeadsigns is the raw (full) stop list, which
+    // would misalign once pass-through stops are excluded.
     const pattern: TripPatternJson = {
       v: 2,
       r: `${prefix}:${p.routeId}`,
@@ -241,7 +286,7 @@ export function extractTripPatternsAndTimetable(
         const stop: TripPatternJson['stops'][number] = {
           id: `${prefix}:${s}`,
         };
-        const sh = refTrip.stopHeadsigns[idx];
+        const sh = p.stopHeadsigns[idx];
         // NULL = stop_headsign not specified → omit sh (consumer falls back to h).
         // In practice, the CSV→DB import converts empty CSV fields to NULL,
         // so sh is either a non-empty string or null here.
@@ -259,7 +304,7 @@ export function extractTripPatternsAndTimetable(
     tripPatterns[patternId] = pattern;
   }
 
-  console.log(`  [${prefix}] ${sortedPatterns.length} trip patterns`);
+  console.log(`  [${prefix}] ${patternEntries.length} trip patterns`);
 
   // 6. Build per-stop timetable
   // stopId -> patternId -> si (stop position within pattern) -> serviceId -> entries
@@ -276,53 +321,55 @@ export function extractTripPatternsAndTimetable(
   };
   const stopTimetable = new Map<string, Map<string, Map<number, Map<string, StopTimeData[]>>>>();
 
-  for (const [, trip] of tripStopTimesMap) {
-    const key = patternKey(trip);
+  // Iterate patterns instead of trips so we have direct access to (patId, key)
+  // and the per-trip servedIdx cached during step 4.
+  for (const [key, p] of patternGroups) {
     const patId = patternIdByKey.get(key)!;
-    const prefixedServiceId = `${prefix}:${trip.serviceId}`;
+    for (const { trip, servedIdx } of p.trips) {
+      const prefixedServiceId = `${prefix}:${trip.serviceId}`;
 
-    for (let stopIdx = 0; stopIdx < trip.stops.length; stopIdx++) {
-      const dep = trip.departures[stopIdx];
-      if (dep == null) {
-        continue;
+      // Walk the served indices only. By construction servedIdx[pos] points
+      // at a row whose departure_time is non-null, so dep is never null here.
+      // pos = 0-based position within pattern.stops (which is the served list)
+      // — this becomes the timetable group's `si`, ensuring pattern.stops[si]
+      // and timetable.si stay in 1:1 alignment.
+      for (let pos = 0; pos < servedIdx.length; pos++) {
+        const stopIdx = servedIdx[pos];
+        const dep = trip.departures[stopIdx]!;
+        const arr = trip.arrivals[stopIdx] ?? dep;
+        const pt = trip.pickupTypes[stopIdx] ?? 0;
+        const dt = trip.dropOffTypes[stopIdx] ?? 0;
+
+        // stop_id is not yet prefixed in the internal TripStopTimes
+        const prefixedStopId = `${prefix}:${trip.stops[stopIdx]}`;
+        const si = pos;
+
+        let patternMap = stopTimetable.get(prefixedStopId);
+        if (!patternMap) {
+          patternMap = new Map();
+          stopTimetable.set(prefixedStopId, patternMap);
+        }
+
+        let siMap = patternMap.get(patId);
+        if (!siMap) {
+          siMap = new Map();
+          patternMap.set(patId, siMap);
+        }
+
+        let serviceMap = siMap.get(si);
+        if (!serviceMap) {
+          serviceMap = new Map();
+          siMap.set(si, serviceMap);
+        }
+
+        let entries = serviceMap.get(prefixedServiceId);
+        if (!entries) {
+          entries = [];
+          serviceMap.set(prefixedServiceId, entries);
+        }
+
+        entries.push({ d: dep, a: arr, pt, dt });
       }
-
-      // stop_id is not yet prefixed in the internal TripStopTimes
-      const prefixedStopId = `${prefix}:${trip.stops[stopIdx]}`;
-      const arr = trip.arrivals[stopIdx] ?? dep;
-      const pt = trip.pickupTypes[stopIdx] ?? 0;
-      const dt = trip.dropOffTypes[stopIdx] ?? 0;
-
-      // si = 0-based position within pattern.stops. Same value across all trips
-      // of the same pattern (pattern key includes JSON.stringify(t.stops), so
-      // trip.stops and pattern.stops are aligned by index).
-      const si = stopIdx;
-
-      let patternMap = stopTimetable.get(prefixedStopId);
-      if (!patternMap) {
-        patternMap = new Map();
-        stopTimetable.set(prefixedStopId, patternMap);
-      }
-
-      let siMap = patternMap.get(patId);
-      if (!siMap) {
-        siMap = new Map();
-        patternMap.set(patId, siMap);
-      }
-
-      let serviceMap = siMap.get(si);
-      if (!serviceMap) {
-        serviceMap = new Map();
-        siMap.set(si, serviceMap);
-      }
-
-      let entries = serviceMap.get(prefixedServiceId);
-      if (!entries) {
-        entries = [];
-        serviceMap.set(prefixedServiceId, entries);
-      }
-
-      entries.push({ d: dep, a: arr, pt, dt });
     }
   }
 

--- a/pipeline/src/lib/pipeline/app-data-v2/gtfs/extract-timetable.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/gtfs/extract-timetable.ts
@@ -194,11 +194,12 @@ export function extractTripPatternsAndTimetable(
   // stop_headsign is also part of the key so that trips with the same served
   // stop sequence but different stop_headsign values form separate patterns
   // (see #92).
-  const patternKey = (t: TripStopTimes, servedIdx: number[]): string => {
-    const servedStops = servedIdx.map((i) => t.stops[i]);
-    const servedHeadsigns = servedIdx.map((i) => t.stopHeadsigns[i]);
-    return `${t.routeId}\0${t.headsign}\0${t.directionId ?? ''}\0${JSON.stringify(servedStops)}\0${JSON.stringify(servedHeadsigns)}`;
-  };
+  const patternKey = (
+    t: TripStopTimes,
+    servedStops: string[],
+    servedHeadsigns: (string | null)[],
+  ): string =>
+    `${t.routeId}\0${t.headsign}\0${t.directionId ?? ''}\0${JSON.stringify(servedStops)}\0${JSON.stringify(servedHeadsigns)}`;
 
   const patternGroups = new Map<
     string,
@@ -233,7 +234,7 @@ export function extractTripPatternsAndTimetable(
 
     const servedStops = servedIdx.map((i) => trip.stops[i]);
     const servedHeadsigns = servedIdx.map((i) => trip.stopHeadsigns[i]);
-    const key = patternKey(trip, servedIdx);
+    const key = patternKey(trip, servedStops, servedHeadsigns);
     let group = patternGroups.get(key);
     if (!group) {
       group = {

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -654,7 +654,7 @@ export function TripInspectionDialog({
             {/* Verbose info for debug */}
             {infoLevelFlag.isVerboseEnabled && (
               <>
-                <details className="mt-1 text-[10px] font-normal text-[#999] dark:text-gray-500">
+                <details className="mt-1 text-[9px] font-normal text-[#999] dark:text-gray-500">
                   <summary
                     tabIndex={-1}
                     className="cursor-pointer select-none"

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -44,6 +44,7 @@ import { findTripStopRow } from '../trip/trip-stop-row-dom';
 import { computeScrolledStopIndex, getSelectedRowScrollTop } from '../trip/trip-stop-scroll';
 import { TripStops } from '../trip/trip-stops';
 import { TripPager } from '../trip/trip-pager';
+import { VerboseTripLocator } from '../verbose/verbose-trip-locator';
 import { VerboseTripStopTime } from '../verbose/verbose-trip-stop-time';
 
 interface TripInspectionDialogProps {
@@ -76,6 +77,14 @@ interface StopSummaryProps {
   stopNames: ReturnType<typeof getStopDisplayNames> | null;
   stopName: string;
   infoLevel: InfoLevel;
+  /** Pre-formatted departure time for this stop (e.g. "16:10"). */
+  departureTime?: string;
+  /** Pre-formatted arrival time for this stop (e.g. "16:35"). */
+  arrivalTime?: string;
+  /** Render the departure time row when {@link departureTime} is provided. */
+  showDepartureTime?: boolean;
+  /** Render the arrival time row when {@link arrivalTime} is provided. */
+  showArrivalTime?: boolean;
 }
 
 interface RichStopSummaryProps {
@@ -99,7 +108,15 @@ function resolveTripStopDisplay(stop: TripStopTime | undefined, dataLangs: reado
   };
 }
 
-function SimpleStopSummary({ stopNames, stopName, infoLevel }: StopSummaryProps) {
+function SimpleStopSummary({
+  stopNames,
+  stopName,
+  infoLevel,
+  departureTime,
+  arrivalTime,
+  showDepartureTime = false,
+  showArrivalTime = false,
+}: StopSummaryProps) {
   const infoLevelFlag = useInfoLevel(infoLevel);
   return (
     <div className="min-w-0 rounded-md border p-2">
@@ -109,6 +126,16 @@ function SimpleStopSummary({ stopNames, stopName, infoLevel }: StopSummaryProps)
         </div>
       )}
       <div className="truncate text-center text-sm font-medium">{stopName}</div>
+      {showArrivalTime && arrivalTime != null && (
+        <div className="text-muted-foreground truncate text-center text-xs tabular-nums">
+          {arrivalTime}
+        </div>
+      )}
+      {showDepartureTime && departureTime != null && (
+        <div className="text-muted-foreground truncate text-center text-xs tabular-nums">
+          {departureTime}
+        </div>
+      )}
     </div>
   );
 }
@@ -252,7 +279,10 @@ function TripInspectionCurrentStop({ snapshot }: TripInspectionCurrentStopProps)
   );
 }
 
-function TripInspectionRowsSummary({ snapshot }: TripInspectionCurrentStopProps) {
+function TripInspectionRowsSummary({
+  snapshot,
+  defaultOpen = false,
+}: TripInspectionCurrentStopProps & { defaultOpen?: boolean }) {
   const totalStops = snapshot.selectedStop.timetableEntry.patternPosition.totalStops;
   const selectedStopIndex = snapshot.selectedStop.timetableEntry.patternPosition.stopIndex;
   const stopByIndex = new Map(
@@ -288,7 +318,10 @@ function TripInspectionRowsSummary({ snapshot }: TripInspectionCurrentStopProps)
   );
 
   return (
-    <details className="mt-1 text-[9px] font-normal text-[#999] dark:text-gray-500">
+    <details
+      open={defaultOpen}
+      className="mt-1 text-[9px] font-normal text-[#999] dark:text-gray-500"
+    >
       <summary
         tabIndex={-1}
         className="cursor-pointer select-none"
@@ -296,16 +329,20 @@ function TripInspectionRowsSummary({ snapshot }: TripInspectionCurrentStopProps)
       >
         [RowsSummary]
       </summary>
-      <section className="mt-0.5 space-y-1 rounded-md border px-2 py-2 font-mono text-[11px] leading-4">
-        <div>
-          [rows] reconstructed={snapshot.stopTimes.length} expected={totalStops}{' '}
-          missingPatternStops=
-          {missingPatternStops.length > 0 ? `[${missingPatternStops.join(',')}]` : '[]'}
+      <div className="mt-0.5 space-y-0.5">
+        <div className="border-app-neutral overflow-x-auto rounded border border-dashed p-1.5 whitespace-nowrap">
+          <p className="m-0">
+            [rows] reconstructed={snapshot.stopTimes.length} expected={totalStops}{' '}
+            missingPatternStops=
+            {missingPatternStops.length > 0 ? `[${missingPatternStops.join(',')}]` : '[]'}
+          </p>
+          {lines.map((line: string, index: number) => (
+            <div key={index} className="m-0">
+              {line}
+            </div>
+          ))}
         </div>
-        {lines.map((line: string, index: number) => (
-          <div key={index}>{line}</div>
-        ))}
-      </section>
+      </div>
     </details>
   );
 }
@@ -505,6 +542,11 @@ export function TripInspectionDialog({
     firstStop,
     dataLangs,
   );
+  const firstStopDepartureTime = firstStop
+    ? formatAbsoluteTime(
+        minutesToDate(snapshot.serviceDate, firstStop.timetableEntry.schedule.departureMinutes),
+      )
+    : undefined;
 
   // Last TripStopTime
   const lastStop = tripStopTimes[tripStopTimes.length - 1];
@@ -512,6 +554,11 @@ export function TripInspectionDialog({
     lastStop,
     dataLangs,
   );
+  const lastStopArrivalTime = lastStop
+    ? formatAbsoluteTime(
+        minutesToDate(snapshot.serviceDate, lastStop.timetableEntry.schedule.arrivalMinutes),
+      )
+    : undefined;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -575,6 +622,8 @@ export function TripInspectionDialog({
                 stopNames={firstStopNames}
                 stopName={firstStopName}
                 infoLevel={infoLevel}
+                departureTime={firstStopDepartureTime}
+                showDepartureTime
               />
               <div className="flex items-center justify-center">
                 <span
@@ -586,6 +635,8 @@ export function TripInspectionDialog({
                 stopNames={lastStopNames}
                 stopName={lastStopName}
                 infoLevel={infoLevel}
+                arrivalTime={lastStopArrivalTime}
+                showArrivalTime
               />
             </div>
           </DialogDescription>
@@ -599,16 +650,32 @@ export function TripInspectionDialog({
               infoLevel={infoLevel}
               dataLangs={dataLangs}
             />
+
+            {/* Verbose info for debug */}
             {infoLevelFlag.isVerboseEnabled && (
               <>
-                {/* {now.toISOString()} */}
-                <TripInspectionCurrentStop snapshot={snapshot} />
-                <VerboseTripStopTime
-                  tripStopTime={snapshot.selectedStop}
-                  serviceDate={snapshot.serviceDate}
-                  dataLangs={dataLangs}
-                />
-                <TripInspectionRowsSummary snapshot={snapshot} />
+                <details className="mt-1 text-[10px] font-normal text-[#999] dark:text-gray-500">
+                  <summary
+                    tabIndex={-1}
+                    className="cursor-pointer select-none"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    [Verbose]
+                  </summary>
+
+                  <div className="mt-1 space-y-1">
+                    {now.toISOString()}
+                    <TripInspectionCurrentStop snapshot={snapshot} />
+                    <VerboseTripLocator locator={snapshot.locator} defaultOpen={true} />
+                    <VerboseTripStopTime
+                      tripStopTime={snapshot.selectedStop}
+                      serviceDate={snapshot.serviceDate}
+                      dataLangs={dataLangs}
+                      defaultOpen={true}
+                    />
+                    <TripInspectionRowsSummary snapshot={snapshot} defaultOpen={true} />
+                  </div>
+                </details>
               </>
             )}
           </div>

--- a/src/components/trip/trip-stops.tsx
+++ b/src/components/trip/trip-stops.tsx
@@ -240,16 +240,18 @@ function TripStopRow({
           )}
         </div>
       </div>
-      <TripInfo
-        size="md"
-        routeDirection={tripStopTime.timetableEntry.routeDirection}
-        infoLevel={infoLevel}
-        dataLangs={dataLangs}
-        showRouteTypeIcon={false}
-        agency={stopAgency}
-        showAgency={false}
-        attributes={stopAttributes}
-      />
+      {infoLevelFlag.isDetailedEnabled && (
+        <TripInfo
+          size="md"
+          routeDirection={tripStopTime.timetableEntry.routeDirection}
+          infoLevel={infoLevel}
+          dataLangs={dataLangs}
+          showRouteTypeIcon={false}
+          agency={stopAgency}
+          showAgency={false}
+          attributes={stopAttributes}
+        />
+      )}
 
       {infoLevelFlag.isVerboseEnabled && (
         <>

--- a/src/components/verbose/verbose-trip-locator.tsx
+++ b/src/components/verbose/verbose-trip-locator.tsx
@@ -1,0 +1,42 @@
+import type { TripLocator } from '../../types/app/transit-composed';
+
+/**
+ * Debug dump of a TripLocator (patternId, serviceId, tripIndex).
+ *
+ * Surfaces the three fields that uniquely identify a reconstructed trip
+ * in v2 data so they can be cross-referenced against the data files
+ * (`tripPatterns[patternId]`, `timetable[stopId][].d[serviceId][tripIndex]`)
+ * during debugging.
+ *
+ * Symmetric with the console.debug log emitted by
+ * `buildTripInspectionSummaryLog` (`pattern=... service=... tripIndex=...`).
+ */
+export function VerboseTripLocator({
+  locator,
+  defaultOpen = false,
+}: {
+  locator: TripLocator;
+  defaultOpen?: boolean;
+}) {
+  return (
+    <details
+      open={defaultOpen}
+      className="mt-1 text-[9px] font-normal text-[#999] dark:text-gray-500"
+    >
+      <summary
+        tabIndex={-1}
+        className="cursor-pointer select-none"
+        onClick={(e) => e.stopPropagation()}
+      >
+        [TripLocator]
+      </summary>
+      <div className="mt-0.5 space-y-0.5">
+        <div className="border-app-neutral overflow-x-auto rounded border border-dashed p-1.5 whitespace-nowrap">
+          <p className="m-0">
+            pattern={locator.patternId} service={locator.serviceId} tripIndex={locator.tripIndex}
+          </p>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/src/types/data/transit-v2-json.ts
+++ b/src/types/data/transit-v2-json.ts
@@ -357,10 +357,25 @@ export interface TripPatternJson {
    * Derived from GTFS stop_times (ORDER BY stop_sequence) or
    * ODPT stationOrder truncated at destinationStation.
    *
-   * **Note**: Some stops in this array may have no corresponding
-   * timetable entry (e.g. GTFS stops with NULL departure_time —
-   * intermediate timepoints without scheduled stop times). Consumers
-   * MUST NOT assume every stop has stop times in the timetable.
+   * **Note**: how `stops` is constructed is source-dependent:
+   *
+   * - **GTFS-derived patterns** (pipeline `gtfs/extract-timetable.ts`):
+   *   `stops` lists only the stops where the trips of this pattern
+   *   actually stop, i.e. stop_times rows whose `departure_time` is
+   *   non-null. Pass-through stations (NULL `departure_time`) are
+   *   excluded. The timetable group's `si` is the 0-based index into
+   *   `stops`, so `pattern.stops[si]` and the timetable entry for that
+   *   `si` are in 1:1 correspondence.
+   * - **ODPT-derived patterns** (pipeline `odpt/build-timetable.ts`):
+   *   `stops` is built from the railway's `stationOrder` truncated at
+   *   the destination, independently of whether each station has actual
+   *   timetable data. A stop in `stops` may therefore have no
+   *   corresponding timetable group (e.g. terminal stations with no
+   *   StationTimetable in the source).
+   *
+   * Across sources, consumers MUST NOT assume every stop has stop
+   * times in the timetable. When a (patternId, si) lookup yields no
+   * group, treat it as "no scheduled stop time" rather than an error.
    */
   stops: {
     /** Stop ID (prefixed). FK -> stops section in DataBundle. */


### PR DESCRIPTION
## Summary

- Fixes Issue #154 (GTFS pipeline pattern key includes pass-through stops, breaking trip reconstruction). The GTFS extractor now derives `patternKey` from the *served* stop sequence (rows whose `departure_time` is non-null), so express and local trips with different served-stop subsets form separate `TripPattern`s. Within each resulting pattern, the per-stop `d[serviceId]` arrays have consistent length across stops, so `buildTripStopTimes` resolves a single trip identity end-to-end.
- Adds a `VerboseTripLocator` component and shows it in `TripInspectionDialog`'s verbose section, exposing the v2 lookup keys (`patternId`, `serviceId`, `tripIndex`) for cross-referencing the data files. Also threads the trip's first-stop departure time and last-stop arrival time into `SimpleStopSummary` so users see the actual trip start / end times next to the stop names. Per-row `TripInfo` is gated to the detailed info level to keep the default trip-stops list compact.

Refs: #154

## Files changed

| File | Type | Notes |
|--|--|--|
| `pipeline/src/lib/pipeline/app-data-v2/gtfs/extract-timetable.ts` | impl | served-only `patternKey`; emit `pattern.stops` / `pattern.stops[].sh` from group-stored served versions; iterate timetable by served indices; skip empty trips with one warning line |
| `pipeline/src/lib/pipeline/app-data-v2/gtfs/__tests__/extract-timetable.test.ts` | tests | renamed two existing tests to fit the new contract; added six new tests (express + local separation, through-running mid-pattern skip, cross-stop d/a length, sh regression guard, empty-trip skip + warning, terminal arr-only exclusion) |
| `src/types/data/transit-v2-json.ts` | docs | rewrote `TripPatternJson.stops` Note to document source-dependent semantics: GTFS = served-only / ODPT = `stationOrder`-based |
| `src/components/dialog/trip-inspection-dialog.tsx` | UI | wire `VerboseTripLocator` in; add `departureTime` / `arrivalTime` props to `SimpleStopSummary`; align `TripInspectionRowsSummary` with the other verbose blocks (`text-[9px]`, dashed border, `defaultOpen` prop) |
| `src/components/verbose/verbose-trip-locator.tsx` | UI (new) | small `<details>` block rendering `pattern=` / `service=` / `tripIndex=` |
| `src/components/trip/trip-stops.tsx` | UI | per-row `TripInfo` is now gated behind `infoLevelFlag.isDetailedEnabled` |

## Verification

### Structural invariant (cross-stop `d_len`)

Re-built data for all 20 GTFS sources and compared the `(patternId, serviceId)` cross-stop `d.length` invariant against the pre-fix baseline:

| Source | Mismatches (before) | Mismatches (after) |
|--|--|--|
| `mir` (TX) | **6** (e.g. `mir:p1 / mir:0 → d_lens=[33,41,89,97,118]`) | **0** |
| `toaran` (Toei) | **19** (e.g. `toaran:p17 / toaran:0 → d_lens=[26,37]`) | **0** |
| Other 19 GTFS sources | 0 | 0 |

### Pattern count change

| Source | Before | After | Ratio | Note |
|--|--|--|--|--|
| `mir` | 9 | 16 | 1.78x | TX local / sectional rapid / commuter rapid / rapid split |
| `toaran` | 106 | 115 | 1.08x | Asakusa-line through-running, Shinjuku-line variants split |
| Other 19 sources | (each) | (same) | 1.00x | bus and other train feeds — no NULL-dep rows, no impact |

### Smoking guns confirmed in `TripInspectionDialog`

Three different visible symptoms of the same root cause (`tripIndex` cannot consistently identify a single trip when express and local share a `TripPattern`), all resolved post-fix:

1. **mir 05:42 local (Akihabara → Tsukuba)** — Issue body's smoking gun. Pre-fix: `r19 6:43 → r20 6:36` time inversion at the terminus. Post-fix: `r19 6:43 → r20 6:45`, monotonic.
2. **mir 05:51 rapid** — pre-fix: scrambled departure times throughout. Post-fix: 10 served stops in a dedicated `mir:p4` pattern, monotonic 05:51 → 06:36 (matches official TX timetable).
3. **toaran 16:10 local (Sengakuji → Oshiage)** — pre-fix: six interior stations missing from the reconstructed trip even though the train stops there. Post-fix: all 14 stops present in `toaran:p18`, monotonic 16:10 → 16:35 (matches official Toei timetable).

See verification comments on Issue #154 for the full before / after dialog dumps.

### arr-only row check (terminal arr-only concern)

`SELECT COUNT(*) FROM stop_times WHERE departure_time IS NULL AND arrival_time IS NOT NULL` returned **0** for every GTFS source. The terminal-arr-only edge case documented in the Plan does not surface in current data.

### Tests

- `pipeline` 819 tests pass.
- WebApp 2678 tests pass.
- Lint, format, typecheck, build all clean.

## Out of scope (deliberately not touched)

- `pipeline/.../odpt/build-timetable.ts` — ODPT-side equivalent issue tracked in #153.
- `src/repositories/.../buildTripStopTimes` and callers — interface unchanged.
- `athenai-repository-v2.ts:213-229` "first-wins" route-shape aggregation — rail feeds may now see `pathDist` / `cl` representative values that depend on which split pattern sorts first; left for a separate downstream cleanup.
- `pattern.stops` short-circuit downstream consequences for rail feeds: `tripPatternGeo.pathDist` / `cl` and `tripPatternStats.rd` shift to "served-stop-based" semantics. Bus feeds unaffected. `TripPatternJson.stops` TSDoc updated to make this explicit.
- Permanent cross-stop `d_len` validator at the `validate-data` step is tracked as a follow-up in #156 (deferred until #153 + #154 are both merged).
- `public/data-v2/` is **not** updated by this PR — production data refresh happens out of band on the user's normal data-update cadence.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npx prettier --check`
- [x] `npx vitest run pipeline/`
- [x] `npx vitest run src/`
- [x] `npm run build`
- [x] `npm run pipeline:build:v2-data` (regenerated all 20 GTFS sources, no errors)
- [x] Manual `TripInspectionDialog` checks for the three smoking-gun trips above
- [x] arr-only DB query across all GTFS sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)
