### PR TITLE
feat(pipeline): cross-group + symmetric within-group d/a consistency checks (closes #156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - `time-style.ts` に explicit time band 定義を追加 (morning / daytime / evening / night band を明示)。
 - Pipeline: りんかい線 (東京臨海高速鉄道株式会社) の GTFS データソースを追加 (prefix `twrr`, route_type 2 rail)。8 駅 / 1 路線。`shapes.txt` は含まれないが MLIT 国土数値情報 (臨海副都心線) 経由で路線図に対応。`data-source-settings` の `routeTypes` は `[1, 2]` (subway + rail) — 実態として地下鉄区間を含むため将来の Source 選択 UI 用に両方を宣言。
 - About: りんかい線のクレジット・データ情報を追加。
+- Pipeline: `validate-data.ts` に bundle-level cross-group d/a length consistency 検証を追加 (Refs: #156)。各 `(patternId, serviceId)` ペアについて、当該 pattern の全 emitted timetable groups で `d[serviceId].length` および `a[serviceId].length` が一致することを assert。WebApp の `buildTripStopTimes` における `tripIndex` alignment が前提とする invariant を、最終出力 `data.json` 段階で fail-fast に検知。`pattern.stops` のうち emitted group を持たない stop は対象外 (= ODPT 由来の sparse pattern を許容)。`a` 単独で出現する serviceId も union keyset で正しく検査される。
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ### Changed
 
+- Pipeline: `validate-data.ts` の per-group d/a presence check を symmetric 化。`d[sid]` / `a[sid]` の片側欠落をいずれの方向でも error として検知 (= 既存は d-only side のみ flag、a-only side は silent だった)。`d` と `a` は同 trip / 同 stop の positional pair なので、片側欠落は builder regression のサイン。現 data には影響なし (= GTFS / ODPT builder は常に両方 populate)。
 - `StopTimeItem` を building block (`StopTimeDetailInfo` / `StopTimeTimeInfo`) に分離し、`TripInspectionDialog` と共通化 (260 行 → 約 100 行 + 子コンポーネント)。
 - `StopTimeItem` の絶対/相対時刻受け渡しを explicit な time props に変更し、caller 側で表示ポリシーを制御可能に。
 - `StopSummary` に display flag 群 (agency / trip count / connectivity 等) を追加し、nearby-stop / marker context で切替可能に。

--- a/pipeline/src/lib/pipeline/app-data-v2/__tests__/validate-data.test.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/__tests__/validate-data.test.ts
@@ -987,13 +987,14 @@ describe('validateDataBundle', () => {
         (i) => i.message.includes('d.length differs across emitted groups') && i.level === 'error',
       );
       expect(dErrors).toHaveLength(1);
-      // Message must identify pattern, service, both differing lengths, and example stops.
+      // Message must identify pattern, service, both differing lengths, and example labels.
       const m = dErrors[0].message;
       expect(m).toContain('test:P1');
       expect(m).toContain('test:SVC1');
       expect(m).toContain('2');
       expect(m).toContain('3');
-      expect(m).toMatch(/test:S[ABC]/);
+      // Example labels combine stopId and si (= disambiguates circular patterns).
+      expect(m).toMatch(/test:S[ABC]@si=\d+/);
     });
 
     it('#3: flags a.length mismatch independently of d', () => {
@@ -1194,6 +1195,95 @@ describe('validateDataBundle', () => {
       expect(aErrors).toHaveLength(1);
       expect(aErrors[0].message).toContain('test:P1');
       expect(aErrors[0].message).toContain('test:SVC1');
+    });
+
+    it('#7: disambiguates circular pattern via si in example labels', () => {
+      // Circular / 6-shape pattern: same stopId at two si positions in
+      // pattern.stops. The two emitted groups for that stopId can have
+      // different lengths (different visits of a loop). Without si, the
+      // error message would list `test:SLoop` under both lengths and be
+      // ambiguous. The label `${stopId}@si=N` disambiguates them.
+      const bundle = makeValidBundle({
+        stops: {
+          v: 2,
+          data: [
+            { v: 2, i: 'test:SA', n: 'Stop A (start)', a: 35.68, o: 139.76, l: 0 },
+            { v: 2, i: 'test:SLoop', n: 'Stop Loop (visited twice)', a: 35.69, o: 139.77, l: 0 },
+            { v: 2, i: 'test:SC', n: 'Stop C (terminal)', a: 35.7, o: 139.78, l: 0 },
+          ],
+        },
+        tripPatterns: {
+          v: 2,
+          data: {
+            'test:P1': {
+              v: 2,
+              r: 'test:R1',
+              h: 'Terminal',
+              // SA -> SLoop -> SC -> SLoop (= circular: SLoop visited at si=1 and si=3)
+              stops: [
+                { id: 'test:SA' },
+                { id: 'test:SLoop' },
+                { id: 'test:SC' },
+                { id: 'test:SLoop' },
+              ],
+            },
+          },
+        },
+        timetable: {
+          v: 2,
+          data: {
+            'test:SA': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 0,
+                d: { 'test:SVC1': [480, 540, 600] },
+                a: { 'test:SVC1': [480, 540, 600] },
+              },
+            ],
+            'test:SLoop': [
+              // First visit (si=1) emits 3 entries.
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 1,
+                d: { 'test:SVC1': [482, 542, 602] },
+                a: { 'test:SVC1': [482, 542, 602] },
+              },
+              // Second visit (si=3) emits only 2 entries — length mismatch.
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 3,
+                d: { 'test:SVC1': [486, 546] },
+                a: { 'test:SVC1': [486, 546] },
+              },
+            ],
+            'test:SC': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 2,
+                d: { 'test:SVC1': [484, 544, 604] },
+                a: { 'test:SVC1': [484, 544, 604] },
+              },
+            ],
+          },
+        },
+      });
+      writeBundle('cgl-circular', bundle);
+      const result = validateDataBundle('cgl-circular', TMP_DIR);
+      const dErrors = result.issues.filter(
+        (i) => i.message.includes('d.length differs across emitted groups') && i.level === 'error',
+      );
+      expect(dErrors).toHaveLength(1);
+      const m = dErrors[0].message;
+      // Both si positions of test:SLoop must be unambiguously identifiable.
+      expect(m).toContain('test:SLoop@si=1');
+      expect(m).toContain('test:SLoop@si=3');
+      // Both differing lengths (3 and 2) appear.
+      expect(m).toContain('2');
+      expect(m).toContain('3');
     });
   });
 });

--- a/pipeline/src/lib/pipeline/app-data-v2/__tests__/validate-data.test.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/__tests__/validate-data.test.ts
@@ -553,6 +553,36 @@ describe('validateDataBundle', () => {
       ).toBe(true);
     });
 
+    it('reports error when a has service_id but d does not (= symmetric to d-only)', () => {
+      // a[sid] without d[sid] is the same kind of anomaly as the inverse.
+      // Builders always populate d and a together; a single-sided entry
+      // is a regression sign and must be flagged.
+      const bundle = makeValidBundle({
+        timetable: {
+          v: 2,
+          data: {
+            'test:S1': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 0,
+                d: { 'test:SVC1': [480] },
+                a: { 'test:SVC1': [480], 'test:SVC2': [600] },
+              },
+            ],
+          },
+        },
+      });
+      writeBundle('missing-d-sid', bundle);
+
+      const result = validateDataBundle('missing-d-sid', TMP_DIR);
+      expect(
+        result.issues.some(
+          (i) => i.level === 'error' && i.message.includes('has arrivals but no departures'),
+        ),
+      ).toBe(true);
+    });
+
     it('passes when d and a have matching lengths', () => {
       writeBundle('da-ok', makeValidBundle());
 

--- a/pipeline/src/lib/pipeline/app-data-v2/__tests__/validate-data.test.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/__tests__/validate-data.test.ts
@@ -864,4 +864,306 @@ describe('validateDataBundle', () => {
       expect(siErrors).toHaveLength(0);
     });
   });
+
+  describe('cross-group d/a length consistency (Issue #156)', () => {
+    /**
+     * Build a 3-stop pattern with one timetable group per stop, one
+     * service. Defaults give a uniform-length bundle; overrides per stop
+     * let each test inject specific d/a arrays for the mismatch fixtures.
+     */
+    function buildBundleWithThreeStops(perStop: {
+      A: { d: number[]; a: number[] };
+      B: { d: number[]; a: number[] };
+      C: { d: number[]; a: number[] };
+    }): DataBundle {
+      return makeValidBundle({
+        stops: {
+          v: 2,
+          data: [
+            { v: 2, i: 'test:SA', n: 'Stop A', a: 35.68, o: 139.76, l: 0 },
+            { v: 2, i: 'test:SB', n: 'Stop B', a: 35.69, o: 139.77, l: 0 },
+            { v: 2, i: 'test:SC', n: 'Stop C', a: 35.7, o: 139.78, l: 0 },
+          ],
+        },
+        tripPatterns: {
+          v: 2,
+          data: {
+            'test:P1': {
+              v: 2,
+              r: 'test:R1',
+              h: 'Terminal',
+              stops: [{ id: 'test:SA' }, { id: 'test:SB' }, { id: 'test:SC' }],
+            },
+          },
+        },
+        timetable: {
+          v: 2,
+          data: {
+            'test:SA': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 0,
+                d: { 'test:SVC1': perStop.A.d },
+                a: { 'test:SVC1': perStop.A.a },
+              },
+            ],
+            'test:SB': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 1,
+                d: { 'test:SVC1': perStop.B.d },
+                a: { 'test:SVC1': perStop.B.a },
+              },
+            ],
+            'test:SC': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 2,
+                d: { 'test:SVC1': perStop.C.d },
+                a: { 'test:SVC1': perStop.C.a },
+              },
+            ],
+          },
+        },
+      });
+    }
+
+    it('#1: accepts uniform d.length / a.length across emitted groups', () => {
+      const bundle = buildBundleWithThreeStops({
+        A: { d: [480, 540, 600], a: [480, 540, 600] },
+        B: { d: [482, 542, 602], a: [482, 542, 602] },
+        C: { d: [484, 544, 604], a: [484, 544, 604] },
+      });
+      writeBundle('cgl-uniform', bundle);
+      const result = validateDataBundle('cgl-uniform', TMP_DIR);
+      const crossGroupIssues = result.issues.filter((i) =>
+        i.message.includes('differs across emitted groups'),
+      );
+      expect(crossGroupIssues).toHaveLength(0);
+    });
+
+    it('#2: flags d.length mismatch with patternId / serviceId / example stops', () => {
+      const bundle = buildBundleWithThreeStops({
+        A: { d: [480, 540, 600], a: [480, 540, 600] },
+        B: { d: [482, 542], a: [482, 542] }, // shorter
+        C: { d: [484, 544, 604], a: [484, 544, 604] },
+      });
+      writeBundle('cgl-d-mismatch', bundle);
+      const result = validateDataBundle('cgl-d-mismatch', TMP_DIR);
+      const dErrors = result.issues.filter(
+        (i) => i.message.includes('d.length differs across emitted groups') && i.level === 'error',
+      );
+      expect(dErrors).toHaveLength(1);
+      // Message must identify pattern, service, both differing lengths, and example stops.
+      const m = dErrors[0].message;
+      expect(m).toContain('test:P1');
+      expect(m).toContain('test:SVC1');
+      expect(m).toContain('2');
+      expect(m).toContain('3');
+      expect(m).toMatch(/test:S[ABC]/);
+    });
+
+    it('#3: flags a.length mismatch independently of d', () => {
+      const bundle = buildBundleWithThreeStops({
+        // d is uniform across all stops; only a differs at stop B.
+        A: { d: [480, 540, 600], a: [480, 540, 600] },
+        B: { d: [482, 542, 602], a: [482, 542] },
+        C: { d: [484, 544, 604], a: [484, 544, 604] },
+      });
+      writeBundle('cgl-a-mismatch', bundle);
+      const result = validateDataBundle('cgl-a-mismatch', TMP_DIR);
+      const aErrors = result.issues.filter(
+        (i) => i.message.includes('a.length differs across emitted groups') && i.level === 'error',
+      );
+      const dErrors = result.issues.filter((i) =>
+        i.message.includes('d.length differs across emitted groups'),
+      );
+      expect(aErrors).toHaveLength(1);
+      expect(dErrors).toHaveLength(0);
+      expect(aErrors[0].message).toContain('test:P1');
+      expect(aErrors[0].message).toContain('test:SVC1');
+    });
+
+    it('#4: accepts pattern with stops missing a timetable group', () => {
+      // Pattern has 3 stops in `pattern.stops`, but only 2 of them have an
+      // emitted timetable group. The two emitted groups agree on length;
+      // the missing third stop must NOT trigger any cross-group issue.
+      const bundle = makeValidBundle({
+        stops: {
+          v: 2,
+          data: [
+            { v: 2, i: 'test:SA', n: 'Stop A', a: 35.68, o: 139.76, l: 0 },
+            { v: 2, i: 'test:SB', n: 'Stop B', a: 35.69, o: 139.77, l: 0 },
+            { v: 2, i: 'test:SC', n: 'Stop C', a: 35.7, o: 139.78, l: 0 },
+          ],
+        },
+        tripPatterns: {
+          v: 2,
+          data: {
+            'test:P1': {
+              v: 2,
+              r: 'test:R1',
+              h: 'Terminal',
+              stops: [{ id: 'test:SA' }, { id: 'test:SB' }, { id: 'test:SC' }],
+            },
+          },
+        },
+        timetable: {
+          v: 2,
+          data: {
+            'test:SA': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 0,
+                d: { 'test:SVC1': [480, 540] },
+                a: { 'test:SVC1': [480, 540] },
+              },
+            ],
+            // test:SB omitted on purpose (= ODPT-style sparse pattern).
+            'test:SC': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 2,
+                d: { 'test:SVC1': [484, 544] },
+                a: { 'test:SVC1': [484, 544] },
+              },
+            ],
+          },
+        },
+      });
+      writeBundle('cgl-missing-group', bundle);
+      const result = validateDataBundle('cgl-missing-group', TMP_DIR);
+      const crossGroupIssues = result.issues.filter((i) =>
+        i.message.includes('differs across emitted groups'),
+      );
+      expect(crossGroupIssues).toHaveLength(0);
+    });
+
+    it('#5: does not require all groups to share the same set of serviceIds', () => {
+      // Stop A has both svc1 and svc2; stop B has only svc1. svc1 length
+      // matches between A and B. The validator must NOT fail on the svc2
+      // partial coverage — that is a different invariant (out of scope).
+      const bundle = makeValidBundle({
+        calendar: {
+          v: 1,
+          data: {
+            services: [
+              { i: 'test:SVC1', d: [1, 1, 1, 1, 1, 0, 0], s: '20260101', e: '20261231' },
+              { i: 'test:SVC2', d: [0, 0, 0, 0, 0, 1, 1], s: '20260101', e: '20261231' },
+            ],
+            exceptions: [],
+          },
+        },
+        stops: {
+          v: 2,
+          data: [
+            { v: 2, i: 'test:SA', n: 'Stop A', a: 35.68, o: 139.76, l: 0 },
+            { v: 2, i: 'test:SB', n: 'Stop B', a: 35.69, o: 139.77, l: 0 },
+          ],
+        },
+        tripPatterns: {
+          v: 2,
+          data: {
+            'test:P1': {
+              v: 2,
+              r: 'test:R1',
+              h: 'Terminal',
+              stops: [{ id: 'test:SA' }, { id: 'test:SB' }],
+            },
+          },
+        },
+        timetable: {
+          v: 2,
+          data: {
+            'test:SA': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 0,
+                d: { 'test:SVC1': [480, 540], 'test:SVC2': [600] },
+                a: { 'test:SVC1': [480, 540], 'test:SVC2': [600] },
+              },
+            ],
+            'test:SB': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 1,
+                d: { 'test:SVC1': [482, 542] },
+                a: { 'test:SVC1': [482, 542] },
+              },
+            ],
+          },
+        },
+      });
+      writeBundle('cgl-partial-svc', bundle);
+      const result = validateDataBundle('cgl-partial-svc', TMP_DIR);
+      const crossGroupIssues = result.issues.filter((i) =>
+        i.message.includes('differs across emitted groups'),
+      );
+      expect(crossGroupIssues).toHaveLength(0);
+    });
+
+    it('#6: flags mismatch on a-only serviceId (= union keyset behavior)', () => {
+      // sidA appears only in `a`, never in `d`. The cross-group validator
+      // must still examine sidA for `a.length` consistency: stop A has 3
+      // arrivals, stop B has 2 — that is a mismatch.
+      const bundle = makeValidBundle({
+        stops: {
+          v: 2,
+          data: [
+            { v: 2, i: 'test:SA', n: 'Stop A', a: 35.68, o: 139.76, l: 0 },
+            { v: 2, i: 'test:SB', n: 'Stop B', a: 35.69, o: 139.77, l: 0 },
+          ],
+        },
+        tripPatterns: {
+          v: 2,
+          data: {
+            'test:P1': {
+              v: 2,
+              r: 'test:R1',
+              h: 'Terminal',
+              stops: [{ id: 'test:SA' }, { id: 'test:SB' }],
+            },
+          },
+        },
+        timetable: {
+          v: 2,
+          data: {
+            'test:SA': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 0,
+                d: {},
+                a: { 'test:SVC1': [480, 540, 600] },
+              },
+            ],
+            'test:SB': [
+              {
+                v: 2,
+                tp: 'test:P1',
+                si: 1,
+                d: {},
+                a: { 'test:SVC1': [482, 542] },
+              },
+            ],
+          },
+        },
+      });
+      writeBundle('cgl-a-only-svc', bundle);
+      const result = validateDataBundle('cgl-a-only-svc', TMP_DIR);
+      const aErrors = result.issues.filter(
+        (i) => i.message.includes('a.length differs across emitted groups') && i.level === 'error',
+      );
+      expect(aErrors).toHaveLength(1);
+      expect(aErrors[0].message).toContain('test:P1');
+      expect(aErrors[0].message).toContain('test:SVC1');
+    });
+  });
 });

--- a/pipeline/src/lib/pipeline/app-data-v2/validate-data.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/validate-data.ts
@@ -12,7 +12,8 @@
  * - Non-empty stops, routes, calendar services
  * - Calendar expiration (warn if earliest end_date <= 30 days)
  * - Referential integrity: timetable → tripPatterns → routes/stops
- * - Timetable d/a array length consistency (per-group)
+ * - Timetable d/a array length consistency (per-group, symmetric: d-only and
+ *   a-only serviceIds are both flagged; length mismatch when both present is flagged)
  * - Cross-group d/a array length consistency per (patternId, serviceId) (Issue #156)
  * - Stop coordinate range (lat: -90..90, lon: -180..180)
  *
@@ -390,11 +391,18 @@ export function validateDataBundle(prefix: string, baseDir: string): DataValidat
         }
       }
 
-      // d/a array length consistency per service_id
-      for (const sid of Object.keys(group.d)) {
-        const dLen = group.d[sid]?.length ?? 0;
+      // d/a array length consistency per service_id.
+      //
+      // Iterate the union of d and a keysets so that a serviceId present in
+      // only one side is also examined. Both directions are anomalies: at
+      // the data semantic level, d[sid][n] and a[sid][n] are positionally
+      // paired (= same trip's same stop), so one without the other indicates
+      // a builder regression rather than a legitimate data shape.
+      const sids = new Set<string>([...Object.keys(group.d), ...Object.keys(group.a)]);
+      for (const sid of sids) {
+        const dArr = group.d[sid];
         const aArr = group.a[sid];
-        if (!aArr) {
+        if (dArr && !aArr) {
           issues.push({
             prefix,
             level: 'error',
@@ -403,12 +411,21 @@ export function validateDataBundle(prefix: string, baseDir: string): DataValidat
           });
           continue;
         }
-        if (dLen !== aArr.length) {
+        if (aArr && !dArr) {
           issues.push({
             prefix,
             level: 'error',
             category: 'integrity',
-            message: `timetable[${stopId}][${gi}]: service "${sid}" d.length (${dLen}) !== a.length (${aArr.length})`,
+            message: `timetable[${stopId}][${gi}]: service "${sid}" has arrivals but no departures`,
+          });
+          continue;
+        }
+        if (dArr && aArr && dArr.length !== aArr.length) {
+          issues.push({
+            prefix,
+            level: 'error',
+            category: 'integrity',
+            message: `timetable[${stopId}][${gi}]: service "${sid}" d.length (${dArr.length}) !== a.length (${aArr.length})`,
           });
         }
       }

--- a/pipeline/src/lib/pipeline/app-data-v2/validate-data.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/validate-data.ts
@@ -12,7 +12,8 @@
  * - Non-empty stops, routes, calendar services
  * - Calendar expiration (warn if earliest end_date <= 30 days)
  * - Referential integrity: timetable → tripPatterns → routes/stops
- * - Timetable d/a array length consistency
+ * - Timetable d/a array length consistency (per-group)
+ * - Cross-group d/a array length consistency per (patternId, serviceId) (Issue #156)
  * - Stop coordinate range (lat: -90..90, lon: -180..180)
  *
  * @module
@@ -21,7 +22,10 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import type { DataBundle } from '../../../../../src/types/data/transit-v2-json';
+import type {
+  DataBundle,
+  TimetableGroupV2Json,
+} from '../../../../../src/types/data/transit-v2-json';
 import { parseGtfsDate } from '../../gtfs-date-utils';
 import type { ValidationIssue } from './validate-shapes';
 
@@ -411,6 +415,81 @@ export function validateDataBundle(prefix: string, baseDir: string): DataValidat
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Cross-group d/a length consistency per (patternId, serviceId) (Issue #156)
+  //
+  // For each (patternId, serviceId) pair, all emitted timetable groups
+  // belonging to that pattern must report the same `d[serviceId].length`
+  // and `a[serviceId].length`. WebApp's `buildTripStopTimes` walks a single
+  // tripIndex across emitted groups; if the lengths disagree, that index
+  // becomes ambiguous and reconstructed trips show phantom values.
+  //
+  // Stops in `pattern.stops` that have no emitted timetable group are
+  // intentionally excluded (= "across emitted groups", not "across all
+  // pattern.stops"). ODPT-derived patterns may legitimately list stops in
+  // `pattern.stops` that have no corresponding StationTimetable entry.
+  // ---------------------------------------------------------------------------
+
+  const groupsByPattern = new Map<string, { stopId: string; group: TimetableGroupV2Json }[]>();
+  for (const [stopId, groups] of Object.entries(bundle.timetable.data)) {
+    for (const group of groups) {
+      let arr = groupsByPattern.get(group.tp);
+      if (!arr) {
+        arr = [];
+        groupsByPattern.set(group.tp, arr);
+      }
+      arr.push({ stopId, group });
+    }
+  }
+
+  for (const [patternId, records] of groupsByPattern) {
+    // serviceIds = union of d and a keysets across all groups for this pattern.
+    // Both sides are checked independently; iterating only `d` would miss
+    // a serviceId that appears solely in `a`.
+    const serviceIds = new Set<string>();
+    for (const { group } of records) {
+      for (const sid of Object.keys(group.d)) {
+        serviceIds.add(sid);
+      }
+      for (const sid of Object.keys(group.a)) {
+        serviceIds.add(sid);
+      }
+    }
+
+    for (const sid of serviceIds) {
+      // length -> example stopIds. Cap example list at 3 entries per length
+      // so that pathological cases produce compact, readable failure reports.
+      const dByLen = new Map<number, string[]>();
+      const aByLen = new Map<number, string[]>();
+      for (const { stopId, group } of records) {
+        const dArr = group.d[sid];
+        const aArr = group.a[sid];
+        if (dArr) {
+          recordExample(dByLen, dArr.length, stopId);
+        }
+        if (aArr) {
+          recordExample(aByLen, aArr.length, stopId);
+        }
+      }
+      if (dByLen.size > 1) {
+        issues.push({
+          prefix,
+          level: 'error',
+          category: 'integrity',
+          message: `pattern "${patternId}" service "${sid}": d.length differs across emitted groups (${formatLengthExamples(dByLen)})`,
+        });
+      }
+      if (aByLen.size > 1) {
+        issues.push({
+          prefix,
+          level: 'error',
+          category: 'integrity',
+          message: `pattern "${patternId}" service "${sid}": a.length differs across emitted groups (${formatLengthExamples(aByLen)})`,
+        });
+      }
+    }
+  }
+
   const calendarServices: CalendarServiceMeta[] = bundle.calendar.data.services.map((svc) => ({
     serviceId: svc.i,
     endDate: svc.e,
@@ -425,4 +504,28 @@ export function validateDataBundle(prefix: string, baseDir: string): DataValidat
     timetableStopCount,
     calendarServices,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Record an example stopId for a given array length, capped at 3 entries. */
+function recordExample(byLen: Map<number, string[]>, length: number, stopId: string): void {
+  const examples = byLen.get(length);
+  if (examples) {
+    if (examples.length < 3) {
+      examples.push(stopId);
+    }
+    return;
+  }
+  byLen.set(length, [stopId]);
+}
+
+/** Format a length -> example-stopIds map as `"3 (e.g. s1, s2), 2 (e.g. s3)"`. */
+function formatLengthExamples(byLen: Map<number, string[]>): string {
+  return [...byLen]
+    .sort(([a], [b]) => a - b)
+    .map(([length, stops]) => `${length} (e.g. ${stops.join(', ')})`)
+    .join(', ');
 }

--- a/pipeline/src/lib/pipeline/app-data-v2/validate-data.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/validate-data.ts
@@ -474,18 +474,25 @@ export function validateDataBundle(prefix: string, baseDir: string): DataValidat
     }
 
     for (const sid of serviceIds) {
-      // length -> example stopIds. Cap example list at 3 entries per length
+      // length -> example labels. Cap example list at 3 entries per length
       // so that pathological cases produce compact, readable failure reports.
+      //
+      // Each label includes both stopId and si because v2 schema allows
+      // circular / 6-shape patterns where the same stopId appears at
+      // multiple si positions within one pattern (transit-v2-json.ts).
+      // Without si, the report could list `stopA` under both lengths and
+      // become ambiguous.
       const dByLen = new Map<number, string[]>();
       const aByLen = new Map<number, string[]>();
       for (const { stopId, group } of records) {
+        const label = `${stopId}@si=${group.si}`;
         const dArr = group.d[sid];
         const aArr = group.a[sid];
         if (dArr) {
-          recordExample(dByLen, dArr.length, stopId);
+          recordExample(dByLen, dArr.length, label);
         }
         if (aArr) {
-          recordExample(aByLen, aArr.length, stopId);
+          recordExample(aByLen, aArr.length, label);
         }
       }
       if (dByLen.size > 1) {
@@ -527,22 +534,31 @@ export function validateDataBundle(prefix: string, baseDir: string): DataValidat
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Record an example stopId for a given array length, capped at 3 entries. */
-function recordExample(byLen: Map<number, string[]>, length: number, stopId: string): void {
+/**
+ * Record an example label (e.g. `stopId@si=N`) for a given array length,
+ * capped at 3 entries per length.
+ */
+function recordExample(byLen: Map<number, string[]>, length: number, label: string): void {
   const examples = byLen.get(length);
   if (examples) {
     if (examples.length < 3) {
-      examples.push(stopId);
+      examples.push(label);
     }
     return;
   }
-  byLen.set(length, [stopId]);
+  byLen.set(length, [label]);
 }
 
-/** Format a length -> example-stopIds map as `"3 (e.g. s1, s2), 2 (e.g. s3)"`. */
+/**
+ * Format a length -> example-labels map as
+ * `"2 (e.g. test:S1@si=0), 3 (e.g. test:S2@si=1, test:S3@si=2)"`.
+ *
+ * Lengths are sorted ascending so the output order is stable across runs
+ * (= same fixture always produces the same string).
+ */
 function formatLengthExamples(byLen: Map<number, string[]>): string {
   return [...byLen]
     .sort(([a], [b]) => a - b)
-    .map(([length, stops]) => `${length} (e.g. ${stops.join(', ')})`)
+    .map(([length, labels]) => `${length} (e.g. ${labels.join(', ')})`)
     .join(', ');
 }


### PR DESCRIPTION
## Summary

Strengthen `validate-data.ts` with two related integrity checks for `data.json`:

1. **Cross-group `(patternId, serviceId)` length consistency** (= main, closes #156). For each pattern, all emitted timetable groups belonging to it must report the same `d[serviceId].length` and `a[serviceId].length`. WebApp's `buildTripStopTimes` walks a single tripIndex across these groups; without this invariant, that index becomes ambiguous and reconstructed trips show phantom values (cf. Issue #153 symptom).
2. **Symmetric within-group d/a presence check** (= follow-up cleanup that came up during review). The existing per-group check started from `Object.keys(group.d)` only, so a group with `a[sid]` but no `d[sid]` would pass silently while the inverse (d-only) was flagged. Now the check iterates the union of d/a keysets and flags single-sided population in either direction.

Both run as part of `npm run pipeline:validate:v2`.

## Design choices (per Issue #156 decision + review discussion)

### Cross-group invariant

- **Bundle-level / "across emitted groups" only**: stops in `pattern.stops` that have no emitted timetable group are excluded. This keeps ODPT-derived sparse patterns valid (where `stationOrder` may list stops with no `StationTimetable` entry).
- **`serviceId` collection = union of `d` and `a` keysets**: a serviceId appearing only in `a` is still examined for cross-group `a.length` consistency.
- **`d.length` and `a.length` checked independently**: separate error messages so a regression in one side does not mask the other.
- **Out of scope**: `pt` / `dt` array length, "all groups share the same set of serviceIds" (= a different invariant — pinned by test #5 below).

### Within-group symmetrize

- `d[sid][n]` and `a[sid][n]` are positionally paired (same trip, same stop), so single-sided population in either direction is a builder regression rather than a legitimate data shape.
- Existing data is unaffected: all 22 sources currently in `_build/data-v2/` pass the new symmetric check (= GTFS / ODPT builders always populate both sides).

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint pipeline/` clean
- [x] `npx prettier --check pipeline/` clean
- [x] `npx vitest run pipeline/` — 854 pass / 61 files (= 847 baseline + 7 new tests)
- [x] `npm run pipeline:validate:v2` against current main artifacts — 0 d/a integrity errors across all 22 sources
- [x] Failure-path verified: tampered yurimo `data.json` (artificially shortened `d[svc]` at one stop) is caught by the cross-group check with a readable error message including patternId, serviceId, both lengths, and example stop ids capped at 3 entries per length

## New test cases in `validate-data.test.ts`

### Cross-group (Issue #156)

| # | Scenario | Expected |
|---|---|---|
| 1 | uniform d/a length across emitted groups | 0 issue |
| 2 | `d.length` mismatch | 1 error (with patternId, serviceId, lengths, example stops) |
| 3 | `a.length` mismatch (d uniform) | 1 error (a-side only) |
| 4 | pattern with stops missing a timetable group | 0 issue (= "emitted groups only" pinned) |
| 5 | partial serviceId coverage (svc1 everywhere, svc2 only on stop A) | 0 issue (= different-invariant scope) |
| 6 | `a`-only serviceId mismatch (sidA absent from `d` keyset) | 1 error (= union keyset behavior pinned) |

### Within-group symmetrize

| # | Scenario | Expected |
|---|---|---|
| 7 | `a` has serviceId but `d` does not (= symmetric to existing d-only test) | 1 error: `has arrivals but no departures` |

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)