### PR TITLE
Refine timetable modal filters and metadata stats

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -113,7 +113,7 @@ export default function App({ loadResult }: AppProps) {
   const [radiusStops, setNearbyStops] = useState<StopWithMeta[]>([]);
   const [mapCenter, setMapCenter] = useState<LatLng | null>(null);
   const [routeShapes, setRouteShapes] = useState<RouteShape[]>([]);
-  const [timetableModal, setTimetableModal] = useState<TimetableData | null>(null);
+  const [timetableData, setTimetableData] = useState<TimetableData | null>(null);
   const [hasNearbyLoaded, setHasNearbyLoaded] = useState(false);
   const [searchModalOpen, setSearchModalOpen] = useState(false);
   const [infoDialogOpen, setInfoDialogOpen] = useState(false);
@@ -142,7 +142,7 @@ export default function App({ loadResult }: AppProps) {
       !searchModalOpen &&
       !infoDialogOpen &&
       !shortcutHelpOpen &&
-      timetableModal === null &&
+      timetableData === null &&
       tripInspectionSnapshot === null,
     handlers: {
       onOpenSearch: () => setSearchModalOpen(true),
@@ -492,13 +492,8 @@ export default function App({ loadResult }: AppProps) {
       const { allEntries, isBoardableOnServiceDay } = await fetchTimetableEntries(stopId);
       const { entries, omitted } =
         filter.type === 'route-headsign'
-          ? prepareRouteHeadsignTimetable(
-              allEntries,
-              filter.routeId,
-              filter.headsign,
-              infoLevelFlags.isDetailedEnabled,
-            )
-          : prepareStopTimetable(allEntries, infoLevelFlags.isDetailedEnabled);
+          ? prepareRouteHeadsignTimetable(allEntries, filter.routeId, filter.headsign, true)
+          : prepareStopTimetable(allEntries, true);
 
       const headsign = filter.type === 'route-headsign' ? filter.headsign : undefined;
 
@@ -506,7 +501,7 @@ export default function App({ loadResult }: AppProps) {
         `timetable(${filter.type}) [${settings.infoLevel}]: ${stopId}${filter.type === 'route-headsign' ? ` ${filter.routeId} "${headsign}"` : ''} → entries=${entries.length} omitted.nonBoardable=${omitted.nonBoardable} total=${allEntries.length}`,
       );
 
-      setTimetableModal({
+      setTimetableData({
         type: filter.type,
         stop: meta.stop,
         routes,
@@ -521,7 +516,7 @@ export default function App({ loadResult }: AppProps) {
         agencies: meta.agencies,
       });
     },
-    [dateTime, radiusStops, infoLevelFlags, fetchTimetableEntries, settings.infoLevel],
+    [dateTime, radiusStops, fetchTimetableEntries, settings.infoLevel],
   );
 
   const handleShowTimetable = useCallback(
@@ -876,12 +871,14 @@ export default function App({ loadResult }: AppProps) {
         }}
       />
       <TimetableModal
-        data={timetableModal}
+        key={timetableData?.stop.stop_id ?? 'closed'}
+        data={timetableData}
         time={dateTime}
         infoLevel={settings.infoLevel}
+        boardableOnly={!infoLevelFlags.isDetailedEnabled}
         dataLangs={langChain}
         onInspectTrip={openTripInspection}
-        onClose={() => setTimetableModal(null)}
+        onClose={() => setTimetableData(null)}
       />
       <Toaster
         theme={settings.theme}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -503,7 +503,7 @@ export default function App({ loadResult }: AppProps) {
       const headsign = filter.type === 'route-headsign' ? filter.headsign : undefined;
 
       logger.debug(
-        `timetable(${filter.type}) [${settings.infoLevel}]: ${stopId}${filter.type === 'route-headsign' ? ` ${filter.routeId} "${headsign}"` : ''} → entries=${entries.length} omitted.terminal=${omitted.terminal} total=${allEntries.length}`,
+        `timetable(${filter.type}) [${settings.infoLevel}]: ${stopId}${filter.type === 'route-headsign' ? ` ${filter.routeId} "${headsign}"` : ''} → entries=${entries.length} omitted.nonBoardable=${omitted.nonBoardable} total=${allEntries.length}`,
       );
 
       setTimetableModal({

--- a/src/components/badge/label-count-badge.tsx
+++ b/src/components/badge/label-count-badge.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { cn } from '../../lib/utils';
 import { BaseLabel, type BaseLabelSize } from '../label/base-label';
 
 interface LabelCountBadgeProps {
@@ -18,6 +19,12 @@ interface LabelCountBadgeProps {
   countFg?: string;
   /** Outer frame border color. @default labelBg */
   frameColor?: string;
+  /** Optional utility classes for the outer frame wrapper. */
+  frameClassName?: string;
+  /** Optional utility classes for the label half. */
+  labelClassName?: string;
+  /** Optional utility classes for the count half. */
+  countClassName?: string;
 }
 
 /**
@@ -55,18 +62,29 @@ export function LabelCountBadge({
   countBg = labelFg,
   countFg = labelBg,
   frameColor = labelBg,
+  frameClassName,
+  labelClassName,
+  countClassName,
 }: LabelCountBadgeProps) {
   const { i18n } = useTranslation();
   const labelStyle = labelBg ? { background: labelBg, color: labelFg } : undefined;
   const countStyle = countBg ? { background: countBg, color: countFg } : undefined;
   const frameStyle = frameColor ? { borderColor: frameColor } : undefined;
   return (
-    <span className="inline-flex items-stretch overflow-hidden rounded border" style={frameStyle}>
-      <BaseLabel size={size} value={label} className="rounded-none" style={labelStyle} />
+    <span
+      className={cn('inline-flex items-stretch overflow-hidden rounded border', frameClassName)}
+      style={frameStyle}
+    >
+      <BaseLabel
+        size={size}
+        value={label}
+        className={cn('rounded-none', labelClassName)}
+        style={labelStyle}
+      />
       <BaseLabel
         size={size}
         value={count.toLocaleString(i18n.language)}
-        className="rounded-none"
+        className={cn('rounded-none', countClassName)}
         style={countStyle}
       />
     </span>

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -62,6 +62,14 @@ interface TimetableModalProps {
   infoLevel: InfoLevel;
   /** Display language chain for translated GTFS/ODPT data names. */
   dataLangs: readonly string[];
+  /**
+   * Initial value of the boardable-only filter toggle. When true, the
+   * dialog opens with the filter ON (= the user can still toggle it
+   * off via the filter pill). The value is read once at mount; pair
+   * with a stable `key` on `<TimetableModal>` so the dialog re-mounts
+   * (= re-evaluates the initial value) per stop.
+   */
+  boardableOnly: boolean;
   onInspectTrip?: (target: TripInspectionTarget) => void;
   onClose: () => void;
 }
@@ -69,16 +77,9 @@ interface TimetableModalProps {
 interface EntriesPanelProps {
   timetableEntries: TimetableEntry[];
   entryStats: TimetableEntryStats;
-  type: TimetableData['type'];
   agencies: Agency[];
   dataLangs: readonly string[];
   filteredCount: number;
-  activeFilters: Set<string>;
-  onToggleFilter: (key: string) => void;
-  showOriginOnly: boolean;
-  onToggleOriginOnly: () => void;
-  showBoardableOnly: boolean;
-  onToggleBoardableOnly: () => void;
 }
 
 /**
@@ -89,16 +90,9 @@ interface EntriesPanelProps {
 function EntriesPanel({
   timetableEntries,
   entryStats,
-  type,
   dataLangs,
   agencies,
   filteredCount,
-  activeFilters,
-  onToggleFilter,
-  showOriginOnly,
-  onToggleOriginOnly,
-  showBoardableOnly,
-  onToggleBoardableOnly,
 }: EntriesPanelProps) {
   return (
     <>
@@ -110,35 +104,37 @@ function EntriesPanel({
           stats={entryStats}
         />
       )}
-
-      {/* Origin filter (始発のみ) — hidden when no origin entries exist at this stop */}
-      {/* {originCount > 0 && ( */}
-      <TimetableOriginFilter
-        origin={showOriginOnly}
-        onToggleOrigin={onToggleOriginOnly}
-        count={entryStats.originCount}
-      />
-      {/* )} */}
-      {/* Boardability filter */}
-      <TimetableBoardabilityFilter
-        boardable={showBoardableOnly}
-        count={entryStats.boardableCount}
-        onToggleBoardable={onToggleBoardableOnly}
-      />
-
-      {/* Headsign filter */}
-      {type === 'stop' && (
-        <>
-          <TimetableHeadsignFilter
-            timetableEntries={timetableEntries}
-            activeFilters={activeFilters}
-            onToggleFilter={onToggleFilter}
-            dataLang={dataLangs}
-            agencies={agencies}
-          />
-        </>
-      )}
     </>
+  );
+}
+
+/** Date and time label shown at the bottom of the dialog header. */
+function TimetableDateLabel({
+  serviceDate,
+  time,
+  lang,
+}: {
+  serviceDate: Date;
+  time: Date;
+  lang: string;
+}) {
+  const { dateText, dayLabel, dayColorCategory } = formatDateParts(
+    serviceDate,
+    lang,
+    DEFAULT_TIMEZONE,
+    { showYear: true },
+  );
+  const { time: currentTimeText } = formatDateParts(time, lang, DEFAULT_TIMEZONE, {
+    showTime: true,
+  });
+  // Weekday inherits the parent's muted color; only sat/sun/holiday get color override.
+  const dayLabelClass =
+    dayColorCategory === 'weekday' ? undefined : DAY_COLOR_CATEGORY_CLASSES[dayColorCategory];
+
+  return (
+    <p className="text-muted-foreground m-0 text-center font-normal">
+      {dateText} <span className={dayLabelClass}>({dayLabel})</span> {currentTimeText}
+    </p>
   );
 }
 
@@ -147,6 +143,7 @@ export function TimetableModal({
   time,
   infoLevel,
   dataLangs,
+  boardableOnly,
   onInspectTrip,
   onClose,
 }: TimetableModalProps) {
@@ -161,9 +158,10 @@ export function TimetableModal({
   // Empty set = show all timetable (no filter active).
   const [activeFilters, setActiveFilters] = useState<Set<string>>(() => new Set());
 
-  // Boardable-only filter toggle. OFF by default (preserves existing behavior).
-  // When ON, applies filterBoardable on top of any other active filters.
-  const [showBoardableOnly, setShowBoardableOnly] = useState(false);
+  // Boardable-only filter toggle. Initial value comes from the
+  // `boardableOnly` prop (read once at mount; the caller should use a
+  // `key` on <TimetableModal> to re-mount per stop).
+  const [showBoardableOnly, setShowBoardableOnly] = useState(boardableOnly);
 
   // Origin-only filter toggle (= 始発のみ). OFF by default.
   // When ON, applies filterOrigin on top of any other active filters.
@@ -196,36 +194,38 @@ export function TimetableModal({
     }
     return data.timetableEntries;
   }, [data]);
+  // const allEntriesStats = computeTimetableEntryStats( allTimetableEntries, data?.agencies ?? [], dataLangs,);
 
-  const filteredTimetableEntries = useMemo(() => {
-    if (!data) {
-      return allTimetableEntries;
-    }
+  const entriesBeforeRouteHeadsignFilter = useMemo(() => {
     let entries = allTimetableEntries;
-    // Route+headsign filter (stop type only, when active).
-    if (data.type === 'stop' && activeFilters.size > 0) {
-      entries = entries.filter((entry) =>
-        activeFilters.has(getRouteHeadsignKey(entry.routeDirection)),
-      );
-    }
-    // Origin-only filter (both types). Applied before boardability so
-    // the boardability check operates on origin entries when both are on.
     if (showOriginOnly) {
       entries = filterOrigin(entries);
     }
-    // Boardable-only filter (both types). Applied last; combined with
-    // origin-only this yields "boardable origins only" (= intersection).
     if (showBoardableOnly) {
       entries = filterBoardable(entries);
     }
     return entries;
-  }, [data, allTimetableEntries, activeFilters, showOriginOnly, showBoardableOnly]);
+  }, [allTimetableEntries, showOriginOnly, showBoardableOnly]);
+  const entriesBeforeRouteHeadsignFilterStats = computeTimetableEntryStats(
+    entriesBeforeRouteHeadsignFilter,
+    data?.agencies ?? [],
+    dataLangs,
+  );
 
-  // Aggregated stats. `allEntriesStats` is the stable count for filter
-  // pills and the "all data" metadata block; `filteredEntriesStats`
-  // reflects the currently-displayed entries.
-  const allEntriesStats = computeTimetableEntryStats(allTimetableEntries);
-  const filteredEntriesStats = computeTimetableEntryStats(filteredTimetableEntries);
+  const routeHeadsignFilteredEntries = useMemo(() => {
+    let entries = entriesBeforeRouteHeadsignFilter;
+    if (activeFilters.size > 0) {
+      entries = entries.filter((entry) =>
+        activeFilters.has(getRouteHeadsignKey(entry.routeDirection)),
+      );
+    }
+    return entries;
+  }, [entriesBeforeRouteHeadsignFilter, activeFilters]);
+  const routeHeadsignFilteredEntriesStats = computeTimetableEntryStats(
+    routeHeadsignFilteredEntries,
+    data?.agencies ?? [],
+    dataLangs,
+  );
 
   const descriptionHeadsign = useMemo(() => {
     if (!data?.headsign || data.type !== 'route-headsign') {
@@ -247,11 +247,11 @@ export function TimetableModal({
 
   const headerScroll = useScrollFades(
     headerContainerRef,
-    `${data?.type ?? 'closed'}:${data?.headsign ?? ''}:${filteredTimetableEntries.length}:${infoLevel}`,
+    `${data?.type ?? 'closed'}:${data?.headsign ?? ''}:${entriesBeforeRouteHeadsignFilter.length}:${infoLevel}`,
   );
   const gridScroll = useScrollFades(
     gridContainerRef,
-    `${data?.type ?? 'closed'}:${filteredTimetableEntries.length}:${infoLevel}:${currentHour}`,
+    `${data?.type ?? 'closed'}:${entriesBeforeRouteHeadsignFilter.length}:${infoLevel}:${currentHour}`,
   );
 
   if (!data) {
@@ -288,13 +288,13 @@ export function TimetableModal({
         stop: descriptionStopName,
         route: descriptionRouteName,
         headsign: descriptionHeadsign,
-        count: filteredTimetableEntries.length.toLocaleString(i18n.language),
+        count: entriesBeforeRouteHeadsignFilter.length.toLocaleString(i18n.language),
       },
     );
   } else {
     timetableDescription = t('timetable.header.stopDescription', {
       stop: descriptionStopName,
-      count: filteredTimetableEntries.length.toLocaleString(i18n.language),
+      count: entriesBeforeRouteHeadsignFilter.length.toLocaleString(i18n.language),
     });
   }
 
@@ -327,7 +327,7 @@ export function TimetableModal({
                 type={data.type}
                 headsign={data.headsign}
                 serviceDate={data.serviceDate}
-                timetableEntries={filteredTimetableEntries}
+                timetableEntries={entriesBeforeRouteHeadsignFilter}
                 omitted={data.omitted}
                 stopServiceState={data.stopServiceState}
               />
@@ -348,55 +348,69 @@ export function TimetableModal({
             />
 
             {/* All entries */}
-            {info.isVerboseEnabled && (
+            {/* {info.isVerboseEnabled && (
               <EntriesPanel
                 timetableEntries={allTimetableEntries}
-                type={data.type}
                 entryStats={allEntriesStats}
                 agencies={data.agencies}
                 dataLangs={dataLangs}
                 filteredCount={allTimetableEntries.length}
-                activeFilters={activeFilters}
-                onToggleFilter={toggleFilter}
-                showOriginOnly={showOriginOnly}
-                onToggleOriginOnly={toggleOriginOnly}
-                showBoardableOnly={showBoardableOnly}
-                onToggleBoardableOnly={toggleBoardableOnly}
               />
-            )}
+            )} */}
 
-            {/* Filtered entries */}
-            {info.isDetailedEnabled && (
+            {/* entriesBeforeRouteHeadsignFilter */}
+            {/* {info.isVerboseEnabled && (
               <EntriesPanel
-                timetableEntries={filteredTimetableEntries}
-                type={data.type}
-                entryStats={filteredEntriesStats}
+                timetableEntries={entriesBeforeRouteHeadsignFilter}
+                entryStats={entriesBeforeRouteHeadsignFilterStats}
                 agencies={data.agencies}
                 dataLangs={dataLangs}
-                filteredCount={filteredTimetableEntries.length}
-                activeFilters={activeFilters}
-                onToggleFilter={toggleFilter}
-                showOriginOnly={showOriginOnly}
-                onToggleOriginOnly={toggleOriginOnly}
-                showBoardableOnly={showBoardableOnly}
-                onToggleBoardableOnly={toggleBoardableOnly}
+                filteredCount={entriesBeforeRouteHeadsignFilter.length}
+              />
+            )} */}
+
+            {/* routeHeadsignFilteredEntriesStats */}
+            {info.isDetailedEnabled && (
+              <EntriesPanel
+                timetableEntries={routeHeadsignFilteredEntries}
+                entryStats={routeHeadsignFilteredEntriesStats}
+                agencies={data.agencies}
+                dataLangs={dataLangs}
+                filteredCount={routeHeadsignFilteredEntries.length}
               />
             )}
 
+            {/* Date time */}
             <TimetableDateLabel serviceDate={data.serviceDate} time={time} lang={dataLangs[0]} />
 
-            {/* Headsign filter */}
-            {data.type === 'stop' && (
-              <>
+            <div className="flex flex-wrap gap-1">
+              {/* Origin filter — hidden when no origin entries exist at this stop */}
+              {entriesBeforeRouteHeadsignFilterStats.originCount > 0 && (
+                <TimetableOriginFilter
+                  origin={showOriginOnly}
+                  count={entriesBeforeRouteHeadsignFilterStats.originCount}
+                  onToggleOrigin={toggleOriginOnly}
+                />
+              )}
+              {/* Boardability filter */}
+              {/* {filteredEntriesStats.nonBoardableCount > 0 && ( */}
+              <TimetableBoardabilityFilter
+                boardable={showBoardableOnly}
+                count={entriesBeforeRouteHeadsignFilterStats.boardableCount}
+                onToggleBoardable={toggleBoardableOnly}
+              />
+              {/* )} */}
+              {/* Headsign filter */}
+              {data.type === 'stop' && (
                 <TimetableHeadsignFilter
-                  timetableEntries={filteredTimetableEntries}
+                  timetableEntries={entriesBeforeRouteHeadsignFilter}
                   activeFilters={activeFilters}
                   onToggleFilter={toggleFilter}
                   dataLang={dataLangs}
                   agencies={data.agencies}
                 />
-              </>
-            )}
+              )}
+            </div>
             {/* Unknown destination warning */}
             {((data.type === 'route-headsign' && data.headsign === '') ||
               (data.type === 'stop' &&
@@ -424,12 +438,12 @@ export function TimetableModal({
           )}
           <div className="px-4 pt-3 pb-4">
             <TimetableGrid
-              timetableEntries={filteredTimetableEntries}
+              timetableEntries={routeHeadsignFilteredEntries}
               serviceDate={data.serviceDate}
               showHeadsign={
                 info.isVerboseEnabled ||
                 new Set(
-                  filteredTimetableEntries.map((entry) =>
+                  routeHeadsignFilteredEntries.map((entry) =>
                     getRouteHeadsignKey(entry.routeDirection),
                   ),
                 ).size > 1
@@ -450,35 +464,3 @@ export function TimetableModal({
     </Dialog>
   );
 }
-
-/** Date and time label shown at the bottom of the dialog header. */
-function TimetableDateLabel({
-  serviceDate,
-  time,
-  lang,
-}: {
-  serviceDate: Date;
-  time: Date;
-  lang: string;
-}) {
-  const { dateText, dayLabel, dayColorCategory } = formatDateParts(
-    serviceDate,
-    lang,
-    DEFAULT_TIMEZONE,
-    { showYear: true },
-  );
-  const { time: currentTimeText } = formatDateParts(time, lang, DEFAULT_TIMEZONE, {
-    showTime: true,
-  });
-  // Weekday inherits the parent's muted color; only sat/sun/holiday get color override.
-  const dayLabelClass =
-    dayColorCategory === 'weekday' ? undefined : DAY_COLOR_CATEGORY_CLASSES[dayColorCategory];
-
-  return (
-    <p className="text-muted-foreground m-0 text-center font-normal">
-      {dateText} <span className={dayLabelClass}>({dayLabel})</span> {currentTimeText}
-    </p>
-  );
-}
-
-/** Verbose-only metadata dump: boarding stats, direction, pattern breakdown. */

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -11,6 +11,8 @@ import { findRouteDirectionForHeadsign } from '@/domain/transit/find-route-direc
 import { getStopDisplayNames } from '@/domain/transit/get-stop-display-names';
 import { getRouteHeadsignKey } from '../../domain/transit/get-route-headsign-key';
 import { filterBoardable, filterOrigin } from '@/domain/transit/timetable-filter';
+import { computeTimetableEntryStats } from '@/domain/transit/timetable-stats';
+import type { TimetableEntryStats } from '@/domain/transit/timetable-stats';
 import { getServiceDayMinutes } from '@/domain/transit/service-day';
 import { useScrollFades } from '@/hooks/use-scroll-fades';
 import type { InfoLevel } from '@/types/app/settings';
@@ -62,6 +64,82 @@ interface TimetableModalProps {
   dataLangs: readonly string[];
   onInspectTrip?: (target: TripInspectionTarget) => void;
   onClose: () => void;
+}
+
+interface EntriesPanelProps {
+  timetableEntries: TimetableEntry[];
+  entryStats: TimetableEntryStats;
+  type: TimetableData['type'];
+  agencies: Agency[];
+  dataLangs: readonly string[];
+  filteredCount: number;
+  activeFilters: Set<string>;
+  onToggleFilter: (key: string) => void;
+  showOriginOnly: boolean;
+  onToggleOriginOnly: () => void;
+  showBoardableOnly: boolean;
+  onToggleBoardableOnly: () => void;
+}
+
+/**
+ * The "all entries" overview block: stats summary for the unfiltered
+ * entry set plus the filter toggles that operate on it (headsign /
+ * origin-only / boardability).
+ */
+function EntriesPanel({
+  timetableEntries,
+  entryStats,
+  type,
+  dataLangs,
+  agencies,
+  filteredCount,
+  activeFilters,
+  onToggleFilter,
+  showOriginOnly,
+  onToggleOriginOnly,
+  showBoardableOnly,
+  onToggleBoardableOnly,
+}: EntriesPanelProps) {
+  return (
+    <>
+      {filteredCount > 0 && (
+        <TimetableMetadata
+          timetableEntries={timetableEntries}
+          dataLang={dataLangs}
+          agencies={agencies}
+          stats={entryStats}
+        />
+      )}
+
+      {/* Origin filter (始発のみ) — hidden when no origin entries exist at this stop */}
+      {/* {originCount > 0 && ( */}
+      <TimetableOriginFilter
+        origin={showOriginOnly}
+        onToggleOrigin={onToggleOriginOnly}
+        count={entryStats.originCount}
+      />
+      {/* )} */}
+      {/* Boardability filter */}
+      <TimetableBoardabilityFilter
+        boardable={showBoardableOnly}
+        count={entryStats.boardableCount}
+        onToggleBoardable={onToggleBoardableOnly}
+      />
+
+      {/* Headsign filter */}
+      {type === 'stop' && (
+        <>
+          <TimetableHeadsignFilter
+            timetableEntries={timetableEntries}
+            activeFilters={activeFilters}
+            onToggleFilter={onToggleFilter}
+            dataLang={dataLangs}
+            agencies={agencies}
+          />
+        </>
+      )}
+    </>
+  );
 }
 
 export function TimetableModal({
@@ -143,17 +221,11 @@ export function TimetableModal({
     return entries;
   }, [data, allTimetableEntries, activeFilters, showOriginOnly, showBoardableOnly]);
 
-  // Counts shown on each filter pill. Computed against the unfiltered
-  // entries so the count is stable regardless of other filter state
-  // (= "total entries matching this dimension at this stop").
-  const boardableCount = useMemo(
-    () => filterBoardable(allTimetableEntries).length,
-    [allTimetableEntries],
-  );
-  const originCount = useMemo(
-    () => filterOrigin(allTimetableEntries).length,
-    [allTimetableEntries],
-  );
+  // Aggregated stats. `allEntriesStats` is the stable count for filter
+  // pills and the "all data" metadata block; `filteredEntriesStats`
+  // reflects the currently-displayed entries.
+  const allEntriesStats = computeTimetableEntryStats(allTimetableEntries);
+  const filteredEntriesStats = computeTimetableEntryStats(filteredTimetableEntries);
 
   const descriptionHeadsign = useMemo(() => {
     if (!data?.headsign || data.type !== 'route-headsign') {
@@ -275,40 +347,55 @@ export function TimetableModal({
               dataLangs={dataLangs}
             />
 
-            {info.isDetailedEnabled && filteredTimetableEntries.length > 0 && (
-              <TimetableMetadata
-                timetableEntries={filteredTimetableEntries}
-                dataLang={dataLangs}
+            {/* All entries */}
+            {info.isVerboseEnabled && (
+              <EntriesPanel
+                timetableEntries={allTimetableEntries}
+                type={data.type}
+                entryStats={allEntriesStats}
                 agencies={data.agencies}
-                boardableCount={boardableCount}
-                originCount={originCount}
+                dataLangs={dataLangs}
+                filteredCount={allTimetableEntries.length}
+                activeFilters={activeFilters}
+                onToggleFilter={toggleFilter}
+                showOriginOnly={showOriginOnly}
+                onToggleOriginOnly={toggleOriginOnly}
+                showBoardableOnly={showBoardableOnly}
+                onToggleBoardableOnly={toggleBoardableOnly}
+              />
+            )}
+
+            {/* Filtered entries */}
+            {info.isDetailedEnabled && (
+              <EntriesPanel
+                timetableEntries={filteredTimetableEntries}
+                type={data.type}
+                entryStats={filteredEntriesStats}
+                agencies={data.agencies}
+                dataLangs={dataLangs}
+                filteredCount={filteredTimetableEntries.length}
+                activeFilters={activeFilters}
+                onToggleFilter={toggleFilter}
+                showOriginOnly={showOriginOnly}
+                onToggleOriginOnly={toggleOriginOnly}
+                showBoardableOnly={showBoardableOnly}
+                onToggleBoardableOnly={toggleBoardableOnly}
               />
             )}
 
             <TimetableDateLabel serviceDate={data.serviceDate} time={time} lang={dataLangs[0]} />
-            {/* Origin filter (始発のみ) — hidden when no origin entries exist at this stop */}
-            {/* {originCount > 0 && ( */}
-            <TimetableOriginFilter
-              origin={showOriginOnly}
-              onToggleOrigin={toggleOriginOnly}
-              count={originCount}
-            />
-            {/* )} */}
-            {/* Boardability filter */}
-            <TimetableBoardabilityFilter
-              boardable={showBoardableOnly}
-              count={boardableCount}
-              onToggleBoardable={toggleBoardableOnly}
-            />
+
             {/* Headsign filter */}
             {data.type === 'stop' && (
-              <TimetableHeadsignFilter
-                timetableEntries={data.timetableEntries}
-                activeFilters={activeFilters}
-                onToggleFilter={toggleFilter}
-                dataLang={dataLangs}
-                agencies={data.agencies}
-              />
+              <>
+                <TimetableHeadsignFilter
+                  timetableEntries={filteredTimetableEntries}
+                  activeFilters={activeFilters}
+                  onToggleFilter={toggleFilter}
+                  dataLang={dataLangs}
+                  agencies={data.agencies}
+                />
+              </>
             )}
             {/* Unknown destination warning */}
             {((data.type === 'route-headsign' && data.headsign === '') ||

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -5,11 +5,12 @@ import { TimetableHeader } from '../timetable/timetable-header';
 import { TimetableMetadata } from '../timetable/timetable-metadata';
 import { TimetableHeadsignFilter } from '../timetable/timetable-headsign-filter';
 import { TimetableBoardabilityFilter } from '../timetable/timetable-boardability-filter';
+import { TimetableOriginFilter } from '../timetable/timetable-origin-filter';
 import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
 import { findRouteDirectionForHeadsign } from '@/domain/transit/find-route-direction-for-headsign';
 import { getStopDisplayNames } from '@/domain/transit/get-stop-display-names';
 import { getRouteHeadsignKey } from '../../domain/transit/get-route-headsign-key';
-import { filterBoardable } from '@/domain/transit/timetable-filter';
+import { filterBoardable, filterOrigin } from '@/domain/transit/timetable-filter';
 import { getServiceDayMinutes } from '@/domain/transit/service-day';
 import { useScrollFades } from '@/hooks/use-scroll-fades';
 import type { InfoLevel } from '@/types/app/settings';
@@ -86,6 +87,10 @@ export function TimetableModal({
   // When ON, applies filterBoardable on top of any other active filters.
   const [showBoardableOnly, setShowBoardableOnly] = useState(false);
 
+  // Origin-only filter toggle (= 始発のみ). OFF by default.
+  // When ON, applies filterOrigin on top of any other active filters.
+  const [showOriginOnly, setShowOriginOnly] = useState(false);
+
   const toggleFilter = useCallback((key: string) => {
     setActiveFilters((prev) => {
       const next = new Set(prev);
@@ -100,6 +105,10 @@ export function TimetableModal({
 
   const toggleBoardableOnly = useCallback(() => {
     setShowBoardableOnly((prev) => !prev);
+  }, []);
+
+  const toggleOriginOnly = useCallback(() => {
+    setShowOriginOnly((prev) => !prev);
   }, []);
 
   // Both timetable types now use TimetableEntry[] directly.
@@ -121,13 +130,30 @@ export function TimetableModal({
         activeFilters.has(getRouteHeadsignKey(entry.routeDirection)),
       );
     }
-    // Boardable-only filter (both types). Applied last so that the
-    // route+headsign filter narrows the candidate set first.
+    // Origin-only filter (both types). Applied before boardability so
+    // the boardability check operates on origin entries when both are on.
+    if (showOriginOnly) {
+      entries = filterOrigin(entries);
+    }
+    // Boardable-only filter (both types). Applied last; combined with
+    // origin-only this yields "boardable origins only" (= intersection).
     if (showBoardableOnly) {
       entries = filterBoardable(entries);
     }
     return entries;
-  }, [data, allTimetableEntries, activeFilters, showBoardableOnly]);
+  }, [data, allTimetableEntries, activeFilters, showOriginOnly, showBoardableOnly]);
+
+  // Counts shown on each filter pill. Computed against the unfiltered
+  // entries so the count is stable regardless of other filter state
+  // (= "total entries matching this dimension at this stop").
+  const boardableCount = useMemo(
+    () => filterBoardable(allTimetableEntries).length,
+    [allTimetableEntries],
+  );
+  const originCount = useMemo(
+    () => filterOrigin(allTimetableEntries).length,
+    [allTimetableEntries],
+  );
 
   const descriptionHeadsign = useMemo(() => {
     if (!data?.headsign || data.type !== 'route-headsign') {
@@ -254,13 +280,24 @@ export function TimetableModal({
                 timetableEntries={filteredTimetableEntries}
                 dataLang={dataLangs}
                 agencies={data.agencies}
+                boardableCount={boardableCount}
+                originCount={originCount}
               />
             )}
 
             <TimetableDateLabel serviceDate={data.serviceDate} time={time} lang={dataLangs[0]} />
+            {/* Origin filter (始発のみ) — hidden when no origin entries exist at this stop */}
+            {/* {originCount > 0 && ( */}
+            <TimetableOriginFilter
+              origin={showOriginOnly}
+              onToggleOrigin={toggleOriginOnly}
+              count={originCount}
+            />
+            {/* )} */}
             {/* Boardability filter */}
             <TimetableBoardabilityFilter
               boardable={showBoardableOnly}
+              count={boardableCount}
               onToggleBoardable={toggleBoardableOnly}
             />
             {/* Headsign filter */}

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -3,11 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { TimetableGrid } from '../timetable/timetable-grid';
 import { TimetableHeader } from '../timetable/timetable-header';
 import { TimetableMetadata } from '../timetable/timetable-metadata';
-import { StopTimetableFilter } from '../timetable/stop-timetable-filter';
+import { TimetableHeadsignFilter } from '../timetable/timetable-headsign-filter';
+import { TimetableBoardabilityFilter } from '../timetable/timetable-boardability-filter';
 import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
 import { findRouteDirectionForHeadsign } from '@/domain/transit/find-route-direction-for-headsign';
 import { getStopDisplayNames } from '@/domain/transit/get-stop-display-names';
 import { getRouteHeadsignKey } from '../../domain/transit/get-route-headsign-key';
+import { filterBoardable } from '@/domain/transit/timetable-filter';
 import { getServiceDayMinutes } from '@/domain/transit/service-day';
 import { useScrollFades } from '@/hooks/use-scroll-fades';
 import type { InfoLevel } from '@/types/app/settings';
@@ -80,6 +82,10 @@ export function TimetableModal({
   // Empty set = show all timetable (no filter active).
   const [activeFilters, setActiveFilters] = useState<Set<string>>(() => new Set());
 
+  // Boardable-only filter toggle. OFF by default (preserves existing behavior).
+  // When ON, applies filterBoardable on top of any other active filters.
+  const [showBoardableOnly, setShowBoardableOnly] = useState(false);
+
   const toggleFilter = useCallback((key: string) => {
     setActiveFilters((prev) => {
       const next = new Set(prev);
@@ -92,6 +98,10 @@ export function TimetableModal({
     });
   }, []);
 
+  const toggleBoardableOnly = useCallback(() => {
+    setShowBoardableOnly((prev) => !prev);
+  }, []);
+
   // Both timetable types now use TimetableEntry[] directly.
   const allTimetableEntries: TimetableEntry[] = useMemo(() => {
     if (!data) {
@@ -101,13 +111,23 @@ export function TimetableModal({
   }, [data]);
 
   const filteredTimetableEntries = useMemo(() => {
-    if (!data || data.type !== 'stop' || activeFilters.size === 0) {
+    if (!data) {
       return allTimetableEntries;
     }
-    return allTimetableEntries.filter((entry) =>
-      activeFilters.has(getRouteHeadsignKey(entry.routeDirection)),
-    );
-  }, [data, allTimetableEntries, activeFilters]);
+    let entries = allTimetableEntries;
+    // Route+headsign filter (stop type only, when active).
+    if (data.type === 'stop' && activeFilters.size > 0) {
+      entries = entries.filter((entry) =>
+        activeFilters.has(getRouteHeadsignKey(entry.routeDirection)),
+      );
+    }
+    // Boardable-only filter (both types). Applied last so that the
+    // route+headsign filter narrows the candidate set first.
+    if (showBoardableOnly) {
+      entries = filterBoardable(entries);
+    }
+    return entries;
+  }, [data, allTimetableEntries, activeFilters, showBoardableOnly]);
 
   const descriptionHeadsign = useMemo(() => {
     if (!data?.headsign || data.type !== 'route-headsign') {
@@ -238,8 +258,14 @@ export function TimetableModal({
             )}
 
             <TimetableDateLabel serviceDate={data.serviceDate} time={time} lang={dataLangs[0]} />
+            {/* Boardability filter */}
+            <TimetableBoardabilityFilter
+              boardable={showBoardableOnly}
+              onToggleBoardable={toggleBoardableOnly}
+            />
+            {/* Headsign filter */}
             {data.type === 'stop' && (
-              <StopTimetableFilter
+              <TimetableHeadsignFilter
                 timetableEntries={data.timetableEntries}
                 activeFilters={activeFilters}
                 onToggleFilter={toggleFilter}
@@ -247,6 +273,7 @@ export function TimetableModal({
                 agencies={data.agencies}
               />
             )}
+            {/* Unknown destination warning */}
             {((data.type === 'route-headsign' && data.headsign === '') ||
               (data.type === 'stop' &&
                 hasUnknownDestination(

--- a/src/components/timetable/timetable-boardability-filter.tsx
+++ b/src/components/timetable/timetable-boardability-filter.tsx
@@ -37,6 +37,9 @@ export function TimetableBoardabilityFilter({
       <PillButton
         size="sm"
         active={boardable}
+        activeBg={'#1565c0'}
+        activeBorder={'#1565c0'}
+        inactiveBorder={'#1565c0'}
         onClick={onToggleBoardable}
         title={t('timetable.filter.boardableOnlyTitle')}
         count={count}

--- a/src/components/timetable/timetable-boardability-filter.tsx
+++ b/src/components/timetable/timetable-boardability-filter.tsx
@@ -4,6 +4,8 @@ import { PillButton } from '../button/pill-button';
 interface TimetableBoardabilityFilterProps {
   boardable: boolean;
   onToggleBoardable: () => void;
+  /** Number of boardable entries (= count to display on the pill). */
+  count?: number;
 }
 
 /**
@@ -15,12 +17,18 @@ interface TimetableBoardabilityFilterProps {
  * this filter; if added in the future, expose them as a separate filter
  * component to keep dimensions distinct.
  *
+ * The `count` is owned by the caller so the same predicate is not
+ * computed twice (= once for filter, once for count). Caller decides
+ * which scope the count reflects (= total at stop, post-other-filters,
+ * etc.).
+ *
  * @param props - Filter rendering inputs.
  * @returns The rendered filter toggle.
  */
 export function TimetableBoardabilityFilter({
   boardable,
   onToggleBoardable,
+  count,
 }: TimetableBoardabilityFilterProps) {
   const { t } = useTranslation();
 
@@ -31,6 +39,7 @@ export function TimetableBoardabilityFilter({
         active={boardable}
         onClick={onToggleBoardable}
         title={t('timetable.filter.boardableOnlyTitle')}
+        count={count}
       >
         {t('timetable.filter.boardableOnly')}
       </PillButton>

--- a/src/components/timetable/timetable-boardability-filter.tsx
+++ b/src/components/timetable/timetable-boardability-filter.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from 'react-i18next';
+import { PillButton } from '../button/pill-button';
+
+interface TimetableBoardabilityFilterProps {
+  boardable: boolean;
+  onToggleBoardable: () => void;
+}
+
+/**
+ * Render the stop-level boardability filter toggle for a timetable view.
+ *
+ * Currently filters by stop-level boardability (= GTFS `pickup_type` and
+ * pattern-inferred `isTerminal`). Segment-level boardability signals
+ * (`continuous_pickup` / `continuous_drop_off`) are out of scope for
+ * this filter; if added in the future, expose them as a separate filter
+ * component to keep dimensions distinct.
+ *
+ * @param props - Filter rendering inputs.
+ * @returns The rendered filter toggle.
+ */
+export function TimetableBoardabilityFilter({
+  boardable,
+  onToggleBoardable,
+}: TimetableBoardabilityFilterProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      <PillButton
+        size="sm"
+        active={boardable}
+        onClick={onToggleBoardable}
+        title={t('timetable.filter.boardableOnlyTitle')}
+      >
+        {t('timetable.filter.boardableOnly')}
+      </PillButton>
+    </div>
+  );
+}

--- a/src/components/timetable/timetable-grid.tsx
+++ b/src/components/timetable/timetable-grid.tsx
@@ -81,7 +81,7 @@ export function TimetableGrid({
   if (hourGroups.size === 0) {
     return (
       <p className="text-muted-foreground p-4 text-center">
-        {omitted.terminal > 0
+        {omitted.nonBoardable > 0
           ? t('timetable.grid.empty.dropOffOnly')
           : t('timetable.grid.empty.noService')}
       </p>

--- a/src/components/timetable/timetable-headsign-filter.tsx
+++ b/src/components/timetable/timetable-headsign-filter.tsx
@@ -12,7 +12,7 @@ import type { TimetableEntry } from '@/types/app/transit-composed';
 import { getContrastAssessment } from '@/utils/color/color-contrast';
 import { PillButton } from '../button/pill-button';
 
-interface StopTimetableFilterProps {
+interface TimetableHeadsignFilterProps {
   timetableEntries: TimetableEntry[];
   activeFilters: Set<string>;
   onToggleFilter: (key: string) => void;
@@ -21,18 +21,23 @@ interface StopTimetableFilterProps {
 }
 
 /**
- * Render route+headsign filter pills for the stop timetable view.
+ * Render route+headsign filter pills for a timetable view.
+ *
+ * Pills are derived from the route+headsign combinations present in
+ * `timetableEntries`. Toggling a pill includes / excludes that
+ * route+headsign from the displayed timetable. The filter axis is
+ * route+headsign even though the user-facing label centers on headsign.
  *
  * @param props - Filter rendering inputs.
- * @returns The rendered stop timetable filter controls.
+ * @returns The rendered headsign filter controls.
  */
-export function StopTimetableFilter({
+export function TimetableHeadsignFilter({
   timetableEntries,
   activeFilters,
   onToggleFilter,
   dataLang,
   agencies,
-}: StopTimetableFilterProps) {
+}: TimetableHeadsignFilterProps) {
   const themeContrastBackgroundColor = useThemeContrastBackgroundColor();
 
   const routeHeadsigns = useMemo(() => {

--- a/src/components/timetable/timetable-metadata.tsx
+++ b/src/components/timetable/timetable-metadata.tsx
@@ -9,6 +9,10 @@ interface TimetableMetadataProps {
   timetableEntries: TimetableEntry[];
   dataLang: readonly string[];
   agencies: Agency[];
+  /** Number of boardable entries (= computed by caller for shared scope). */
+  boardableCount: number;
+  /** Number of origin entries (= computed by caller for shared scope). */
+  originCount: number;
 }
 
 function formatMinutes(minutes: number): string {
@@ -36,6 +40,8 @@ export function TimetableMetadata({
   timetableEntries,
   dataLang,
   agencies,
+  boardableCount,
+  originCount,
 }: TimetableMetadataProps) {
   const { t, i18n } = useTranslation();
   const allMinutes = timetableEntries.map((entry) => getDisplayMinutes(entry));
@@ -81,6 +87,20 @@ export function TimetableMetadata({
             })}
           </span>
         )}
+        <span>
+          {' '}
+          /{' '}
+          {t('timetable.metadata.boardableCount', {
+            count: boardableCount.toLocaleString(i18n.language),
+          })}
+        </span>
+        <span>
+          {' '}
+          /{' '}
+          {t('timetable.metadata.originCount', {
+            count: originCount.toLocaleString(i18n.language),
+          })}
+        </span>
       </p>
 
       {/* Routes with their counts.

--- a/src/components/timetable/timetable-metadata.tsx
+++ b/src/components/timetable/timetable-metadata.tsx
@@ -4,6 +4,7 @@ import { getDisplayMinutes } from '@/domain/transit/timetable-utils';
 import type { TimetableEntryStats } from '@/domain/transit/timetable-stats';
 import type { Agency, Route } from '@/types/app/transit';
 import type { TimetableEntry } from '@/types/app/transit-composed';
+import { LabelCountBadge } from '../badge/label-count-badge';
 import { RouteCountBadge } from '../badge/route-count-badge';
 
 interface TimetableMetadataProps {
@@ -58,6 +59,33 @@ function PatternPositionAxisStats({ stats }: { stats: TimetableEntryStats }) {
   );
 }
 
+function PatternPositionAxisBadges({ stats }: { stats: TimetableEntryStats }) {
+  const { t } = useTranslation();
+  const originLabelBadgeClassName = 'bg-blue-500 text-white';
+  const originCountBadgeClassName = 'border-l border-blue-500 bg-background text-foreground';
+  const terminalLabelBadgeClassName = 'bg-gray-500 text-white';
+  const terminalCountBadgeClassName = 'border-l border-gray-500 bg-background text-foreground';
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      <LabelCountBadge
+        label={t('timetable.entry.origin')}
+        count={stats.originCount}
+        frameClassName="border-blue-500"
+        labelClassName={originLabelBadgeClassName}
+        countClassName={originCountBadgeClassName}
+      />
+      <LabelCountBadge
+        label={t('timetable.entry.terminal')}
+        count={stats.terminalCount}
+        frameClassName="border-gray-500"
+        labelClassName={terminalLabelBadgeClassName}
+        countClassName={terminalCountBadgeClassName}
+      />
+    </div>
+  );
+}
+
 /**
  * Render the B-axis (boarding availability) stats span:
  * `[boardable / non-boardable / drop-off-only / no-drop-off]`.
@@ -91,6 +119,40 @@ function BoardingAxisStats({ stats }: { stats: TimetableEntryStats }) {
   );
 }
 
+function BoardingAxisBadges({ stats }: { stats: TimetableEntryStats }) {
+  const { t } = useTranslation();
+  const noPickupLabelBadgeClassName =
+    'border-yellow-600 bg-yellow-100 text-yellow-900 dark:border-yellow-600 dark:bg-yellow-950 dark:text-yellow-200';
+  const noPickupCountBadgeClassName = 'border-l border-yellow-600 bg-background text-foreground';
+  const noDropOffLabelBadgeClassName =
+    'bg-yellow-100 text-yellow-900 dark:bg-yellow-950 dark:text-yellow-200';
+  const noDropOffCountBadgeClassName =
+    'border-l border-dashed border-yellow-600 bg-background text-foreground';
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      <LabelCountBadge label={t('stop.serviceState.boardable')} count={stats.boardableCount} />
+      {/* <LabelCountBadge label={t('timetable.entry.noPickup')} count={stats.nonBoardableCount} /> */}
+      <LabelCountBadge
+        label={t('timetable.entry.noPickup')}
+        count={stats.nonBoardableCount}
+        frameClassName="border-yellow-600"
+        labelClassName={noPickupLabelBadgeClassName}
+        countClassName={noPickupCountBadgeClassName}
+      />
+      {/* <LabelCountBadge label={t('timetable.entry.noDropOff')} count={stats.noDropOffCount} /> */}
+      <LabelCountBadge
+        label={t('timetable.entry.noDropOff')}
+        count={stats.noDropOffCount}
+        frameClassName="border-dashed border-yellow-600"
+        labelClassName={noDropOffLabelBadgeClassName}
+        countClassName={noDropOffCountBadgeClassName}
+      />
+      <LabelCountBadge label={t('stop.serviceState.dropOffOnly')} count={stats.dropOffOnlyCount} />
+    </div>
+  );
+}
+
 /**
  * Render the C-axis (route direction) stats span. Split into two
  * bracket groups: `[route / headsign]` for unique-name signals and
@@ -105,29 +167,25 @@ function RouteDirectionAxisStats({ stats }: { stats: TimetableEntryStats }) {
   const { t, i18n } = useTranslation();
   return (
     <>
-    <span>
-      {'['}
-      {t('timetable.metadata.routeCount', {
-        count: stats.routeCount.toLocaleString(i18n.language),
-      })}
-      {' / '}
-      {t('timetable.metadata.headsignCount', {
-        count: stats.headsignCount.toLocaleString(i18n.language),
-      })}
-      {'] / ['}
-      {t('timetable.metadata.routeHeadsignCount', {
-        count: stats.routeHeadsignCount.toLocaleString(i18n.language),
-      })}
-      {' / '}
-      {t('timetable.metadata.stopHeadsignOverrideCount', {
-        count: stats.stopHeadsignOverrideCount.toLocaleString(i18n.language),
-      })}
-      {' / '}
-      {t('timetable.metadata.directionCount', {
-        count: stats.directionCount.toLocaleString(i18n.language),
-      })}
-      {']'}
-    </span>
+      <span>
+        {'['}
+        {t('timetable.metadata.routeCount', {
+          count: stats.routeCount.toLocaleString(i18n.language),
+        })}
+        {' / '}
+        {t('timetable.metadata.headsignCount', {
+          count: stats.stopHeadsignCount.toLocaleString(i18n.language),
+        })}
+        {'] / ['}
+        {t('timetable.metadata.routeHeadsignCount', {
+          count: stats.tripHeadsignCount.toLocaleString(i18n.language),
+        })}
+        {' / '}
+        {t('timetable.metadata.directionCount', {
+          count: stats.directionCount.toLocaleString(i18n.language),
+        })}
+        {']'}
+      </span>
     </>
   );
 }
@@ -188,16 +246,30 @@ export function TimetableMetadata({
             })}
           </span>
         )}
-        {/* A axis: pattern position */}
-        {' / '}
-        <PatternPositionAxisStats stats={stats} />
-        {/* B axis: boarding availability */}
-        {' / '}
-        <BoardingAxisStats stats={stats} />
-        {/* C axis: route direction */}
-        {/* {' / '} */}
-        <RouteDirectionAxisStats stats={stats} />
+        {false && (
+          <>
+            {' / '}
+            <PatternPositionAxisStats stats={stats} />
+          </>
+        )}
+        {false && (
+          <>
+            {' / '}
+            <BoardingAxisStats stats={stats} />
+          </>
+        )}
+        {false && (
+          <>
+            {' / '}
+            <RouteDirectionAxisStats stats={stats} />
+          </>
+        )}
       </p>
+
+      <div className="flex flex-wrap items-start gap-1">
+        <PatternPositionAxisBadges stats={stats} />
+        <BoardingAxisBadges stats={stats} />
+      </div>
 
       {/* Routes with their counts.
        *

--- a/src/components/timetable/timetable-metadata.tsx
+++ b/src/components/timetable/timetable-metadata.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getDisplayMinutes } from '@/domain/transit/timetable-utils';
+import type { TimetableEntryStats } from '@/domain/transit/timetable-stats';
 import type { Agency, Route } from '@/types/app/transit';
 import type { TimetableEntry } from '@/types/app/transit-composed';
 import { RouteCountBadge } from '../badge/route-count-badge';
@@ -9,10 +10,12 @@ interface TimetableMetadataProps {
   timetableEntries: TimetableEntry[];
   dataLang: readonly string[];
   agencies: Agency[];
-  /** Number of boardable entries (= computed by caller for shared scope). */
-  boardableCount: number;
-  /** Number of origin entries (= computed by caller for shared scope). */
-  originCount: number;
+  /**
+   * Aggregated stats for the displayed entries.
+   * Owned by the caller so the same aggregation is not repeated for the
+   * filter pills and the metadata block.
+   */
+  stats: TimetableEntryStats;
 }
 
 function formatMinutes(minutes: number): string {
@@ -31,6 +34,105 @@ function computeAverageInterval(minutes: number[]): number | null {
 }
 
 /**
+ * Render the A-axis (pattern position) stats span:
+ * `[origin / terminal / passing]`.
+ */
+function PatternPositionAxisStats({ stats }: { stats: TimetableEntryStats }) {
+  const { t, i18n } = useTranslation();
+  return (
+    <span>
+      {'['}
+      {t('timetable.metadata.originCount', {
+        count: stats.originCount.toLocaleString(i18n.language),
+      })}
+      {' / '}
+      {t('timetable.metadata.terminalCount', {
+        count: stats.terminalCount.toLocaleString(i18n.language),
+      })}
+      {' / '}
+      {t('timetable.metadata.passingCount', {
+        count: stats.passingCount.toLocaleString(i18n.language),
+      })}
+      {']'}
+    </span>
+  );
+}
+
+/**
+ * Render the B-axis (boarding availability) stats span:
+ * `[boardable / non-boardable / drop-off-only / no-drop-off]`.
+ *
+ * Reads only the boarding-related fields of {@link TimetableEntryStats},
+ * so callers can pass either the all-entries or filtered-entries stats
+ * depending on the metadata block scope.
+ */
+function BoardingAxisStats({ stats }: { stats: TimetableEntryStats }) {
+  const { t, i18n } = useTranslation();
+  return (
+    <span>
+      {'['}
+      {t('timetable.metadata.boardableCount', {
+        count: stats.boardableCount.toLocaleString(i18n.language),
+      })}
+      {' / '}
+      {t('timetable.metadata.nonBoardableCount', {
+        count: stats.nonBoardableCount.toLocaleString(i18n.language),
+      })}
+      {' / '}
+      {t('timetable.metadata.dropOffOnlyCount', {
+        count: stats.dropOffOnlyCount.toLocaleString(i18n.language),
+      })}
+      {' / '}
+      {t('timetable.metadata.noDropOffCount', {
+        count: stats.noDropOffCount.toLocaleString(i18n.language),
+      })}
+      {']'}
+    </span>
+  );
+}
+
+/**
+ * Render the C-axis (route direction) stats span. Split into two
+ * bracket groups: `[route / headsign]` for unique-name signals and
+ * `[routeHeadsign / stopHeadsignOverride / direction]` for combined /
+ * override / direction signals.
+ *
+ * `headsignCount` is currently aggregated from `tripHeadsign.name`;
+ * sources that publish trip_headsign as empty (= rely on stop_headsign,
+ * e.g. kobus) will report `headsignCount === 1`.
+ */
+function RouteDirectionAxisStats({ stats }: { stats: TimetableEntryStats }) {
+  const { t, i18n } = useTranslation();
+  return (
+    <>
+    <span>
+      {'['}
+      {t('timetable.metadata.routeCount', {
+        count: stats.routeCount.toLocaleString(i18n.language),
+      })}
+      {' / '}
+      {t('timetable.metadata.headsignCount', {
+        count: stats.headsignCount.toLocaleString(i18n.language),
+      })}
+      {'] / ['}
+      {t('timetable.metadata.routeHeadsignCount', {
+        count: stats.routeHeadsignCount.toLocaleString(i18n.language),
+      })}
+      {' / '}
+      {t('timetable.metadata.stopHeadsignOverrideCount', {
+        count: stats.stopHeadsignOverrideCount.toLocaleString(i18n.language),
+      })}
+      {' / '}
+      {t('timetable.metadata.directionCount', {
+        count: stats.directionCount.toLocaleString(i18n.language),
+      })}
+      {']'}
+    </span>
+    </>
+  );
+}
+
+/**
  * Render timetable statistics and per-route counts above the timetable grid.
  *
  * @param props - Metadata rendering inputs.
@@ -40,8 +142,7 @@ export function TimetableMetadata({
   timetableEntries,
   dataLang,
   agencies,
-  boardableCount,
-  originCount,
+  stats,
 }: TimetableMetadataProps) {
   const { t, i18n } = useTranslation();
   const allMinutes = timetableEntries.map((entry) => getDisplayMinutes(entry));
@@ -87,20 +188,15 @@ export function TimetableMetadata({
             })}
           </span>
         )}
-        <span>
-          {' '}
-          /{' '}
-          {t('timetable.metadata.boardableCount', {
-            count: boardableCount.toLocaleString(i18n.language),
-          })}
-        </span>
-        <span>
-          {' '}
-          /{' '}
-          {t('timetable.metadata.originCount', {
-            count: originCount.toLocaleString(i18n.language),
-          })}
-        </span>
+        {/* A axis: pattern position */}
+        {' / '}
+        <PatternPositionAxisStats stats={stats} />
+        {/* B axis: boarding availability */}
+        {' / '}
+        <BoardingAxisStats stats={stats} />
+        {/* C axis: route direction */}
+        {/* {' / '} */}
+        <RouteDirectionAxisStats stats={stats} />
       </p>
 
       {/* Routes with their counts.

--- a/src/components/timetable/timetable-origin-filter.tsx
+++ b/src/components/timetable/timetable-origin-filter.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'react-i18next';
+import { PillButton } from '../button/pill-button';
+
+interface TimetableOriginFilterProps {
+  origin: boolean;
+  onToggleOrigin: () => void;
+  /** Number of origin entries (= count to display on the pill). */
+  count?: number;
+}
+
+/**
+ * Render the origin (始発) filter toggle for a timetable view.
+ *
+ * Filters to entries where this stop is the trip's origin
+ * (= `entry.patternPosition.isOrigin === true`). Includes non-boardable
+ * origins (e.g. depot / yard departures with `pickup_type === 1`); the
+ * grid distinguishes those visually with `乗×` / `降×` markers, so
+ * hiding them at this layer would suppress legitimate GTFS data the
+ * viewer is meant to surface.
+ *
+ * If the caller wants only "boardable origins", combine this with
+ * `TimetableBoardabilityFilter` (= toggle both on); the result is the
+ * intersection.
+ *
+ * @param props - Filter rendering inputs.
+ * @returns The rendered filter toggle.
+ */
+export function TimetableOriginFilter({
+  origin,
+  onToggleOrigin,
+  count,
+}: TimetableOriginFilterProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      <PillButton
+        size="sm"
+        active={origin}
+        onClick={onToggleOrigin}
+        title={t('timetable.filter.originOnlyTitle')}
+        count={count}
+      >
+        {t('timetable.filter.originOnly')}
+      </PillButton>
+    </div>
+  );
+}

--- a/src/components/timetable/timetable-origin-filter.tsx
+++ b/src/components/timetable/timetable-origin-filter.tsx
@@ -37,6 +37,9 @@ export function TimetableOriginFilter({
       <PillButton
         size="sm"
         active={origin}
+        activeBg={'#1565c0'}
+        activeBorder={'#1565c0'}
+        inactiveBorder={'#1565c0'}
         onClick={onToggleOrigin}
         title={t('timetable.filter.originOnlyTitle')}
         count={count}

--- a/src/components/verbose/verbose-timetable-summary.tsx
+++ b/src/components/verbose/verbose-timetable-summary.tsx
@@ -84,8 +84,8 @@ export function VerboseTimetableSummary({
           </span>
           {dwellCount > 0 && <span className="block">[dwell] count={dwellCount}</span>}
           <span className="block">
-            [state] stopServiceState={stopServiceState} omitted.terminal=
-            {omitted.terminal}
+            [state] stopServiceState={stopServiceState} omitted.nonBoardable=
+            {omitted.nonBoardable}
           </span>
         </span>
       </div>

--- a/src/domain/transit/__tests__/timetable-filter.test.ts
+++ b/src/domain/transit/__tests__/timetable-filter.test.ts
@@ -90,7 +90,7 @@ function makeEntry(
 // ---------------------------------------------------------------------------
 
 describe('prepareStopTimetable', () => {
-  describe('includeTerminals = true (detailed/verbose)', () => {
+  describe('includeNonBoardable = true (detailed/verbose)', () => {
     it('returns all entries including terminals', () => {
       const entries = [
         makeEntry(),
@@ -99,25 +99,25 @@ describe('prepareStopTimetable', () => {
       ];
       const result = prepareStopTimetable(entries, true);
       expect(result.entries).toHaveLength(3);
-      expect(result.omitted.terminal).toBe(0);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
     it('returns all entries when none are terminal', () => {
       const entries = [makeEntry(), makeEntry(), makeEntry()];
       const result = prepareStopTimetable(entries, true);
       expect(result.entries).toHaveLength(3);
-      expect(result.omitted.terminal).toBe(0);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
     it('returns all entries when all are terminal (drop-off only stop)', () => {
       const entries = [makeEntry({ isTerminal: true }), makeEntry({ isTerminal: true })];
       const result = prepareStopTimetable(entries, true);
       expect(result.entries).toHaveLength(2);
-      expect(result.omitted.terminal).toBe(0);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
   });
 
-  describe('includeTerminals = false (simple/normal)', () => {
+  describe('includeNonBoardable = false (simple/normal)', () => {
     it('filters out terminal entries', () => {
       const entries = [
         makeEntry(),
@@ -126,21 +126,21 @@ describe('prepareStopTimetable', () => {
       ];
       const result = prepareStopTimetable(entries, false);
       expect(result.entries).toHaveLength(1);
-      expect(result.omitted.terminal).toBe(2);
+      expect(result.omitted.nonBoardable).toBe(2);
     });
 
     it('returns all entries when none are terminal', () => {
       const entries = [makeEntry(), makeEntry(), makeEntry()];
       const result = prepareStopTimetable(entries, false);
       expect(result.entries).toHaveLength(3);
-      expect(result.omitted.terminal).toBe(0);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
     it('returns empty when all are terminal (drop-off only stop)', () => {
       const entries = [makeEntry({ isTerminal: true }), makeEntry({ isTerminal: true })];
       const result = prepareStopTimetable(entries, false);
       expect(result.entries).toHaveLength(0);
-      expect(result.omitted.terminal).toBe(2);
+      expect(result.omitted.nonBoardable).toBe(2);
     });
 
     it('preserves non-terminal entries from multiple routes', () => {
@@ -152,11 +152,11 @@ describe('prepareStopTimetable', () => {
       ];
       const result = prepareStopTimetable(entries, false);
       expect(result.entries).toHaveLength(2);
-      expect(result.omitted.terminal).toBe(2);
+      expect(result.omitted.nonBoardable).toBe(2);
     });
   });
 
-  describe('invariant: entries.length + omitted.terminal = input.length', () => {
+  describe('invariant: entries.length + omitted.nonBoardable = input.length', () => {
     it('holds for mixed entries', () => {
       const entries = [
         makeEntry(),
@@ -167,13 +167,13 @@ describe('prepareStopTimetable', () => {
         makeEntry({ isTerminal: true }),
       ];
       const result = prepareStopTimetable(entries, false);
-      expect(result.entries.length + result.omitted.terminal).toBe(entries.length);
+      expect(result.entries.length + result.omitted.nonBoardable).toBe(entries.length);
     });
 
-    it('holds when includeTerminals is true', () => {
+    it('holds when includeNonBoardable is true', () => {
       const entries = [makeEntry(), makeEntry({ isTerminal: true })];
       const result = prepareStopTimetable(entries, true);
-      expect(result.entries.length + result.omitted.terminal).toBe(entries.length);
+      expect(result.entries.length + result.omitted.nonBoardable).toBe(entries.length);
     });
   });
 
@@ -181,19 +181,19 @@ describe('prepareStopTimetable', () => {
     it('handles empty array', () => {
       const result = prepareStopTimetable([], false);
       expect(result.entries).toHaveLength(0);
-      expect(result.omitted.terminal).toBe(0);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
     it('handles single non-terminal entry', () => {
       const result = prepareStopTimetable([makeEntry()], false);
       expect(result.entries).toHaveLength(1);
-      expect(result.omitted.terminal).toBe(0);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
     it('handles single terminal entry', () => {
       const result = prepareStopTimetable([makeEntry({ isTerminal: true })], false);
       expect(result.entries).toHaveLength(0);
-      expect(result.omitted.terminal).toBe(1);
+      expect(result.omitted.nonBoardable).toBe(1);
     });
 
     it('preserves entry order', () => {
@@ -207,23 +207,28 @@ describe('prepareStopTimetable', () => {
       expect(result.entries[1].schedule.departureMinutes).toBe(540);
     });
 
-    it('is not affected by boarding pickupType/dropOffType values', () => {
-      // This function filters by isTerminal only, not by boarding types.
-      // Entries with pickupType 2/3 (phone/coordinate) are not filtered.
+    it('filters by boardability: pickupType=1 removed, 2/3 kept, dropOffType=1 kept', () => {
+      // The boardability filter (= !isDropOffOnly) excludes entries with
+      // pickupType === 1 (= source explicit "no pickup"). pickupType 2/3
+      // (phone/coordinate arrangement required, but still boardable) and
+      // dropOffType=1 (drop-off-only-side signal, irrelevant to boarding)
+      // are kept.
       const entries = [
-        makeEntry({ pickupType: 0 }),
-        makeEntry({ pickupType: 1 }),
-        makeEntry({ pickupType: 2 }),
-        makeEntry({ pickupType: 3 }),
-        makeEntry({ dropOffType: 1 }),
+        makeEntry({ pickupType: 0 }), // kept
+        makeEntry({ pickupType: 1 }), // removed (non-boardable)
+        makeEntry({ pickupType: 2 }), // kept (phone arrangement, boardable)
+        makeEntry({ pickupType: 3 }), // kept (driver coordinate, boardable)
+        makeEntry({ dropOffType: 1 }), // kept (drop-off side does not affect boarding)
       ];
       const result = prepareStopTimetable(entries, false);
-      expect(result.entries).toHaveLength(5);
-      expect(result.omitted.terminal).toBe(0);
+      expect(result.entries).toHaveLength(4);
+      expect(result.omitted.nonBoardable).toBe(1);
     });
 
-    it('is not affected by isOrigin (only isTerminal matters)', () => {
-      // isOrigin: true entries are kept — only isTerminal triggers removal.
+    it('isOrigin alone does not trigger removal (origin remains boardable)', () => {
+      // Only isTerminal (or pickupType === 1) triggers removal.
+      // isOrigin: true entries are kept unless they are also terminal
+      // (= circular route case).
       const entries = [
         makeEntry({ isOrigin: true }),
         makeEntry({ isOrigin: true, isTerminal: true }),
@@ -231,20 +236,20 @@ describe('prepareStopTimetable', () => {
       ];
       const result = prepareStopTimetable(entries, false);
       expect(result.entries).toHaveLength(2);
-      expect(result.omitted.terminal).toBe(1);
+      expect(result.omitted.nonBoardable).toBe(1);
     });
 
-    it('filter criterion is isTerminal only, not boarding (mixed scenario)', () => {
-      // terminal + pickupType=0: removed (terminal wins)
-      // non-terminal + pickupType=1: kept (boarding does not affect filter)
+    it('filter criterion is !isDropOffOnly (terminal OR pickupType=1)', () => {
+      // Both signals trigger removal independently:
+      //   terminal + pickupType=0 → removed (terminal triggers isDropOffOnly)
+      //   non-terminal + pickupType=1 → removed (pickupType=1 triggers isDropOffOnly)
       const entries = [
         makeEntry({ isTerminal: true, pickupType: 0 }),
         makeEntry({ isTerminal: false, pickupType: 1 }),
       ];
       const result = prepareStopTimetable(entries, false);
-      expect(result.entries).toHaveLength(1);
-      expect(result.entries[0].boarding.pickupType).toBe(1);
-      expect(result.omitted.terminal).toBe(1);
+      expect(result.entries).toHaveLength(0);
+      expect(result.omitted.nonBoardable).toBe(2);
     });
 
     it('circular route: isTerminal && isOrigin both true → filtered out', () => {
@@ -253,7 +258,7 @@ describe('prepareStopTimetable', () => {
       const entries = [makeEntry({ isTerminal: true, isOrigin: true }), makeEntry()];
       const result = prepareStopTimetable(entries, false);
       expect(result.entries).toHaveLength(1);
-      expect(result.omitted.terminal).toBe(1);
+      expect(result.omitted.nonBoardable).toBe(1);
     });
 
     it('does not modify the input array', () => {
@@ -328,17 +333,17 @@ describe('prepareRouteHeadsignTimetable', () => {
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', false);
       expect(result.entries).toHaveLength(1);
-      expect(result.omitted.terminal).toBe(1);
+      expect(result.omitted.nonBoardable).toBe(1);
     });
 
-    it('includes terminals when includeTerminals is true', () => {
+    it('includes terminals when includeNonBoardable is true', () => {
       const entries = [
         makeEntry({ route: routeA, headsign: 'North' }),
         makeEntry({ route: routeA, headsign: 'North', isTerminal: true }),
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', true);
       expect(result.entries).toHaveLength(2);
-      expect(result.omitted.terminal).toBe(0);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
     it('returns empty when all matching entries are terminal', () => {
@@ -348,12 +353,12 @@ describe('prepareRouteHeadsignTimetable', () => {
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', false);
       expect(result.entries).toHaveLength(0);
-      expect(result.omitted.terminal).toBe(2);
+      expect(result.omitted.nonBoardable).toBe(2);
     });
   });
 
   describe('omitted scoping (PR #62 issue #5)', () => {
-    it('omitted.terminal does not include other routes terminals', () => {
+    it('omitted.nonBoardable does not include other routes terminals', () => {
       const entries = [
         // routeA North: 2 normal + 1 terminal
         makeEntry({ route: routeA, headsign: 'North' }),
@@ -366,10 +371,10 @@ describe('prepareRouteHeadsignTimetable', () => {
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', false);
       expect(result.entries).toHaveLength(2);
-      expect(result.omitted.terminal).toBe(1); // not 4
+      expect(result.omitted.nonBoardable).toBe(1); // not 4
     });
 
-    it('omitted.terminal does not include other headsigns terminals', () => {
+    it('omitted.nonBoardable does not include other headsigns terminals', () => {
       const entries = [
         // routeA North: 1 normal
         makeEntry({ route: routeA, headsign: 'North' }),
@@ -380,7 +385,7 @@ describe('prepareRouteHeadsignTimetable', () => {
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', false);
       expect(result.entries).toHaveLength(1);
-      expect(result.omitted.terminal).toBe(0);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
     it('real-world scenario: バスタ新宿 (mixed routes, drop-off only stop-wide)', () => {
@@ -401,16 +406,16 @@ describe('prepareRouteHeadsignTimetable', () => {
       // Route A Shinjuku: all 5 are terminal
       const resultA = prepareRouteHeadsignTimetable(entries, 'routeA', 'Shinjuku', false);
       expect(resultA.entries).toHaveLength(0);
-      expect(resultA.omitted.terminal).toBe(5); // not 8 (5+3)
+      expect(resultA.omitted.nonBoardable).toBe(5); // not 8 (5+3)
 
       // Route A Nakano: no terminals
       const resultB = prepareRouteHeadsignTimetable(entries, 'routeA', 'Nakano', false);
       expect(resultB.entries).toHaveLength(2);
-      expect(resultB.omitted.terminal).toBe(0);
+      expect(resultB.omitted.nonBoardable).toBe(0);
     });
   });
 
-  describe('invariant: entries.length + omitted.terminal = matching entries count', () => {
+  describe('invariant: entries.length + omitted.nonBoardable = matching entries count', () => {
     it('holds for filtered results', () => {
       const entries = [
         makeEntry({ route: routeA, headsign: 'North' }),
@@ -424,16 +429,16 @@ describe('prepareRouteHeadsignTimetable', () => {
           e.routeDirection.route.route_id === 'routeA' &&
           getEffectiveHeadsign(e.routeDirection) === 'North',
       ).length;
-      expect(result.entries.length + result.omitted.terminal).toBe(totalMatching);
+      expect(result.entries.length + result.omitted.nonBoardable).toBe(totalMatching);
     });
 
-    it('holds when includeTerminals is true', () => {
+    it('holds when includeNonBoardable is true', () => {
       const entries = [
         makeEntry({ route: routeA, headsign: 'North' }),
         makeEntry({ route: routeA, headsign: 'North', isTerminal: true }),
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', true);
-      expect(result.entries.length + result.omitted.terminal).toBe(2);
+      expect(result.entries.length + result.omitted.nonBoardable).toBe(2);
     });
   });
 
@@ -441,7 +446,7 @@ describe('prepareRouteHeadsignTimetable', () => {
     it('handles empty array', () => {
       const result = prepareRouteHeadsignTimetable([], 'routeA', 'North', false);
       expect(result.entries).toHaveLength(0);
-      expect(result.omitted.terminal).toBe(0);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
     it('preserves entry order within matched route+headsign', () => {
@@ -455,8 +460,10 @@ describe('prepareRouteHeadsignTimetable', () => {
       expect(result.entries[1].schedule.departureMinutes).toBe(540);
     });
 
-    it('is not affected by boarding pickupType/dropOffType values', () => {
-      // Filtering is by isTerminal and route+headsign only, not boarding types.
+    it('filters by boardability within route+headsign: pickupType=1 removed', () => {
+      // The boardability filter (= !isDropOffOnly) excludes pickupType === 1.
+      // pickupType 2/3 (arrangement required, still boardable) and dropOffType=1
+      // (drop-off-side signal, irrelevant to boarding) are kept.
       const entries = [
         makeEntry({ route: routeA, headsign: 'North', pickupType: 0 }),
         makeEntry({ route: routeA, headsign: 'North', pickupType: 1 }),
@@ -465,8 +472,8 @@ describe('prepareRouteHeadsignTimetable', () => {
         makeEntry({ route: routeA, headsign: 'North', dropOffType: 1 }),
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', false);
-      expect(result.entries).toHaveLength(5);
-      expect(result.omitted.terminal).toBe(0);
+      expect(result.entries).toHaveLength(4);
+      expect(result.omitted.nonBoardable).toBe(1);
     });
 
     it('is not affected by isOrigin (only isTerminal matters)', () => {
@@ -476,7 +483,7 @@ describe('prepareRouteHeadsignTimetable', () => {
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', false);
       expect(result.entries).toHaveLength(1);
-      expect(result.omitted.terminal).toBe(1);
+      expect(result.omitted.nonBoardable).toBe(1);
     });
 
     it('uses exact match for route_id and headsign (no normalization)', () => {
@@ -497,7 +504,7 @@ describe('prepareRouteHeadsignTimetable', () => {
       );
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', false);
       expect(result.entries).toHaveLength(0);
-      expect(result.omitted.terminal).toBe(0); // not 100
+      expect(result.omitted.nonBoardable).toBe(0); // not 100
     });
 
     it('circular route: isTerminal && isOrigin both true → filtered out', () => {
@@ -507,7 +514,7 @@ describe('prepareRouteHeadsignTimetable', () => {
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', false);
       expect(result.entries).toHaveLength(1);
-      expect(result.omitted.terminal).toBe(1);
+      expect(result.omitted.nonBoardable).toBe(1);
     });
 
     it('does not modify the input array', () => {

--- a/src/domain/transit/__tests__/timetable-filter.test.ts
+++ b/src/domain/transit/__tests__/timetable-filter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Route } from '../../../types/app/transit';
 import type { TimetableEntry } from '../../../types/app/transit-composed';
 import {
+  filterBoardable,
   filterByAgency,
   filterByRouteType,
   prepareStopTimetable,
@@ -35,6 +36,20 @@ const routeB: Route = {
   agency_id: 'test',
 };
 
+function makeRoute(id: string, agencyId = 'test'): Route {
+  return {
+    route_id: id,
+    route_short_name: id,
+    route_short_names: {},
+    route_long_name: '',
+    route_long_names: {},
+    route_type: 3,
+    route_color: '000000',
+    route_text_color: 'FFFFFF',
+    agency_id: agencyId,
+  };
+}
+
 function makeEntry(
   overrides: {
     route?: Route;
@@ -44,6 +59,8 @@ function makeEntry(
     pickupType?: 0 | 1 | 2 | 3;
     dropOffType?: 0 | 1 | 2 | 3;
     departureMinutes?: number;
+    stopIndex?: number;
+    totalStops?: number;
   } = {},
 ): TimetableEntry {
   const route = overrides.route ?? routeA;
@@ -59,8 +76,8 @@ function makeEntry(
     },
     boarding: { pickupType: overrides.pickupType ?? 0, dropOffType: overrides.dropOffType ?? 0 },
     patternPosition: {
-      stopIndex: 0,
-      totalStops: 10,
+      stopIndex: overrides.stopIndex ?? 0,
+      totalStops: overrides.totalStops ?? 10,
       isTerminal: overrides.isTerminal ?? false,
       isOrigin: overrides.isOrigin ?? false,
     },
@@ -633,5 +650,244 @@ describe('filterByRouteType', () => {
     const original = [...entries];
     filterByRouteType(entries, new Set([0]));
     expect(entries).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterBoardable
+// ---------------------------------------------------------------------------
+
+describe('filterBoardable', () => {
+  describe('empty input', () => {
+    it('returns empty array', () => {
+      expect(filterBoardable([])).toEqual([]);
+    });
+  });
+
+  describe('all boardable (!isDropOffOnly)', () => {
+    it('returns single entry', () => {
+      expect(filterBoardable([makeEntry()])).toHaveLength(1);
+    });
+
+    it('returns all entries', () => {
+      expect(filterBoardable([makeEntry(), makeEntry(), makeEntry()])).toHaveLength(3);
+    });
+
+    it('keeps isOrigin entries', () => {
+      expect(filterBoardable([makeEntry({ isOrigin: true })])).toHaveLength(1);
+    });
+
+    it('keeps pickupType=0 (available)', () => {
+      expect(filterBoardable([makeEntry({ pickupType: 0 })])).toHaveLength(1);
+    });
+
+    it('keeps pickupType=2 (phone required) — requires arrangement but boardable', () => {
+      expect(filterBoardable([makeEntry({ pickupType: 2 })])).toHaveLength(1);
+    });
+
+    it('keeps pickupType=3 (coordinate required) — requires arrangement but boardable', () => {
+      expect(filterBoardable([makeEntry({ pickupType: 3 })])).toHaveLength(1);
+    });
+  });
+
+  describe('all isDropOffOnly', () => {
+    it('filters single terminal entry', () => {
+      expect(filterBoardable([makeEntry({ isTerminal: true })])).toHaveLength(0);
+    });
+
+    it('filters single pickupType=1 entry', () => {
+      expect(filterBoardable([makeEntry({ pickupType: 1 })])).toHaveLength(0);
+    });
+
+    it('filters multiple terminal entries', () => {
+      const entries = [makeEntry({ isTerminal: true }), makeEntry({ isTerminal: true })];
+      expect(filterBoardable(entries)).toHaveLength(0);
+    });
+
+    it('filters multiple pickupType=1 entries', () => {
+      const entries = [makeEntry({ pickupType: 1 }), makeEntry({ pickupType: 1 })];
+      expect(filterBoardable(entries)).toHaveLength(0);
+    });
+
+    it('filters when both isTerminal and pickupType=1 are set', () => {
+      expect(filterBoardable([makeEntry({ isTerminal: true, pickupType: 1 })])).toHaveLength(0);
+    });
+
+    it('filters mix of terminal and pickupType=1', () => {
+      const entries = [
+        makeEntry({ isTerminal: true }),
+        makeEntry({ pickupType: 1 }),
+        makeEntry({ isTerminal: true, pickupType: 1 }),
+      ];
+      expect(filterBoardable(entries)).toHaveLength(0);
+    });
+  });
+
+  describe('mixed boardable and isDropOffOnly', () => {
+    it('keeps boardable, filters terminal', () => {
+      const boardable = makeEntry();
+      const terminal = makeEntry({ isTerminal: true });
+      expect(filterBoardable([terminal, boardable])).toEqual([boardable]);
+    });
+
+    it('keeps boardable, filters pickupType=1', () => {
+      const boardable = makeEntry();
+      const pickup1 = makeEntry({ pickupType: 1 });
+      expect(filterBoardable([pickup1, boardable])).toEqual([boardable]);
+    });
+
+    it('keeps boardable, filters both terminal and pickupType=1', () => {
+      const boardable = makeEntry();
+      const terminal = makeEntry({ isTerminal: true });
+      const pickup1 = makeEntry({ pickupType: 1 });
+      expect(filterBoardable([terminal, boardable, pickup1])).toEqual([boardable]);
+    });
+
+    it('preserves order of boardable entries', () => {
+      const a = makeEntry({ departureMinutes: 480 });
+      const b = makeEntry({ departureMinutes: 540 });
+      const c = makeEntry({ departureMinutes: 600 });
+      const term = makeEntry({ departureMinutes: 500, isTerminal: true });
+      expect(filterBoardable([a, term, b, c]).map((e) => e.schedule.departureMinutes)).toEqual([
+        480, 540, 600,
+      ]);
+    });
+  });
+
+  describe('multi-route / multi-agency', () => {
+    const routeA = makeRoute('route-A', 'agency-1');
+    const routeB = makeRoute('route-B', 'agency-2');
+
+    it('filters per-entry regardless of route (mixed agencies)', () => {
+      const entries = [
+        makeEntry({ route: routeA, isTerminal: true }), // agency-1, terminal
+        makeEntry({ route: routeB }), // agency-2, boardable
+        makeEntry({ route: routeA }), // agency-1, boardable
+        makeEntry({ route: routeB, pickupType: 1 }), // agency-2, pickup unavailable
+      ];
+      const result = filterBoardable(entries);
+      expect(result).toHaveLength(2);
+      expect(result[0].routeDirection.route.route_id).toBe('route-B');
+      expect(result[1].routeDirection.route.route_id).toBe('route-A');
+    });
+
+    it('returns empty when all routes are terminal (single agency)', () => {
+      const entries = [
+        makeEntry({ route: routeA, isTerminal: true }),
+        makeEntry({ route: routeA, isTerminal: true }),
+      ];
+      expect(filterBoardable(entries)).toHaveLength(0);
+    });
+
+    it('returns empty when all routes are drop-off only (multiple agencies)', () => {
+      const entries = [
+        makeEntry({ route: routeA, isTerminal: true }),
+        makeEntry({ route: routeB, pickupType: 1 }),
+      ];
+      expect(filterBoardable(entries)).toHaveLength(0);
+    });
+
+    it('keeps boardable entries from one agency while filtering terminal from another', () => {
+      const entries = [
+        makeEntry({ route: routeA, isTerminal: true, departureMinutes: 480 }),
+        makeEntry({ route: routeB, departureMinutes: 490 }),
+        makeEntry({ route: routeA, isTerminal: true, departureMinutes: 500 }),
+        makeEntry({ route: routeB, departureMinutes: 510 }),
+      ];
+      const result = filterBoardable(entries);
+      expect(result).toHaveLength(2);
+      expect(result.every((e) => e.routeDirection.route.agency_id === 'agency-2')).toBe(true);
+    });
+  });
+
+  describe('turnaround stop (同一路線で ORIG/TERM 交互 — 日野駅パターン)', () => {
+    it('keeps ORIG entries and filters TERM entries from same route', () => {
+      const route = makeRoute('route-bus');
+      const entries = [
+        makeEntry({ route, departureMinutes: 1255, isTerminal: true, pickupType: 1 }), // 20:55 着
+        makeEntry({ route, departureMinutes: 1258, isTerminal: true, pickupType: 1 }), // 20:58 着
+        makeEntry({ route, departureMinutes: 1260, isOrigin: true, pickupType: 0 }), // 21:00 発
+        makeEntry({ route, departureMinutes: 1265, isTerminal: true, pickupType: 1 }), // 21:05 着
+        makeEntry({ route, departureMinutes: 1270, isOrigin: true, pickupType: 0 }), // 21:10 発
+      ];
+      const result = filterBoardable(entries);
+      expect(result).toHaveLength(2);
+      expect(result.map((e) => e.schedule.departureMinutes)).toEqual([1260, 1270]);
+    });
+  });
+
+  describe('pt=0 with isTerminal fallback (都バス — pt 未設定ソース)', () => {
+    it('filters all entries when pt=0 but all are terminal', () => {
+      // 都バスは pickup_type を設定しない (全て 0)。
+      // isTerminal フォールバックで終点を検出。
+      const entries = [
+        makeEntry({ pickupType: 0, isTerminal: true, departureMinutes: 480 }),
+        makeEntry({ pickupType: 0, isTerminal: true, departureMinutes: 540 }),
+        makeEntry({ pickupType: 0, isTerminal: true, departureMinutes: 600 }),
+      ];
+      expect(filterBoardable(entries)).toHaveLength(0);
+    });
+
+    it('keeps non-terminal entries when pt=0', () => {
+      const entries = [
+        makeEntry({ pickupType: 0, isTerminal: true }),
+        makeEntry({ pickupType: 0, isTerminal: false }),
+        makeEntry({ pickupType: 0, isOrigin: true }),
+      ];
+      expect(filterBoardable(entries)).toHaveLength(2);
+    });
+  });
+
+  describe('mid-route pickup unavailable (途中停留所で pt=1)', () => {
+    it('filters pt=1 entry that is not terminal', () => {
+      // 途中停留所だが乗車不可 — 本来の「降車専用」
+      const entry = makeEntry({ pickupType: 1, isTerminal: false, stopIndex: 5, totalStops: 10 });
+      expect(filterBoardable([entry])).toHaveLength(0);
+    });
+
+    it('keeps other entries at same stop when only some have pt=1', () => {
+      const route = makeRoute('route-express');
+      const entries = [
+        makeEntry({ route, pickupType: 1, departureMinutes: 480 }), // express: no pickup
+        makeEntry({ route, pickupType: 0, departureMinutes: 510 }), // local: pickup ok
+        makeEntry({ route, pickupType: 1, departureMinutes: 540 }), // express: no pickup
+      ];
+      const result = filterBoardable(entries);
+      expect(result).toHaveLength(1);
+      expect(result[0].schedule.departureMinutes).toBe(510);
+    });
+  });
+
+  describe('same route+headsign with mixed pt per stop time', () => {
+    it('filters individually even within same route+headsign', () => {
+      // v2 pipeline では pt は便ごとの配列。同じ trip pattern でも
+      // 便によって pt が異なりうる。
+      const route = makeRoute('route-X');
+      const entries = [
+        makeEntry({ route, headsign: 'Terminal', pickupType: 0, departureMinutes: 480 }),
+        makeEntry({ route, headsign: 'Terminal', pickupType: 1, departureMinutes: 510 }),
+        makeEntry({ route, headsign: 'Terminal', pickupType: 0, departureMinutes: 540 }),
+      ];
+      const result = filterBoardable(entries);
+      expect(result).toHaveLength(2);
+      expect(result.map((e) => e.schedule.departureMinutes)).toEqual([480, 540]);
+    });
+  });
+
+  describe('circular route edge case', () => {
+    it('filters isTerminal && isOrigin — current behavior', () => {
+      // Circular routes have the same stop as both origin and terminal.
+      // isDropOffOnly returns true because isTerminal is checked.
+      // This may cause false positives for circular routes where
+      // passengers CAN board at the terminal/origin stop.
+      const entry = makeEntry({ isTerminal: true, isOrigin: true });
+      expect(filterBoardable([entry])).toHaveLength(0);
+    });
+
+    it('filters isTerminal && isOrigin even with pickupType=0', () => {
+      // pt=0 is ambiguous (available OR not set). isTerminal takes precedence.
+      const entry = makeEntry({ isTerminal: true, isOrigin: true, pickupType: 0 });
+      expect(filterBoardable([entry])).toHaveLength(0);
+    });
   });
 });

--- a/src/domain/transit/__tests__/timetable-stats.test.ts
+++ b/src/domain/transit/__tests__/timetable-stats.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from 'vitest';
+import type { Route } from '../../../types/app/transit';
+import type { TimetableEntry, TranslatableText } from '../../../types/app/transit-composed';
+import { computeTimetableEntryStats } from '../timetable-stats';
+
+// --- Test fixtures ---
+
+function makeRoute(id: string, agencyId = 'test'): Route {
+  return {
+    route_id: id,
+    route_short_name: id,
+    route_short_names: {},
+    route_long_name: '',
+    route_long_names: {},
+    route_type: 3,
+    route_color: '000000',
+    route_text_color: 'FFFFFF',
+    agency_id: agencyId,
+  };
+}
+
+function makeEntry(
+  overrides: {
+    routeId?: string;
+    headsign?: string;
+    stopHeadsign?: TranslatableText;
+    direction?: 0 | 1;
+    isOrigin?: boolean;
+    isTerminal?: boolean;
+    stopIndex?: number;
+    totalStops?: number;
+    pickupType?: 0 | 1 | 2 | 3;
+    dropOffType?: 0 | 1 | 2 | 3;
+    patternId?: string;
+    serviceId?: string;
+    tripIndex?: number;
+  } = {},
+): TimetableEntry {
+  const routeId = overrides.routeId ?? 'routeA';
+  const headsign = overrides.headsign ?? 'Terminal';
+  return {
+    schedule: { departureMinutes: 480, arrivalMinutes: 480 },
+    routeDirection: {
+      route: makeRoute(routeId),
+      tripHeadsign: { name: headsign, names: {} },
+      ...(overrides.stopHeadsign !== undefined ? { stopHeadsign: overrides.stopHeadsign } : {}),
+      ...(overrides.direction !== undefined ? { direction: overrides.direction } : {}),
+    },
+    boarding: {
+      pickupType: overrides.pickupType ?? 0,
+      dropOffType: overrides.dropOffType ?? 0,
+    },
+    patternPosition: {
+      stopIndex: overrides.stopIndex ?? 1,
+      totalStops: overrides.totalStops ?? 5,
+      isTerminal: overrides.isTerminal ?? false,
+      isOrigin: overrides.isOrigin ?? false,
+    },
+    tripLocator: {
+      patternId: overrides.patternId ?? `${routeId}__${headsign}`,
+      serviceId: overrides.serviceId ?? 'svc1',
+      tripIndex: overrides.tripIndex ?? 0,
+    },
+  };
+}
+
+describe('computeTimetableEntryStats', () => {
+  it('returns all-zero stats for an empty input', () => {
+    const stats = computeTimetableEntryStats([]);
+    expect(stats).toEqual({
+      totalCount: 0,
+      originCount: 0,
+      terminalCount: 0,
+      passingCount: 0,
+      boardableCount: 0,
+      nonBoardableCount: 0,
+      dropOffOnlyCount: 0,
+      noDropOffCount: 0,
+      routeCount: 0,
+      headsignCount: 0,
+      routeHeadsignCount: 0,
+      stopHeadsignOverrideCount: 0,
+      directionCount: 0,
+      patternCount: 0,
+      serviceCount: 0,
+      uniqueTripCount: 0,
+    });
+  });
+
+  describe('A axis (pattern position)', () => {
+    it('counts origin / terminal / passing entries independently', () => {
+      const entries = [
+        makeEntry({ isOrigin: true, stopIndex: 0 }),
+        makeEntry({ isTerminal: true, stopIndex: 4 }),
+        makeEntry({ stopIndex: 2 }),
+        makeEntry({ stopIndex: 3 }),
+      ];
+      const stats = computeTimetableEntryStats(entries);
+      expect(stats.totalCount).toBe(4);
+      expect(stats.originCount).toBe(1);
+      expect(stats.terminalCount).toBe(1);
+      expect(stats.passingCount).toBe(2);
+    });
+
+    it('counts both origin and terminal on a single-stop pattern', () => {
+      const entries = [
+        makeEntry({ isOrigin: true, isTerminal: true, stopIndex: 0, totalStops: 1 }),
+      ];
+      const stats = computeTimetableEntryStats(entries);
+      expect(stats.totalCount).toBe(1);
+      expect(stats.originCount).toBe(1);
+      expect(stats.terminalCount).toBe(1);
+      expect(stats.passingCount).toBe(0);
+    });
+  });
+
+  describe('B axis (boarding)', () => {
+    it('partitions boardable vs non-boardable', () => {
+      const entries = [makeEntry(), makeEntry({ isTerminal: true }), makeEntry({ pickupType: 1 })];
+      const stats = computeTimetableEntryStats(entries);
+      expect(stats.totalCount).toBe(3);
+      expect(stats.boardableCount).toBe(1);
+      expect(stats.nonBoardableCount).toBe(2);
+      expect(stats.boardableCount + stats.nonBoardableCount).toBe(stats.totalCount);
+    });
+
+    it('counts dropOffOnly entries (= explicit pickup_type === 1)', () => {
+      const entries = [
+        makeEntry({ pickupType: 1 }),
+        makeEntry({ pickupType: 1 }),
+        makeEntry({ isTerminal: true }),
+        makeEntry(),
+      ];
+      const stats = computeTimetableEntryStats(entries);
+      expect(stats.dropOffOnlyCount).toBe(2);
+      expect(stats.nonBoardableCount).toBe(3);
+    });
+
+    it('counts noDropOff entries (= explicit drop_off_type === 1)', () => {
+      const entries = [
+        makeEntry({ dropOffType: 1, isOrigin: true, stopIndex: 0 }),
+        makeEntry({ dropOffType: 1 }),
+        makeEntry(),
+      ];
+      const stats = computeTimetableEntryStats(entries);
+      expect(stats.noDropOffCount).toBe(2);
+    });
+  });
+
+  describe('C axis (route direction)', () => {
+    it('counts unique routes / headsigns / route+headsign pairs', () => {
+      const entries = [
+        makeEntry({ routeId: 'rA', headsign: 'X' }),
+        makeEntry({ routeId: 'rA', headsign: 'Y' }),
+        makeEntry({ routeId: 'rB', headsign: 'X' }),
+        makeEntry({ routeId: 'rB', headsign: 'X' }),
+      ];
+      const stats = computeTimetableEntryStats(entries);
+      expect(stats.routeCount).toBe(2);
+      expect(stats.headsignCount).toBe(2);
+      expect(stats.routeHeadsignCount).toBe(3);
+    });
+
+    it('counts entries with stopHeadsign set', () => {
+      const entries = [
+        makeEntry({ stopHeadsign: { name: 'override', names: {} } }),
+        makeEntry({ stopHeadsign: { name: 'override2', names: {} } }),
+        makeEntry(),
+      ];
+      const stats = computeTimetableEntryStats(entries);
+      expect(stats.stopHeadsignOverrideCount).toBe(2);
+    });
+
+    it('counts unique direction values (undefined is one value)', () => {
+      const entries = [
+        makeEntry({ direction: 0 }),
+        makeEntry({ direction: 0 }),
+        makeEntry({ direction: 1 }),
+        makeEntry(),
+      ];
+      const stats = computeTimetableEntryStats(entries);
+      expect(stats.directionCount).toBe(3);
+    });
+  });
+
+  describe('D axis (trip locator)', () => {
+    it('counts unique patternIds / serviceIds', () => {
+      const entries = [
+        makeEntry({ patternId: 'p1', serviceId: 's1' }),
+        makeEntry({ patternId: 'p1', serviceId: 's2', tripIndex: 1 }),
+        makeEntry({ patternId: 'p2', serviceId: 's1', tripIndex: 2 }),
+      ];
+      const stats = computeTimetableEntryStats(entries);
+      expect(stats.patternCount).toBe(2);
+      expect(stats.serviceCount).toBe(2);
+    });
+
+    it('uniqueTripCount equals totalCount for a non-circular pattern', () => {
+      const entries = [
+        makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 0 }),
+        makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 1 }),
+        makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 2 }),
+      ];
+      const stats = computeTimetableEntryStats(entries);
+      expect(stats.uniqueTripCount).toBe(3);
+      expect(stats.uniqueTripCount).toBe(stats.totalCount);
+    });
+
+    it('uniqueTripCount is lower than totalCount for circular patterns', () => {
+      // 6-shape / circular: same (patternId, serviceId, tripIndex) appears
+      // at two different stopIndex values for the same physical stop.
+      const entries = [
+        makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 0, stopIndex: 0 }),
+        makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 0, stopIndex: 28 }),
+        makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 1, stopIndex: 0 }),
+        makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 1, stopIndex: 28 }),
+      ];
+      const stats = computeTimetableEntryStats(entries);
+      expect(stats.totalCount).toBe(4);
+      expect(stats.uniqueTripCount).toBe(2);
+    });
+  });
+
+  it('aggregates a mixed input across all axes', () => {
+    const entries = [
+      // origin, boardable, route A
+      makeEntry({
+        routeId: 'rA',
+        headsign: 'X',
+        direction: 0,
+        isOrigin: true,
+        stopIndex: 0,
+        patternId: 'p1',
+        tripIndex: 0,
+      }),
+      // mid-route, boardable, route A, stopHeadsign override
+      makeEntry({
+        routeId: 'rA',
+        headsign: 'X',
+        direction: 0,
+        stopHeadsign: { name: 'X-via', names: {} },
+        stopIndex: 2,
+        patternId: 'p1',
+        tripIndex: 0,
+      }),
+      // terminal, non-boardable, route A
+      makeEntry({
+        routeId: 'rA',
+        headsign: 'X',
+        direction: 0,
+        isTerminal: true,
+        stopIndex: 4,
+        patternId: 'p1',
+        tripIndex: 0,
+      }),
+      // origin with pickup_type=1 (= depot departure), route B
+      makeEntry({
+        routeId: 'rB',
+        headsign: 'Y',
+        direction: 1,
+        isOrigin: true,
+        stopIndex: 0,
+        pickupType: 1,
+        patternId: 'p2',
+        tripIndex: 0,
+      }),
+    ];
+    const stats = computeTimetableEntryStats(entries);
+
+    expect(stats.totalCount).toBe(4);
+
+    // A axis
+    expect(stats.originCount).toBe(2);
+    expect(stats.terminalCount).toBe(1);
+    expect(stats.passingCount).toBe(1);
+
+    // B axis
+    expect(stats.boardableCount).toBe(2);
+    expect(stats.nonBoardableCount).toBe(2);
+    expect(stats.dropOffOnlyCount).toBe(1);
+    expect(stats.noDropOffCount).toBe(0);
+
+    // C axis
+    expect(stats.routeCount).toBe(2);
+    expect(stats.headsignCount).toBe(2);
+    expect(stats.routeHeadsignCount).toBe(2);
+    expect(stats.stopHeadsignOverrideCount).toBe(1);
+    expect(stats.directionCount).toBe(2);
+
+    // D axis
+    expect(stats.patternCount).toBe(2);
+    expect(stats.serviceCount).toBe(1);
+    expect(stats.uniqueTripCount).toBe(2);
+  });
+});

--- a/src/domain/transit/__tests__/timetable-stats.test.ts
+++ b/src/domain/transit/__tests__/timetable-stats.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import type { Route } from '../../../types/app/transit';
+import type { Agency, Route } from '../../../types/app/transit';
 import type { TimetableEntry, TranslatableText } from '../../../types/app/transit-composed';
 import { computeTimetableEntryStats } from '../timetable-stats';
+
+const TEST_AGENCIES: readonly Agency[] = [];
+const TEST_LANGS = ['ja'] as const;
 
 // --- Test fixtures ---
 
@@ -66,7 +69,7 @@ function makeEntry(
 
 describe('computeTimetableEntryStats', () => {
   it('returns all-zero stats for an empty input', () => {
-    const stats = computeTimetableEntryStats([]);
+    const stats = computeTimetableEntryStats([], TEST_AGENCIES, TEST_LANGS);
     expect(stats).toEqual({
       totalCount: 0,
       originCount: 0,
@@ -77,10 +80,9 @@ describe('computeTimetableEntryStats', () => {
       dropOffOnlyCount: 0,
       noDropOffCount: 0,
       routeCount: 0,
-      headsignCount: 0,
-      routeHeadsignCount: 0,
-      stopHeadsignOverrideCount: 0,
       directionCount: 0,
+      tripHeadsignCount: 0,
+      stopHeadsignCount: 0,
       patternCount: 0,
       serviceCount: 0,
       uniqueTripCount: 0,
@@ -95,7 +97,7 @@ describe('computeTimetableEntryStats', () => {
         makeEntry({ stopIndex: 2 }),
         makeEntry({ stopIndex: 3 }),
       ];
-      const stats = computeTimetableEntryStats(entries);
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.totalCount).toBe(4);
       expect(stats.originCount).toBe(1);
       expect(stats.terminalCount).toBe(1);
@@ -106,7 +108,7 @@ describe('computeTimetableEntryStats', () => {
       const entries = [
         makeEntry({ isOrigin: true, isTerminal: true, stopIndex: 0, totalStops: 1 }),
       ];
-      const stats = computeTimetableEntryStats(entries);
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.totalCount).toBe(1);
       expect(stats.originCount).toBe(1);
       expect(stats.terminalCount).toBe(1);
@@ -117,7 +119,7 @@ describe('computeTimetableEntryStats', () => {
   describe('B axis (boarding)', () => {
     it('partitions boardable vs non-boardable', () => {
       const entries = [makeEntry(), makeEntry({ isTerminal: true }), makeEntry({ pickupType: 1 })];
-      const stats = computeTimetableEntryStats(entries);
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.totalCount).toBe(3);
       expect(stats.boardableCount).toBe(1);
       expect(stats.nonBoardableCount).toBe(2);
@@ -131,7 +133,7 @@ describe('computeTimetableEntryStats', () => {
         makeEntry({ isTerminal: true }),
         makeEntry(),
       ];
-      const stats = computeTimetableEntryStats(entries);
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.dropOffOnlyCount).toBe(2);
       expect(stats.nonBoardableCount).toBe(3);
     });
@@ -142,7 +144,7 @@ describe('computeTimetableEntryStats', () => {
         makeEntry({ dropOffType: 1 }),
         makeEntry(),
       ];
-      const stats = computeTimetableEntryStats(entries);
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.noDropOffCount).toBe(2);
     });
   });
@@ -155,20 +157,20 @@ describe('computeTimetableEntryStats', () => {
         makeEntry({ routeId: 'rB', headsign: 'X' }),
         makeEntry({ routeId: 'rB', headsign: 'X' }),
       ];
-      const stats = computeTimetableEntryStats(entries);
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.routeCount).toBe(2);
-      expect(stats.headsignCount).toBe(2);
-      expect(stats.routeHeadsignCount).toBe(3);
+      expect(stats.stopHeadsignCount).toBe(2);
+      expect(stats.tripHeadsignCount).toBe(2);
     });
 
-    it('counts entries with stopHeadsign set', () => {
+    it('counts unique resolved stop headsigns', () => {
       const entries = [
         makeEntry({ stopHeadsign: { name: 'override', names: {} } }),
         makeEntry({ stopHeadsign: { name: 'override2', names: {} } }),
         makeEntry(),
       ];
-      const stats = computeTimetableEntryStats(entries);
-      expect(stats.stopHeadsignOverrideCount).toBe(2);
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
+      expect(stats.stopHeadsignCount).toBe(3);
     });
 
     it('counts unique direction values (undefined is one value)', () => {
@@ -178,7 +180,7 @@ describe('computeTimetableEntryStats', () => {
         makeEntry({ direction: 1 }),
         makeEntry(),
       ];
-      const stats = computeTimetableEntryStats(entries);
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.directionCount).toBe(3);
     });
   });
@@ -190,7 +192,7 @@ describe('computeTimetableEntryStats', () => {
         makeEntry({ patternId: 'p1', serviceId: 's2', tripIndex: 1 }),
         makeEntry({ patternId: 'p2', serviceId: 's1', tripIndex: 2 }),
       ];
-      const stats = computeTimetableEntryStats(entries);
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.patternCount).toBe(2);
       expect(stats.serviceCount).toBe(2);
     });
@@ -201,7 +203,7 @@ describe('computeTimetableEntryStats', () => {
         makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 1 }),
         makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 2 }),
       ];
-      const stats = computeTimetableEntryStats(entries);
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.uniqueTripCount).toBe(3);
       expect(stats.uniqueTripCount).toBe(stats.totalCount);
     });
@@ -215,7 +217,7 @@ describe('computeTimetableEntryStats', () => {
         makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 1, stopIndex: 0 }),
         makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 1, stopIndex: 28 }),
       ];
-      const stats = computeTimetableEntryStats(entries);
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.totalCount).toBe(4);
       expect(stats.uniqueTripCount).toBe(2);
     });
@@ -265,7 +267,7 @@ describe('computeTimetableEntryStats', () => {
         tripIndex: 0,
       }),
     ];
-    const stats = computeTimetableEntryStats(entries);
+    const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
 
     expect(stats.totalCount).toBe(4);
 
@@ -280,11 +282,11 @@ describe('computeTimetableEntryStats', () => {
     expect(stats.dropOffOnlyCount).toBe(1);
     expect(stats.noDropOffCount).toBe(0);
 
-    // C axis
+    // C axis: resolver picks stopHeadsign when present (entry 2 -> 'X-via'),
+    // so headsign and routeHeadsign uniqueness reflects that override.
     expect(stats.routeCount).toBe(2);
-    expect(stats.headsignCount).toBe(2);
-    expect(stats.routeHeadsignCount).toBe(2);
-    expect(stats.stopHeadsignOverrideCount).toBe(1);
+    expect(stats.stopHeadsignCount).toBe(3); // X, X-via, Y
+    expect(stats.tripHeadsignCount).toBe(2); // X, Y
     expect(stats.directionCount).toBe(2);
 
     // D axis

--- a/src/domain/transit/__tests__/timetable-utils.test.ts
+++ b/src/domain/transit/__tests__/timetable-utils.test.ts
@@ -8,7 +8,6 @@ import {
   getDwellMinutes,
   getRemainingMinutes,
   hasBoardable,
-  filterBoardable,
   getDisplayMinutes,
   getStopServiceState,
   getTimetableEntriesState,
@@ -17,6 +16,7 @@ import {
 import type { StopServiceStateInput } from '../../../types/app/transit';
 import type { TimetableEntry } from '../../../types/app/transit-composed';
 import type { Route } from '../../../types/app/transit';
+import { filterBoardable } from '../timetable-filter';
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -242,452 +242,213 @@ describe('hasBoardable', () => {
   });
 });
 
+// -------------------------------------------------------------------------
+// getDisplayMinutes
+// -------------------------------------------------------------------------
+
+describe('getDisplayMinutes', () => {
+  it('returns departureMinutes for non-terminal stop', () => {
+    const entry = makeEntry({ departureMinutes: 600, arrivalMinutes: 598, isTerminal: false });
+    expect(getDisplayMinutes(entry)).toBe(600);
+  });
+
+  it('returns arrivalMinutes for terminal stop', () => {
+    const entry = makeEntry({ departureMinutes: 600, arrivalMinutes: 598, isTerminal: true });
+    expect(getDisplayMinutes(entry)).toBe(598);
+  });
+
+  it('returns departureMinutes when arrival equals departure (non-terminal)', () => {
+    const entry = makeEntry({ departureMinutes: 480, arrivalMinutes: 480, isTerminal: false });
+    expect(getDisplayMinutes(entry)).toBe(480);
+  });
+
+  it('returns arrivalMinutes when arrival equals departure (terminal)', () => {
+    const entry = makeEntry({ departureMinutes: 480, arrivalMinutes: 480, isTerminal: true });
+    expect(getDisplayMinutes(entry)).toBe(480);
+  });
+
+  it('handles overnight times (>= 1440)', () => {
+    const entry = makeEntry({ departureMinutes: 1500, arrivalMinutes: 1498, isTerminal: false });
+    expect(getDisplayMinutes(entry)).toBe(1500);
+  });
+
+  it('handles overnight terminal times (>= 1440)', () => {
+    const entry = makeEntry({ departureMinutes: 1500, arrivalMinutes: 1498, isTerminal: true });
+    expect(getDisplayMinutes(entry)).toBe(1498);
+  });
+});
+
+// -------------------------------------------------------------------------
+// getStopServiceState
+// -------------------------------------------------------------------------
+
+describe('getStopServiceState', () => {
+  function makeInput(overrides: Partial<StopServiceStateInput> = {}): StopServiceStateInput {
+    return {
+      isBoardableOnServiceDay: overrides.isBoardableOnServiceDay ?? false,
+      totalEntries: overrides.totalEntries ?? 0,
+    };
+  }
+
+  it('returns "no-service" when totalEntries is 0', () => {
+    expect(
+      getStopServiceState(makeInput({ totalEntries: 0, isBoardableOnServiceDay: false })),
+    ).toBe('no-service');
+  });
+
+  it('returns "no-service" even if isBoardableOnServiceDay is true (defensive)', () => {
+    // This combination should not happen in practice, but the totalEntries
+    // signal takes precedence — no entries means no service regardless.
+    expect(getStopServiceState(makeInput({ totalEntries: 0, isBoardableOnServiceDay: true }))).toBe(
+      'no-service',
+    );
+  });
+
+  it('returns "drop-off-only" when entries exist but none are boardable', () => {
+    expect(
+      getStopServiceState(makeInput({ totalEntries: 5, isBoardableOnServiceDay: false })),
+    ).toBe('drop-off-only');
+  });
+
+  it('returns "boardable" when at least one boardable entry exists', () => {
+    expect(
+      getStopServiceState(makeInput({ totalEntries: 10, isBoardableOnServiceDay: true })),
+    ).toBe('boardable');
+  });
+
+  it('returns "boardable" for a single-entry boardable stop', () => {
+    expect(getStopServiceState(makeInput({ totalEntries: 1, isBoardableOnServiceDay: true }))).toBe(
+      'boardable',
+    );
+  });
+
+  it('returns "drop-off-only" for a single-entry non-boardable stop', () => {
+    expect(
+      getStopServiceState(makeInput({ totalEntries: 1, isBoardableOnServiceDay: false })),
+    ).toBe('drop-off-only');
+  });
+});
+
 // ---------------------------------------------------------------------------
-// filterBoardable
+// getTimetableEntriesState
 // ---------------------------------------------------------------------------
 
-describe('filterBoardable', () => {
-  describe('empty input', () => {
-    it('returns empty array', () => {
-      expect(filterBoardable([])).toEqual([]);
-    });
+describe('getTimetableEntriesState', () => {
+  it('returns "no-service" for empty entries', () => {
+    expect(getTimetableEntriesState([])).toBe('no-service');
   });
 
-  describe('all boardable (!isDropOffOnly)', () => {
-    it('returns single entry', () => {
-      expect(filterBoardable([makeEntry()])).toHaveLength(1);
-    });
-
-    it('returns all entries', () => {
-      expect(filterBoardable([makeEntry(), makeEntry(), makeEntry()])).toHaveLength(3);
-    });
-
-    it('keeps isOrigin entries', () => {
-      expect(filterBoardable([makeEntry({ isOrigin: true })])).toHaveLength(1);
-    });
-
-    it('keeps pickupType=0 (available)', () => {
-      expect(filterBoardable([makeEntry({ pickupType: 0 })])).toHaveLength(1);
-    });
-
-    it('keeps pickupType=2 (phone required) — requires arrangement but boardable', () => {
-      expect(filterBoardable([makeEntry({ pickupType: 2 })])).toHaveLength(1);
-    });
-
-    it('keeps pickupType=3 (coordinate required) — requires arrangement but boardable', () => {
-      expect(filterBoardable([makeEntry({ pickupType: 3 })])).toHaveLength(1);
-    });
+  it('returns "boardable" when at least one entry is boardable', () => {
+    const entries = [makeEntry(), makeEntry({ pickupType: 1 })];
+    expect(getTimetableEntriesState(entries)).toBe('boardable');
   });
 
-  describe('all isDropOffOnly', () => {
-    it('filters single terminal entry', () => {
-      expect(filterBoardable([makeEntry({ isTerminal: true })])).toHaveLength(0);
-    });
-
-    it('filters single pickupType=1 entry', () => {
-      expect(filterBoardable([makeEntry({ pickupType: 1 })])).toHaveLength(0);
-    });
-
-    it('filters multiple terminal entries', () => {
-      const entries = [makeEntry({ isTerminal: true }), makeEntry({ isTerminal: true })];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
-
-    it('filters multiple pickupType=1 entries', () => {
-      const entries = [makeEntry({ pickupType: 1 }), makeEntry({ pickupType: 1 })];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
-
-    it('filters when both isTerminal and pickupType=1 are set', () => {
-      expect(filterBoardable([makeEntry({ isTerminal: true, pickupType: 1 })])).toHaveLength(0);
-    });
-
-    it('filters mix of terminal and pickupType=1', () => {
-      const entries = [
-        makeEntry({ isTerminal: true }),
-        makeEntry({ pickupType: 1 }),
-        makeEntry({ isTerminal: true, pickupType: 1 }),
-      ];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
+  it('returns "drop-off-only" when all entries are drop-off only (pickupType)', () => {
+    const entries = [makeEntry({ pickupType: 1 }), makeEntry({ pickupType: 1 })];
+    expect(getTimetableEntriesState(entries)).toBe('drop-off-only');
   });
 
-  describe('mixed boardable and isDropOffOnly', () => {
-    it('keeps boardable, filters terminal', () => {
-      const boardable = makeEntry();
-      const terminal = makeEntry({ isTerminal: true });
-      expect(filterBoardable([terminal, boardable])).toEqual([boardable]);
-    });
-
-    it('keeps boardable, filters pickupType=1', () => {
-      const boardable = makeEntry();
-      const pickup1 = makeEntry({ pickupType: 1 });
-      expect(filterBoardable([pickup1, boardable])).toEqual([boardable]);
-    });
-
-    it('keeps boardable, filters both terminal and pickupType=1', () => {
-      const boardable = makeEntry();
-      const terminal = makeEntry({ isTerminal: true });
-      const pickup1 = makeEntry({ pickupType: 1 });
-      expect(filterBoardable([terminal, boardable, pickup1])).toEqual([boardable]);
-    });
-
-    it('preserves order of boardable entries', () => {
-      const a = makeEntry({ departureMinutes: 480 });
-      const b = makeEntry({ departureMinutes: 540 });
-      const c = makeEntry({ departureMinutes: 600 });
-      const term = makeEntry({ departureMinutes: 500, isTerminal: true });
-      expect(filterBoardable([a, term, b, c]).map((e) => e.schedule.departureMinutes)).toEqual([
-        480, 540, 600,
-      ]);
-    });
+  it('returns "drop-off-only" when all entries are terminal', () => {
+    const entries = [makeEntry({ isTerminal: true }), makeEntry({ isTerminal: true })];
+    expect(getTimetableEntriesState(entries)).toBe('drop-off-only');
   });
 
-  describe('multi-route / multi-agency', () => {
-    const routeA = makeRoute('route-A', 'agency-1');
-    const routeB = makeRoute('route-B', 'agency-2');
-
-    it('filters per-entry regardless of route (mixed agencies)', () => {
-      const entries = [
-        makeEntry({ route: routeA, isTerminal: true }), // agency-1, terminal
-        makeEntry({ route: routeB }), // agency-2, boardable
-        makeEntry({ route: routeA }), // agency-1, boardable
-        makeEntry({ route: routeB, pickupType: 1 }), // agency-2, pickup unavailable
-      ];
-      const result = filterBoardable(entries);
-      expect(result).toHaveLength(2);
-      expect(result[0].routeDirection.route.route_id).toBe('route-B');
-      expect(result[1].routeDirection.route.route_id).toBe('route-A');
-    });
-
-    it('returns empty when all routes are terminal (single agency)', () => {
-      const entries = [
-        makeEntry({ route: routeA, isTerminal: true }),
-        makeEntry({ route: routeA, isTerminal: true }),
-      ];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
-
-    it('returns empty when all routes are drop-off only (multiple agencies)', () => {
-      const entries = [
-        makeEntry({ route: routeA, isTerminal: true }),
-        makeEntry({ route: routeB, pickupType: 1 }),
-      ];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
-
-    it('keeps boardable entries from one agency while filtering terminal from another', () => {
-      const entries = [
-        makeEntry({ route: routeA, isTerminal: true, departureMinutes: 480 }),
-        makeEntry({ route: routeB, departureMinutes: 490 }),
-        makeEntry({ route: routeA, isTerminal: true, departureMinutes: 500 }),
-        makeEntry({ route: routeB, departureMinutes: 510 }),
-      ];
-      const result = filterBoardable(entries);
-      expect(result).toHaveLength(2);
-      expect(result.every((e) => e.routeDirection.route.agency_id === 'agency-2')).toBe(true);
-    });
+  it('returns "boardable" when mixed boardable and terminal entries', () => {
+    const entries = [makeEntry(), makeEntry({ isTerminal: true })];
+    expect(getTimetableEntriesState(entries)).toBe('boardable');
   });
 
-  describe('turnaround stop (同一路線で ORIG/TERM 交互 — 日野駅パターン)', () => {
-    it('keeps ORIG entries and filters TERM entries from same route', () => {
-      const route = makeRoute('route-bus');
-      const entries = [
-        makeEntry({ route, departureMinutes: 1255, isTerminal: true, pickupType: 1 }), // 20:55 着
-        makeEntry({ route, departureMinutes: 1258, isTerminal: true, pickupType: 1 }), // 20:58 着
-        makeEntry({ route, departureMinutes: 1260, isOrigin: true, pickupType: 0 }), // 21:00 発
-        makeEntry({ route, departureMinutes: 1265, isTerminal: true, pickupType: 1 }), // 21:05 着
-        makeEntry({ route, departureMinutes: 1270, isOrigin: true, pickupType: 0 }), // 21:10 発
-      ];
-      const result = filterBoardable(entries);
-      expect(result).toHaveLength(2);
-      expect(result.map((e) => e.schedule.departureMinutes)).toEqual([1260, 1270]);
-    });
+  it('returns "boardable" for a single boardable entry', () => {
+    expect(getTimetableEntriesState([makeEntry()])).toBe('boardable');
   });
 
-  describe('pt=0 with isTerminal fallback (都バス — pt 未設定ソース)', () => {
-    it('filters all entries when pt=0 but all are terminal', () => {
-      // 都バスは pickup_type を設定しない (全て 0)。
-      // isTerminal フォールバックで終点を検出。
-      const entries = [
-        makeEntry({ pickupType: 0, isTerminal: true, departureMinutes: 480 }),
-        makeEntry({ pickupType: 0, isTerminal: true, departureMinutes: 540 }),
-        makeEntry({ pickupType: 0, isTerminal: true, departureMinutes: 600 }),
-      ];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
+  it('returns "drop-off-only" for a single terminal entry', () => {
+    expect(getTimetableEntriesState([makeEntry({ isTerminal: true })])).toBe('drop-off-only');
+  });
+});
 
-    it('keeps non-terminal entries when pt=0', () => {
-      const entries = [
-        makeEntry({ pickupType: 0, isTerminal: true }),
-        makeEntry({ pickupType: 0, isTerminal: false }),
-        makeEntry({ pickupType: 0, isOrigin: true }),
-      ];
-      expect(filterBoardable(entries)).toHaveLength(2);
-    });
+// ---------------------------------------------------------------------------
+// getFilteredTimetableEntriesState
+// ---------------------------------------------------------------------------
+
+describe('getFilteredTimetableEntriesState', () => {
+  // Matrix of all physically-reachable (stopServiceState, upcomingEntriesState,
+  // filteredEntriesState) combinations. The function is purely combinatorial,
+  // so we enumerate the truth table directly.
+  //
+  // Constraints:
+  //   - filtered is a subset of upcoming → if upcoming='no-service', filtered must be 'no-service'
+  //   - upcoming is a subset of full-day → if stopServiceState='no-service', upcoming must be 'no-service'
+
+  it('returns "no-service" when the repo has no data for this stop (case 1)', () => {
+    expect(getFilteredTimetableEntriesState('no-service', 'no-service', 'no-service')).toBe(
+      'no-service',
+    );
   });
 
-  describe('mid-route pickup unavailable (途中停留所で pt=1)', () => {
-    it('filters pt=1 entry that is not terminal', () => {
-      // 途中停留所だが乗車不可 — 本来の「降車専用」
-      const entry = makeEntry({ pickupType: 1, isTerminal: false, stopIndex: 5, totalStops: 10 });
-      expect(filterBoardable([entry])).toHaveLength(0);
-    });
-
-    it('keeps other entries at same stop when only some have pt=1', () => {
-      const route = makeRoute('route-express');
-      const entries = [
-        makeEntry({ route, pickupType: 1, departureMinutes: 480 }), // express: no pickup
-        makeEntry({ route, pickupType: 0, departureMinutes: 510 }), // local: pickup ok
-        makeEntry({ route, pickupType: 1, departureMinutes: 540 }), // express: no pickup
-      ];
-      const result = filterBoardable(entries);
-      expect(result).toHaveLength(1);
-      expect(result[0].schedule.departureMinutes).toBe(510);
-    });
+  it('returns "service-ended" when boardable repo but upcoming is empty (case 2, late-night)', () => {
+    expect(getFilteredTimetableEntriesState('boardable', 'no-service', 'no-service')).toBe(
+      'service-ended',
+    );
   });
 
-  describe('same route+headsign with mixed pt per stop time', () => {
-    it('filters individually even within same route+headsign', () => {
-      // v2 pipeline では pt は便ごとの配列。同じ trip pattern でも
-      // 便によって pt が異なりうる。
-      const route = makeRoute('route-X');
-      const entries = [
-        makeEntry({ route, headsign: 'Terminal', pickupType: 0, departureMinutes: 480 }),
-        makeEntry({ route, headsign: 'Terminal', pickupType: 1, departureMinutes: 510 }),
-        makeEntry({ route, headsign: 'Terminal', pickupType: 0, departureMinutes: 540 }),
-      ];
-      const result = filterBoardable(entries);
-      expect(result).toHaveLength(2);
-      expect(result.map((e) => e.schedule.departureMinutes)).toEqual([480, 540]);
-    });
+  it('returns "service-ended" when drop-off-only repo but upcoming is empty (case 3, late-night)', () => {
+    expect(getFilteredTimetableEntriesState('drop-off-only', 'no-service', 'no-service')).toBe(
+      'service-ended',
+    );
   });
 
-  describe('circular route edge case', () => {
-    it('filters isTerminal && isOrigin — current behavior', () => {
-      // Circular routes have the same stop as both origin and terminal.
-      // isDropOffOnly returns true because isTerminal is checked.
-      // This may cause false positives for circular routes where
-      // passengers CAN board at the terminal/origin stop.
-      const entry = makeEntry({ isTerminal: true, isOrigin: true });
-      expect(filterBoardable([entry])).toHaveLength(0);
-    });
-
-    it('filters isTerminal && isOrigin even with pickupType=0', () => {
-      // pt=0 is ambiguous (available OR not set). isTerminal takes precedence.
-      const entry = makeEntry({ isTerminal: true, isOrigin: true, pickupType: 0 });
-      expect(filterBoardable([entry])).toHaveLength(0);
-    });
+  it('returns "filter-hidden" when boardable repo + boardable upcoming but filtered empty (case 4)', () => {
+    expect(getFilteredTimetableEntriesState('boardable', 'boardable', 'no-service')).toBe(
+      'filter-hidden',
+    );
   });
 
-  // -------------------------------------------------------------------------
-  // getDisplayMinutes
-  // -------------------------------------------------------------------------
-
-  describe('getDisplayMinutes', () => {
-    it('returns departureMinutes for non-terminal stop', () => {
-      const entry = makeEntry({ departureMinutes: 600, arrivalMinutes: 598, isTerminal: false });
-      expect(getDisplayMinutes(entry)).toBe(600);
-    });
-
-    it('returns arrivalMinutes for terminal stop', () => {
-      const entry = makeEntry({ departureMinutes: 600, arrivalMinutes: 598, isTerminal: true });
-      expect(getDisplayMinutes(entry)).toBe(598);
-    });
-
-    it('returns departureMinutes when arrival equals departure (non-terminal)', () => {
-      const entry = makeEntry({ departureMinutes: 480, arrivalMinutes: 480, isTerminal: false });
-      expect(getDisplayMinutes(entry)).toBe(480);
-    });
-
-    it('returns arrivalMinutes when arrival equals departure (terminal)', () => {
-      const entry = makeEntry({ departureMinutes: 480, arrivalMinutes: 480, isTerminal: true });
-      expect(getDisplayMinutes(entry)).toBe(480);
-    });
-
-    it('handles overnight times (>= 1440)', () => {
-      const entry = makeEntry({ departureMinutes: 1500, arrivalMinutes: 1498, isTerminal: false });
-      expect(getDisplayMinutes(entry)).toBe(1500);
-    });
-
-    it('handles overnight terminal times (>= 1440)', () => {
-      const entry = makeEntry({ departureMinutes: 1500, arrivalMinutes: 1498, isTerminal: true });
-      expect(getDisplayMinutes(entry)).toBe(1498);
-    });
+  it('returns "filter-hidden" when boardable repo + drop-off-only upcoming but filtered empty (case 5)', () => {
+    expect(getFilteredTimetableEntriesState('boardable', 'drop-off-only', 'no-service')).toBe(
+      'filter-hidden',
+    );
   });
 
-  // -------------------------------------------------------------------------
-  // getStopServiceState
-  // -------------------------------------------------------------------------
-
-  describe('getStopServiceState', () => {
-    function makeInput(overrides: Partial<StopServiceStateInput> = {}): StopServiceStateInput {
-      return {
-        isBoardableOnServiceDay: overrides.isBoardableOnServiceDay ?? false,
-        totalEntries: overrides.totalEntries ?? 0,
-      };
-    }
-
-    it('returns "no-service" when totalEntries is 0', () => {
-      expect(
-        getStopServiceState(makeInput({ totalEntries: 0, isBoardableOnServiceDay: false })),
-      ).toBe('no-service');
-    });
-
-    it('returns "no-service" even if isBoardableOnServiceDay is true (defensive)', () => {
-      // This combination should not happen in practice, but the totalEntries
-      // signal takes precedence — no entries means no service regardless.
-      expect(
-        getStopServiceState(makeInput({ totalEntries: 0, isBoardableOnServiceDay: true })),
-      ).toBe('no-service');
-    });
-
-    it('returns "drop-off-only" when entries exist but none are boardable', () => {
-      expect(
-        getStopServiceState(makeInput({ totalEntries: 5, isBoardableOnServiceDay: false })),
-      ).toBe('drop-off-only');
-    });
-
-    it('returns "boardable" when at least one boardable entry exists', () => {
-      expect(
-        getStopServiceState(makeInput({ totalEntries: 10, isBoardableOnServiceDay: true })),
-      ).toBe('boardable');
-    });
-
-    it('returns "boardable" for a single-entry boardable stop', () => {
-      expect(
-        getStopServiceState(makeInput({ totalEntries: 1, isBoardableOnServiceDay: true })),
-      ).toBe('boardable');
-    });
-
-    it('returns "drop-off-only" for a single-entry non-boardable stop', () => {
-      expect(
-        getStopServiceState(makeInput({ totalEntries: 1, isBoardableOnServiceDay: false })),
-      ).toBe('drop-off-only');
-    });
+  it('returns "filter-hidden" when drop-off-only repo + drop-off-only upcoming but filtered empty (case 6)', () => {
+    expect(getFilteredTimetableEntriesState('drop-off-only', 'drop-off-only', 'no-service')).toBe(
+      'filter-hidden',
+    );
   });
 
-  // ---------------------------------------------------------------------------
-  // getTimetableEntriesState
-  // ---------------------------------------------------------------------------
-
-  describe('getTimetableEntriesState', () => {
-    it('returns "no-service" for empty entries', () => {
-      expect(getTimetableEntriesState([])).toBe('no-service');
-    });
-
-    it('returns "boardable" when at least one entry is boardable', () => {
-      const entries = [makeEntry(), makeEntry({ pickupType: 1 })];
-      expect(getTimetableEntriesState(entries)).toBe('boardable');
-    });
-
-    it('returns "drop-off-only" when all entries are drop-off only (pickupType)', () => {
-      const entries = [makeEntry({ pickupType: 1 }), makeEntry({ pickupType: 1 })];
-      expect(getTimetableEntriesState(entries)).toBe('drop-off-only');
-    });
-
-    it('returns "drop-off-only" when all entries are terminal', () => {
-      const entries = [makeEntry({ isTerminal: true }), makeEntry({ isTerminal: true })];
-      expect(getTimetableEntriesState(entries)).toBe('drop-off-only');
-    });
-
-    it('returns "boardable" when mixed boardable and terminal entries', () => {
-      const entries = [makeEntry(), makeEntry({ isTerminal: true })];
-      expect(getTimetableEntriesState(entries)).toBe('boardable');
-    });
-
-    it('returns "boardable" for a single boardable entry', () => {
-      expect(getTimetableEntriesState([makeEntry()])).toBe('boardable');
-    });
-
-    it('returns "drop-off-only" for a single terminal entry', () => {
-      expect(getTimetableEntriesState([makeEntry({ isTerminal: true })])).toBe('drop-off-only');
-    });
+  it('returns "boardable" when boardable at every level (case 7, normal display)', () => {
+    expect(getFilteredTimetableEntriesState('boardable', 'boardable', 'boardable')).toBe(
+      'boardable',
+    );
   });
 
-  // ---------------------------------------------------------------------------
-  // getFilteredTimetableEntriesState
-  // ---------------------------------------------------------------------------
+  it('returns "drop-off-only" when filter removed all boardable from a boardable upcoming (case 8)', () => {
+    expect(getFilteredTimetableEntriesState('boardable', 'boardable', 'drop-off-only')).toBe(
+      'drop-off-only',
+    );
+  });
 
-  describe('getFilteredTimetableEntriesState', () => {
-    // Matrix of all physically-reachable (stopServiceState, upcomingEntriesState,
-    // filteredEntriesState) combinations. The function is purely combinatorial,
-    // so we enumerate the truth table directly.
-    //
-    // Constraints:
-    //   - filtered is a subset of upcoming → if upcoming='no-service', filtered must be 'no-service'
-    //   - upcoming is a subset of full-day → if stopServiceState='no-service', upcoming must be 'no-service'
+  it('returns "drop-off-only" when boardable repo but upcoming is already drop-off-only (case 9)', () => {
+    expect(getFilteredTimetableEntriesState('boardable', 'drop-off-only', 'drop-off-only')).toBe(
+      'drop-off-only',
+    );
+  });
 
-    it('returns "no-service" when the repo has no data for this stop (case 1)', () => {
-      expect(getFilteredTimetableEntriesState('no-service', 'no-service', 'no-service')).toBe(
-        'no-service',
-      );
-    });
+  it('returns "drop-off-only" when drop-off-only at every level (case 10)', () => {
+    expect(
+      getFilteredTimetableEntriesState('drop-off-only', 'drop-off-only', 'drop-off-only'),
+    ).toBe('drop-off-only');
+  });
 
-    it('returns "service-ended" when boardable repo but upcoming is empty (case 2, late-night)', () => {
-      expect(getFilteredTimetableEntriesState('boardable', 'no-service', 'no-service')).toBe(
-        'service-ended',
-      );
-    });
-
-    it('returns "service-ended" when drop-off-only repo but upcoming is empty (case 3, late-night)', () => {
-      expect(getFilteredTimetableEntriesState('drop-off-only', 'no-service', 'no-service')).toBe(
-        'service-ended',
-      );
-    });
-
-    it('returns "filter-hidden" when boardable repo + boardable upcoming but filtered empty (case 4)', () => {
-      expect(getFilteredTimetableEntriesState('boardable', 'boardable', 'no-service')).toBe(
-        'filter-hidden',
-      );
-    });
-
-    it('returns "filter-hidden" when boardable repo + drop-off-only upcoming but filtered empty (case 5)', () => {
-      expect(getFilteredTimetableEntriesState('boardable', 'drop-off-only', 'no-service')).toBe(
-        'filter-hidden',
-      );
-    });
-
-    it('returns "filter-hidden" when drop-off-only repo + drop-off-only upcoming but filtered empty (case 6)', () => {
-      expect(getFilteredTimetableEntriesState('drop-off-only', 'drop-off-only', 'no-service')).toBe(
-        'filter-hidden',
-      );
-    });
-
-    it('returns "boardable" when boardable at every level (case 7, normal display)', () => {
-      expect(getFilteredTimetableEntriesState('boardable', 'boardable', 'boardable')).toBe(
-        'boardable',
-      );
-    });
-
-    it('returns "drop-off-only" when filter removed all boardable from a boardable upcoming (case 8)', () => {
-      expect(getFilteredTimetableEntriesState('boardable', 'boardable', 'drop-off-only')).toBe(
-        'drop-off-only',
-      );
-    });
-
-    it('returns "drop-off-only" when boardable repo but upcoming is already drop-off-only (case 9)', () => {
-      expect(getFilteredTimetableEntriesState('boardable', 'drop-off-only', 'drop-off-only')).toBe(
-        'drop-off-only',
-      );
-    });
-
-    it('returns "drop-off-only" when drop-off-only at every level (case 10)', () => {
-      expect(
-        getFilteredTimetableEntriesState('drop-off-only', 'drop-off-only', 'drop-off-only'),
-      ).toBe('drop-off-only');
-    });
-
-    it('stopServiceState="no-service" dominates regardless of other inputs (defensive)', () => {
-      // These combinations are physically impossible (filtered cannot exist
-      // if repo says no-service), but the function must remain total — the
-      // repo's truth takes precedence.
-      expect(getFilteredTimetableEntriesState('no-service', 'boardable', 'boardable')).toBe(
-        'no-service',
-      );
-      expect(getFilteredTimetableEntriesState('no-service', 'drop-off-only', 'drop-off-only')).toBe(
-        'no-service',
-      );
-    });
+  it('stopServiceState="no-service" dominates regardless of other inputs (defensive)', () => {
+    // These combinations are physically impossible (filtered cannot exist
+    // if repo says no-service), but the function must remain total — the
+    // repo's truth takes precedence.
+    expect(getFilteredTimetableEntriesState('no-service', 'boardable', 'boardable')).toBe(
+      'no-service',
+    );
+    expect(getFilteredTimetableEntriesState('no-service', 'drop-off-only', 'drop-off-only')).toBe(
+      'no-service',
+    );
   });
 });

--- a/src/domain/transit/__tests__/timetable-utils.test.ts
+++ b/src/domain/transit/__tests__/timetable-utils.test.ts
@@ -16,7 +16,6 @@ import {
 import type { StopServiceStateInput } from '../../../types/app/transit';
 import type { TimetableEntry } from '../../../types/app/transit-composed';
 import type { Route } from '../../../types/app/transit';
-import { filterBoardable } from '../timetable-filter';
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -33,20 +32,6 @@ const testRoute: Route = {
   route_text_color: 'FFFFFF',
   agency_id: 'test:agency',
 };
-
-function makeRoute(id: string, agencyId = 'test:agency'): Route {
-  return {
-    route_id: id,
-    route_short_name: id,
-    route_short_names: {},
-    route_long_name: '',
-    route_long_names: {},
-    route_type: 3,
-    route_color: '2E7D32',
-    route_text_color: 'FFFFFF',
-    agency_id: agencyId,
-  };
-}
 
 function makeEntry(
   overrides: {
@@ -105,12 +90,34 @@ describe('isDropOffOnly', () => {
     expect(isDropOffOnly(makeEntry({ isTerminal: true }))).toBe(true);
   });
 
+  it('returns false when pickupType is 2 and stop is not terminal', () => {
+    expect(isDropOffOnly(makeEntry({ pickupType: 2, isTerminal: false }))).toBe(false);
+  });
+
+  it('returns false when pickupType is 3 and stop is not terminal', () => {
+    expect(isDropOffOnly(makeEntry({ pickupType: 3, isTerminal: false }))).toBe(false);
+  });
+
+  it('returns true for terminal stop even when pickupType is 2', () => {
+    expect(isDropOffOnly(makeEntry({ pickupType: 2, isTerminal: true }))).toBe(true);
+  });
+
+  it('returns true for terminal stop even when pickupType is 3', () => {
+    expect(isDropOffOnly(makeEntry({ pickupType: 3, isTerminal: true }))).toBe(true);
+  });
+
   it('returns false for regular mid-route stop', () => {
     expect(isDropOffOnly(makeEntry())).toBe(false);
   });
 
   it('returns true when both signals agree', () => {
     expect(isDropOffOnly(makeEntry({ pickupType: 1, isTerminal: true }))).toBe(true);
+  });
+
+  it('returns true when a circular stop is both origin and terminal', () => {
+    expect(isDropOffOnly(makeEntry({ isOrigin: true, isTerminal: true, pickupType: 0 }))).toBe(
+      true,
+    );
   });
 });
 

--- a/src/domain/transit/timetable-filter.ts
+++ b/src/domain/transit/timetable-filter.ts
@@ -11,6 +11,7 @@
 import type { TimetableEntry } from '../../types/app/transit-composed';
 import type { TimetableOmitted } from '../../types/app/repository';
 import { getEffectiveHeadsign } from './get-effective-headsign';
+import { isDropOffOnly } from './timetable-utils';
 
 /**
  * Filter and compute omitted stats for a stop timetable.
@@ -113,4 +114,14 @@ export function filterByRouteType<T extends TimetableEntry>(
     return entries as T[];
   }
   return entries.filter((e) => !hiddenRouteTypes.has(e.routeDirection.route.route_type));
+}
+
+/**
+ * Filter out drop-off-only entries, returning only boardable stop times.
+ *
+ * Each entry's boardability is determined by {@link isDropOffOnly}
+ * (pickupType === 1 OR isTerminal).
+ */
+export function filterBoardable(entries: TimetableEntry[]): TimetableEntry[] {
+  return entries.filter((entry) => !isDropOffOnly(entry));
 }

--- a/src/domain/transit/timetable-filter.ts
+++ b/src/domain/transit/timetable-filter.ts
@@ -16,54 +16,56 @@ import { isDropOffOnly } from './timetable-utils';
 /**
  * Filter and compute omitted stats for a stop timetable.
  *
- * When `includeTerminals` is false (simple/normal), terminal entries are
- * removed and their count is reported in `omitted.terminal`.
+ * When `includeNonBoardable` is false (simple/normal), non-boardable
+ * entries (= terminal arrivals and `pickup_type === 1` mid-route stops,
+ * see {@link isDropOffOnly}) are removed and their count is reported in
+ * `omitted.nonBoardable`.
  *
  * @param allEntries - All entries from getFullDayTimetableEntries (unfiltered).
- * @param includeTerminals - true at detailed+, false at simple/normal.
- * @returns Filtered entries and omitted terminal count.
+ * @param includeNonBoardable - true at detailed+, false at simple/normal.
+ * @returns Filtered entries and omitted non-boardable count.
  */
 export function prepareStopTimetable(
   allEntries: TimetableEntry[],
-  includeTerminals: boolean,
+  includeNonBoardable: boolean,
 ): { entries: TimetableEntry[]; omitted: TimetableOmitted } {
-  if (includeTerminals) {
-    return { entries: allEntries, omitted: { terminal: 0 } };
+  if (includeNonBoardable) {
+    return { entries: allEntries, omitted: { nonBoardable: 0 } };
   }
-  const entries = allEntries.filter((e) => !e.patternPosition.isTerminal);
-  return { entries, omitted: { terminal: allEntries.length - entries.length } };
+  const entries = filterBoardable(allEntries);
+  return { entries, omitted: { nonBoardable: allEntries.length - entries.length } };
 }
 
 /**
  * Filter and compute omitted stats for a route+headsign timetable.
  *
  * Unlike {@link prepareStopTimetable}, this first narrows to a specific
- * route+headsign, then applies terminal filtering. The resulting
- * `omitted.terminal` is scoped to that route+headsign — it does not
- * include terminal counts from other routes at the same stop.
+ * route+headsign, then applies the boardability filter. The resulting
+ * `omitted.nonBoardable` is scoped to that route+headsign — it does
+ * not include non-boardable counts from other routes at the same stop.
  *
  * @param allEntries - All entries from getFullDayTimetableEntries (unfiltered).
  * @param routeId - Target route ID.
  * @param headsign - Target headsign.
- * @param includeTerminals - true at detailed+, false at simple/normal.
- * @returns Filtered entries and omitted terminal count for this route+headsign.
+ * @param includeNonBoardable - true at detailed+, false at simple/normal.
+ * @returns Filtered entries and omitted non-boardable count for this route+headsign.
  */
 export function prepareRouteHeadsignTimetable(
   allEntries: TimetableEntry[],
   routeId: string,
   headsign: string,
-  includeTerminals: boolean,
+  includeNonBoardable: boolean,
 ): { entries: TimetableEntry[]; omitted: TimetableOmitted } {
   const routeEntries = allEntries.filter(
     (e) =>
       e.routeDirection.route.route_id === routeId &&
       getEffectiveHeadsign(e.routeDirection) === headsign,
   );
-  if (includeTerminals) {
-    return { entries: routeEntries, omitted: { terminal: 0 } };
+  if (includeNonBoardable) {
+    return { entries: routeEntries, omitted: { nonBoardable: 0 } };
   }
-  const entries = routeEntries.filter((e) => !e.patternPosition.isTerminal);
-  return { entries, omitted: { terminal: routeEntries.length - entries.length } };
+  const entries = filterBoardable(routeEntries);
+  return { entries, omitted: { nonBoardable: routeEntries.length - entries.length } };
 }
 
 /**

--- a/src/domain/transit/timetable-filter.ts
+++ b/src/domain/transit/timetable-filter.ts
@@ -127,3 +127,21 @@ export function filterByRouteType<T extends TimetableEntry>(
 export function filterBoardable(entries: TimetableEntry[]): TimetableEntry[] {
   return entries.filter((entry) => !isDropOffOnly(entry));
 }
+
+/**
+ * Filter to entries where this stop is the trip's origin (= 始発).
+ *
+ * Keeps every entry with `entry.patternPosition.isOrigin === true`,
+ * including ones that are also non-boardable (= the bus departs from a
+ * depot or yard with `pickup_type === 1` / `drop_off_type === 1`). Those
+ * entries are visually distinguished by `乗×` / `降×` markers in the
+ * grid, so hiding them at the filter layer would suppress legitimate
+ * GTFS-described "起点運用" data the viewer is meant to surface.
+ *
+ * Callers that want only boardable origins should compose this with
+ * {@link filterBoardable} (= apply both filters) rather than baking a
+ * combined predicate into a single function.
+ */
+export function filterOrigin(entries: TimetableEntry[]): TimetableEntry[] {
+  return entries.filter((entry) => entry.patternPosition.isOrigin);
+}

--- a/src/domain/transit/timetable-stats.ts
+++ b/src/domain/transit/timetable-stats.ts
@@ -1,0 +1,165 @@
+import type { TimetableEntry } from '@/types/app/transit-composed';
+import { isDropOffOnly } from './timetable-utils';
+
+/**
+ * Aggregated statistics computed from a list of {@link TimetableEntry}.
+ *
+ * Each count answers a single question on a single axis. Counts on
+ * different axes are independent, so summing them is meaningless
+ * (e.g. one entry can be counted in both `originCount` and
+ * `boardableCount`).
+ *
+ * Axes:
+ * - **A (pattern position)**: `originCount` / `terminalCount` / `passingCount`.
+ *   `originCount` and `terminalCount` are NOT mutually exclusive — a
+ *   single-stop pattern (= `totalStops === 1`) increments both. `passingCount`
+ *   is strictly mid-route (= `!isOrigin && !isTerminal`).
+ * - **B (boarding)**: `boardableCount` / `nonBoardableCount` /
+ *   `dropOffOnlyCount` / `noDropOffCount`. The boardable / non-boardable
+ *   pair partitions all entries (sum equals `totalCount`).
+ *   `dropOffOnlyCount` (= explicit `pickup_type === 1`) and `noDropOffCount`
+ *   (= explicit `drop_off_type === 1`) are independent GTFS signals.
+ * - **C (route direction)**: unique counts of `route_id`, headsign,
+ *   `(route, headsign)` pairs, observed `direction` values, plus the
+ *   number of entries whose `stopHeadsign` is set.
+ * - **D (trip locator)**: unique counts of `patternId`, `serviceId`,
+ *   and `(patternId, serviceId, tripIndex)` triples. `uniqueTripCount`
+ *   can be lower than `totalCount` for 6-shape / circular patterns
+ *   where the same trip visits the same stop more than once.
+ *
+ * @see computeTimetableEntryStats
+ */
+export interface TimetableEntryStats {
+  /** Total number of entries (= input length). */
+  totalCount: number;
+
+  // A axis: pattern position
+  /** Entries where this stop is the trip's origin (= `isOrigin === true`). */
+  originCount: number;
+  /** Entries where this stop is the trip's terminal (= `isTerminal === true`). */
+  terminalCount: number;
+  /** Entries where this stop is mid-route (= `!isOrigin && !isTerminal`). */
+  passingCount: number;
+
+  // B axis: boarding availability
+  /** Entries where boarding is available (= `!isDropOffOnly`). */
+  boardableCount: number;
+  /** Entries where boarding is NOT available (= `isDropOffOnly`). */
+  nonBoardableCount: number;
+  /** Entries with explicit `pickup_type === 1` (= GTFS "drop-off only"). */
+  dropOffOnlyCount: number;
+  /** Entries with explicit `drop_off_type === 1` (= alighting unavailable). */
+  noDropOffCount: number;
+
+  // C axis: route direction
+  /** Number of unique `route_id` values across the entries. */
+  routeCount: number;
+  /** Number of unique `tripHeadsign.name` values (empty string is one value). */
+  headsignCount: number;
+  /** Number of unique `(route_id, headsign)` combinations. */
+  routeHeadsignCount: number;
+  /** Entries where `stopHeadsign` is set (= GTFS stop_headsign override). */
+  stopHeadsignOverrideCount: number;
+  /** Number of unique `direction` values observed (`undefined` is one value). */
+  directionCount: number;
+
+  // D axis: trip locator
+  /** Number of unique `patternId` values. */
+  patternCount: number;
+  /** Number of unique `serviceId` values. */
+  serviceCount: number;
+  /**
+   * Number of unique `(patternId, serviceId, tripIndex)` triples.
+   * Differs from `totalCount` when 6-shape / circular patterns place
+   * the same trip at the same stop multiple times.
+   */
+  uniqueTripCount: number;
+}
+
+/**
+ * Compute aggregated statistics for a list of {@link TimetableEntry}.
+ *
+ * Single pass over the input; O(n) time, O(unique values) space for the
+ * "unique" counts.
+ *
+ * Returns all-zero stats for an empty input.
+ *
+ * @param entries - The entries to analyze.
+ * @returns Aggregated stats. See {@link TimetableEntryStats} for axis details.
+ */
+export function computeTimetableEntryStats(entries: TimetableEntry[]): TimetableEntryStats {
+  let originCount = 0;
+  let terminalCount = 0;
+  let passingCount = 0;
+  let boardableCount = 0;
+  let nonBoardableCount = 0;
+  let dropOffOnlyCount = 0;
+  let noDropOffCount = 0;
+  let stopHeadsignOverrideCount = 0;
+
+  const routeIds = new Set<string>();
+  const headsigns = new Set<string>();
+  const routeHeadsigns = new Set<string>();
+  const directions = new Set<string>();
+  const patternIds = new Set<string>();
+  const serviceIds = new Set<string>();
+  const trips = new Set<string>();
+
+  for (const entry of entries) {
+    if (entry.patternPosition.isOrigin) {
+      originCount++;
+    }
+    if (entry.patternPosition.isTerminal) {
+      terminalCount++;
+    }
+    if (!entry.patternPosition.isOrigin && !entry.patternPosition.isTerminal) {
+      passingCount++;
+    }
+
+    if (isDropOffOnly(entry)) {
+      nonBoardableCount++;
+    } else {
+      boardableCount++;
+    }
+    if (entry.boarding.pickupType === 1) {
+      dropOffOnlyCount++;
+    }
+    if (entry.boarding.dropOffType === 1) {
+      noDropOffCount++;
+    }
+
+    const routeId = entry.routeDirection.route.route_id;
+    const headsign = entry.routeDirection.tripHeadsign.name;
+    routeIds.add(routeId);
+    headsigns.add(headsign);
+    routeHeadsigns.add(`${routeId}|${headsign}`);
+    directions.add(String(entry.routeDirection.direction));
+    if (entry.routeDirection.stopHeadsign !== undefined) {
+      stopHeadsignOverrideCount++;
+    }
+
+    const tl = entry.tripLocator;
+    patternIds.add(tl.patternId);
+    serviceIds.add(tl.serviceId);
+    trips.add(`${tl.patternId}|${tl.serviceId}|${tl.tripIndex}`);
+  }
+
+  return {
+    totalCount: entries.length,
+    originCount,
+    terminalCount,
+    passingCount,
+    boardableCount,
+    nonBoardableCount,
+    dropOffOnlyCount,
+    noDropOffCount,
+    routeCount: routeIds.size,
+    headsignCount: headsigns.size,
+    routeHeadsignCount: routeHeadsigns.size,
+    stopHeadsignOverrideCount,
+    directionCount: directions.size,
+    patternCount: patternIds.size,
+    serviceCount: serviceIds.size,
+    uniqueTripCount: trips.size,
+  };
+}

--- a/src/domain/transit/timetable-stats.ts
+++ b/src/domain/transit/timetable-stats.ts
@@ -1,5 +1,11 @@
 import type { TimetableEntry } from '@/types/app/transit-composed';
+import { getHeadsignDisplayNames } from './name-resolver/get-headsign-display-names';
 import { isDropOffOnly } from './timetable-utils';
+import type { Agency } from '@/types/app/transit';
+import { resolveAgencyLang } from '@/config/transit-defaults';
+import { createLogger } from '../../lib/logger';
+
+const logger = createLogger('TimetableStats');
 
 /**
  * Aggregated statistics computed from a list of {@link TimetableEntry}.
@@ -19,7 +25,8 @@ import { isDropOffOnly } from './timetable-utils';
  *   pair partitions all entries (sum equals `totalCount`).
  *   `dropOffOnlyCount` (= explicit `pickup_type === 1`) and `noDropOffCount`
  *   (= explicit `drop_off_type === 1`) are independent GTFS signals.
- * - **C (route direction)**: unique counts of `route_id`, headsign,
+ * - **C (route direction)**: unique counts of `route_id`, resolved
+ *   headsign (= the user-facing string from {@link getHeadsignDisplayNames}),
  *   `(route, headsign)` pairs, observed `direction` values, plus the
  *   number of entries whose `stopHeadsign` is set.
  * - **D (trip locator)**: unique counts of `patternId`, `serviceId`,
@@ -54,14 +61,10 @@ export interface TimetableEntryStats {
   // C axis: route direction
   /** Number of unique `route_id` values across the entries. */
   routeCount: number;
-  /** Number of unique `tripHeadsign.name` values (empty string is one value). */
-  headsignCount: number;
-  /** Number of unique `(route_id, headsign)` combinations. */
-  routeHeadsignCount: number;
-  /** Entries where `stopHeadsign` is set (= GTFS stop_headsign override). */
-  stopHeadsignOverrideCount: number;
   /** Number of unique `direction` values observed (`undefined` is one value). */
   directionCount: number;
+  tripHeadsignCount: number;
+  stopHeadsignCount: number;
 
   // D axis: trip locator
   /** Number of unique `patternId` values. */
@@ -84,10 +87,21 @@ export interface TimetableEntryStats {
  *
  * Returns all-zero stats for an empty input.
  *
+ * `headsignCount` and `routeHeadsignCount` are aggregated from the
+ * resolved (= user-facing) headsign string produced by
+ * {@link getHeadsignDisplayNames}, so the same `preferredDisplayLangs`,
+ * `agencyLangs`, and `prefer` arguments are forwarded.
+ *
  * @param entries - The entries to analyze.
+ * @param agencies - Agency languages used for sub-name priority within the resolver.
+ * @param preferredDisplayLangs - Ordered language fallback chain for the resolved headsign.
  * @returns Aggregated stats. See {@link TimetableEntryStats} for axis details.
  */
-export function computeTimetableEntryStats(entries: TimetableEntry[]): TimetableEntryStats {
+export function computeTimetableEntryStats(
+  entries: TimetableEntry[],
+  agencies: readonly Agency[],
+  preferredDisplayLangs: readonly string[],
+): TimetableEntryStats {
   let originCount = 0;
   let terminalCount = 0;
   let passingCount = 0;
@@ -95,17 +109,18 @@ export function computeTimetableEntryStats(entries: TimetableEntry[]): Timetable
   let nonBoardableCount = 0;
   let dropOffOnlyCount = 0;
   let noDropOffCount = 0;
-  let stopHeadsignOverrideCount = 0;
 
   const routeIds = new Set<string>();
-  const headsigns = new Set<string>();
-  const routeHeadsigns = new Set<string>();
+  const tripsHeadsigns = new Set<string>();
+  const stopHeadsigns = new Set<string>();
   const directions = new Set<string>();
   const patternIds = new Set<string>();
   const serviceIds = new Set<string>();
   const trips = new Set<string>();
 
   for (const entry of entries) {
+    const agencyLangs = resolveAgencyLang(agencies, entry.routeDirection.route.agency_id);
+
     if (entry.patternPosition.isOrigin) {
       originCount++;
     }
@@ -129,20 +144,36 @@ export function computeTimetableEntryStats(entries: TimetableEntry[]): Timetable
     }
 
     const routeId = entry.routeDirection.route.route_id;
-    const headsign = entry.routeDirection.tripHeadsign.name;
     routeIds.add(routeId);
-    headsigns.add(headsign);
-    routeHeadsigns.add(`${routeId}|${headsign}`);
+
+    const tripHeadsign = getHeadsignDisplayNames(
+      entry.routeDirection,
+      preferredDisplayLangs,
+      agencyLangs,
+      'trip',
+    ).resolved.name;
+    tripsHeadsigns.add(tripHeadsign);
+
+    const stopHeadsign = getHeadsignDisplayNames(
+      entry.routeDirection,
+      preferredDisplayLangs,
+      agencyLangs,
+      'stop',
+    ).resolved.name;
+    stopHeadsigns.add(stopHeadsign);
+
+    // console.debug({ stopHeadsign, tripHeadsign });
+
     directions.add(String(entry.routeDirection.direction));
-    if (entry.routeDirection.stopHeadsign !== undefined) {
-      stopHeadsignOverrideCount++;
-    }
 
     const tl = entry.tripLocator;
     patternIds.add(tl.patternId);
     serviceIds.add(tl.serviceId);
     trips.add(`${tl.patternId}|${tl.serviceId}|${tl.tripIndex}`);
   }
+
+  logger.debug('tripsHeadsigns', [...tripsHeadsigns]);
+  logger.debug('stopHeadsigns', [...stopHeadsigns]);
 
   return {
     totalCount: entries.length,
@@ -154,10 +185,9 @@ export function computeTimetableEntryStats(entries: TimetableEntry[]): Timetable
     dropOffOnlyCount,
     noDropOffCount,
     routeCount: routeIds.size,
-    headsignCount: headsigns.size,
-    routeHeadsignCount: routeHeadsigns.size,
-    stopHeadsignOverrideCount,
     directionCount: directions.size,
+    tripHeadsignCount: tripsHeadsigns.size,
+    stopHeadsignCount: stopHeadsigns.size,
     patternCount: patternIds.size,
     serviceCount: serviceIds.size,
     uniqueTripCount: trips.size,

--- a/src/domain/transit/timetable-utils.ts
+++ b/src/domain/transit/timetable-utils.ts
@@ -15,6 +15,19 @@ import type {
 } from '../../types/app/transit';
 
 /**
+ * Get the display time in minutes for a timetable entry.
+ *
+ * Terminal entries show arrival time; all others show departure time.
+ * This is a key domain rule: the time shown to the user depends on
+ * whether the stop is the last stop in the pattern.
+ */
+export function getDisplayMinutes(entry: TimetableEntry): number {
+  return entry.patternPosition.isTerminal
+    ? entry.schedule.arrivalMinutes
+    : entry.schedule.departureMinutes;
+}
+
+/**
  * Derive the stop service state from service day signals.
  *
  * Signals are passed as a narrow structural object (see
@@ -205,30 +218,4 @@ export function isPassThrough(entry: TimetableEntry): boolean {
  */
 export function hasBoardable(entries: TimetableEntry[]): boolean {
   return entries.some((entry) => !isDropOffOnly(entry));
-}
-
-/**
- * Filter out drop-off-only entries, returning only boardable stop times.
- *
- * Used to exclude terminal arrivals and pickup-unavailable stops
- * from the NearbyStop display in non-verbose mode.
- *
- * Each entry's boardability is determined by {@link isDropOffOnly}
- * (pickupType === 1 OR isTerminal).
- */
-export function filterBoardable(entries: TimetableEntry[]): TimetableEntry[] {
-  return entries.filter((entry) => !isDropOffOnly(entry));
-}
-
-/**
- * Get the display time in minutes for a timetable entry.
- *
- * Terminal entries show arrival time; all others show departure time.
- * This is a key domain rule: the time shown to the user depends on
- * whether the stop is the last stop in the pattern.
- */
-export function getDisplayMinutes(entry: TimetableEntry): number {
-  return entry.patternPosition.isTerminal
-    ? entry.schedule.arrivalMinutes
-    : entry.schedule.departureMinutes;
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -114,7 +114,9 @@
     },
     "metadata": {
       "count": "{{count}} trips",
-      "avgInterval": "avg. {{interval}} min interval"
+      "avgInterval": "avg. {{interval}} min interval",
+      "boardableCount": "{{count}} boardable",
+      "originCount": "{{count}} origin"
     },
     "header": {
       "routeHeadsignDescription": "Timetable at {{stop}}: {{route}} -> {{headsign}} ({{count}})",
@@ -123,8 +125,10 @@
       "noDestination": "Some routes have no destination"
     },
     "filter": {
-      "boardableOnly": "🚏 Boardable only",
-      "boardableOnlyTitle": "Show only boardable trips (exclude terminals and pickup-unavailable)"
+      "boardableOnly": "🚏 Boardable",
+      "boardableOnlyTitle": "Show only boardable trips (exclude terminals and pickup-unavailable)",
+      "originOnly": "🚩 Origin",
+      "originOnlyTitle": "Show only trips originating at this stop (includes non-boardable origins like depot departures)"
     }
   },
   "panel": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -121,6 +121,10 @@
       "routeDescription": "Timetable at {{stop}}: {{route}} ({{count}})",
       "stopDescription": "Timetable at {{stop}}: all routes ({{count}})",
       "noDestination": "Some routes have no destination"
+    },
+    "filter": {
+      "boardableOnly": "🚏 Boardable only",
+      "boardableOnlyTitle": "Show only boardable trips (exclude terminals and pickup-unavailable)"
     }
   },
   "panel": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -115,8 +115,18 @@
     "metadata": {
       "count": "{{count}} trips",
       "avgInterval": "avg. {{interval}} min interval",
+      "originCount": "{{count}} origin",
+      "terminalCount": "{{count}} terminal",
+      "passingCount": "{{count}} passing",
       "boardableCount": "{{count}} boardable",
-      "originCount": "{{count}} origin"
+      "nonBoardableCount": "{{count}} non-boardable",
+      "dropOffOnlyCount": "{{count}} drop-off only",
+      "noDropOffCount": "{{count}} no drop-off",
+      "routeCount": "{{count}} routes",
+      "headsignCount": "{{count}} headsigns",
+      "routeHeadsignCount": "{{count}} route×headsign",
+      "stopHeadsignOverrideCount": "{{count}} stop_headsign override",
+      "directionCount": "{{count}} directions"
     },
     "header": {
       "routeHeadsignDescription": "Timetable at {{stop}}: {{route}} -> {{headsign}} ({{count}})",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -135,7 +135,7 @@
       "noDestination": "行先が表示されない路線があります"
     },
     "filter": {
-      "boardableOnly": "🚏 乗車可能",
+      "boardableOnly": "🚏 乗車可",
       "boardableOnlyTitle": "乗車できる便のみ表示 (終点や乗車不可便を除外)",
       "originOnly": "🚩 始発",
       "originOnlyTitle": "ここを始発とする便のみ表示 (出庫便など乗車不可な始発も含む)"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -121,6 +121,10 @@
       "routeDescription": "{{stop}}: {{route}} 時刻表 {{count}}本",
       "stopDescription": "{{stop}}: 全路線時刻表 {{count}}本",
       "noDestination": "行先が表示されない路線があります"
+    },
+    "filter": {
+      "boardableOnly": "🚏 乗車可能",
+      "boardableOnlyTitle": "乗車できる便のみ表示 (終点や乗車不可便を除外)"
     }
   },
   "panel": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -114,7 +114,9 @@
     },
     "metadata": {
       "count": "{{count}}本",
-      "avgInterval": "平均{{interval}}分間隔"
+      "avgInterval": "平均{{interval}}分間隔",
+      "boardableCount": "乗車可 {{count}}本",
+      "originCount": "始発 {{count}}本"
     },
     "header": {
       "routeHeadsignDescription": "{{stop}}: {{route}} -> {{headsign}} 方面 時刻表 {{count}}本",
@@ -124,7 +126,9 @@
     },
     "filter": {
       "boardableOnly": "🚏 乗車可能",
-      "boardableOnlyTitle": "乗車できる便のみ表示 (終点や乗車不可便を除外)"
+      "boardableOnlyTitle": "乗車できる便のみ表示 (終点や乗車不可便を除外)",
+      "originOnly": "🚩 始発",
+      "originOnlyTitle": "ここを始発とする便のみ表示 (出庫便など乗車不可な始発も含む)"
     }
   },
   "panel": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -115,8 +115,18 @@
     "metadata": {
       "count": "{{count}}本",
       "avgInterval": "平均{{interval}}分間隔",
+      "originCount": "始発 {{count}}本",
+      "terminalCount": "終点 {{count}}本",
+      "passingCount": "途中 {{count}}本",
       "boardableCount": "乗車可 {{count}}本",
-      "originCount": "始発 {{count}}本"
+      "nonBoardableCount": "乗車不可 {{count}}本",
+      "dropOffOnlyCount": "降車専用 {{count}}本",
+      "noDropOffCount": "降車不可 {{count}}本",
+      "routeCount": "路線 {{count}}",
+      "headsignCount": "行先 {{count}}",
+      "routeHeadsignCount": "路線×行先 {{count}}",
+      "stopHeadsignOverrideCount": "stopHeadsign指定 {{count}}本",
+      "directionCount": "direction {{count}}"
     },
     "header": {
       "routeHeadsignDescription": "{{stop}}: {{route}} -> {{headsign}} 方面 時刻表 {{count}}本",

--- a/src/types/app/repository.ts
+++ b/src/types/app/repository.ts
@@ -28,10 +28,14 @@ export type CollectionResult<T> =
   | { success: true; data: T[]; truncated: boolean }
   | { success: false; error: string };
 
-/** Entries omitted by pre-filter (e.g. terminal arrivals hidden in simple/normal). */
+/** Entries omitted by pre-filter (e.g. drop-off-only entries hidden in simple/normal). */
 export interface TimetableOmitted {
-  /** Number of terminal arrival entries omitted. */
-  terminal: number;
+  /**
+   * Number of non-boardable entries omitted (= entries where
+   * `isDropOffOnly` returns true: `pickup_type === 1` or
+   * pattern-inferred `isTerminal`).
+   */
+  nonBoardable: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Refine timetable modal filtering flow and surface richer metadata for the displayed timetable entries.

## What changed

- add and style origin / boardable filters in the timetable modal
- reorganize modal filtering so origin and boardable filters apply before route-headsign filtering
- add timetable entry aggregate stats and use them in the modal metadata block
- add badge-based metadata display for origin / terminal / boarding-related counts
- update timetable stats aggregation and tests to cover the new metadata and filtering behavior

## Validation

- `npm run build`
- `npx eslint src/app.tsx src/components/dialog/timetable-modal.tsx src/components/timetable/timetable-boardability-filter.tsx src/components/timetable/timetable-metadata.tsx src/components/timetable/timetable-origin-filter.tsx src/domain/transit/__tests__/timetable-stats.test.ts src/domain/transit/timetable-stats.ts`
- `vitest` for `src/domain/transit/__tests__/timetable-stats.test.ts`

## Notes

- includes the earlier `LabelCountBadge` class customization commit because the metadata badges depend on it
- related follow-up for boarding/alighting state semantics: #162