### PR TITLE
TripInspectionDialog tweaks: endpoint jump, info token, button polish

### DIFF
--- a/src/components/dialog/time-setting-dialog.tsx
+++ b/src/components/dialog/time-setting-dialog.tsx
@@ -95,7 +95,7 @@ export function TimeSettingDialog({
         <div className="flex justify-end gap-2">
           <Button
             size="lg"
-            className="mr-auto border-2 border-emerald-500 bg-emerald-200 text-emerald-900 hover:bg-emerald-300 disabled:opacity-40"
+            className="mr-auto cursor-pointer border-2 border-emerald-500 bg-emerald-200 text-emerald-900 hover:bg-emerald-300 disabled:opacity-40"
             disabled={!isCustomTime}
             onClick={handleResetToNowAndClose}
           >
@@ -103,7 +103,7 @@ export function TimeSettingDialog({
           </Button>
           <Button
             size="lg"
-            className="border-2 border-blue-500 bg-blue-200 text-blue-900 hover:bg-blue-300"
+            className="cursor-pointer border-2 border-blue-500 bg-blue-200 text-blue-900 hover:bg-blue-300"
             onClick={handleSubmit}
           >
             {t('time.set')}

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { JourneyTimeBar } from '@/components/journey-time-bar';
 import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
 import { StopInfo } from '@/components/stop-info';
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -101,6 +102,16 @@ interface TripEndpointsSummaryProps {
   lastStopName: string;
   lastStopArrivalTime: string | undefined;
   infoLevel: InfoLevel;
+  /**
+   * Invoked when the first-stop summary cell is activated. Disabled when omitted.
+   * The handler should scroll the trip stops list to the corresponding row.
+   */
+  onSelectFirst?: () => void;
+  /**
+   * Invoked when the last-stop summary cell is activated. Disabled when omitted.
+   * The handler should scroll the trip stops list to the corresponding row.
+   */
+  onSelectLast?: () => void;
 }
 
 function resolveTripStopDisplay(stop: TripStopTime | undefined, dataLangs: readonly string[]) {
@@ -158,29 +169,49 @@ function TripEndpointsSummary({
   lastStopName,
   lastStopArrivalTime,
   infoLevel,
+  onSelectFirst,
+  onSelectLast,
 }: TripEndpointsSummaryProps) {
+  // Override Button's inherent fixed height / horizontal padding so the
+  // wrapped SimpleStopSummary controls sizing, while keeping the design
+  // system's focus ring, hover accent, and disabled handling.
+  const buttonClassName = 'block h-auto w-full cursor-pointer p-0';
   return (
     <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-x-2 select-none">
-      <SimpleStopSummary
-        stopNames={firstStopNames}
-        stopName={firstStopName}
-        infoLevel={infoLevel}
-        departureTime={firstStopDepartureTime}
-        showDepartureTime
-      />
+      <Button
+        variant="ghost"
+        onClick={onSelectFirst}
+        disabled={!onSelectFirst}
+        className={buttonClassName}
+      >
+        <SimpleStopSummary
+          stopNames={firstStopNames}
+          stopName={firstStopName}
+          infoLevel={infoLevel}
+          departureTime={firstStopDepartureTime}
+          showDepartureTime
+        />
+      </Button>
       <div className="flex items-center justify-center">
         <span
           aria-hidden="true"
           className="border-l-muted-foreground h-0 w-0 border-y-[6px] border-l-10 border-y-transparent"
         />
       </div>
-      <SimpleStopSummary
-        stopNames={lastStopNames}
-        stopName={lastStopName}
-        infoLevel={infoLevel}
-        arrivalTime={lastStopArrivalTime}
-        showArrivalTime
-      />
+      <Button
+        variant="ghost"
+        onClick={onSelectLast}
+        disabled={!onSelectLast}
+        className={buttonClassName}
+      >
+        <SimpleStopSummary
+          stopNames={lastStopNames}
+          stopName={lastStopName}
+          infoLevel={infoLevel}
+          arrivalTime={lastStopArrivalTime}
+          showArrivalTime
+        />
+      </Button>
     </div>
   );
 }
@@ -475,6 +506,44 @@ export function TripInspectionDialog({
     };
   }, [open, snapshot]);
 
+  const scrollToStopRow = useCallback((stopIndex: number, behavior: ScrollBehavior): boolean => {
+    const container = contentContainerRef.current;
+    const row = container ? findTripStopRow(container, stopIndex) : null;
+
+    if (!container || !row) {
+      return false;
+    }
+
+    const nextScrollTop = getSelectedRowScrollTop(container, row);
+
+    if (container.scrollTop === nextScrollTop) {
+      return false;
+    }
+
+    container.scrollTo({
+      top: nextScrollTop,
+      behavior,
+    });
+
+    return true;
+  }, []);
+
+  // Imperative scroll triggered by user actions (= origin/destination click).
+  // Sets focus synchronously to the target so the journey-time / position
+  // indicators reflect the click intent immediately. The suppress timer keeps
+  // scroll-driven focus updates quiet while the smooth scroll is settling
+  // (smooth-scroll typically completes before the timer expires, after which
+  // no further scroll events fire — so we cannot rely on `handleBodyScroll`
+  // to set focus for a click-driven jump).
+  const handleSelectStopRow = useCallback(
+    (stopIndex: number) => {
+      programmaticScrollSettleRef.current = Date.now() + 800;
+      setFocusedStopIndex(stopIndex);
+      scrollToStopRow(stopIndex, 'smooth');
+    },
+    [scrollToStopRow],
+  );
+
   useEffect(() => {
     if (!open || !snapshot || !contentContainerEl) {
       return;
@@ -488,35 +557,13 @@ export function TripInspectionDialog({
     let secondFrameId = 0;
     let correctionFrameId = 0;
 
-    const applyScrollToSelectedRow = (behavior: ScrollBehavior) => {
-      const container = contentContainerEl;
-      const selectedRow = container ? findTripStopRow(container, selectedPatternStopIndex) : null;
-
-      if (!container || !selectedRow) {
-        return false;
-      }
-
-      const nextScrollTop = getSelectedRowScrollTop(container, selectedRow);
-
-      if (container.scrollTop === nextScrollTop) {
-        return false;
-      }
-
-      container.scrollTo({
-        top: nextScrollTop,
-        behavior,
-      });
-
-      return true;
-    };
-
     const correctSelectedRowVisibility = (remainingPasses: number) => {
       if (remainingPasses <= 0) {
         return;
       }
 
       correctionFrameId = window.requestAnimationFrame(() => {
-        const didScroll = applyScrollToSelectedRow('auto');
+        const didScroll = scrollToStopRow(selectedPatternStopIndex, 'auto');
 
         if (didScroll) {
           correctSelectedRowVisibility(remainingPasses - 1);
@@ -526,7 +573,7 @@ export function TripInspectionDialog({
 
     firstFrameId = window.requestAnimationFrame(() => {
       secondFrameId = window.requestAnimationFrame(() => {
-        applyScrollToSelectedRow('smooth');
+        scrollToStopRow(selectedPatternStopIndex, 'smooth');
         correctSelectedRowVisibility(3);
       });
     });
@@ -536,7 +583,14 @@ export function TripInspectionDialog({
       window.cancelAnimationFrame(secondFrameId);
       window.cancelAnimationFrame(correctionFrameId);
     };
-  }, [contentContainerEl, open, selectedPatternStopIndex, selectedStopRowKey, snapshot]);
+  }, [
+    contentContainerEl,
+    open,
+    selectedPatternStopIndex,
+    selectedStopRowKey,
+    snapshot,
+    scrollToStopRow,
+  ]);
 
   const handleBodyScroll = useCallback(() => {
     contentScroll.handleScroll();
@@ -670,6 +724,16 @@ export function TripInspectionDialog({
               lastStopName={lastStopName}
               lastStopArrivalTime={lastStopArrivalTime}
               infoLevel={infoLevel}
+              onSelectFirst={
+                firstStop
+                  ? () => handleSelectStopRow(firstStop.timetableEntry.patternPosition.stopIndex)
+                  : undefined
+              }
+              onSelectLast={
+                lastStop
+                  ? () => handleSelectStopRow(lastStop.timetableEntry.patternPosition.stopIndex)
+                  : undefined
+              }
             />
           </DialogDescription>
 

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -178,6 +178,7 @@ function TripEndpointsSummary({
   const buttonClassName = 'block h-auto w-full cursor-pointer p-0';
   return (
     <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-x-2 select-none">
+      {/* First Stop Button */}
       <Button
         variant="ghost"
         onClick={onSelectFirst}
@@ -192,12 +193,14 @@ function TripEndpointsSummary({
           showDepartureTime
         />
       </Button>
+      {/* Divider */}
       <div className="flex items-center justify-center">
         <span
           aria-hidden="true"
           className="border-l-muted-foreground h-0 w-0 border-y-[6px] border-l-10 border-y-transparent"
         />
       </div>
+      {/* Last Stop Button */}
       <Button
         variant="ghost"
         onClick={onSelectLast}

--- a/src/components/trip/trip-pager.tsx
+++ b/src/components/trip/trip-pager.tsx
@@ -3,6 +3,8 @@ import { minutesToDate } from '@/domain/transit/calendar-utils';
 import { formatAbsoluteTime } from '@/domain/transit/time';
 import { cn } from '@/lib/utils';
 import type { TripInspectionTarget, TripStopTime } from '@/types/app/transit-composed';
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
+import { LabelCountBadge } from '../badge/label-count-badge';
 import { StopTimeTimeInfo } from '../stop-time-time-info';
 
 interface TripPagerProps {
@@ -32,6 +34,9 @@ export function TripPager({
   onOpenPreviousTrip,
   onOpenNextTrip,
 }: TripPagerProps) {
+  const displayedTripIndex =
+    tripInspectionTargets.length > 0 ? currentTripInspectionTargetIndex + 1 : 0;
+  const totalTripCount = tripInspectionTargets.length;
   const hasPreviousTrip = currentTripInspectionTargetIndex > 0;
   const hasNextTrip = currentTripInspectionTargetIndex < tripInspectionTargets.length - 1;
   const previousTarget = hasPreviousTrip
@@ -45,6 +50,15 @@ export function TripPager({
 
   return (
     <div className="flex items-center justify-center gap-2 pb-2 select-none">
+      <LabelCountBadge
+        label={`${displayedTripIndex}`}
+        count={totalTripCount}
+        size="md"
+        labelClassName="bg-info text-info-foreground"
+        countClassName="bg-background text-info"
+        frameClassName="border-info"
+      />
+      {/* Previous Trip Button */}
       <Button
         className={cn('cursor-pointer', !hasPreviousTrip && 'pointer-events-none invisible')}
         size="sm"
@@ -52,8 +66,10 @@ export function TripPager({
         disabled={!hasPreviousTrip}
         onClick={onOpenPreviousTrip}
       >
-        {previousDepartureTime ? `${previousDepartureTime}` : 'Prev'}
+        <ChevronLeftIcon className="size-3" />
+        {previousDepartureTime ? `${previousDepartureTime}` : ''}
       </Button>
+      {/* Current Trip Info */}
       <div className="flex min-w-16 flex-col items-center justify-center gap-1">
         <StopTimeTimeInfo
           arrivalMinutes={selectedStop.timetableEntry.schedule.arrivalMinutes}
@@ -68,6 +84,7 @@ export function TripPager({
           showVerbose={false}
         />
       </div>
+      {/* Next Trip Button */}
       <Button
         className={cn('cursor-pointer', !hasNextTrip && 'pointer-events-none invisible')}
         size="sm"
@@ -75,14 +92,9 @@ export function TripPager({
         disabled={!hasNextTrip}
         onClick={onOpenNextTrip}
       >
-        {nextDepartureTime ? `${nextDepartureTime}` : 'Next'}
+        {nextDepartureTime ? `${nextDepartureTime}` : ''}
+        <ChevronRightIcon className="size-3" />
       </Button>
-
-      <span className="text-muted-foreground text-center text-xs">
-        {tripInspectionTargets.length > 0
-          ? `${currentTripInspectionTargetIndex + 1} / ${tripInspectionTargets.length}`
-          : '0 / 0'}
-      </span>
     </div>
   );
 }

--- a/src/components/trip/trip-pager.tsx
+++ b/src/components/trip/trip-pager.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { minutesToDate } from '@/domain/transit/calendar-utils';
 import { formatAbsoluteTime } from '@/domain/transit/time';
+import { cn } from '@/lib/utils';
 import type { TripInspectionTarget, TripStopTime } from '@/types/app/transit-composed';
 import { StopTimeTimeInfo } from '../stop-time-time-info';
 
@@ -45,7 +46,7 @@ export function TripPager({
   return (
     <div className="flex items-center justify-center gap-2 pb-2 select-none">
       <Button
-        className={!hasPreviousTrip ? 'pointer-events-none invisible' : undefined}
+        className={cn('cursor-pointer', !hasPreviousTrip && 'pointer-events-none invisible')}
         size="sm"
         variant="outline"
         disabled={!hasPreviousTrip}
@@ -68,7 +69,7 @@ export function TripPager({
         />
       </div>
       <Button
-        className={!hasNextTrip ? 'pointer-events-none invisible' : undefined}
+        className={cn('cursor-pointer', !hasNextTrip && 'pointer-events-none invisible')}
         size="sm"
         variant="outline"
         disabled={!hasNextTrip}

--- a/src/index.css
+++ b/src/index.css
@@ -148,6 +148,8 @@
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -183,6 +185,9 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
+  /* Material Blue 800 (#1565c0). Used for info badges, status indicators, and the boardability filter pill. */
+  --info: oklch(0.507 0.166 258);
+  --info-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -217,6 +222,9 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
+  /* Lighter blue (Material Blue 500 family) for dark bg visibility. Foreground stays white as in the standard info badge convention. */
+  --info: oklch(0.66 0.16 245);
+  --info-foreground: oklch(0.985 0 0);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);


### PR DESCRIPTION
## Summary

- **Trip inspection: click origin / destination to scroll the stop list.** Activating the start-stop or end-stop cell in `TripEndpointsSummary` smooth-scrolls the trip stops list to that row and shifts `focusedStopIndex` (driving `TripInspectionSummary`'s position / journey-time bar) in sync. Implemented by lifting the inline auto-scroll logic into a stable `scrollToStopRow(index, behavior)` `useCallback` reused both by the existing open-time auto-scroll effect and by the new `handleSelectStopRow` handler that updates focus synchronously (smooth-scroll events stop before the suppress timer lifts, so we cannot wait on `handleBodyScroll` for click-driven jumps). `SimpleStopSummary` cells are now wrapped in shadcn `<Button variant="ghost">` with `block h-auto w-full p-0` so the badge keeps its content-driven size.
- **Theme: add `info` semantic color token.** New `--info` / `--info-foreground` CSS variables for both light and dark modes, exposed via `@theme inline` so Tailwind generates `bg-info` / `text-info` / `text-info-foreground` / `border-info`. Anchored to Material Blue 800 (`#1565c0`, the same blue already used by `TimetableBoardabilityFilter`); dark mode uses a lighter blue for visibility on dark bg, foregrounds stay white per the standard info-badge convention.
- **TripPager redesign.** Pull the trip-index `LabelCountBadge` (`displayedTripIndex / totalTripCount`) up to the leading edge of the pager strip and color it with the new `info` token (route color would mislead because the count aggregates across multiple routes). Add `ChevronLeftIcon` / `ChevronRightIcon` (lucide) to the prev / next buttons so direction reads at a glance, and add JSX section comments.
- **Cursor consistency.** Add `cursor-pointer` to all app-side shadcn `Button` callsites (`time-setting-dialog`, `trip-pager`, `TripEndpointsSummary`). shadcn upstream files (`ui/calendar`, `ui/dialog`) are intentionally not touched per the upstream-immutable policy.

## Test plan

- [ ] Trip inspection dialog: open from a timetable entry — header still scrolls to the selected row, no regression.
- [ ] Click `始発` cell — list scrolls to row 0; `TripInspectionSummary` reflects "at origin".
- [x] Click `終点` cell — list scrolls to last row; `TripInspectionSummary` reflects "at destination".
- [x] Verify cells show focus ring on tab navigation; `cursor: pointer` on hover.
- [x] TripPager: prev / next chevrons render correctly in both directions; index badge uses info color (blue) and is readable in both light and dark themes.
- [x] Time-setting dialog: now / set buttons show pointer cursor on hover.
- [x] Sparse trips (where `tripStopTimes[0]` is not pattern-position 0): clicking origin / destination still scrolls to a real row.