### PR TITLE
refactor(stop-times-item): align naming, harden key, surface 着 suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [CalVer](https://calver.org/).
 - `deriveStopTimeRoleDisplayProps` の tolerance default を `verbose ? null : 2` に設定。GTFS / ODPT 全 20 source の中間 stop dwell 分布 (d=1: 2.34% = 鉄道発車待ち、d=2: 0.082% = 軽 hub dwell、d>=3: 0.078% = 通過待ち / 折返し / 高速バス起点) から、d=1+d=2 を collapse 対象とし d>=3 を 2 行展開する設計。
 - 動作仕様: 非 verbose では origin = dep のみ / terminal = arr のみ / middle = 両方 (tolerance=2) / single-stop = 両方 (tolerance=2) を表示。verbose では全 role で両方表示し tolerance は null (= 全 dwell 開示)。terminal の operator-recorded `departure_time` (例: 京成 妙典駅 d=8 の折返し時間、京都市バス 松尾橋 d=6) も verbose で可視化。
 - `StopTimeTimeInfo` から `showVerbose` prop と verbose 用 `着` / `発` badge ブロックを削除。badge は collapse 判定 (`shouldCollapseArrival`) と独立に render されており、`着` badge と arrival 行の表示が連動しない不整合があったため、機能ごと撤去。caller (`stop-time-item.tsx` / `trip-pager.tsx` / `trip-stops.tsx`) も `showVerbose` の引き渡しを削除。
+- `StopTimesItem` の `dataLang` prop を `dataLangs` にリネーム (project-wide 命名規約整合)。caller (`nearby-stop.tsx`) と stories の引き渡しも併せて更新。React key を loop index (`i`) から `${patternId}__${serviceId}__${tripIndex}__${stopIndex}` ベースの安定 ID に変更し、Issue #47 の 6-shape / circular pattern (同 trip が異なる stopIndex で登場) でも一意性を保つ。
+- `StopTimesItem` の絶対時刻表示を `formatAbsoluteTime` 直書きから `AbsoluteStopTime` コンポーネントに置換。terminal entry に `着` suffix が `showArrivalMarker={isTerminal}` 経由で表示され、TERM badge と併せて到着便を一目で識別可能に (`発` suffix は compact 性維持のため非表示)。各 entry wrapper の hardcoded `text-[#757575] dark:text-gray-400` も theme token `text-muted-foreground` に統一。
 
 ## [2026.04.29]
 

--- a/src/components/nearby-stop.tsx
+++ b/src/components/nearby-stop.tsx
@@ -252,7 +252,7 @@ export function NearbyStop({
                   entries={entries}
                   now={now}
                   infoLevel={infoLevel}
-                  dataLang={dataLangs}
+                  dataLangs={dataLangs}
                   showRouteTypeIcon={showRouteTypeIconForAllStopTimes}
                   agency={agencies.find(
                     (a) => a.agency_id === entries[0].routeDirection.route.agency_id,

--- a/src/components/stop-times-item.stories.tsx
+++ b/src/components/stop-times-item.stories.tsx
@@ -169,7 +169,7 @@ const meta = {
     entries: threeEntries,
     now,
     infoLevel: 'normal',
-    dataLang: ['ja'],
+    dataLangs: ['ja'],
     showRouteTypeIcon: false,
   },
   argTypes: {
@@ -347,7 +347,7 @@ export const MultipleGroups: Story = {
             entries={group.entries}
             now={now}
             infoLevel="normal"
-            dataLang={['ja']}
+            dataLangs={['ja']}
             showRouteTypeIcon
             onShowTimetable={fn()}
           />
@@ -448,7 +448,7 @@ export const LangComparison: Story = {
             entries={args.entries}
             now={args.now}
             infoLevel={args.infoLevel}
-            dataLang={dataLang}
+            dataLangs={dataLang}
             showRouteTypeIcon={args.showRouteTypeIcon}
             agency={args.agency}
             maxDisplay={args.maxDisplay}
@@ -642,7 +642,7 @@ export const LogicalLongInfoLevelComparison: Story = {
               entries={args.entries}
               now={now}
               infoLevel={level}
-              dataLang={['ja']}
+              dataLangs={['ja']}
               showRouteTypeIcon
               agency={args.agency}
               showAgency={false}
@@ -702,7 +702,7 @@ export const LogicalKitchenSink: Story = {
             entries={group.entries}
             now={now}
             infoLevel="detailed"
-            dataLang={['ja']}
+            dataLangs={['ja']}
             showRouteTypeIcon
             agency={group.agency}
             onShowTimetable={fn()}
@@ -723,7 +723,7 @@ export const KitchenSink: Story = {
           entries={group.entries}
           now={now}
           infoLevel="detailed"
-          dataLang={['ja']}
+          dataLangs={['ja']}
           showRouteTypeIcon
           agency={group.agency}
           onShowTimetable={fn()}

--- a/src/components/stop-times-item.tsx
+++ b/src/components/stop-times-item.tsx
@@ -1,5 +1,6 @@
 import { Clock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { AbsoluteStopTime } from './absolute-stop-time';
 import { minutesToDate } from '../domain/transit/calendar-utils';
 import { getEffectiveHeadsign } from '../domain/transit/get-effective-headsign';
 import { formatAbsoluteTime } from '../domain/transit/time';
@@ -119,7 +120,13 @@ export function StopTimesItem({
             const entryKey = `${entry.tripLocator.patternId}__${entry.tripLocator.serviceId}__${entry.tripLocator.tripIndex}__${entry.patternPosition.stopIndex}`;
             const content = (
               <>
-                {formatAbsoluteTime(displayTimes[i])}
+                <AbsoluteStopTime
+                  timeText={formatAbsoluteTime(displayTimes[i])}
+                  size="md"
+                  showArrivalMarker={entry.patternPosition.isTerminal}
+                  showDepartureMarker={false}
+                  className="text-muted-foreground"
+                />
                 <TimetableEntryAttributesLabels
                   attributes={getTimetableEntryAttributes(entry)}
                   size="xs"
@@ -135,7 +142,7 @@ export function StopTimesItem({
               <button
                 key={entryKey}
                 type="button"
-                className="inline-flex cursor-pointer items-center gap-0.5 rounded-sm text-sm font-bold whitespace-nowrap text-[#757575] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-gray-400"
+                className="text-muted-foreground inline-flex cursor-pointer items-center gap-0.5 rounded-sm text-sm font-bold whitespace-nowrap focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
                 onClick={(e) => {
                   e.stopPropagation();
                   onInspectTrip({
@@ -151,7 +158,7 @@ export function StopTimesItem({
             ) : (
               <span
                 key={entryKey}
-                className="inline-flex items-center gap-0.5 text-sm font-bold whitespace-nowrap text-[#757575] dark:text-gray-400"
+                className="text-muted-foreground inline-flex items-center gap-0.5 text-sm font-bold whitespace-nowrap"
               >
                 {content}
               </span>

--- a/src/components/stop-times-item.tsx
+++ b/src/components/stop-times-item.tsx
@@ -19,7 +19,7 @@ interface StopTimesItemProps {
   now: Date;
   infoLevel: InfoLevel;
   /** Display language chain for translated GTFS/ODPT data names. */
-  dataLang: readonly string[];
+  dataLangs: readonly string[];
   /** Whether to show route_type emoji (e.g. when stop serves multiple route types). */
   showRouteTypeIcon: boolean;
   /** Agency object for badge display at detailed+ info level. */
@@ -44,7 +44,7 @@ export function StopTimesItem({
   entries,
   now,
   infoLevel,
-  dataLang,
+  dataLangs,
   showRouteTypeIcon,
   agency,
   showAgency = false,
@@ -86,7 +86,7 @@ export function StopTimesItem({
           size="md"
           routeDirection={firstEntry.routeDirection}
           infoLevel={infoLevel}
-          dataLangs={dataLang}
+          dataLangs={dataLangs}
           showRouteTypeIcon={showRouteTypeIcon}
           agency={agency}
           showAgency={showAgency}
@@ -112,6 +112,11 @@ export function StopTimesItem({
               Per Issue #47 / Alt F, each time renders its own per-stop-time
               attribute labels (TERM/ORIG/noPickup/noDropOff) inline. */}
           {displayEntries.map((entry, i) => {
+            // Issue #47: 6-shape / circular routes can place the same trip
+            // at multiple `stopIndex` values within one route+headsign
+            // bucket, so include `stopIndex` in the key alongside the
+            // tripLocator triple to keep keys unique per stop event.
+            const entryKey = `${entry.tripLocator.patternId}__${entry.tripLocator.serviceId}__${entry.tripLocator.tripIndex}__${entry.patternPosition.stopIndex}`;
             const content = (
               <>
                 {formatAbsoluteTime(displayTimes[i])}
@@ -128,7 +133,7 @@ export function StopTimesItem({
 
             return onInspectTrip ? (
               <button
-                key={i}
+                key={entryKey}
                 type="button"
                 className="inline-flex cursor-pointer items-center gap-0.5 rounded-sm text-sm font-bold whitespace-nowrap text-[#757575] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-gray-400"
                 onClick={(e) => {
@@ -145,7 +150,7 @@ export function StopTimesItem({
               </button>
             ) : (
               <span
-                key={i}
+                key={entryKey}
                 className="inline-flex items-center gap-0.5 text-sm font-bold whitespace-nowrap text-[#757575] dark:text-gray-400"
               >
                 {content}


### PR DESCRIPTION
## Summary

Three small but related cleanups in `StopTimesItem`:

1. **Rename `dataLang` → `dataLangs`** to match the project-wide plural convention used by `StopTimeItem` / `TripInfo` / `StopInfo` etc. Caller (`NearbyStop`) and stories follow.
2. **Harden the React key** for per-entry buttons/spans. The previous loop-index key would silently misbehave for 6-shape / circular routes (Issue #47) where the same trip can appear twice in one route+headsign group with different `stopIndex`. The new key is `${patternId}__${serviceId}__${tripIndex}__${stopIndex}`.
3. **Replace bare `formatAbsoluteTime` text with `AbsoluteStopTime`** so terminal entries render with a `着` suffix next to the time. The pre-existing `[TERM]` attribute badge stays; the suffix makes "this is an arrival, not a departure" recognizable at a glance even if the user does not notice the badge. Departures keep no `発` suffix to preserve the compact stacked layout. Wrapper and absolute time both move from hardcoded `text-[#757575] / dark:text-gray-400` to the theme token `text-muted-foreground`.

## Behavior changes

- terminal entry now renders as `20:19着 [TERM]` instead of `20:19 [TERM]`.
- non-terminal entries unchanged in pixels (still `14:30 [ORIG?]`).
- light / dark theme picks up `--muted-foreground` automatically.

## Test plan

- [x] Open BottomSheet with a stop that has terminal entries (e.g. mock data with `isTerminal=true`). Confirm the time renders as `20:19着`.
- [x] Confirm origin / middle entries render without any suffix.
- [x] Switch dark mode; confirm the muted gray follows the theme.
- [x] `npm run lint` / `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)