### PR TITLE
feat(bottom-sheet): origin / boardable filter pills + helper refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,25 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ### Added
 
+- `filterByStopEventAttributes` helper (`src/domain/transit/timetable-filter.ts`) を追加。`TimetableEntry[]` に対して per-stop-event 属性 (schedule range / `pickUpState` / patternPosition) を hybrid Set / range API で single-pass 合成 filter する。trip-level 属性 (route / headsign / agency) は対象外で `filterByAgency` / `filterByRouteType` と責務分離。empty filter bundle は input reference をそのまま返す fast-path 付き。
+- `PickUpState` 型 (`'boardable' | 'nonBoardable' | 'phoneArrangement' | 'driverArrangement'`) を追加。GTFS `pickup_type` 0/1/2/3 と 1:1 mapping。`isTerminal` は判定に混入させず position 軸の責務に分離。
+- `applyStopEventAttributeToggles` helper を追加。`showOriginOnly` / `showBoardableOnly` の boolean toggle を受けて `filterByStopEventAttributes` を AND 合成する wrapper。BottomSheet と TimetableModal で同じ toggle semantics を共有。
+- BottomSheet に origin / boardable filter pill (`OriginFilter` / `BoardabilityFilter`) を追加。Stage 1 (`showOperatingStopsOnly`) と同性質の "operative presence toggle" として stop drop を行い、filter で entries が空になった stop は list から除外。
+- `NearbyStopsCounts` に `originCount` / `boardableCount` を追加。final `trimmedStopTimes` に対して仮想的に各 toggle を適用した stop 数を計算し、各 filter pill の count として表示。
+- `src/components/filter/origin-filter.tsx` / `boardability-filter.tsx` を追加 (`TimetableOriginFilter` / `TimetableBoardabilityFilter` から rename + 移動)。TimetableModal と BottomSheet 両方で再利用可能な共通 filter pill。
+- i18n key `filter.originOnly` / `filter.originOnlyTitle` / `filter.boardableOnly` / `filter.boardableOnlyTitle` を top-level `filter.*` namespace に追加 (旧 `timetable.filter.*` から re-namespace)。
 - `src/domain/transit/stop-time-display.ts` を追加。`shouldCollapseArrival` (= 表示済み arr 行を dep と冗長な場合に hide するか) と `deriveStopTimeRoleDisplayProps` (= 役割 / infoLevel から `StopTimeTimeInfo` 用の `showArrivalTime` / `showDepartureTime` / `collapseToleranceMinutes` を一括導出) を提供。26 vitest cases で 8 セル真理値表 (verbose × isOrigin × isTerminal) と各種 tolerance 入力をカバー。
 - `StopTimeTimeInfo` に `align` prop に続く `collapseToleranceMinutes` (`number | null`) を導入し、旧 `collapseArrivalWhenSameAsDeparture` (boolean) を置換。`null` で collapse 無効、`0` で厳密一致のみ collapse、`n` で `|dep - arr| <= n` 分以内なら collapse という単一軸の閾値表現に。
 - `src/components/stop-time-time-info.stories.tsx` を新設。Default / Imminent / Past / FarFuture / 各 Show 軸 / Align / Size / Verbose / TextAppearance / InspectTrip 等のストーリーと、tolerance 動作確認用の `ArrivalCloseToDepartureCollapsedWithTolerance` を含む。
 
 ### Changed
 
+- `TimetableModal` の filter pipeline を `applyStopEventAttributeToggles` 経由に統一。旧 `filterBoardable` / `filterOrigin` 直接呼び出しを廃し、BottomSheet と同一の toggle semantics を共有。中間変数 `entriesBeforeRouteHeadsignFilter` を `stopEventAttributesFilteredEntries` にリネーム (= 軸の責務を反映)。
+- BottomSheet の filter pipeline を 3-stage 構成に再編。Stage 1 (`showOperatingStopsOnly`、stop drop) → Stage 2 (`showOriginOnly` / `showBoardableOnly`、stop drop) → Stage 3 (`hiddenAgencyIds` / `hiddenRouteTypes`、entry trim only)。集合属性 trim (Stage 3) は `'allFilteredOut'` fallback 維持、user 操作の presence toggle (Stage 1/2) は stop drop。
+- BottomSheet の `counts` を全て final `trimmedStopTimes` (Stage 3 出力) base に統一。`active` の semantic を旧 "pre-filter で entries が 1 件以上の stop 数" (= filter 状態無関係の固定値) から "現在表示中で entries が 1 件以上の stop 数" (= 全 filter 操作で変動) に変更。Operating pill の count は user の filter 操作で変動するようになる。
+- 4-state `PickUpState` 設計に伴い、`matchesPickUpState` を `isDropOffOnly` 依存から純粋な `pickup_type` 値判定に変更 (`isTerminal` 混入を解消、軸の責務分離を厳密化)。`pickup_type === 1` のみ `'nonBoardable'`、`2`/`3` は `'phoneArrangement'`/`'driverArrangement'` に独立分類。
+- `prepareStopTimetable` / `prepareRouteHeadsignTimetable` の boardable filter 呼び出しを `filterByStopEventAttributes(..., { pickUpState: ['boardable'], position: ['origin', 'middle'] })` に置換。旧 `filterBoardable` (= `pickup_type === 1 || isTerminal` で除外) と挙動差: pure terminal (= `!isOrigin && isTerminal`) は除外 / 1-stop trip (= `isOrigin && isTerminal`) は keep / `pickup_type=2/3` は除外。
+- `verbose-nearby-stop-summary.tsx` の inline `boardable` filter (`pickupType !== 1 && !isTerminal`) を `filterByStopEventAttributes` 合成呼び出しに置換 (count 計算経路を新 helper に統一)。
 - `DialogContent` に `showCloseButton={false}` を渡してデフォルト X を無効化 (Esc / 外側クリックで close 可能なため UX 維持)。
 - `shouldCollapseArrival` 判定ロジックを domain helper (`src/domain/transit/stop-time-display.ts`) に抽出。比較を `at === dt` (整形文字列比較) から `Math.abs(departureMinutes - arrivalMinutes) <= collapseToleranceMinutes` の tolerance-based 整数比較に変更し、`null` で collapse 無効化を表現可能に。
 - `StopTimeItem` の API を簡素化: `showArrivalTime` / `showDepartureTime` / `collapseToleranceMinutes` の 3 props を削除し、`entry.patternPosition` (isOrigin / isTerminal) と `infoLevel` から内部で `deriveStopTimeRoleDisplayProps` を呼んで導出する形に。caller (`nearby-stop.tsx`) はこれら 3 props を渡さなくなる。
@@ -26,6 +39,12 @@ and this project adheres to [CalVer](https://calver.org/).
 - `StopTimeTimeInfo` から `showVerbose` prop と verbose 用 `着` / `発` badge ブロックを削除。badge は collapse 判定 (`shouldCollapseArrival`) と独立に render されており、`着` badge と arrival 行の表示が連動しない不整合があったため、機能ごと撤去。caller (`stop-time-item.tsx` / `trip-pager.tsx` / `trip-stops.tsx`) も `showVerbose` の引き渡しを削除。
 - `StopTimesItem` の `dataLang` prop を `dataLangs` にリネーム (project-wide 命名規約整合)。caller (`nearby-stop.tsx`) と stories の引き渡しも併せて更新。React key を loop index (`i`) から `${patternId}__${serviceId}__${tripIndex}__${stopIndex}` ベースの安定 ID に変更し、Issue #47 の 6-shape / circular pattern (同 trip が異なる stopIndex で登場) でも一意性を保つ。
 - `StopTimesItem` の絶対時刻表示を `formatAbsoluteTime` 直書きから `AbsoluteStopTime` コンポーネントに置換。terminal entry に `着` suffix が `showArrivalMarker={isTerminal}` 経由で表示され、TERM badge と併せて到着便を一目で識別可能に (`発` suffix は compact 性維持のため非表示)。各 entry wrapper の hardcoded `text-[#757575] dark:text-gray-400` も theme token `text-muted-foreground` に統一。
+
+### Removed
+
+- `filterBoardable` / `filterOrigin` 関数を削除 (`src/domain/transit/timetable-filter.ts`)。新 helper `filterByStopEventAttributes` (criteria 受け) と `applyStopEventAttributeToggles` (toggle 受け wrapper) で代替。両者の唯一の caller (`prepareStopTimetable` / `prepareRouteHeadsignTimetable` / `TimetableModal` / `verbose-nearby-stop-summary`) を全て新 helper 経由に置換済み。
+- `TimetableOriginFilter` / `TimetableBoardabilityFilter` を削除 (= `OriginFilter` / `BoardabilityFilter` に rename + `src/components/filter/` に移動)。
+- 旧 i18n key `timetable.filter.originOnly` / `timetable.filter.originOnlyTitle` / `timetable.filter.boardableOnly` / `timetable.filter.boardableOnlyTitle` を削除 (top-level `filter.*` namespace に移行)。
 
 ## [2026.04.29]
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -656,14 +656,14 @@ export default function App({ loadResult }: AppProps) {
 
   // --- Settings handlers ---
 
-  const visibleStopTypes = useMemo(
+  const enabledRouteTypes = useMemo(
     () => new Set(settings.visibleStopTypes),
     [settings.visibleStopTypes],
   );
 
-  const filteredStopTimes = useMemo(
-    () => stopTimes.filter((d) => d.routeTypes.some((rt) => visibleStopTypes.has(rt))),
-    [stopTimes, visibleStopTypes],
+  const routeTypesFilteredStopTimes = useMemo(
+    () => stopTimes.filter((d) => d.routeTypes.some((rt) => enabledRouteTypes.has(rt))),
+    [stopTimes, enabledRouteTypes],
   );
 
   const handleToggleStopType = useCallback(
@@ -785,7 +785,7 @@ export default function App({ loadResult }: AppProps) {
           routeShapes,
           selectionInfo,
           routeStops,
-          visibleStopTypes,
+          visibleStopTypes: enabledRouteTypes,
           visibleRouteShapes,
           tileIndex: settings.tileIndex,
           renderMode: settings.renderMode,
@@ -819,7 +819,7 @@ export default function App({ loadResult }: AppProps) {
           lookupAnchorStopMeta,
         }}
         bottomSheetProps={{
-          stopTimes: filteredStopTimes,
+          stopTimes: routeTypesFilteredStopTimes,
           selectedStopId,
           isNearbyLoading,
           hasNearbyLoaded,

--- a/src/components/bottom-sheet-header.stories.tsx
+++ b/src/components/bottom-sheet-header.stories.tsx
@@ -249,7 +249,7 @@ const kitchenSinkArgs = {
   hasNearbyLoaded: true,
   counts: { total: 42, active: 28, filtered: 21, originCount: 6, boardableCount: 15 },
   dataConfig: defaultDataConfig,
-  dataLang: ['ja'],
+  dataLangs: ['ja'],
   showOperatingStopsOnly: true,
   viewId: 'route-headsign',
   selectedView: selectView('route-headsign'),

--- a/src/components/bottom-sheet-header.stories.tsx
+++ b/src/components/bottom-sheet-header.stories.tsx
@@ -44,6 +44,8 @@ const meta = {
     dataConfig: defaultDataConfig,
     dataLangs: ['ja'],
     showOperatingStopsOnly: false,
+    showOriginOnly: false,
+    showBoardableOnly: false,
     viewId: DEFAULT_VIEW_ID,
     selectedView: defaultSelectedView,
     infoLevel: 'normal',
@@ -52,6 +54,8 @@ const meta = {
     presentAgencies: [agencyTobus],
     hiddenAgencyIds: new Set<string>(),
     onToggleShowOperatingStopsOnly: fn(),
+    onToggleShowOriginOnly: fn(),
+    onToggleShowBoardableOnly: fn(),
     onViewChange: fn(),
     onToggleRouteType: fn(),
     onToggleAgency: fn(),
@@ -59,6 +63,8 @@ const meta = {
   argTypes: {
     infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
     showOperatingStopsOnly: { control: 'boolean' },
+    showOriginOnly: { control: 'boolean' },
+    showBoardableOnly: { control: 'boolean' },
     hasNearbyLoaded: { control: 'boolean' },
   },
   decorators: [

--- a/src/components/bottom-sheet-header.stories.tsx
+++ b/src/components/bottom-sheet-header.stories.tsx
@@ -40,7 +40,7 @@ const meta = {
   component: BottomSheetHeader,
   args: {
     hasNearbyLoaded: true,
-    counts: { total: 12, active: 7, filtered: 7 },
+    counts: { total: 12, active: 7, filtered: 7, originCount: 3, boardableCount: 5 },
     dataConfig: defaultDataConfig,
     dataLangs: ['ja'],
     showOperatingStopsOnly: false,
@@ -86,13 +86,13 @@ export const Default: Story = {};
 export const Loading: Story = {
   args: {
     hasNearbyLoaded: false,
-    counts: { total: 0, active: 0, filtered: 0 },
+    counts: { total: 0, active: 0, filtered: 0, originCount: 0, boardableCount: 0 },
   },
 };
 
 export const NoStops: Story = {
   args: {
-    counts: { total: 0, active: 0, filtered: 0 },
+    counts: { total: 0, active: 0, filtered: 0, originCount: 0, boardableCount: 0 },
     presentRouteTypes: [],
     presentAgencies: [],
   },
@@ -100,7 +100,7 @@ export const NoStops: Story = {
 
 export const NoOperatingStops: Story = {
   args: {
-    counts: { total: 8, active: 0, filtered: 0 },
+    counts: { total: 8, active: 0, filtered: 0, originCount: 0, boardableCount: 0 },
     showOperatingStopsOnly: true,
     presentRouteTypes: [3],
     presentAgencies: [agencyTobus],
@@ -109,7 +109,7 @@ export const NoOperatingStops: Story = {
 
 export const OperatingOnlyActive: Story = {
   args: {
-    counts: { total: 15, active: 9, filtered: 9 },
+    counts: { total: 15, active: 9, filtered: 9, originCount: 4, boardableCount: 7 },
     showOperatingStopsOnly: true,
   },
 };
@@ -247,7 +247,7 @@ export const InfoLevelVerbose: Story = {
 
 const kitchenSinkArgs = {
   hasNearbyLoaded: true,
-  counts: { total: 42, active: 28, filtered: 21 },
+  counts: { total: 42, active: 28, filtered: 21, originCount: 6, boardableCount: 15 },
   dataConfig: defaultDataConfig,
   dataLang: ['ja'],
   showOperatingStopsOnly: true,

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -13,6 +13,8 @@ import { routeTypeEmoji } from '../utils/route-type-emoji';
 import { useInfoLevel } from '../hooks/use-info-level';
 import { useTranslation } from 'react-i18next';
 import { PillButton } from './button/pill-button';
+import { BoardabilityFilter } from './filter/boardability-filter';
+import { OriginFilter } from './filter/origin-filter';
 
 interface BottomSheetHeaderProps {
   hasNearbyLoaded: boolean;
@@ -20,6 +22,8 @@ interface BottomSheetHeaderProps {
   dataConfig: DataConfig;
   dataLangs: readonly string[];
   showOperatingStopsOnly: boolean;
+  showOriginOnly: boolean;
+  showBoardableOnly: boolean;
   viewId: string;
   selectedView: StopTimeViewMeta | undefined;
   infoLevel: InfoLevel;
@@ -28,6 +32,8 @@ interface BottomSheetHeaderProps {
   presentAgencies: Agency[];
   hiddenAgencyIds: Set<string>;
   onToggleShowOperatingStopsOnly: () => void;
+  onToggleShowOriginOnly: () => void;
+  onToggleShowBoardableOnly: () => void;
   onViewChange: (viewId: string) => void;
   onToggleRouteType: (rt: number) => void;
   onToggleAgency: (agency: Agency) => void;
@@ -39,6 +45,8 @@ export function BottomSheetHeader({
   dataConfig,
   dataLangs,
   showOperatingStopsOnly,
+  showOriginOnly,
+  showBoardableOnly,
   viewId,
   selectedView: _selectedView,
   infoLevel,
@@ -47,6 +55,8 @@ export function BottomSheetHeader({
   presentAgencies,
   hiddenAgencyIds,
   onToggleShowOperatingStopsOnly,
+  onToggleShowOriginOnly,
+  onToggleShowBoardableOnly,
   onViewChange,
   onToggleRouteType,
   onToggleAgency,
@@ -81,6 +91,15 @@ export function BottomSheetHeader({
       </div>
       {/* Filters */}
       <div className="no-scrollbar mt-1 flex gap-1 overflow-x-auto">
+        {/* Origin filter (entry-level: patternPosition.isOrigin) */}
+        <OriginFilter origin={showOriginOnly} onToggleOrigin={onToggleShowOriginOnly} />
+
+        {/* Boardable filter (entry-level: pickup_type === 0) */}
+        <BoardabilityFilter
+          boardable={showBoardableOnly}
+          onToggleBoardable={onToggleShowBoardableOnly}
+        />
+
         {/* Operating stops filter */}
         <PillButton
           size={'sm'}
@@ -109,6 +128,7 @@ export function BottomSheetHeader({
             {routeTypeEmoji(rt)}
           </PillButton>
         ))}
+
         {/* Agency filter */}
         {presentAgencies.map((agency) => {
           const { agencyColor: bgColor, agencyTextColor: fgColor } = resolveAgencyColors(

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -92,12 +92,17 @@ export function BottomSheetHeader({
       {/* Filters */}
       <div className="no-scrollbar mt-1 flex gap-1 overflow-x-auto">
         {/* Origin filter (entry-level: patternPosition.isOrigin) */}
-        <OriginFilter origin={showOriginOnly} onToggleOrigin={onToggleShowOriginOnly} />
+        <OriginFilter
+          origin={showOriginOnly}
+          onToggleOrigin={onToggleShowOriginOnly}
+          count={counts.originCount}
+        />
 
         {/* Boardable filter (entry-level: pickup_type === 0) */}
         <BoardabilityFilter
           boardable={showBoardableOnly}
           onToggleBoardable={onToggleShowBoardableOnly}
+          count={counts.boardableCount}
         />
 
         {/* Operating stops filter */}

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -92,11 +92,13 @@ export function BottomSheetHeader({
       {/* Filters */}
       <div className="no-scrollbar mt-1 flex gap-1 overflow-x-auto">
         {/* Origin filter (entry-level: patternPosition.isOrigin) */}
-        <OriginFilter
-          origin={showOriginOnly}
-          onToggleOrigin={onToggleShowOriginOnly}
-          count={counts.originCount}
-        />
+        {counts.originCount > 0 && (
+          <OriginFilter
+            origin={showOriginOnly}
+            onToggleOrigin={onToggleShowOriginOnly}
+            count={counts.originCount}
+          />
+        )}
 
         {/* Boardable filter (entry-level: pickup_type === 0) */}
         <BoardabilityFilter

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -256,19 +256,19 @@ export function BottomSheet({
       total: stopTimes.length,
       active: trimmedStopTimes.filter((swc) => swc.stopTimes.length > 0).length,
       filtered: trimmedStopTimes.length,
-      originCount: trimmedStopTimes.filter(
-        (swc) =>
-          applyStopEventAttributeToggles(swc.stopTimes, {
-            showOriginOnly: true,
-            showBoardableOnly: false,
-          }).length > 0,
+      // Existence-only `.some(...)` predicates — semantic-equivalent to
+      // applyStopEventAttributeToggles({ showOriginOnly: true }).length > 0
+      // and applyStopEventAttributeToggles({ showBoardableOnly: true }).length > 0
+      // respectively, but without allocating a per-stop filtered array.
+      originCount: trimmedStopTimes.filter((swc) =>
+        swc.stopTimes.some((entry) => entry.patternPosition.isOrigin),
       ).length,
-      boardableCount: trimmedStopTimes.filter(
-        (swc) =>
-          applyStopEventAttributeToggles(swc.stopTimes, {
-            showOriginOnly: false,
-            showBoardableOnly: true,
-          }).length > 0,
+      boardableCount: trimmedStopTimes.filter((swc) =>
+        swc.stopTimes.some(
+          (entry) =>
+            entry.boarding.pickupType === 0 &&
+            (entry.patternPosition.isOrigin || !entry.patternPosition.isTerminal),
+        ),
       ).length,
     }),
     [stopTimes, trimmedStopTimes],

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -6,7 +6,11 @@ import type { Agency, AppRouteTypeValue, TimetableEntriesState } from '../types/
 import type { StopWithContext, TripInspectionTarget } from '../types/app/transit-composed';
 import { collectPresentAgencies } from '../domain/transit/collect-present-agencies';
 import { collectPresentRouteTypes } from '../domain/transit/collect-present-route-types';
-import { filterByAgency, filterByRouteType } from '../domain/transit/timetable-filter';
+import {
+  applyStopEventAttributeToggles,
+  filterByAgency,
+  filterByRouteType,
+} from '../domain/transit/timetable-filter';
 import { getTimetableEntriesState } from '../domain/transit/timetable-utils';
 import { STOP_TIMES_VIEWS, DEFAULT_VIEW_ID } from '../domain/transit/stop-time-views';
 import { getServiceDayMinutes } from '../domain/transit/service-day';
@@ -123,6 +127,9 @@ export function BottomSheet({
   const showOperatingStopsOnly = showOperatingStopsOnlyOverride ?? isLateNight;
   const [hiddenRouteTypes, setHiddenRouteTypes] = useState<Set<number>>(() => new Set());
   const [hiddenAgencyIds, setHiddenAgencyIds] = useState<Set<string>>(() => new Set());
+  // Stop-event-level filters (per-entry attributes). Default OFF.
+  const [showOriginOnly, setShowOriginOnly] = useState(false);
+  const [showBoardableOnly, setShowBoardableOnly] = useState(false);
   const selectedView = STOP_TIMES_VIEWS.find((v) => v.id === viewId);
   const touchStartY = useRef(0);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -173,11 +180,16 @@ export function BottomSheet({
     });
   }, []);
 
-  // Split into two stages so the distinct natures of the operations are
-  // visible. The stage order is load-bearing — reversing it produces a
-  // regression where showOperatingStopsOnly checks against post-inner-filter
-  // stopTimes.length, conflating stop visibility with the user's agency /
-  // route_type filters. Do not swap these stages.
+  const toggleShowOriginOnly = useCallback(() => {
+    setShowOriginOnly((prev) => !prev);
+  }, []);
+
+  const toggleShowBoardableOnly = useCallback(() => {
+    setShowBoardableOnly((prev) => !prev);
+  }, []);
+
+  // Three-stage filter pipeline. Each stage has a distinct nature, so
+  // they are kept separate and the stage order is load-bearing.
   //
   // Stage 1 — drop stops that have no upcoming entries today.
   // `showOperatingStopsOnly` is a property of the stop itself and MUST be
@@ -189,16 +201,39 @@ export function BottomSheet({
     return stopTimes.filter((swc) => swc.stopTimes.length > 0);
   }, [stopTimes, showOperatingStopsOnly]);
 
-  // Stage 2 — trim each surviving stop's inner stopTimes by agency /
+  // Stage 2 — trim each surviving stop's inner stopTimes by stop-event
+  // attributes (origin / boardable), and drop stops whose stopTimes
+  // become empty after the trim. This is a user-facing presence toggle
+  // (same nature as Stage 1's `showOperatingStopsOnly`): when the user
+  // enables an entry-level pill, stops with no matching entry are
+  // removed from the list. Runs before the agency / route_type trim so
+  // those non-removing filters operate on entries that have already
+  // passed the user's primary intent (= what kind of trips to see).
+  const stopEventAttributesFilteredStopTimes = useMemo(() => {
+    if (!showOriginOnly && !showBoardableOnly) {
+      return filteredStopTimes;
+    }
+    return filteredStopTimes
+      .map((swc) => {
+        const filtered = applyStopEventAttributeToggles(swc.stopTimes, {
+          showOriginOnly,
+          showBoardableOnly,
+        });
+        return filtered === swc.stopTimes ? swc : { ...swc, stopTimes: filtered };
+      })
+      .filter((swc) => swc.stopTimes.length > 0);
+  }, [filteredStopTimes, showOriginOnly, showBoardableOnly]);
+
+  // Stage 3 — trim each surviving stop's inner stopTimes by agency /
   // route_type filters. This never drops stops: a stop whose stopTimes
   // are all removed stays visible and shows the "allFilteredOut"
   // fallback message. This decouples "which stops are in the list"
   // from "what is shown inside each stop".
   const trimmedStopTimes = useMemo(() => {
     if (hiddenAgencyIds.size === 0 && hiddenRouteTypes.size === 0) {
-      return filteredStopTimes;
+      return stopEventAttributesFilteredStopTimes;
     }
-    return filteredStopTimes.map((swc) => {
+    return stopEventAttributesFilteredStopTimes.map((swc) => {
       let trimmed = swc.stopTimes;
       if (hiddenAgencyIds.size > 0) {
         trimmed = filterByAgency(trimmed, hiddenAgencyIds);
@@ -208,7 +243,7 @@ export function BottomSheet({
       }
       return trimmed === swc.stopTimes ? swc : { ...swc, stopTimes: trimmed };
     });
-  }, [filteredStopTimes, hiddenAgencyIds, hiddenRouteTypes]);
+  }, [stopEventAttributesFilteredStopTimes, hiddenAgencyIds, hiddenRouteTypes]);
 
   const counts: NearbyStopsCounts = useMemo(
     () => ({
@@ -289,6 +324,8 @@ export function BottomSheet({
         dataConfig={dataConfig}
         dataLangs={dataLangs}
         showOperatingStopsOnly={showOperatingStopsOnly}
+        showOriginOnly={showOriginOnly}
+        showBoardableOnly={showBoardableOnly}
         viewId={viewId}
         selectedView={selectedView}
         infoLevel={infoLevel}
@@ -299,6 +336,8 @@ export function BottomSheet({
         onToggleShowOperatingStopsOnly={() =>
           setShowOperatingStopsOnlyOverride((v) => !(v ?? isLateNight))
         }
+        onToggleShowOriginOnly={toggleShowOriginOnly}
+        onToggleShowBoardableOnly={toggleShowBoardableOnly}
         onViewChange={setViewId}
         onToggleRouteType={toggleRouteType}
         onToggleAgency={toggleAgency}

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -47,12 +47,18 @@ const ROUTE_TYPE_ORDER: AppRouteTypeValue[] = [...APP_ROUTE_TYPES.map(({ value }
 );
 
 export interface NearbyStopsCounts {
-  /** Total number of nearby stops before any filtering. */
+  /** Total number of nearby stops before any filtering (= input `stopTimes`). */
   total: number;
-  /** Stops with at least one upcoming entry. */
+  /** Stops with at least one upcoming entry, computed against the final
+   *  `trimmedStopTimes`. Reflects the user's current filter state. */
   active: number;
-  /** Stops remaining after all filters (showOperatingStopsOnly, routeType, agency). */
+  /** Stops remaining after all filters (= `trimmedStopTimes.length`). */
   filtered: number;
+  /** Stops in `trimmedStopTimes` that contain at least one origin entry. */
+  originCount: number;
+  /** Stops in `trimmedStopTimes` that contain at least one boardable
+   *  entry (= `pickup_type === 0` at a non-pure-terminal position). */
+  boardableCount: number;
 }
 
 export interface BottomSheetProps {
@@ -248,8 +254,22 @@ export function BottomSheet({
   const counts: NearbyStopsCounts = useMemo(
     () => ({
       total: stopTimes.length,
-      active: stopTimes.filter((swc) => swc.stopTimes.length > 0).length,
+      active: trimmedStopTimes.filter((swc) => swc.stopTimes.length > 0).length,
       filtered: trimmedStopTimes.length,
+      originCount: trimmedStopTimes.filter(
+        (swc) =>
+          applyStopEventAttributeToggles(swc.stopTimes, {
+            showOriginOnly: true,
+            showBoardableOnly: false,
+          }).length > 0,
+      ).length,
+      boardableCount: trimmedStopTimes.filter(
+        (swc) =>
+          applyStopEventAttributeToggles(swc.stopTimes, {
+            showOriginOnly: false,
+            showBoardableOnly: true,
+          }).length > 0,
+      ).length,
     }),
     [stopTimes, trimmedStopTimes],
   );

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -10,7 +10,7 @@ import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
 import { findRouteDirectionForHeadsign } from '@/domain/transit/find-route-direction-for-headsign';
 import { getStopDisplayNames } from '@/domain/transit/get-stop-display-names';
 import { getRouteHeadsignKey } from '../../domain/transit/get-route-headsign-key';
-import { filterBoardable, filterOrigin } from '@/domain/transit/timetable-filter';
+import { filterByStopEventAttributes } from '@/domain/transit/timetable-filter';
 import { computeTimetableEntryStats } from '@/domain/transit/timetable-stats';
 import type { TimetableEntryStats } from '@/domain/transit/timetable-stats';
 import { getServiceDayMinutes } from '@/domain/transit/service-day';
@@ -164,7 +164,8 @@ export function TimetableModal({
   const [showBoardableOnly, setShowBoardableOnly] = useState(boardableOnly);
 
   // Origin-only filter toggle (= 始発のみ). OFF by default.
-  // When ON, applies filterOrigin on top of any other active filters.
+  // When ON, narrows to entries whose patternPosition.isOrigin is true,
+  // applied on top of any other active filters.
   const [showOriginOnly, setShowOriginOnly] = useState(false);
 
   const toggleFilter = useCallback((key: string) => {
@@ -199,10 +200,15 @@ export function TimetableModal({
   const entriesBeforeRouteHeadsignFilter = useMemo(() => {
     let entries = allTimetableEntries;
     if (showOriginOnly) {
-      entries = filterOrigin(entries);
+      entries = filterByStopEventAttributes(entries, {
+        position: new Set(['origin']),
+      });
     }
     if (showBoardableOnly) {
-      entries = filterBoardable(entries);
+      entries = filterByStopEventAttributes(entries, {
+        pickUpState: new Set(['boardable']),
+        position: new Set(['origin', 'middle']),
+      });
     }
     return entries;
   }, [allTimetableEntries, showOriginOnly, showBoardableOnly]);

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -197,7 +197,7 @@ export function TimetableModal({
   }, [data]);
   // const allEntriesStats = computeTimetableEntryStats( allTimetableEntries, data?.agencies ?? [], dataLangs,);
 
-  const entriesBeforeRouteHeadsignFilter = useMemo(() => {
+  const stopEventAttributesFilteredEntries = useMemo(() => {
     let entries = allTimetableEntries;
     if (showOriginOnly) {
       entries = filterByStopEventAttributes(entries, {
@@ -212,21 +212,21 @@ export function TimetableModal({
     }
     return entries;
   }, [allTimetableEntries, showOriginOnly, showBoardableOnly]);
-  const entriesBeforeRouteHeadsignFilterStats = computeTimetableEntryStats(
-    entriesBeforeRouteHeadsignFilter,
+  const stopEventAttributesFilteredEntriesStats = computeTimetableEntryStats(
+    stopEventAttributesFilteredEntries,
     data?.agencies ?? [],
     dataLangs,
   );
 
   const routeHeadsignFilteredEntries = useMemo(() => {
-    let entries = entriesBeforeRouteHeadsignFilter;
+    let entries = stopEventAttributesFilteredEntries;
     if (activeFilters.size > 0) {
       entries = entries.filter((entry) =>
         activeFilters.has(getRouteHeadsignKey(entry.routeDirection)),
       );
     }
     return entries;
-  }, [entriesBeforeRouteHeadsignFilter, activeFilters]);
+  }, [stopEventAttributesFilteredEntries, activeFilters]);
   const routeHeadsignFilteredEntriesStats = computeTimetableEntryStats(
     routeHeadsignFilteredEntries,
     data?.agencies ?? [],
@@ -253,11 +253,11 @@ export function TimetableModal({
 
   const headerScroll = useScrollFades(
     headerContainerRef,
-    `${data?.type ?? 'closed'}:${data?.headsign ?? ''}:${entriesBeforeRouteHeadsignFilter.length}:${infoLevel}`,
+    `${data?.type ?? 'closed'}:${data?.headsign ?? ''}:${stopEventAttributesFilteredEntries.length}:${infoLevel}`,
   );
   const gridScroll = useScrollFades(
     gridContainerRef,
-    `${data?.type ?? 'closed'}:${entriesBeforeRouteHeadsignFilter.length}:${infoLevel}:${currentHour}`,
+    `${data?.type ?? 'closed'}:${stopEventAttributesFilteredEntries.length}:${infoLevel}:${currentHour}`,
   );
 
   if (!data) {
@@ -294,13 +294,13 @@ export function TimetableModal({
         stop: descriptionStopName,
         route: descriptionRouteName,
         headsign: descriptionHeadsign,
-        count: entriesBeforeRouteHeadsignFilter.length.toLocaleString(i18n.language),
+        count: stopEventAttributesFilteredEntries.length.toLocaleString(i18n.language),
       },
     );
   } else {
     timetableDescription = t('timetable.header.stopDescription', {
       stop: descriptionStopName,
-      count: entriesBeforeRouteHeadsignFilter.length.toLocaleString(i18n.language),
+      count: stopEventAttributesFilteredEntries.length.toLocaleString(i18n.language),
     });
   }
 
@@ -333,7 +333,7 @@ export function TimetableModal({
                 type={data.type}
                 headsign={data.headsign}
                 serviceDate={data.serviceDate}
-                timetableEntries={entriesBeforeRouteHeadsignFilter}
+                timetableEntries={stopEventAttributesFilteredEntries}
                 omitted={data.omitted}
                 stopServiceState={data.stopServiceState}
               />
@@ -391,25 +391,23 @@ export function TimetableModal({
 
             <div className="flex flex-wrap gap-1">
               {/* Origin filter — hidden when no origin entries exist at this stop */}
-              {entriesBeforeRouteHeadsignFilterStats.originCount > 0 && (
+              {stopEventAttributesFilteredEntriesStats.originCount > 0 && (
                 <TimetableOriginFilter
                   origin={showOriginOnly}
-                  count={entriesBeforeRouteHeadsignFilterStats.originCount}
+                  count={stopEventAttributesFilteredEntriesStats.originCount}
                   onToggleOrigin={toggleOriginOnly}
                 />
               )}
               {/* Boardability filter */}
-              {/* {filteredEntriesStats.nonBoardableCount > 0 && ( */}
               <TimetableBoardabilityFilter
                 boardable={showBoardableOnly}
-                count={entriesBeforeRouteHeadsignFilterStats.boardableCount}
+                count={stopEventAttributesFilteredEntriesStats.boardableCount}
                 onToggleBoardable={toggleBoardableOnly}
               />
-              {/* )} */}
               {/* Headsign filter */}
               {data.type === 'stop' && (
                 <TimetableHeadsignFilter
-                  timetableEntries={entriesBeforeRouteHeadsignFilter}
+                  timetableEntries={stopEventAttributesFilteredEntries}
                   activeFilters={activeFilters}
                   onToggleFilter={toggleFilter}
                   dataLang={dataLangs}

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -10,7 +10,7 @@ import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
 import { findRouteDirectionForHeadsign } from '@/domain/transit/find-route-direction-for-headsign';
 import { getStopDisplayNames } from '@/domain/transit/get-stop-display-names';
 import { getRouteHeadsignKey } from '../../domain/transit/get-route-headsign-key';
-import { filterByStopEventAttributes } from '@/domain/transit/timetable-filter';
+import { applyStopEventAttributeToggles } from '@/domain/transit/timetable-filter';
 import { computeTimetableEntryStats } from '@/domain/transit/timetable-stats';
 import type { TimetableEntryStats } from '@/domain/transit/timetable-stats';
 import { getServiceDayMinutes } from '@/domain/transit/service-day';
@@ -197,21 +197,14 @@ export function TimetableModal({
   }, [data]);
   // const allEntriesStats = computeTimetableEntryStats( allTimetableEntries, data?.agencies ?? [], dataLangs,);
 
-  const stopEventAttributesFilteredEntries = useMemo(() => {
-    let entries = allTimetableEntries;
-    if (showOriginOnly) {
-      entries = filterByStopEventAttributes(entries, {
-        position: new Set(['origin']),
-      });
-    }
-    if (showBoardableOnly) {
-      entries = filterByStopEventAttributes(entries, {
-        pickUpState: new Set(['boardable']),
-        position: new Set(['origin', 'middle']),
-      });
-    }
-    return entries;
-  }, [allTimetableEntries, showOriginOnly, showBoardableOnly]);
+  const stopEventAttributesFilteredEntries = useMemo(
+    () =>
+      applyStopEventAttributeToggles(allTimetableEntries, {
+        showOriginOnly,
+        showBoardableOnly,
+      }),
+    [allTimetableEntries, showOriginOnly, showBoardableOnly],
+  );
   const stopEventAttributesFilteredEntriesStats = computeTimetableEntryStats(
     stopEventAttributesFilteredEntries,
     data?.agencies ?? [],

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -4,8 +4,8 @@ import { TimetableGrid } from '../timetable/timetable-grid';
 import { TimetableHeader } from '../timetable/timetable-header';
 import { TimetableMetadata } from '../timetable/timetable-metadata';
 import { TimetableHeadsignFilter } from '../timetable/timetable-headsign-filter';
-import { TimetableBoardabilityFilter } from '../timetable/timetable-boardability-filter';
-import { TimetableOriginFilter } from '../timetable/timetable-origin-filter';
+import { BoardabilityFilter } from '../filter/boardability-filter';
+import { OriginFilter } from '../filter/origin-filter';
 import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
 import { findRouteDirectionForHeadsign } from '@/domain/transit/find-route-direction-for-headsign';
 import { getStopDisplayNames } from '@/domain/transit/get-stop-display-names';
@@ -392,14 +392,14 @@ export function TimetableModal({
             <div className="flex flex-wrap gap-1">
               {/* Origin filter — hidden when no origin entries exist at this stop */}
               {stopEventAttributesFilteredEntriesStats.originCount > 0 && (
-                <TimetableOriginFilter
+                <OriginFilter
                   origin={showOriginOnly}
                   count={stopEventAttributesFilteredEntriesStats.originCount}
                   onToggleOrigin={toggleOriginOnly}
                 />
               )}
               {/* Boardability filter */}
-              <TimetableBoardabilityFilter
+              <BoardabilityFilter
                 boardable={showBoardableOnly}
                 count={stopEventAttributesFilteredEntriesStats.boardableCount}
                 onToggleBoardable={toggleBoardableOnly}

--- a/src/components/filter/boardability-filter.tsx
+++ b/src/components/filter/boardability-filter.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { PillButton } from '../button/pill-button';
 
-interface TimetableBoardabilityFilterProps {
+interface BoardabilityFilterProps {
   boardable: boolean;
   onToggleBoardable: () => void;
   /** Number of boardable entries (= count to display on the pill). */
@@ -9,13 +9,13 @@ interface TimetableBoardabilityFilterProps {
 }
 
 /**
- * Render the stop-level boardability filter toggle for a timetable view.
+ * Render the stop-level boardability filter toggle.
  *
- * Currently filters by stop-level boardability (= GTFS `pickup_type` and
- * pattern-inferred `isTerminal`). Segment-level boardability signals
- * (`continuous_pickup` / `continuous_drop_off`) are out of scope for
- * this filter; if added in the future, expose them as a separate filter
- * component to keep dimensions distinct.
+ * Currently filters by stop-level boardability (= GTFS `pickup_type`).
+ * Segment-level boardability signals (`continuous_pickup` /
+ * `continuous_drop_off`) are out of scope for this filter; if added in
+ * the future, expose them as a separate filter component to keep
+ * dimensions distinct.
  *
  * The `count` is owned by the caller so the same predicate is not
  * computed twice (= once for filter, once for count). Caller decides
@@ -25,11 +25,11 @@ interface TimetableBoardabilityFilterProps {
  * @param props - Filter rendering inputs.
  * @returns The rendered filter toggle.
  */
-export function TimetableBoardabilityFilter({
+export function BoardabilityFilter({
   boardable,
   onToggleBoardable,
   count,
-}: TimetableBoardabilityFilterProps) {
+}: BoardabilityFilterProps) {
   const { t } = useTranslation();
 
   return (
@@ -41,10 +41,10 @@ export function TimetableBoardabilityFilter({
         activeBorder={'var(--info)'}
         inactiveBorder={'var(--info)'}
         onClick={onToggleBoardable}
-        title={t('timetable.filter.boardableOnlyTitle')}
+        title={t('filter.boardableOnlyTitle')}
         count={count}
       >
-        {t('timetable.filter.boardableOnly')}
+        {t('filter.boardableOnly')}
       </PillButton>
     </div>
   );

--- a/src/components/filter/origin-filter.tsx
+++ b/src/components/filter/origin-filter.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { PillButton } from '../button/pill-button';
 
-interface TimetableOriginFilterProps {
+interface OriginFilterProps {
   origin: boolean;
   onToggleOrigin: () => void;
   /** Number of origin entries (= count to display on the pill). */
@@ -9,7 +9,7 @@ interface TimetableOriginFilterProps {
 }
 
 /**
- * Render the origin (始発) filter toggle for a timetable view.
+ * Render the origin (始発) filter toggle.
  *
  * Filters to entries where this stop is the trip's origin
  * (= `entry.patternPosition.isOrigin === true`). Includes non-boardable
@@ -19,17 +19,13 @@ interface TimetableOriginFilterProps {
  * viewer is meant to surface.
  *
  * If the caller wants only "boardable origins", combine this with
- * `TimetableBoardabilityFilter` (= toggle both on); the result is the
+ * {@link BoardabilityFilter} (= toggle both on); the result is the
  * intersection.
  *
  * @param props - Filter rendering inputs.
  * @returns The rendered filter toggle.
  */
-export function TimetableOriginFilter({
-  origin,
-  onToggleOrigin,
-  count,
-}: TimetableOriginFilterProps) {
+export function OriginFilter({ origin, onToggleOrigin, count }: OriginFilterProps) {
   const { t } = useTranslation();
 
   return (
@@ -41,10 +37,10 @@ export function TimetableOriginFilter({
         activeBorder={'var(--info)'}
         inactiveBorder={'var(--info)'}
         onClick={onToggleOrigin}
-        title={t('timetable.filter.originOnlyTitle')}
+        title={t('filter.originOnlyTitle')}
         count={count}
       >
-        {t('timetable.filter.originOnly')}
+        {t('filter.originOnly')}
       </PillButton>
     </div>
   );

--- a/src/components/verbose/verbose-nearby-stop-summary.tsx
+++ b/src/components/verbose/verbose-nearby-stop-summary.tsx
@@ -1,3 +1,4 @@
+import { filterByStopEventAttributes } from '../../domain/transit/timetable-filter';
 import type { ContextualTimetableEntry } from '../../types/app/transit-composed';
 import type { StopServiceState } from '../../types/app/transit';
 
@@ -27,9 +28,10 @@ export function VerboseNearbyStopSummary({
   isAnchor: boolean;
   viewId: string;
 }) {
-  const boardable = stopTimes.filter(
-    (e) => e.boarding.pickupType !== 1 && !e.patternPosition.isTerminal,
-  ).length;
+  const boardable = filterByStopEventAttributes(stopTimes, {
+    pickUpState: new Set(['boardable']),
+    position: new Set(['origin', 'middle']),
+  }).length;
   const dropOffOnly = stopTimes.length - boardable;
 
   return (

--- a/src/components/verbose/verbose-nearby-stop-summary.tsx
+++ b/src/components/verbose/verbose-nearby-stop-summary.tsx
@@ -32,7 +32,7 @@ export function VerboseNearbyStopSummary({
     pickUpState: new Set(['boardable']),
     position: new Set(['origin', 'middle']),
   }).length;
-  const dropOffOnly = stopTimes.length - boardable;
+  const nonBoardable = stopTimes.length - boardable;
 
   return (
     <details className="text-[9px] font-normal text-[#999] dark:text-gray-500">
@@ -50,7 +50,8 @@ export function VerboseNearbyStopSummary({
           </span>
           <span className="block">[service] stopServiceState={stopServiceState}</span>
           <span className="block">
-            [stop times] entries={stopTimes.length} boardable={boardable} dropOffOnly={dropOffOnly}
+            [stop times] entries={stopTimes.length} boardable={boardable} nonBoardable=
+            {nonBoardable}
             {stopTimes.length === 0
               ? ' (NO SERVICE)'
               : stopServiceState === 'drop-off-only'

--- a/src/domain/transit/__tests__/timetable-filter.test.ts
+++ b/src/domain/transit/__tests__/timetable-filter.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { Route } from '../../../types/app/transit';
-import type { TimetableEntry } from '../../../types/app/transit-composed';
+import type { ContextualTimetableEntry, TimetableEntry } from '../../../types/app/transit-composed';
 import {
   filterBoardable,
   filterByAgency,
   filterByRouteType,
+  filterByStopEventAttributes,
+  filterOrigin,
   prepareStopTimetable,
   prepareRouteHeadsignTimetable,
 } from '../timetable-filter';
@@ -895,6 +897,344 @@ describe('filterBoardable', () => {
       // pt=0 is ambiguous (available OR not set). isTerminal takes precedence.
       const entry = makeEntry({ isTerminal: true, isOrigin: true, pickupType: 0 });
       expect(filterBoardable([entry])).toHaveLength(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterByStopEventAttributes
+// ---------------------------------------------------------------------------
+
+/** Build an entry with explicit arrivalMinutes (makeEntry mirrors departure to arrival). */
+function makeEntryWithArrival(
+  departureMinutes: number,
+  arrivalMinutes: number,
+  overrides: Parameters<typeof makeEntry>[0] = {},
+): TimetableEntry {
+  const base = makeEntry({ ...overrides, departureMinutes });
+  return { ...base, schedule: { departureMinutes, arrivalMinutes } };
+}
+
+describe('filterByStopEventAttributes', () => {
+  describe('identity / fast-path', () => {
+    it('returns the input reference unchanged when all axes are undefined', () => {
+      const entries = [makeEntry(), makeEntry({ isTerminal: true })];
+      const result = filterByStopEventAttributes(entries, {});
+      expect(result).toBe(entries);
+    });
+
+    it('returns an empty array when active axes are provided for empty input', () => {
+      const result = filterByStopEventAttributes([], {
+        position: new Set(['origin']),
+        boardingState: new Set(['boardable']),
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('position axis', () => {
+    const origin = makeEntry({ isOrigin: true, departureMinutes: 480 });
+    const terminal = makeEntry({ isTerminal: true, departureMinutes: 540 });
+    const middle = makeEntry({ departureMinutes: 600 });
+    const entries = [origin, terminal, middle];
+
+    it('keeps only origin entries', () => {
+      const result = filterByStopEventAttributes(entries, {
+        position: new Set(['origin']),
+      });
+      expect(result).toEqual([origin]);
+    });
+
+    it('keeps only terminal entries', () => {
+      const result = filterByStopEventAttributes(entries, {
+        position: new Set(['terminal']),
+      });
+      expect(result).toEqual([terminal]);
+    });
+
+    it('keeps only middle entries (= neither origin nor terminal)', () => {
+      const result = filterByStopEventAttributes(entries, {
+        position: new Set(['middle']),
+      });
+      expect(result).toEqual([middle]);
+    });
+
+    it('keeps origin OR terminal when both are listed', () => {
+      const result = filterByStopEventAttributes(entries, {
+        position: new Set(['origin', 'terminal']),
+      });
+      expect(result).toEqual([origin, terminal]);
+    });
+
+    it('returns empty array for an empty Set (literal "match nothing")', () => {
+      const result = filterByStopEventAttributes(entries, {
+        position: new Set(),
+      });
+      expect(result).toEqual([]);
+    });
+
+    describe('single-stop trip (isOrigin AND isTerminal)', () => {
+      const oneStop = makeEntry({ isOrigin: true, isTerminal: true });
+
+      it('matches "origin"', () => {
+        const result = filterByStopEventAttributes([oneStop], {
+          position: new Set(['origin']),
+        });
+        expect(result).toEqual([oneStop]);
+      });
+
+      it('matches "terminal"', () => {
+        const result = filterByStopEventAttributes([oneStop], {
+          position: new Set(['terminal']),
+        });
+        expect(result).toEqual([oneStop]);
+      });
+
+      it('does NOT match "middle"', () => {
+        const result = filterByStopEventAttributes([oneStop], {
+          position: new Set(['middle']),
+        });
+        expect(result).toEqual([]);
+      });
+    });
+  });
+
+  describe('boardingState axis', () => {
+    const boardablePlain = makeEntry({ departureMinutes: 480 });
+    const dropOffByPickup1 = makeEntry({ pickupType: 1, departureMinutes: 540 });
+    const dropOffByTerminal = makeEntry({ isTerminal: true, departureMinutes: 600 });
+    const entries = [boardablePlain, dropOffByPickup1, dropOffByTerminal];
+
+    it('keeps only boardable entries (excludes drop-off-only)', () => {
+      const result = filterByStopEventAttributes(entries, {
+        boardingState: new Set(['boardable']),
+      });
+      expect(result).toEqual([boardablePlain]);
+    });
+
+    it('keeps only nonBoardable entries (= drop-off-only)', () => {
+      const result = filterByStopEventAttributes(entries, {
+        boardingState: new Set(['nonBoardable']),
+      });
+      expect(result).toEqual([dropOffByPickup1, dropOffByTerminal]);
+    });
+
+    it('keeps everything when both states are listed', () => {
+      const result = filterByStopEventAttributes(entries, {
+        boardingState: new Set(['boardable', 'nonBoardable']),
+      });
+      expect(result).toEqual(entries);
+    });
+
+    it('returns empty array for an empty Set', () => {
+      const result = filterByStopEventAttributes(entries, {
+        boardingState: new Set(),
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('treats a single-stop trip as nonBoardable because terminal takes precedence', () => {
+      const circular = makeEntry({ isOrigin: true, isTerminal: true, pickupType: 0 });
+      const result = filterByStopEventAttributes([circular], {
+        boardingState: new Set(['nonBoardable']),
+      });
+      expect(result).toEqual([circular]);
+    });
+  });
+
+  describe('schedule axis', () => {
+    const at0800 = makeEntry({ departureMinutes: 480 });
+    const at0900 = makeEntry({ departureMinutes: 540 });
+    const at1200 = makeEntry({ departureMinutes: 720 });
+    const at1500 = makeEntry({ departureMinutes: 900 });
+    const entries = [at0800, at0900, at1200, at1500];
+
+    it('keeps entries at or after fromMinutes (lower bound, inclusive)', () => {
+      const result = filterByStopEventAttributes(entries, {
+        schedule: { fromMinutes: 540 },
+      });
+      expect(result).toEqual([at0900, at1200, at1500]);
+    });
+
+    it('keeps entries at or before toMinutes (upper bound, inclusive)', () => {
+      const result = filterByStopEventAttributes(entries, {
+        schedule: { toMinutes: 720 },
+      });
+      expect(result).toEqual([at0800, at0900, at1200]);
+    });
+
+    it('applies both bounds inclusively', () => {
+      const result = filterByStopEventAttributes(entries, {
+        schedule: { fromMinutes: 540, toMinutes: 720 },
+      });
+      expect(result).toEqual([at0900, at1200]);
+    });
+
+    it('keeps everything when neither bound is given', () => {
+      const result = filterByStopEventAttributes(entries, {
+        schedule: { field: 'departure' },
+      });
+      expect(result).toEqual(entries);
+    });
+
+    it('uses arrivalMinutes when field === "arrival"', () => {
+      const arr0800 = makeEntryWithArrival(900, 480);
+      const arr0900 = makeEntryWithArrival(900, 540);
+      const arr1000 = makeEntryWithArrival(900, 600);
+      const result = filterByStopEventAttributes([arr0800, arr0900, arr1000], {
+        schedule: { field: 'arrival', fromMinutes: 540 },
+      });
+      expect(result).toEqual([arr0900, arr1000]);
+    });
+
+    it('handles overnight times (>= 1440) as plain numbers', () => {
+      const at2330 = makeEntry({ departureMinutes: 1410 });
+      const at2500 = makeEntry({ departureMinutes: 1500 });
+      const at2630 = makeEntry({ departureMinutes: 1590 });
+      const result = filterByStopEventAttributes([at2330, at2500, at2630], {
+        schedule: { fromMinutes: 1440, toMinutes: 1560 },
+      });
+      expect(result).toEqual([at2500]);
+    });
+
+    describe('boundary values are inclusive', () => {
+      it('keeps an entry equal to fromMinutes', () => {
+        const exact = makeEntry({ departureMinutes: 540 });
+        const result = filterByStopEventAttributes([exact], {
+          schedule: { fromMinutes: 540 },
+        });
+        expect(result).toEqual([exact]);
+      });
+
+      it('keeps an entry equal to toMinutes', () => {
+        const exact = makeEntry({ departureMinutes: 720 });
+        const result = filterByStopEventAttributes([exact], {
+          schedule: { toMinutes: 720 },
+        });
+        expect(result).toEqual([exact]);
+      });
+    });
+  });
+
+  describe('multi-axis composition (AND across axes)', () => {
+    const originBoardable = makeEntry({ isOrigin: true, departureMinutes: 540 });
+    const originDropOff = makeEntry({ isOrigin: true, pickupType: 1, departureMinutes: 600 });
+    const middleBoardable = makeEntry({ departureMinutes: 660 });
+    const terminalDropOff = makeEntry({ isTerminal: true, departureMinutes: 720 });
+    const entries = [originBoardable, originDropOff, middleBoardable, terminalDropOff];
+
+    it('combines position and boardingState (origin AND boardable)', () => {
+      const result = filterByStopEventAttributes(entries, {
+        position: new Set(['origin']),
+        boardingState: new Set(['boardable']),
+      });
+      expect(result).toEqual([originBoardable]);
+    });
+
+    it('combines all three axes', () => {
+      const result = filterByStopEventAttributes(entries, {
+        position: new Set(['origin', 'middle']),
+        boardingState: new Set(['boardable']),
+        schedule: { fromMinutes: 600, toMinutes: 720 },
+      });
+      expect(result).toEqual([middleBoardable]);
+    });
+
+    it('combines arrival-based schedule filtering with position and boardingState', () => {
+      const originEarlyArrival = makeEntryWithArrival(900, 500, { isOrigin: true });
+      const originLateArrival = makeEntryWithArrival(900, 560, { isOrigin: true });
+      const middleLateArrival = makeEntryWithArrival(900, 580);
+      const originLateDropOff = makeEntryWithArrival(900, 600, {
+        isOrigin: true,
+        pickupType: 1,
+      });
+
+      const result = filterByStopEventAttributes(
+        [originEarlyArrival, originLateArrival, middleLateArrival, originLateDropOff],
+        {
+          position: new Set(['origin']),
+          boardingState: new Set(['boardable']),
+          schedule: { field: 'arrival', fromMinutes: 540 },
+        },
+      );
+
+      expect(result).toEqual([originLateArrival]);
+    });
+
+    describe('relation to legacy helpers', () => {
+      it('does not change filterOrigin semantics for non-boardable origins', () => {
+        const nonBoardableOrigin = makeEntry({
+          isOrigin: true,
+          pickupType: 1,
+          departureMinutes: 540,
+        });
+
+        expect(filterOrigin([nonBoardableOrigin])).toEqual([nonBoardableOrigin]);
+        expect(
+          filterByStopEventAttributes([nonBoardableOrigin], {
+            position: new Set(['origin']),
+            boardingState: new Set(['boardable']),
+          }),
+        ).toEqual([]);
+        expect(
+          filterByStopEventAttributes([nonBoardableOrigin], {
+            position: new Set(['origin']),
+            boardingState: new Set(['nonBoardable']),
+          }),
+        ).toEqual([nonBoardableOrigin]);
+      });
+    });
+    it('keeps a single-stop trip when terminal/origin and nonBoardable both match', () => {
+      const oneStop = makeEntry({
+        isOrigin: true,
+        isTerminal: true,
+        pickupType: 0,
+        departureMinutes: 540,
+      });
+      const result = filterByStopEventAttributes([oneStop], {
+        position: new Set(['origin', 'terminal']),
+        boardingState: new Set(['nonBoardable']),
+      });
+      expect(result).toEqual([oneStop]);
+    });
+  });
+
+  describe('generic preservation', () => {
+    it('preserves the input element type at the type level', () => {
+      // Type-level check: `tsc --noEmit` will fail if the function ever
+      // narrows the result back to `TimetableEntry[]`. Runtime is just a
+      // sanity smoke test that the call works.
+      const branded: (TimetableEntry & { _brand: 'sample' })[] = [
+        Object.assign(makeEntry(), { _brand: 'sample' as const }),
+        Object.assign(makeEntry({ isTerminal: true }), { _brand: 'sample' as const }),
+      ];
+      const filtered: (TimetableEntry & { _brand: 'sample' })[] = filterByStopEventAttributes(
+        branded,
+        { boardingState: new Set(['boardable']) },
+      );
+      expect(filtered).toHaveLength(1);
+      // Element type is preserved, so accessing the brand compiles.
+      expect(filtered[0]._brand).toBe('sample');
+    });
+
+    it('preserves ContextualTimetableEntry without dropping serviceDate', () => {
+      const contextual: ContextualTimetableEntry[] = [
+        {
+          ...makeEntry({ departureMinutes: 480 }),
+          serviceDate: new Date(2026, 3, 30),
+        },
+        {
+          ...makeEntry({ isTerminal: true, departureMinutes: 540 }),
+          serviceDate: new Date(2026, 3, 30),
+        },
+      ];
+
+      const filtered: ContextualTimetableEntry[] = filterByStopEventAttributes(contextual, {
+        boardingState: new Set(['boardable']),
+      });
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].serviceDate.getTime()).toBe(contextual[0].serviceDate.getTime());
     });
   });
 });

--- a/src/domain/transit/__tests__/timetable-filter.test.ts
+++ b/src/domain/transit/__tests__/timetable-filter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Route } from '../../../types/app/transit';
 import type { ContextualTimetableEntry, TimetableEntry } from '../../../types/app/transit-composed';
 import {
+  applyStopEventAttributeToggles,
   filterByAgency,
   filterByRouteType,
   filterByStopEventAttributes,
@@ -992,6 +993,80 @@ describe('filterByStopEventAttributes', () => {
         pickUpState: new Set(['boardable']),
       });
 
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].serviceDate.getTime()).toBe(contextual[0].serviceDate.getTime());
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyStopEventAttributeToggles
+// ---------------------------------------------------------------------------
+
+describe('applyStopEventAttributeToggles', () => {
+  const originPt0 = makeEntry({ isOrigin: true, pickupType: 0, departureMinutes: 480 });
+  const originPt1 = makeEntry({ isOrigin: true, pickupType: 1, departureMinutes: 540 });
+  const middlePt0 = makeEntry({ pickupType: 0, departureMinutes: 600 });
+  const middlePt2 = makeEntry({ pickupType: 2, departureMinutes: 660 });
+  const terminalPt0 = makeEntry({ isTerminal: true, pickupType: 0, departureMinutes: 720 });
+  const entries = [originPt0, originPt1, middlePt0, middlePt2, terminalPt0];
+
+  describe('identity / fast-path', () => {
+    it('returns the input reference unchanged when both toggles are false', () => {
+      const result = applyStopEventAttributeToggles(entries, {
+        showOriginOnly: false,
+        showBoardableOnly: false,
+      });
+      expect(result).toBe(entries);
+    });
+  });
+
+  describe('showOriginOnly only', () => {
+    it('keeps origin entries (boardable AND non-boardable origins)', () => {
+      const result = applyStopEventAttributeToggles(entries, {
+        showOriginOnly: true,
+        showBoardableOnly: false,
+      });
+      expect(result).toEqual([originPt0, originPt1]);
+    });
+  });
+
+  describe('showBoardableOnly only', () => {
+    it('keeps pickup_type=0 entries at non-pure-terminal positions', () => {
+      const result = applyStopEventAttributeToggles(entries, {
+        showOriginOnly: false,
+        showBoardableOnly: true,
+      });
+      // originPt0 (origin, pt=0): kept
+      // originPt1 (origin, pt=1): excluded by pickUpState
+      // middlePt0 (middle, pt=0): kept
+      // middlePt2 (middle, pt=2): excluded by pickUpState
+      // terminalPt0 (pure terminal, pt=0): excluded by position
+      expect(result).toEqual([originPt0, middlePt0]);
+    });
+  });
+
+  describe('both toggles on (AND composition)', () => {
+    it('keeps only origin AND boardable entries', () => {
+      const result = applyStopEventAttributeToggles(entries, {
+        showOriginOnly: true,
+        showBoardableOnly: true,
+      });
+      // originPt0 alone matches: isOrigin=true AND pickup_type=0
+      expect(result).toEqual([originPt0]);
+    });
+  });
+
+  describe('generic preservation', () => {
+    it('preserves the input element type at the type level', () => {
+      const contextual: ContextualTimetableEntry[] = [
+        { ...makeEntry({ isOrigin: true, pickupType: 0 }), serviceDate: new Date(2026, 3, 30) },
+        { ...makeEntry({ pickupType: 1 }), serviceDate: new Date(2026, 3, 30) },
+      ];
+      const filtered: ContextualTimetableEntry[] = applyStopEventAttributeToggles(contextual, {
+        showOriginOnly: true,
+        showBoardableOnly: false,
+      });
       expect(filtered).toHaveLength(1);
       expect(filtered[0].serviceDate.getTime()).toBe(contextual[0].serviceDate.getTime());
     });

--- a/src/domain/transit/__tests__/timetable-filter.test.ts
+++ b/src/domain/transit/__tests__/timetable-filter.test.ts
@@ -2,11 +2,9 @@ import { describe, expect, it } from 'vitest';
 import type { Route } from '../../../types/app/transit';
 import type { ContextualTimetableEntry, TimetableEntry } from '../../../types/app/transit-composed';
 import {
-  filterBoardable,
   filterByAgency,
   filterByRouteType,
   filterByStopEventAttributes,
-  filterOrigin,
   prepareStopTimetable,
   prepareRouteHeadsignTimetable,
 } from '../timetable-filter';
@@ -37,20 +35,6 @@ const routeB: Route = {
   route_text_color: 'FFFFFF',
   agency_id: 'test',
 };
-
-function makeRoute(id: string, agencyId = 'test'): Route {
-  return {
-    route_id: id,
-    route_short_name: id,
-    route_short_names: {},
-    route_long_name: '',
-    route_long_names: {},
-    route_type: 3,
-    route_color: '000000',
-    route_text_color: 'FFFFFF',
-    agency_id: agencyId,
-  };
-}
 
 function makeEntry(
   overrides: {
@@ -209,42 +193,41 @@ describe('prepareStopTimetable', () => {
       expect(result.entries[1].schedule.departureMinutes).toBe(540);
     });
 
-    it('filters by boardability: pickupType=1 removed, 2/3 kept, dropOffType=1 kept', () => {
-      // The boardability filter (= !isDropOffOnly) excludes entries with
-      // pickupType === 1 (= source explicit "no pickup"). pickupType 2/3
-      // (phone/coordinate arrangement required, but still boardable) and
-      // dropOffType=1 (drop-off-only-side signal, irrelevant to boarding)
-      // are kept.
+    it('keeps only pickupType=0 entries (1/2/3 all removed)', () => {
+      // The new caller uses pickUpState: Set(['boardable']) which maps
+      // 1:1 to pickup_type === 0. Entries with pickupType 1/2/3 are all
+      // classified as non-boardable / phoneArrangement / driverArrangement
+      // respectively and excluded.
       const entries = [
-        makeEntry({ pickupType: 0 }), // kept
-        makeEntry({ pickupType: 1 }), // removed (non-boardable)
-        makeEntry({ pickupType: 2 }), // kept (phone arrangement, boardable)
-        makeEntry({ pickupType: 3 }), // kept (driver coordinate, boardable)
-        makeEntry({ dropOffType: 1 }), // kept (drop-off side does not affect boarding)
+        makeEntry({ pickupType: 0 }), // kept (boardable)
+        makeEntry({ pickupType: 1 }), // removed (nonBoardable)
+        makeEntry({ pickupType: 2 }), // removed (phoneArrangement)
+        makeEntry({ pickupType: 3 }), // removed (driverArrangement)
+        makeEntry({ dropOffType: 1 }), // kept (default pickupType=0, drop-off side ignored)
       ];
       const result = prepareStopTimetable(entries, false);
-      expect(result.entries).toHaveLength(4);
-      expect(result.omitted.nonBoardable).toBe(1);
+      expect(result.entries).toHaveLength(2);
+      expect(result.omitted.nonBoardable).toBe(3);
     });
 
     it('isOrigin alone does not trigger removal (origin remains boardable)', () => {
-      // Only isTerminal (or pickupType === 1) triggers removal.
-      // isOrigin: true entries are kept unless they are also terminal
-      // (= circular route case).
+      // Only pure terminal (= !isOrigin && isTerminal) or pickupType !== 0
+      // triggers removal. 1-stop trips (isOrigin && isTerminal) match the
+      // 'origin' position and are kept.
       const entries = [
         makeEntry({ isOrigin: true }),
         makeEntry({ isOrigin: true, isTerminal: true }),
         makeEntry({ isOrigin: false }),
       ];
       const result = prepareStopTimetable(entries, false);
-      expect(result.entries).toHaveLength(2);
-      expect(result.omitted.nonBoardable).toBe(1);
+      expect(result.entries).toHaveLength(3);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
-    it('filter criterion is !isDropOffOnly (terminal OR pickupType=1)', () => {
-      // Both signals trigger removal independently:
-      //   terminal + pickupType=0 → removed (terminal triggers isDropOffOnly)
-      //   non-terminal + pickupType=1 → removed (pickupType=1 triggers isDropOffOnly)
+    it('removes pure terminal (isTerminal=true, !isOrigin) and pickupType=1', () => {
+      // The new caller drops entries on two independent grounds:
+      //   pure terminal (= isTerminal=true, !isOrigin) → position axis excludes
+      //   pickupType=1 (anywhere in the pattern) → pickUpState axis excludes
       const entries = [
         makeEntry({ isTerminal: true, pickupType: 0 }),
         makeEntry({ isTerminal: false, pickupType: 1 }),
@@ -254,13 +237,14 @@ describe('prepareStopTimetable', () => {
       expect(result.omitted.nonBoardable).toBe(2);
     });
 
-    it('circular route: isTerminal && isOrigin both true → filtered out', () => {
-      // Circular routes have the same stop as both origin and terminal.
-      // isTerminal should win and the entry should be removed.
+    it('1-stop trip (isOrigin && isTerminal, pickupType=0) is kept as origin', () => {
+      // 1-stop trips have the same stop as both origin and terminal.
+      // The position axis matches via 'origin', and pickUpState='boardable'
+      // matches pickup_type=0, so the entry is kept (= depot/yard origin).
       const entries = [makeEntry({ isTerminal: true, isOrigin: true }), makeEntry()];
       const result = prepareStopTimetable(entries, false);
-      expect(result.entries).toHaveLength(1);
-      expect(result.omitted.nonBoardable).toBe(1);
+      expect(result.entries).toHaveLength(2);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
     it('does not modify the input array', () => {
@@ -462,10 +446,10 @@ describe('prepareRouteHeadsignTimetable', () => {
       expect(result.entries[1].schedule.departureMinutes).toBe(540);
     });
 
-    it('filters by boardability within route+headsign: pickupType=1 removed', () => {
-      // The boardability filter (= !isDropOffOnly) excludes pickupType === 1.
-      // pickupType 2/3 (arrangement required, still boardable) and dropOffType=1
-      // (drop-off-side signal, irrelevant to boarding) are kept.
+    it('keeps only pickupType=0 entries within route+headsign (1/2/3 all removed)', () => {
+      // The new caller uses pickUpState: Set(['boardable']) which maps
+      // 1:1 to pickup_type === 0. Entries with pickupType 1/2/3 are all
+      // excluded.
       const entries = [
         makeEntry({ route: routeA, headsign: 'North', pickupType: 0 }),
         makeEntry({ route: routeA, headsign: 'North', pickupType: 1 }),
@@ -474,18 +458,19 @@ describe('prepareRouteHeadsignTimetable', () => {
         makeEntry({ route: routeA, headsign: 'North', dropOffType: 1 }),
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', false);
-      expect(result.entries).toHaveLength(4);
-      expect(result.omitted.nonBoardable).toBe(1);
+      expect(result.entries).toHaveLength(2);
+      expect(result.omitted.nonBoardable).toBe(3);
     });
 
-    it('is not affected by isOrigin (only isTerminal matters)', () => {
+    it('1-stop trip (isOrigin && isTerminal) is kept as origin within route+headsign', () => {
+      // 1-stop trips match the 'origin' position and are kept.
       const entries = [
         makeEntry({ route: routeA, headsign: 'North', isOrigin: true }),
         makeEntry({ route: routeA, headsign: 'North', isOrigin: true, isTerminal: true }),
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', false);
-      expect(result.entries).toHaveLength(1);
-      expect(result.omitted.nonBoardable).toBe(1);
+      expect(result.entries).toHaveLength(2);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
     it('uses exact match for route_id and headsign (no normalization)', () => {
@@ -509,14 +494,14 @@ describe('prepareRouteHeadsignTimetable', () => {
       expect(result.omitted.nonBoardable).toBe(0); // not 100
     });
 
-    it('circular route: isTerminal && isOrigin both true → filtered out', () => {
+    it('circular route: isTerminal && isOrigin both true → kept (origin match)', () => {
       const entries = [
         makeEntry({ route: routeA, headsign: 'North', isTerminal: true, isOrigin: true }),
         makeEntry({ route: routeA, headsign: 'North' }),
       ];
       const result = prepareRouteHeadsignTimetable(entries, 'routeA', 'North', false);
-      expect(result.entries).toHaveLength(1);
-      expect(result.omitted.nonBoardable).toBe(1);
+      expect(result.entries).toHaveLength(2);
+      expect(result.omitted.nonBoardable).toBe(0);
     });
 
     it('does not modify the input array', () => {
@@ -663,245 +648,6 @@ describe('filterByRouteType', () => {
 });
 
 // ---------------------------------------------------------------------------
-// filterBoardable
-// ---------------------------------------------------------------------------
-
-describe('filterBoardable', () => {
-  describe('empty input', () => {
-    it('returns empty array', () => {
-      expect(filterBoardable([])).toEqual([]);
-    });
-  });
-
-  describe('all boardable (!isDropOffOnly)', () => {
-    it('returns single entry', () => {
-      expect(filterBoardable([makeEntry()])).toHaveLength(1);
-    });
-
-    it('returns all entries', () => {
-      expect(filterBoardable([makeEntry(), makeEntry(), makeEntry()])).toHaveLength(3);
-    });
-
-    it('keeps isOrigin entries', () => {
-      expect(filterBoardable([makeEntry({ isOrigin: true })])).toHaveLength(1);
-    });
-
-    it('keeps pickupType=0 (available)', () => {
-      expect(filterBoardable([makeEntry({ pickupType: 0 })])).toHaveLength(1);
-    });
-
-    it('keeps pickupType=2 (phone required) — requires arrangement but boardable', () => {
-      expect(filterBoardable([makeEntry({ pickupType: 2 })])).toHaveLength(1);
-    });
-
-    it('keeps pickupType=3 (coordinate required) — requires arrangement but boardable', () => {
-      expect(filterBoardable([makeEntry({ pickupType: 3 })])).toHaveLength(1);
-    });
-  });
-
-  describe('all isDropOffOnly', () => {
-    it('filters single terminal entry', () => {
-      expect(filterBoardable([makeEntry({ isTerminal: true })])).toHaveLength(0);
-    });
-
-    it('filters single pickupType=1 entry', () => {
-      expect(filterBoardable([makeEntry({ pickupType: 1 })])).toHaveLength(0);
-    });
-
-    it('filters multiple terminal entries', () => {
-      const entries = [makeEntry({ isTerminal: true }), makeEntry({ isTerminal: true })];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
-
-    it('filters multiple pickupType=1 entries', () => {
-      const entries = [makeEntry({ pickupType: 1 }), makeEntry({ pickupType: 1 })];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
-
-    it('filters when both isTerminal and pickupType=1 are set', () => {
-      expect(filterBoardable([makeEntry({ isTerminal: true, pickupType: 1 })])).toHaveLength(0);
-    });
-
-    it('filters mix of terminal and pickupType=1', () => {
-      const entries = [
-        makeEntry({ isTerminal: true }),
-        makeEntry({ pickupType: 1 }),
-        makeEntry({ isTerminal: true, pickupType: 1 }),
-      ];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
-  });
-
-  describe('mixed boardable and isDropOffOnly', () => {
-    it('keeps boardable, filters terminal', () => {
-      const boardable = makeEntry();
-      const terminal = makeEntry({ isTerminal: true });
-      expect(filterBoardable([terminal, boardable])).toEqual([boardable]);
-    });
-
-    it('keeps boardable, filters pickupType=1', () => {
-      const boardable = makeEntry();
-      const pickup1 = makeEntry({ pickupType: 1 });
-      expect(filterBoardable([pickup1, boardable])).toEqual([boardable]);
-    });
-
-    it('keeps boardable, filters both terminal and pickupType=1', () => {
-      const boardable = makeEntry();
-      const terminal = makeEntry({ isTerminal: true });
-      const pickup1 = makeEntry({ pickupType: 1 });
-      expect(filterBoardable([terminal, boardable, pickup1])).toEqual([boardable]);
-    });
-
-    it('preserves order of boardable entries', () => {
-      const a = makeEntry({ departureMinutes: 480 });
-      const b = makeEntry({ departureMinutes: 540 });
-      const c = makeEntry({ departureMinutes: 600 });
-      const term = makeEntry({ departureMinutes: 500, isTerminal: true });
-      expect(filterBoardable([a, term, b, c]).map((e) => e.schedule.departureMinutes)).toEqual([
-        480, 540, 600,
-      ]);
-    });
-  });
-
-  describe('multi-route / multi-agency', () => {
-    const routeA = makeRoute('route-A', 'agency-1');
-    const routeB = makeRoute('route-B', 'agency-2');
-
-    it('filters per-entry regardless of route (mixed agencies)', () => {
-      const entries = [
-        makeEntry({ route: routeA, isTerminal: true }), // agency-1, terminal
-        makeEntry({ route: routeB }), // agency-2, boardable
-        makeEntry({ route: routeA }), // agency-1, boardable
-        makeEntry({ route: routeB, pickupType: 1 }), // agency-2, pickup unavailable
-      ];
-      const result = filterBoardable(entries);
-      expect(result).toHaveLength(2);
-      expect(result[0].routeDirection.route.route_id).toBe('route-B');
-      expect(result[1].routeDirection.route.route_id).toBe('route-A');
-    });
-
-    it('returns empty when all routes are terminal (single agency)', () => {
-      const entries = [
-        makeEntry({ route: routeA, isTerminal: true }),
-        makeEntry({ route: routeA, isTerminal: true }),
-      ];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
-
-    it('returns empty when all routes are drop-off only (multiple agencies)', () => {
-      const entries = [
-        makeEntry({ route: routeA, isTerminal: true }),
-        makeEntry({ route: routeB, pickupType: 1 }),
-      ];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
-
-    it('keeps boardable entries from one agency while filtering terminal from another', () => {
-      const entries = [
-        makeEntry({ route: routeA, isTerminal: true, departureMinutes: 480 }),
-        makeEntry({ route: routeB, departureMinutes: 490 }),
-        makeEntry({ route: routeA, isTerminal: true, departureMinutes: 500 }),
-        makeEntry({ route: routeB, departureMinutes: 510 }),
-      ];
-      const result = filterBoardable(entries);
-      expect(result).toHaveLength(2);
-      expect(result.every((e) => e.routeDirection.route.agency_id === 'agency-2')).toBe(true);
-    });
-  });
-
-  describe('turnaround stop (同一路線で ORIG/TERM 交互 — 日野駅パターン)', () => {
-    it('keeps ORIG entries and filters TERM entries from same route', () => {
-      const route = makeRoute('route-bus');
-      const entries = [
-        makeEntry({ route, departureMinutes: 1255, isTerminal: true, pickupType: 1 }), // 20:55 着
-        makeEntry({ route, departureMinutes: 1258, isTerminal: true, pickupType: 1 }), // 20:58 着
-        makeEntry({ route, departureMinutes: 1260, isOrigin: true, pickupType: 0 }), // 21:00 発
-        makeEntry({ route, departureMinutes: 1265, isTerminal: true, pickupType: 1 }), // 21:05 着
-        makeEntry({ route, departureMinutes: 1270, isOrigin: true, pickupType: 0 }), // 21:10 発
-      ];
-      const result = filterBoardable(entries);
-      expect(result).toHaveLength(2);
-      expect(result.map((e) => e.schedule.departureMinutes)).toEqual([1260, 1270]);
-    });
-  });
-
-  describe('pt=0 with isTerminal fallback (都バス — pt 未設定ソース)', () => {
-    it('filters all entries when pt=0 but all are terminal', () => {
-      // 都バスは pickup_type を設定しない (全て 0)。
-      // isTerminal フォールバックで終点を検出。
-      const entries = [
-        makeEntry({ pickupType: 0, isTerminal: true, departureMinutes: 480 }),
-        makeEntry({ pickupType: 0, isTerminal: true, departureMinutes: 540 }),
-        makeEntry({ pickupType: 0, isTerminal: true, departureMinutes: 600 }),
-      ];
-      expect(filterBoardable(entries)).toHaveLength(0);
-    });
-
-    it('keeps non-terminal entries when pt=0', () => {
-      const entries = [
-        makeEntry({ pickupType: 0, isTerminal: true }),
-        makeEntry({ pickupType: 0, isTerminal: false }),
-        makeEntry({ pickupType: 0, isOrigin: true }),
-      ];
-      expect(filterBoardable(entries)).toHaveLength(2);
-    });
-  });
-
-  describe('mid-route pickup unavailable (途中停留所で pt=1)', () => {
-    it('filters pt=1 entry that is not terminal', () => {
-      // 途中停留所だが乗車不可 — 本来の「降車専用」
-      const entry = makeEntry({ pickupType: 1, isTerminal: false, stopIndex: 5, totalStops: 10 });
-      expect(filterBoardable([entry])).toHaveLength(0);
-    });
-
-    it('keeps other entries at same stop when only some have pt=1', () => {
-      const route = makeRoute('route-express');
-      const entries = [
-        makeEntry({ route, pickupType: 1, departureMinutes: 480 }), // express: no pickup
-        makeEntry({ route, pickupType: 0, departureMinutes: 510 }), // local: pickup ok
-        makeEntry({ route, pickupType: 1, departureMinutes: 540 }), // express: no pickup
-      ];
-      const result = filterBoardable(entries);
-      expect(result).toHaveLength(1);
-      expect(result[0].schedule.departureMinutes).toBe(510);
-    });
-  });
-
-  describe('same route+headsign with mixed pt per stop time', () => {
-    it('filters individually even within same route+headsign', () => {
-      // v2 pipeline では pt は便ごとの配列。同じ trip pattern でも
-      // 便によって pt が異なりうる。
-      const route = makeRoute('route-X');
-      const entries = [
-        makeEntry({ route, headsign: 'Terminal', pickupType: 0, departureMinutes: 480 }),
-        makeEntry({ route, headsign: 'Terminal', pickupType: 1, departureMinutes: 510 }),
-        makeEntry({ route, headsign: 'Terminal', pickupType: 0, departureMinutes: 540 }),
-      ];
-      const result = filterBoardable(entries);
-      expect(result).toHaveLength(2);
-      expect(result.map((e) => e.schedule.departureMinutes)).toEqual([480, 540]);
-    });
-  });
-
-  describe('circular route edge case', () => {
-    it('filters isTerminal && isOrigin — current behavior', () => {
-      // Circular routes have the same stop as both origin and terminal.
-      // isDropOffOnly returns true because isTerminal is checked.
-      // This may cause false positives for circular routes where
-      // passengers CAN board at the terminal/origin stop.
-      const entry = makeEntry({ isTerminal: true, isOrigin: true });
-      expect(filterBoardable([entry])).toHaveLength(0);
-    });
-
-    it('filters isTerminal && isOrigin even with pickupType=0', () => {
-      // pt=0 is ambiguous (available OR not set). isTerminal takes precedence.
-      const entry = makeEntry({ isTerminal: true, isOrigin: true, pickupType: 0 });
-      expect(filterBoardable([entry])).toHaveLength(0);
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
 // filterByStopEventAttributes
 // ---------------------------------------------------------------------------
 
@@ -926,7 +672,7 @@ describe('filterByStopEventAttributes', () => {
     it('returns an empty array when active axes are provided for empty input', () => {
       const result = filterByStopEventAttributes([], {
         position: new Set(['origin']),
-        boardingState: new Set(['boardable']),
+        pickUpState: new Set(['boardable']),
       });
       expect(result).toEqual([]);
     });
@@ -999,46 +745,77 @@ describe('filterByStopEventAttributes', () => {
     });
   });
 
-  describe('boardingState axis', () => {
-    const boardablePlain = makeEntry({ departureMinutes: 480 });
-    const dropOffByPickup1 = makeEntry({ pickupType: 1, departureMinutes: 540 });
-    const dropOffByTerminal = makeEntry({ isTerminal: true, departureMinutes: 600 });
-    const entries = [boardablePlain, dropOffByPickup1, dropOffByTerminal];
+  describe('pickUpState axis', () => {
+    // Maps 1:1 to GTFS pickup_type values; isTerminal is NOT mixed in.
+    const pt0Plain = makeEntry({ pickupType: 0, departureMinutes: 480 }); // boardable
+    const pt1Plain = makeEntry({ pickupType: 1, departureMinutes: 540 }); // nonBoardable
+    const pt0Terminal = makeEntry({ pickupType: 0, isTerminal: true, departureMinutes: 600 }); // still boardable (pt=0)
+    const pt2Plain = makeEntry({ pickupType: 2, departureMinutes: 660 }); // phoneArrangement
+    const pt3Plain = makeEntry({ pickupType: 3, departureMinutes: 720 }); // driverArrangement
+    const entries = [pt0Plain, pt1Plain, pt0Terminal, pt2Plain, pt3Plain];
 
-    it('keeps only boardable entries (excludes drop-off-only)', () => {
+    it('keeps boardable entries (= pickup_type === 0) regardless of isTerminal', () => {
       const result = filterByStopEventAttributes(entries, {
-        boardingState: new Set(['boardable']),
+        pickUpState: new Set(['boardable']),
       });
-      expect(result).toEqual([boardablePlain]);
+      expect(result).toEqual([pt0Plain, pt0Terminal]);
     });
 
-    it('keeps only nonBoardable entries (= drop-off-only)', () => {
+    it('keeps nonBoardable entries (= pickup_type === 1)', () => {
       const result = filterByStopEventAttributes(entries, {
-        boardingState: new Set(['nonBoardable']),
+        pickUpState: new Set(['nonBoardable']),
       });
-      expect(result).toEqual([dropOffByPickup1, dropOffByTerminal]);
+      expect(result).toEqual([pt1Plain]);
     });
 
-    it('keeps everything when both states are listed', () => {
+    it('keeps phoneArrangement entries (= pickup_type === 2)', () => {
       const result = filterByStopEventAttributes(entries, {
-        boardingState: new Set(['boardable', 'nonBoardable']),
+        pickUpState: new Set(['phoneArrangement']),
+      });
+      expect(result).toEqual([pt2Plain]);
+    });
+
+    it('keeps driverArrangement entries (= pickup_type === 3)', () => {
+      const result = filterByStopEventAttributes(entries, {
+        pickUpState: new Set(['driverArrangement']),
+      });
+      expect(result).toEqual([pt3Plain]);
+    });
+
+    it('keeps everything when all four states are listed', () => {
+      const result = filterByStopEventAttributes(entries, {
+        pickUpState: new Set([
+          'boardable',
+          'nonBoardable',
+          'phoneArrangement',
+          'driverArrangement',
+        ]),
       });
       expect(result).toEqual(entries);
     });
 
+    it('keeps multiple states as union (boardable OR nonBoardable)', () => {
+      const result = filterByStopEventAttributes(entries, {
+        pickUpState: new Set(['boardable', 'nonBoardable']),
+      });
+      expect(result).toEqual([pt0Plain, pt1Plain, pt0Terminal]);
+    });
+
     it('returns empty array for an empty Set', () => {
       const result = filterByStopEventAttributes(entries, {
-        boardingState: new Set(),
+        pickUpState: new Set(),
       });
       expect(result).toEqual([]);
     });
 
-    it('treats a single-stop trip as nonBoardable because terminal takes precedence', () => {
-      const circular = makeEntry({ isOrigin: true, isTerminal: true, pickupType: 0 });
-      const result = filterByStopEventAttributes([circular], {
-        boardingState: new Set(['nonBoardable']),
+    it('classifies a single-stop trip (isOrigin && isTerminal, pt=0) as boardable', () => {
+      // pickUpState only looks at pickup_type; isOrigin / isTerminal
+      // do not influence the classification.
+      const oneStop = makeEntry({ isOrigin: true, isTerminal: true, pickupType: 0 });
+      const result = filterByStopEventAttributes([oneStop], {
+        pickUpState: new Set(['boardable']),
       });
-      expect(result).toEqual([circular]);
+      expect(result).toEqual([oneStop]);
     });
   });
 
@@ -1123,10 +900,10 @@ describe('filterByStopEventAttributes', () => {
     const terminalDropOff = makeEntry({ isTerminal: true, departureMinutes: 720 });
     const entries = [originBoardable, originDropOff, middleBoardable, terminalDropOff];
 
-    it('combines position and boardingState (origin AND boardable)', () => {
+    it('combines position and pickUpState (origin AND boardable)', () => {
       const result = filterByStopEventAttributes(entries, {
         position: new Set(['origin']),
-        boardingState: new Set(['boardable']),
+        pickUpState: new Set(['boardable']),
       });
       expect(result).toEqual([originBoardable]);
     });
@@ -1134,13 +911,13 @@ describe('filterByStopEventAttributes', () => {
     it('combines all three axes', () => {
       const result = filterByStopEventAttributes(entries, {
         position: new Set(['origin', 'middle']),
-        boardingState: new Set(['boardable']),
+        pickUpState: new Set(['boardable']),
         schedule: { fromMinutes: 600, toMinutes: 720 },
       });
       expect(result).toEqual([middleBoardable]);
     });
 
-    it('combines arrival-based schedule filtering with position and boardingState', () => {
+    it('combines arrival-based schedule filtering with position and pickUpState', () => {
       const originEarlyArrival = makeEntryWithArrival(900, 500, { isOrigin: true });
       const originLateArrival = makeEntryWithArrival(900, 560, { isOrigin: true });
       const middleLateArrival = makeEntryWithArrival(900, 580);
@@ -1153,7 +930,7 @@ describe('filterByStopEventAttributes', () => {
         [originEarlyArrival, originLateArrival, middleLateArrival, originLateDropOff],
         {
           position: new Set(['origin']),
-          boardingState: new Set(['boardable']),
+          pickUpState: new Set(['boardable']),
           schedule: { field: 'arrival', fromMinutes: 540 },
         },
       );
@@ -1161,30 +938,10 @@ describe('filterByStopEventAttributes', () => {
       expect(result).toEqual([originLateArrival]);
     });
 
-    describe('relation to legacy helpers', () => {
-      it('does not change filterOrigin semantics for non-boardable origins', () => {
-        const nonBoardableOrigin = makeEntry({
-          isOrigin: true,
-          pickupType: 1,
-          departureMinutes: 540,
-        });
-
-        expect(filterOrigin([nonBoardableOrigin])).toEqual([nonBoardableOrigin]);
-        expect(
-          filterByStopEventAttributes([nonBoardableOrigin], {
-            position: new Set(['origin']),
-            boardingState: new Set(['boardable']),
-          }),
-        ).toEqual([]);
-        expect(
-          filterByStopEventAttributes([nonBoardableOrigin], {
-            position: new Set(['origin']),
-            boardingState: new Set(['nonBoardable']),
-          }),
-        ).toEqual([nonBoardableOrigin]);
-      });
-    });
-    it('keeps a single-stop trip when terminal/origin and nonBoardable both match', () => {
+    it('keeps a single-stop trip when origin/terminal and boardable both match', () => {
+      // 1-stop trip (isOrigin && isTerminal) matches both 'origin' and
+      // 'terminal'. With pickup_type=0 the entry is also classified as
+      // boardable, so all axes match and the entry is kept.
       const oneStop = makeEntry({
         isOrigin: true,
         isTerminal: true,
@@ -1193,7 +950,7 @@ describe('filterByStopEventAttributes', () => {
       });
       const result = filterByStopEventAttributes([oneStop], {
         position: new Set(['origin', 'terminal']),
-        boardingState: new Set(['nonBoardable']),
+        pickUpState: new Set(['boardable']),
       });
       expect(result).toEqual([oneStop]);
     });
@@ -1203,14 +960,16 @@ describe('filterByStopEventAttributes', () => {
     it('preserves the input element type at the type level', () => {
       // Type-level check: `tsc --noEmit` will fail if the function ever
       // narrows the result back to `TimetableEntry[]`. Runtime is just a
-      // sanity smoke test that the call works.
+      // sanity smoke test that the call works. Both entries have
+      // pickup_type=0 (default), so pickUpState='boardable' keeps both
+      // regardless of isTerminal.
       const branded: (TimetableEntry & { _brand: 'sample' })[] = [
         Object.assign(makeEntry(), { _brand: 'sample' as const }),
-        Object.assign(makeEntry({ isTerminal: true }), { _brand: 'sample' as const }),
+        Object.assign(makeEntry({ pickupType: 1 }), { _brand: 'sample' as const }),
       ];
       const filtered: (TimetableEntry & { _brand: 'sample' })[] = filterByStopEventAttributes(
         branded,
-        { boardingState: new Set(['boardable']) },
+        { pickUpState: new Set(['boardable']) },
       );
       expect(filtered).toHaveLength(1);
       // Element type is preserved, so accessing the brand compiles.
@@ -1224,13 +983,13 @@ describe('filterByStopEventAttributes', () => {
           serviceDate: new Date(2026, 3, 30),
         },
         {
-          ...makeEntry({ isTerminal: true, departureMinutes: 540 }),
+          ...makeEntry({ pickupType: 1, departureMinutes: 540 }),
           serviceDate: new Date(2026, 3, 30),
         },
       ];
 
       const filtered: ContextualTimetableEntry[] = filterByStopEventAttributes(contextual, {
-        boardingState: new Set(['boardable']),
+        pickUpState: new Set(['boardable']),
       });
 
       expect(filtered).toHaveLength(1);

--- a/src/domain/transit/timetable-filter.ts
+++ b/src/domain/transit/timetable-filter.ts
@@ -145,3 +145,123 @@ export function filterBoardable(entries: TimetableEntry[]): TimetableEntry[] {
 export function filterOrigin(entries: TimetableEntry[]): TimetableEntry[] {
   return entries.filter((entry) => entry.patternPosition.isOrigin);
 }
+
+// ---------------------------------------------------------------------------
+// filterByStopEventAttributes
+// ---------------------------------------------------------------------------
+
+/** Pattern position values an entry can match. */
+export type PatternPosition = 'origin' | 'terminal' | 'middle';
+
+/** Boarding state values an entry can match. */
+export type BoardingState = 'boardable' | 'nonBoardable';
+
+/**
+ * Schedule range filter for departure / arrival times.
+ *
+ * Both bounds are inclusive and expressed in minutes from midnight of
+ * the service day (so values >= 1440 represent overnight times, which
+ * compare correctly as numbers). Omit a bound to leave that side open.
+ */
+export interface ScheduleRangeFilter {
+  /** Time field to apply the range to. @default 'departure' */
+  field?: 'departure' | 'arrival';
+  /** Inclusive lower bound. Omit for no lower bound. */
+  fromMinutes?: number;
+  /** Inclusive upper bound. Omit for no upper bound. */
+  toMinutes?: number;
+}
+
+/**
+ * Bundle of stop-event attribute axes for {@link filterByStopEventAttributes}.
+ *
+ * "Stop event" = a single occurrence of a trip visiting a stop. Trip
+ * identity (route, headsign, agency, service_id) is intentionally NOT
+ * part of this filter; use {@link filterByAgency} / {@link filterByRouteType}
+ * for those.
+ *
+ * Each field is independent and additively narrows the result set
+ * (AND semantics across axes); an undefined field disables that axis.
+ * An empty Set yields no matches (literal interpretation).
+ *
+ * Semantics:
+ * - 'origin' / 'terminal' map to `patternPosition.isOrigin` /
+ *   `.isTerminal`; 'middle' = neither. Single-stop trips
+ *   (isOrigin AND isTerminal) match both 'origin' and 'terminal'.
+ * - 'boardable' / 'nonBoardable' invert {@link isDropOffOnly}
+ *   (`pickup_type === 1` OR `isTerminal`).
+ * - Schedule range is inclusive on both ends. `field` selects
+ *   `entry.schedule.departureMinutes` (default) or
+ *   `entry.schedule.arrivalMinutes`.
+ */
+export interface StopEventAttributeFilters {
+  /** Schedule time range to keep. Omit to disable. */
+  schedule?: ScheduleRangeFilter;
+  /** Boarding states to keep. Omit to disable. */
+  boardingState?: ReadonlySet<BoardingState>;
+  /** Pattern positions to keep. Omit to disable. */
+  position?: ReadonlySet<PatternPosition>;
+}
+
+function matchesPosition(entry: TimetableEntry, allowed: ReadonlySet<PatternPosition>): boolean {
+  const { isOrigin, isTerminal } = entry.patternPosition;
+  if (isOrigin && allowed.has('origin')) {
+    return true;
+  }
+  if (isTerminal && allowed.has('terminal')) {
+    return true;
+  }
+  if (!isOrigin && !isTerminal && allowed.has('middle')) {
+    return true;
+  }
+  return false;
+}
+
+function matchesBoardingState(entry: TimetableEntry, allowed: ReadonlySet<BoardingState>): boolean {
+  return allowed.has(isDropOffOnly(entry) ? 'nonBoardable' : 'boardable');
+}
+
+function matchesSchedule(entry: TimetableEntry, range: ScheduleRangeFilter): boolean {
+  const value =
+    range.field === 'arrival' ? entry.schedule.arrivalMinutes : entry.schedule.departureMinutes;
+  if (range.fromMinutes !== undefined && value < range.fromMinutes) {
+    return false;
+  }
+  if (range.toMinutes !== undefined && value > range.toMinutes) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Filter entries by stop-event-level attributes (schedule / boarding /
+ * pattern position) in a single array pass.
+ *
+ * Trip-level attributes (route, headsign, agency) are NOT considered —
+ * use {@link filterByAgency} / {@link filterByRouteType} for those.
+ *
+ * When all axes are undefined, the input reference is returned
+ * unchanged (no allocation), so this is safe to call with an empty
+ * filter bundle from `useMemo` etc.
+ */
+export function filterByStopEventAttributes<T extends TimetableEntry>(
+  entries: readonly T[],
+  filters: StopEventAttributeFilters,
+): T[] {
+  const { position, boardingState, schedule } = filters;
+  if (!position && !boardingState && !schedule) {
+    return entries as T[];
+  }
+  return entries.filter((entry) => {
+    if (position && !matchesPosition(entry, position)) {
+      return false;
+    }
+    if (boardingState && !matchesBoardingState(entry, boardingState)) {
+      return false;
+    }
+    if (schedule && !matchesSchedule(entry, schedule)) {
+      return false;
+    }
+    return true;
+  });
+}

--- a/src/domain/transit/timetable-filter.ts
+++ b/src/domain/transit/timetable-filter.ts
@@ -260,3 +260,51 @@ export function filterByStopEventAttributes<T extends TimetableEntry>(
     return true;
   });
 }
+
+/** Toggle bundle for {@link applyStopEventAttributeToggles}. */
+export interface StopEventAttributeToggles {
+  /**
+   * When true, narrows to entries where this stop is the trip's origin
+   * (= `entry.patternPosition.isOrigin === true`). Includes
+   * non-boardable origins; combine with `showBoardableOnly` to
+   * intersect.
+   */
+  showOriginOnly: boolean;
+  /**
+   * When true, narrows to entries with `pickup_type === 0` whose
+   * `patternPosition` is `'origin'` or `'middle'` (i.e. not a pure
+   * terminal). Composes with `showOriginOnly` (AND) when both are on.
+   */
+  showBoardableOnly: boolean;
+}
+
+/**
+ * Apply the user-facing entry-attribute toggles
+ * (`showOriginOnly` / `showBoardableOnly`) to a list of entries.
+ *
+ * Each enabled toggle narrows the result via
+ * {@link filterByStopEventAttributes} (AND across toggles). When both
+ * toggles are false, the input reference is returned unchanged.
+ *
+ * Used by both BottomSheet (per-stop entries) and TimetableModal (the
+ * stop's full timetable) so the toggle semantics stay aligned across
+ * surfaces.
+ */
+export function applyStopEventAttributeToggles<T extends TimetableEntry>(
+  entries: readonly T[],
+  toggles: StopEventAttributeToggles,
+): T[] {
+  let result = entries as T[];
+  if (toggles.showOriginOnly) {
+    result = filterByStopEventAttributes(result, {
+      position: new Set(['origin']),
+    });
+  }
+  if (toggles.showBoardableOnly) {
+    result = filterByStopEventAttributes(result, {
+      pickUpState: new Set(['boardable']),
+      position: new Set(['origin', 'middle']),
+    });
+  }
+  return result;
+}

--- a/src/domain/transit/timetable-filter.ts
+++ b/src/domain/transit/timetable-filter.ts
@@ -11,15 +11,13 @@
 import type { TimetableEntry } from '../../types/app/transit-composed';
 import type { TimetableOmitted } from '../../types/app/repository';
 import { getEffectiveHeadsign } from './get-effective-headsign';
-import { isDropOffOnly } from './timetable-utils';
 
 /**
  * Filter and compute omitted stats for a stop timetable.
  *
  * When `includeNonBoardable` is false (simple/normal), non-boardable
- * entries (= terminal arrivals and `pickup_type === 1` mid-route stops,
- * see {@link isDropOffOnly}) are removed and their count is reported in
- * `omitted.nonBoardable`.
+ * entries (= entries with `pickup_type !== 0` or `isTerminal`) are
+ * removed and their count is reported in `omitted.nonBoardable`.
  *
  * @param allEntries - All entries from getFullDayTimetableEntries (unfiltered).
  * @param includeNonBoardable - true at detailed+, false at simple/normal.
@@ -32,7 +30,10 @@ export function prepareStopTimetable(
   if (includeNonBoardable) {
     return { entries: allEntries, omitted: { nonBoardable: 0 } };
   }
-  const entries = filterBoardable(allEntries);
+  const entries = filterByStopEventAttributes(allEntries, {
+    pickUpState: new Set(['boardable']),
+    position: new Set(['origin', 'middle']),
+  });
   return { entries, omitted: { nonBoardable: allEntries.length - entries.length } };
 }
 
@@ -64,7 +65,10 @@ export function prepareRouteHeadsignTimetable(
   if (includeNonBoardable) {
     return { entries: routeEntries, omitted: { nonBoardable: 0 } };
   }
-  const entries = filterBoardable(routeEntries);
+  const entries = filterByStopEventAttributes(routeEntries, {
+    pickUpState: new Set(['boardable']),
+    position: new Set(['origin', 'middle']),
+  });
   return { entries, omitted: { nonBoardable: routeEntries.length - entries.length } };
 }
 
@@ -118,34 +122,6 @@ export function filterByRouteType<T extends TimetableEntry>(
   return entries.filter((e) => !hiddenRouteTypes.has(e.routeDirection.route.route_type));
 }
 
-/**
- * Filter out drop-off-only entries, returning only boardable stop times.
- *
- * Each entry's boardability is determined by {@link isDropOffOnly}
- * (pickupType === 1 OR isTerminal).
- */
-export function filterBoardable(entries: TimetableEntry[]): TimetableEntry[] {
-  return entries.filter((entry) => !isDropOffOnly(entry));
-}
-
-/**
- * Filter to entries where this stop is the trip's origin (= 始発).
- *
- * Keeps every entry with `entry.patternPosition.isOrigin === true`,
- * including ones that are also non-boardable (= the bus departs from a
- * depot or yard with `pickup_type === 1` / `drop_off_type === 1`). Those
- * entries are visually distinguished by `乗×` / `降×` markers in the
- * grid, so hiding them at the filter layer would suppress legitimate
- * GTFS-described "起点運用" data the viewer is meant to surface.
- *
- * Callers that want only boardable origins should compose this with
- * {@link filterBoardable} (= apply both filters) rather than baking a
- * combined predicate into a single function.
- */
-export function filterOrigin(entries: TimetableEntry[]): TimetableEntry[] {
-  return entries.filter((entry) => entry.patternPosition.isOrigin);
-}
-
 // ---------------------------------------------------------------------------
 // filterByStopEventAttributes
 // ---------------------------------------------------------------------------
@@ -153,8 +129,16 @@ export function filterOrigin(entries: TimetableEntry[]): TimetableEntry[] {
 /** Pattern position values an entry can match. */
 export type PatternPosition = 'origin' | 'terminal' | 'middle';
 
-/** Boarding state values an entry can match. */
-export type BoardingState = 'boardable' | 'nonBoardable';
+/**
+ * Pick-up state values an entry can match. Maps 1:1 to GTFS
+ * `pickup_type` values (= boarding side, no `drop_off_type` involvement):
+ *
+ * - `'boardable'` — `pickup_type === 0` (regular pickup).
+ * - `'nonBoardable'` — `pickup_type === 1` (no pickup available).
+ * - `'phoneArrangement'` — `pickup_type === 2` (phone agency to arrange).
+ * - `'driverArrangement'` — `pickup_type === 3` (coordinate with driver).
+ */
+export type PickUpState = 'boardable' | 'nonBoardable' | 'phoneArrangement' | 'driverArrangement';
 
 /**
  * Schedule range filter for departure / arrival times.
@@ -184,12 +168,14 @@ export interface ScheduleRangeFilter {
  * (AND semantics across axes); an undefined field disables that axis.
  * An empty Set yields no matches (literal interpretation).
  *
+
  * Semantics:
  * - 'origin' / 'terminal' map to `patternPosition.isOrigin` /
  *   `.isTerminal`; 'middle' = neither. Single-stop trips
  *   (isOrigin AND isTerminal) match both 'origin' and 'terminal'.
- * - 'boardable' / 'nonBoardable' invert {@link isDropOffOnly}
- *   (`pickup_type === 1` OR `isTerminal`).
+ * - 'boardable' / 'nonBoardable' / 'phoneArrangement' /
+ *   'driverArrangement' map 1:1 to `boarding.pickupType` (0 / 1 / 2 / 3).
+ *   `isTerminal` is NOT mixed in (use the position axis if needed).
  * - Schedule range is inclusive on both ends. `field` selects
  *   `entry.schedule.departureMinutes` (default) or
  *   `entry.schedule.arrivalMinutes`.
@@ -197,8 +183,8 @@ export interface ScheduleRangeFilter {
 export interface StopEventAttributeFilters {
   /** Schedule time range to keep. Omit to disable. */
   schedule?: ScheduleRangeFilter;
-  /** Boarding states to keep. Omit to disable. */
-  boardingState?: ReadonlySet<BoardingState>;
+  /** Pick-up states to keep. Omit to disable. */
+  pickUpState?: ReadonlySet<PickUpState>;
   /** Pattern positions to keep. Omit to disable. */
   position?: ReadonlySet<PatternPosition>;
 }
@@ -217,8 +203,17 @@ function matchesPosition(entry: TimetableEntry, allowed: ReadonlySet<PatternPosi
   return false;
 }
 
-function matchesBoardingState(entry: TimetableEntry, allowed: ReadonlySet<BoardingState>): boolean {
-  return allowed.has(isDropOffOnly(entry) ? 'nonBoardable' : 'boardable');
+function matchesPickUpState(entry: TimetableEntry, allowed: ReadonlySet<PickUpState>): boolean {
+  switch (entry.boarding.pickupType) {
+    case 0:
+      return allowed.has('boardable');
+    case 1:
+      return allowed.has('nonBoardable');
+    case 2:
+      return allowed.has('phoneArrangement');
+    case 3:
+      return allowed.has('driverArrangement');
+  }
 }
 
 function matchesSchedule(entry: TimetableEntry, range: ScheduleRangeFilter): boolean {
@@ -234,8 +229,8 @@ function matchesSchedule(entry: TimetableEntry, range: ScheduleRangeFilter): boo
 }
 
 /**
- * Filter entries by stop-event-level attributes (schedule / boarding /
- * pattern position) in a single array pass.
+ * Filter entries by stop-event-level attributes (schedule / pick-up
+ * state / pattern position) in a single array pass.
  *
  * Trip-level attributes (route, headsign, agency) are NOT considered —
  * use {@link filterByAgency} / {@link filterByRouteType} for those.
@@ -248,15 +243,15 @@ export function filterByStopEventAttributes<T extends TimetableEntry>(
   entries: readonly T[],
   filters: StopEventAttributeFilters,
 ): T[] {
-  const { position, boardingState, schedule } = filters;
-  if (!position && !boardingState && !schedule) {
+  const { position, pickUpState, schedule } = filters;
+  if (!position && !pickUpState && !schedule) {
     return entries as T[];
   }
   return entries.filter((entry) => {
     if (position && !matchesPosition(entry, position)) {
       return false;
     }
-    if (boardingState && !matchesBoardingState(entry, boardingState)) {
+    if (pickUpState && !matchesPickUpState(entry, pickUpState)) {
       return false;
     }
     if (schedule && !matchesSchedule(entry, schedule)) {

--- a/src/domain/transit/timetable-filter.ts
+++ b/src/domain/transit/timetable-filter.ts
@@ -16,8 +16,11 @@ import { getEffectiveHeadsign } from './get-effective-headsign';
  * Filter and compute omitted stats for a stop timetable.
  *
  * When `includeNonBoardable` is false (simple/normal), non-boardable
- * entries (= entries with `pickup_type !== 0` or `isTerminal`) are
- * removed and their count is reported in `omitted.nonBoardable`.
+ * entries are removed and their count is reported in
+ * `omitted.nonBoardable`. An entry is considered non-boardable when
+ * `pickup_type !== 0`, or when it is a pure terminal stop
+ * (`isTerminal && !isOrigin`); 1-stop trips (`isOrigin && isTerminal`)
+ * are kept as origin.
  *
  * @param allEntries - All entries from getFullDayTimetableEntries (unfiltered).
  * @param includeNonBoardable - true at detailed+, false at simple/normal.

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -133,13 +133,13 @@
       "routeDescription": "Timetable at {{stop}}: {{route}} ({{count}})",
       "stopDescription": "Timetable at {{stop}}: all routes ({{count}})",
       "noDestination": "Some routes have no destination"
-    },
-    "filter": {
-      "boardableOnly": "🚏 Boardable",
-      "boardableOnlyTitle": "Show only boardable trips (exclude terminals and pickup-unavailable)",
-      "originOnly": "🚩 Origin",
-      "originOnlyTitle": "Show only trips originating at this stop (includes non-boardable origins like depot departures)"
     }
+  },
+  "filter": {
+    "boardableOnly": "🚏 Boardable",
+    "boardableOnlyTitle": "Show only boardable trips (exclude terminals and pickup-unavailable)",
+    "originOnly": "🚩 Origin",
+    "originOnlyTitle": "Show only trips originating at this stop (includes non-boardable origins like depot departures)"
   },
   "panel": {
     "appInfo": "App info",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -133,13 +133,13 @@
       "routeDescription": "{{stop}}: {{route}} 時刻表 {{count}}本",
       "stopDescription": "{{stop}}: 全路線時刻表 {{count}}本",
       "noDestination": "行先が表示されない路線があります"
-    },
-    "filter": {
-      "boardableOnly": "🚏 乗車可",
-      "boardableOnlyTitle": "乗車できる便のみ表示 (終点や乗車不可便を除外)",
-      "originOnly": "🚩 始発",
-      "originOnlyTitle": "ここを始発とする便のみ表示 (出庫便など乗車不可な始発も含む)"
     }
+  },
+  "filter": {
+    "boardableOnly": "🚏 乗車可",
+    "boardableOnlyTitle": "乗車できる便のみ表示 (終点や乗車不可便を除外)",
+    "originOnly": "🚩 始発",
+    "originOnlyTitle": "ここを始発とする便のみ表示 (出庫便など乗車不可な始発も含む)"
   },
   "panel": {
     "appInfo": "アプリ情報",


### PR DESCRIPTION
## Summary

- BottomSheet に origin (始発のみ) / boardable (乗車可能のみ) filter pill を追加。Stage 1 (`showOperatingStopsOnly`) と同性質の operative presence toggle として、filter で entries が空になる stop を list から drop。
- filter pipeline 全体を 3-stage 構成に再編 (operating → stop-event toggle → agency/route_type)。`counts` を最終 `trimmedStopTimes` base に統一し、各 pill に count 表示。`active` の semantic も filter 状態反映に変更。
- per-stop-event 軸の generic helper `filterByStopEventAttributes` (criteria 受け、4-state `PickUpState` で GTFS `pickup_type` 0/1/2/3 と 1:1 mapping) と、toggle wrapper `applyStopEventAttributeToggles` を新設。BottomSheet と TimetableModal で同じ toggle semantics を共有。
- legacy `filterBoardable` / `filterOrigin` を削除、新 helper で全 caller 置換。
- filter pill (`OriginFilter` / `BoardabilityFilter`) を `src/components/timetable/` から `src/components/filter/` に移動し、i18n key を `timetable.filter.*` から top-level `filter.*` に re-namespace。

## Test plan

- [x] BottomSheet を開き、Origin pill ON で始発便を持つ stop のみ表示される
- [x] Boardable pill ON で乗車可能便 (`pickup_type === 0`) を持つ stop のみ表示される
- [x] 両方 ON で AND 動作 (= 始発かつ乗車可能な便を持つ stop のみ)
- [x] OFF 状態で全 stop 表示に戻る
- [x] origin / boardable pill の count が現在の表示状態を正しく反映
- [x] Operating pill の count も filter 状態で変動する (= 既存挙動からの semantic 変更)
- [x] TimetableModal の origin / boardable filter が回帰なく動く
- [x] i18n: en / ja で pill ラベルが正しく表示される
- [x] Dark mode で pill / count が崩れていない
- [x] originCount === 0 のとき OriginFilter pill が hide される (TimetableModal 同様)

🤖 Generated with [Claude Code](https://claude.com/claude-code)