### PR TITLE
refactor: lift origin / boardable filter state to app-wide GlobalFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ### Added
 
+- `GlobalFilter` 型 (`src/types/app/global-filter.ts`) を追加。app-wide で共有する filter state (`showOriginOnly` / `showBoardableOnly`) と toggle handler を 1 つの interface に集約。BottomSheet / TimetableModal / MapBottomSheetLayout で `globalFilter: GlobalFilter` 1 props として nest 渡し (= 名前空間明確、将来 MapView / TripInspectionDialog にも展開可能)。
 - `filterByStopEventAttributes` helper (`src/domain/transit/timetable-filter.ts`) を追加。`TimetableEntry[]` に対して per-stop-event 属性 (schedule range / `pickUpState` / patternPosition) を hybrid Set / range API で single-pass 合成 filter する。trip-level 属性 (route / headsign / agency) は対象外で `filterByAgency` / `filterByRouteType` と責務分離。empty filter bundle は input reference をそのまま返す fast-path 付き。
 - `PickUpState` 型 (`'boardable' | 'nonBoardable' | 'phoneArrangement' | 'driverArrangement'`) を追加。GTFS `pickup_type` 0/1/2/3 と 1:1 mapping。`isTerminal` は判定に混入させず position 軸の責務に分離。
 - `applyStopEventAttributeToggles` helper を追加。`showOriginOnly` / `showBoardableOnly` の boolean toggle を受けて `filterByStopEventAttributes` を AND 合成する wrapper。BottomSheet と TimetableModal で同じ toggle semantics を共有。
@@ -24,6 +25,8 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ### Changed
 
+- `showOriginOnly` / `showBoardableOnly` の state を BottomSheet / TimetableModal の internal `useState` から app.tsx に lift。両 component を controlled component 化し、`globalFilter: GlobalFilter` 経由で受け取る。BottomSheet と TimetableModal 間で filter 状態が同期 (= 一方で boardable ON にすると他方でも反映)。`MapBottomSheetLayout` にも `globalFilter` を中継するための props を追加 (`app.tsx → MapBottomSheetLayout → BottomSheet`)。
+- TimetableModal の `boardableOnly` prop (= 初期値) と infoLevel-based 初期値 logic (`!isDetailedEnabled` で boardable filter を初期 ON する自動化) を廃止。filter 状態は app-wide `globalFilter` を完全に反映 (= simple/normal でも boardable filter は user の手動 toggle で ON)。
 - `TimetableModal` の filter pipeline を `applyStopEventAttributeToggles` 経由に統一。旧 `filterBoardable` / `filterOrigin` 直接呼び出しを廃し、BottomSheet と同一の toggle semantics を共有。中間変数 `entriesBeforeRouteHeadsignFilter` を `stopEventAttributesFilteredEntries` にリネーム (= 軸の責務を反映)。
 - BottomSheet の filter pipeline を 3-stage 構成に再編。Stage 1 (`showOperatingStopsOnly`、stop drop) → Stage 2 (`showOriginOnly` / `showBoardableOnly`、stop drop) → Stage 3 (`hiddenAgencyIds` / `hiddenRouteTypes`、entry trim only)。集合属性 trim (Stage 3) は `'allFilteredOut'` fallback 維持、user 操作の presence toggle (Stage 1/2) は stop drop。
 - BottomSheet の `counts` を全て final `trimmedStopTimes` (Stage 3 出力) base に統一。`active` の semantic を旧 "pre-filter で entries が 1 件以上の stop 数" (= filter 状態無関係の固定値) から "現在表示中で entries が 1 件以上の stop 数" (= 全 filter 操作で変動) に変更。Operating pill の count は user の filter 操作で変動するようになる。

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -17,7 +17,6 @@ import { LocalStorageUserDataRepository } from './repositories/local-storage-use
 import { useRouteStops } from './hooks/use-route-stops';
 import { PERF_PROFILES } from './config/perf-profiles';
 import { TILE_SOURCES } from './config/tile-sources';
-import { createInfoLevel } from './utils/create-info-level';
 import { toggleGroupInList } from './utils/list-toggle';
 import { routeTypeGroup } from './utils/route-type-category';
 import { routeTypesEmoji } from './utils/route-type-emoji';
@@ -457,8 +456,6 @@ export default function App({ loadResult }: AppProps) {
     [repo, dateTime, inBoundStops, radiusStops],
   );
 
-  const infoLevelFlags = useMemo(() => createInfoLevel(settings.infoLevel), [settings.infoLevel]);
-
   /** Fetch full-day timetable entries for a stop (no filtering). */
   const fetchTimetableEntries = useCallback(
     async (stopId: string) => {
@@ -654,6 +651,24 @@ export default function App({ loadResult }: AppProps) {
     [focusStop, pushStop, findStopWithMeta],
   );
 
+  // --- App-wide filter state (shared across surfaces) ---
+
+  // Stop-event-level filter toggles. Lifted to app.tsx so MapView,
+  // BottomSheet, TripInspectionDialog, and TimetableModal can share the
+  // same data state (= "what kind of trips the user is currently
+  // interested in"). The toggles control entry-level filtering through
+  // `applyStopEventAttributeToggles`; each surface decides how to apply
+  // it given its own data shape.
+  const [showOriginOnly, setShowOriginOnly] = useState(false);
+  const [showBoardableOnly, setShowBoardableOnly] = useState(false);
+
+  const toggleShowOriginOnly = useCallback(() => {
+    setShowOriginOnly((prev) => !prev);
+  }, []);
+  const toggleShowBoardableOnly = useCallback(() => {
+    setShowBoardableOnly((prev) => !prev);
+  }, []);
+
   // --- Settings handlers ---
 
   const enabledRouteTypes = useMemo(
@@ -835,6 +850,12 @@ export default function App({ loadResult }: AppProps) {
           onToggleAnchor: handleToggleAnchor,
           onInspectTrip: openTripInspection,
         }}
+        globalFilter={{
+          showOriginOnly,
+          showBoardableOnly,
+          onToggleShowOriginOnly: toggleShowOriginOnly,
+          onToggleShowBoardableOnly: toggleShowBoardableOnly,
+        }}
         mapOverlay={
           <TimeControls
             time={dateTime}
@@ -875,8 +896,13 @@ export default function App({ loadResult }: AppProps) {
         data={timetableData}
         time={dateTime}
         infoLevel={settings.infoLevel}
-        boardableOnly={!infoLevelFlags.isDetailedEnabled}
         dataLangs={langChain}
+        globalFilter={{
+          showOriginOnly,
+          showBoardableOnly,
+          onToggleShowOriginOnly: toggleShowOriginOnly,
+          onToggleShowBoardableOnly: toggleShowBoardableOnly,
+        }}
         onInspectTrip={openTripInspection}
         onClose={() => setTimetableData(null)}
       />

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -669,6 +669,19 @@ export default function App({ loadResult }: AppProps) {
     setShowBoardableOnly((prev) => !prev);
   }, []);
 
+  // Bundle the app-wide filter state + toggle handlers into a single
+  // memoized object so consumers (BottomSheet / TimetableModal /
+  // future MapView etc.) receive a stable reference between toggles.
+  const globalFilter = useMemo(
+    () => ({
+      showOriginOnly,
+      showBoardableOnly,
+      onToggleShowOriginOnly: toggleShowOriginOnly,
+      onToggleShowBoardableOnly: toggleShowBoardableOnly,
+    }),
+    [showOriginOnly, showBoardableOnly, toggleShowOriginOnly, toggleShowBoardableOnly],
+  );
+
   // --- Settings handlers ---
 
   const enabledRouteTypes = useMemo(
@@ -850,12 +863,7 @@ export default function App({ loadResult }: AppProps) {
           onToggleAnchor: handleToggleAnchor,
           onInspectTrip: openTripInspection,
         }}
-        globalFilter={{
-          showOriginOnly,
-          showBoardableOnly,
-          onToggleShowOriginOnly: toggleShowOriginOnly,
-          onToggleShowBoardableOnly: toggleShowBoardableOnly,
-        }}
+        globalFilter={globalFilter}
         mapOverlay={
           <TimeControls
             time={dateTime}
@@ -897,12 +905,7 @@ export default function App({ loadResult }: AppProps) {
         time={dateTime}
         infoLevel={settings.infoLevel}
         dataLangs={langChain}
-        globalFilter={{
-          showOriginOnly,
-          showBoardableOnly,
-          onToggleShowOriginOnly: toggleShowOriginOnly,
-          onToggleShowBoardableOnly: toggleShowBoardableOnly,
-        }}
+        globalFilter={globalFilter}
         onInspectTrip={openTripInspection}
         onClose={() => setTimetableData(null)}
       />

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -3,6 +3,7 @@ import type { LatLng } from '../types/app/map';
 import type { DataConfig } from '../config/perf-profiles';
 import type { InfoLevel } from '../types/app/settings';
 import type { Agency, AppRouteTypeValue, TimetableEntriesState } from '../types/app/transit';
+import type { GlobalFilter } from '../types/app/global-filter';
 import type { StopWithContext, TripInspectionTarget } from '../types/app/transit-composed';
 import { collectPresentAgencies } from '../domain/transit/collect-present-agencies';
 import { collectPresentRouteTypes } from '../domain/transit/collect-present-route-types';
@@ -74,6 +75,8 @@ export interface BottomSheetProps {
   dataLangs: readonly string[];
   /** Set of stop IDs currently in the anchor list. */
   anchorIds: Set<string>;
+  /** App-wide filter state shared across surfaces. */
+  globalFilter: GlobalFilter;
   onStopSelected: (stopId: string) => void;
   onShowTimetable?: (stopId: string, routeId: string, headsign: string) => void;
   onShowStopTimetable?: (stopId: string) => void;
@@ -102,6 +105,7 @@ export function BottomSheet({
   infoLevel,
   dataLangs,
   anchorIds,
+  globalFilter,
   onStopSelected,
   onShowTimetable,
   onShowStopTimetable,
@@ -112,6 +116,8 @@ export function BottomSheet({
   expanded: expandedProp,
   onExpandedChange,
 }: BottomSheetProps) {
+  const { showOriginOnly, showBoardableOnly, onToggleShowOriginOnly, onToggleShowBoardableOnly } =
+    globalFilter;
   const [uncontrolledExpanded, setUncontrolledExpanded] = useState(false);
   const expanded = expandedProp ?? uncontrolledExpanded;
   const setExpanded = useCallback(
@@ -133,9 +139,6 @@ export function BottomSheet({
   const showOperatingStopsOnly = showOperatingStopsOnlyOverride ?? isLateNight;
   const [hiddenRouteTypes, setHiddenRouteTypes] = useState<Set<number>>(() => new Set());
   const [hiddenAgencyIds, setHiddenAgencyIds] = useState<Set<string>>(() => new Set());
-  // Stop-event-level filters (per-entry attributes). Default OFF.
-  const [showOriginOnly, setShowOriginOnly] = useState(false);
-  const [showBoardableOnly, setShowBoardableOnly] = useState(false);
   const selectedView = STOP_TIMES_VIEWS.find((v) => v.id === viewId);
   const touchStartY = useRef(0);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -184,14 +187,6 @@ export function BottomSheet({
       }
       return next;
     });
-  }, []);
-
-  const toggleShowOriginOnly = useCallback(() => {
-    setShowOriginOnly((prev) => !prev);
-  }, []);
-
-  const toggleShowBoardableOnly = useCallback(() => {
-    setShowBoardableOnly((prev) => !prev);
   }, []);
 
   // Three-stage filter pipeline. Each stage has a distinct nature, so
@@ -356,8 +351,8 @@ export function BottomSheet({
         onToggleShowOperatingStopsOnly={() =>
           setShowOperatingStopsOnlyOverride((v) => !(v ?? isLateNight))
         }
-        onToggleShowOriginOnly={toggleShowOriginOnly}
-        onToggleShowBoardableOnly={toggleShowBoardableOnly}
+        onToggleShowOriginOnly={onToggleShowOriginOnly}
+        onToggleShowBoardableOnly={onToggleShowBoardableOnly}
         onViewChange={setViewId}
         onToggleRouteType={toggleRouteType}
         onToggleAgency={toggleAgency}

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -15,6 +15,7 @@ import { computeTimetableEntryStats } from '@/domain/transit/timetable-stats';
 import type { TimetableEntryStats } from '@/domain/transit/timetable-stats';
 import { getServiceDayMinutes } from '@/domain/transit/service-day';
 import { useScrollFades } from '@/hooks/use-scroll-fades';
+import type { GlobalFilter } from '@/types/app/global-filter';
 import type { InfoLevel } from '@/types/app/settings';
 import type { Agency, Route, Stop, StopServiceState } from '@/types/app/transit';
 import type { TimetableEntry, TripInspectionTarget } from '@/types/app/transit-composed';
@@ -62,14 +63,8 @@ interface TimetableModalProps {
   infoLevel: InfoLevel;
   /** Display language chain for translated GTFS/ODPT data names. */
   dataLangs: readonly string[];
-  /**
-   * Initial value of the boardable-only filter toggle. When true, the
-   * dialog opens with the filter ON (= the user can still toggle it
-   * off via the filter pill). The value is read once at mount; pair
-   * with a stable `key` on `<TimetableModal>` so the dialog re-mounts
-   * (= re-evaluates the initial value) per stop.
-   */
-  boardableOnly: boolean;
+  /** App-wide filter state shared across surfaces. */
+  globalFilter: GlobalFilter;
   onInspectTrip?: (target: TripInspectionTarget) => void;
   onClose: () => void;
 }
@@ -143,10 +138,12 @@ export function TimetableModal({
   time,
   infoLevel,
   dataLangs,
-  boardableOnly,
+  globalFilter,
   onInspectTrip,
   onClose,
 }: TimetableModalProps) {
+  const { showOriginOnly, showBoardableOnly, onToggleShowOriginOnly, onToggleShowBoardableOnly } =
+    globalFilter;
   const { t, i18n } = useTranslation();
   const open = data !== null;
   const info = useInfoLevel(infoLevel);
@@ -158,16 +155,6 @@ export function TimetableModal({
   // Empty set = show all timetable (no filter active).
   const [activeFilters, setActiveFilters] = useState<Set<string>>(() => new Set());
 
-  // Boardable-only filter toggle. Initial value comes from the
-  // `boardableOnly` prop (read once at mount; the caller should use a
-  // `key` on <TimetableModal> to re-mount per stop).
-  const [showBoardableOnly, setShowBoardableOnly] = useState(boardableOnly);
-
-  // Origin-only filter toggle (= 始発のみ). OFF by default.
-  // When ON, narrows to entries whose patternPosition.isOrigin is true,
-  // applied on top of any other active filters.
-  const [showOriginOnly, setShowOriginOnly] = useState(false);
-
   const toggleFilter = useCallback((key: string) => {
     setActiveFilters((prev) => {
       const next = new Set(prev);
@@ -178,14 +165,6 @@ export function TimetableModal({
       }
       return next;
     });
-  }, []);
-
-  const toggleBoardableOnly = useCallback(() => {
-    setShowBoardableOnly((prev) => !prev);
-  }, []);
-
-  const toggleOriginOnly = useCallback(() => {
-    setShowOriginOnly((prev) => !prev);
   }, []);
 
   // Both timetable types now use TimetableEntry[] directly.
@@ -388,14 +367,14 @@ export function TimetableModal({
                 <OriginFilter
                   origin={showOriginOnly}
                   count={stopEventAttributesFilteredEntriesStats.originCount}
-                  onToggleOrigin={toggleOriginOnly}
+                  onToggleOrigin={onToggleShowOriginOnly}
                 />
               )}
               {/* Boardability filter */}
               <BoardabilityFilter
                 boardable={showBoardableOnly}
                 count={stopEventAttributesFilteredEntriesStats.boardableCount}
-                onToggleBoardable={toggleBoardableOnly}
+                onToggleBoardable={onToggleShowBoardableOnly}
               />
               {/* Headsign filter */}
               {data.type === 'stop' && (

--- a/src/components/map-bottom-sheet-layout.tsx
+++ b/src/components/map-bottom-sheet-layout.tsx
@@ -4,6 +4,7 @@ import { MapView, type MapViewProps } from './map/map-view';
 import { useViewportHeight } from '../hooks/use-viewport-height';
 import { resolveMapBottomSheetLayoutPreset } from '../utils/map-bottom-sheet-layout-preset';
 import { createLogger } from '../lib/logger';
+import type { GlobalFilter } from '../types/app/global-filter';
 
 const logger = createLogger('MapBottomSheetLayout');
 
@@ -11,14 +12,21 @@ interface MapBottomSheetLayoutProps {
   mapViewProps: Omit<MapViewProps, 'heightClassName'>;
   bottomSheetProps: Omit<
     BottomSheetProps,
-    'collapsedHeightClassName' | 'expandedHeightClassName' | 'expanded' | 'onExpandedChange'
+    | 'collapsedHeightClassName'
+    | 'expandedHeightClassName'
+    | 'expanded'
+    | 'onExpandedChange'
+    | 'globalFilter'
   >;
+  /** App-wide filter state shared with BottomSheet (and forthcoming MapView etc.). */
+  globalFilter: GlobalFilter;
   mapOverlay?: ReactNode;
 }
 
 export function MapBottomSheetLayout({
   mapViewProps,
   bottomSheetProps,
+  globalFilter,
   mapOverlay,
 }: MapBottomSheetLayoutProps) {
   const [expanded, setExpanded] = useState(false);
@@ -46,6 +54,7 @@ export function MapBottomSheetLayout({
       </div>
       <BottomSheet
         {...bottomSheetProps}
+        globalFilter={globalFilter}
         expanded={expanded}
         onExpandedChange={setExpanded}
         collapsedHeightClassName={layoutPreset.collapsedSheetHeightClassName}

--- a/src/types/app/global-filter.ts
+++ b/src/types/app/global-filter.ts
@@ -1,0 +1,19 @@
+/**
+ * App-wide filter state shared across surfaces (BottomSheet,
+ * TimetableModal, MapView, TripInspectionDialog, etc.).
+ *
+ * Owned by `app.tsx` and threaded through props as a single
+ * `globalFilter` object so the namespace is explicit at every
+ * receiver. Drilling depth is shallow (1–2 levels), so explicit
+ * props are clearer than a Context provider.
+ */
+export interface GlobalFilter {
+  /** When true, narrow to entries whose patternPosition.isOrigin is true. */
+  showOriginOnly: boolean;
+  /** When true, narrow to entries with `pickup_type === 0` at non-pure-terminal positions. */
+  showBoardableOnly: boolean;
+  /** Toggle `showOriginOnly`. */
+  onToggleShowOriginOnly: () => void;
+  /** Toggle `showBoardableOnly`. */
+  onToggleShowBoardableOnly: () => void;
+}


### PR DESCRIPTION
## Summary

- 新 type `GlobalFilter` (`src/types/app/global-filter.ts`) を追加。`showOriginOnly` / `showBoardableOnly` の state と toggle handler を 1 つの interface に集約。
- BottomSheet / TimetableModal の internal \`useState\` を app.tsx に lift し、両 component を **controlled component** 化。`globalFilter: GlobalFilter` を 1 つの nest 形 prop で受け取る。
- `MapBottomSheetLayout` も中継 prop \`globalFilter\` を持ち、`app.tsx → MapBottomSheetLayout → BottomSheet` の経路で渡す (旧 `sharedProps` の形を `globalFilter` に統一)。
- BottomSheet と TimetableModal で **filter 状態が同期** (= 一方で toggle ON すると他方でも反映)。
- 将来的に MapView / TripInspectionDialog にも同じ `globalFilter` prop を渡すことで、marker や indicator の filter 反映を実現可能。

## 挙動変更

- TimetableModal の `boardableOnly` prop (= 初期値) を **廃止**。
- 旧: \`infoLevel\` ベースの初期値 logic (`simple/normal` で開くと boardable filter が **自動 ON**、`detailed/verbose` で **自動 OFF**) を **廃止**。
- 新: TimetableModal は常に app-wide `globalFilter` を反映 (= BottomSheet で OFF なら TimetableModal でも OFF)。

## Test plan

- [x] BottomSheet で boardable pill を ON にすると TimetableModal を開いた時も ON 状態
- [x] TimetableModal で boardable pill を OFF にすると BottomSheet にも反映
- [x] origin filter も同様に同期
- [x] simple/normal infoLevel で TimetableModal を開いても boardable filter は自動 ON にならない (= 旧挙動からの変更)
- [x] BottomSheet を re-mount しても filter 状態が保持される (= app.tsx の state)
- [x] TimetableModal を閉じて再度開いても filter 状態が保持される
- [x] 既存 BottomSheet の Stage 1/2/3 filter pipeline が回帰なく動作 (operating / agency / route_type)
- [x] dark mode で pill 表示崩れなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)