### PR TITLE
refactor: lift filtered stops + per-stop service state to app.tsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `globalFilter` (`showOriginOnly` / `showBoardableOnly`) 適用後の stop list と、per-stop の `TimetableEntriesState` map を、BottomSheet 内部から `app.tsx` に lift。`stopEventAttributesFilteredNearbyStopTimes` (= filter 適用後 stop 配列) と `nearbyStopTimesServiceState` (= 各 stop の state map、`'filter-hidden'` を `'no-service'` から区別するため pre-`globalFilter` base で計算) を `app.tsx` で `useMemo` 化し、BottomSheet と MapView 双方に渡す。MapView の `stopTimes` prop も生 `nearbyStopTimes` から filter 適用後の値に切替、marker と BottomSheet list の filter 状態が同期。
+- BottomSheet 内の filter pipeline を 2 stage (`showOperatingStopsOnly` の stop drop + agency / route_type の entry trim) に縮小。origin / boardable 由来の Stage 1 は app.tsx 側に吸収。`upcomingEntriesStates` の局所 `useMemo` を削除し、`stopServiceState` props (= `ReadonlyMap<stop_id, TimetableEntriesState>`) を parent から受け取る形に変更 (`BottomSheetStops` / `NearbyStop` も同 prop 名で透過)。
+
+### Fixed
+
+- `pipeline/scripts/pipeline/lib/check-odpt-report.test.ts` の `printRemoteResources` describe を `vi.useFakeTimers()` + `vi.setSystemTime(new Date('2026-04-15'))` で時刻 pin。`getPeriodStatus()` の default `new Date()` がテスト実行日を境に "currently valid" 判定を変えていた (= fixture `start_at: 2026-05-01` を境に 2 → 3 へ drift) のを解消。
+
 ### Added
 
 - `GlobalFilter` 型 (`src/types/app/global-filter.ts`) を追加。app-wide で共有する filter state (`showOriginOnly` / `showBoardableOnly`) と toggle handler を 1 つの interface に集約。BottomSheet / TimetableModal / MapBottomSheetLayout で `globalFilter: GlobalFilter` 1 props として nest 渡し (= 名前空間明確、将来 MapView / TripInspectionDialog にも展開可能)。

--- a/pipeline/scripts/pipeline/lib/check-odpt-report.test.ts
+++ b/pipeline/scripts/pipeline/lib/check-odpt-report.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   sanitizeUrl,
   formatRemoteResourceLine,
@@ -272,7 +272,17 @@ describe('formatLocalFeedLine', () => {
 // ---------------------------------------------------------------------------
 
 describe('printRemoteResources', () => {
+  // `getPeriodStatus()` defaults to `new Date()`, so the "currently
+  // valid" count depends on the wall clock. Pin time to a date that
+  // sits between the fixture `start_at`s used in the suite below
+  // (2026-03-01 / 2026-04-01 / 2026-05-01) so the assertion stays
+  // stable regardless of when the suite runs.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-15T00:00:00Z'));
+  });
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import i18n from './i18n';
 import type { Bounds, LatLng, RouteShape } from './types/app/map';
-import type { AppRouteTypeValue, Stop } from './types/app/transit';
+import type { AppRouteTypeValue, Stop, TimetableEntriesState } from './types/app/transit';
 import type { StopWithContext, StopWithMeta } from './types/app/transit-composed';
 import type { LoadResult } from './repositories/athenai-repository';
 import { useTransitRepository } from './hooks/use-transit-repository';
@@ -37,8 +37,9 @@ import { getStopParam } from './lib/query-params';
 import { getServiceDay } from './domain/transit/service-day';
 import { formatDateKey } from './domain/transit/calendar-utils';
 import { resolveStopRouteTypes } from './domain/transit/resolve-stop-route-types';
-import { getStopServiceState } from './domain/transit/timetable-utils';
+import { getStopServiceState, getTimetableEntriesState } from './domain/transit/timetable-utils';
 import {
+  applyStopEventAttributeToggles,
   prepareStopTimetable,
   prepareRouteHeadsignTimetable,
 } from './domain/transit/timetable-filter';
@@ -153,7 +154,11 @@ export default function App({ loadResult }: AppProps) {
 
   const { dateTime, isCustomTime, resetToNow, setCustomTime } = useDateTime();
 
-  const { stopTimes, isNearbyLoading } = useNearbyStopTimes(radiusStops, dateTime, repo);
+  const { stopTimes: nearbyStopTimes, isNearbyLoading } = useNearbyStopTimes(
+    radiusStops,
+    dateTime,
+    repo,
+  );
 
   // Build routeTypes lookup covering all visible stops (in-bound + nearby)
   const [routeTypeMap, setRouteTypeMap] = useState<Map<string, AppRouteTypeValue[]>>(
@@ -190,7 +195,7 @@ export default function App({ loadResult }: AppProps) {
     clearFocus,
   } = useSelection({
     routeTypeMap,
-    stopTimes: stopTimes,
+    stopTimes: nearbyStopTimes,
     routeShapes,
     radiusStops,
     inBoundStops,
@@ -689,10 +694,43 @@ export default function App({ loadResult }: AppProps) {
     [settings.visibleStopTypes],
   );
 
-  const routeTypesFilteredStopTimes = useMemo(
-    () => stopTimes.filter((d) => d.routeTypes.some((rt) => enabledRouteTypes.has(rt))),
-    [stopTimes, enabledRouteTypes],
+  const routeTypesFilteredNearbyStopTimes = useMemo(
+    () => nearbyStopTimes.filter((d) => d.routeTypes.some((rt) => enabledRouteTypes.has(rt))),
+    [nearbyStopTimes, enabledRouteTypes],
   );
+
+  // Apply origin / boardable filter (= app-wide `globalFilter` toggles)
+  // per-stop and drop stops whose entries become empty. The result is
+  // the stop list that BottomSheet (and forthcoming MapView etc.)
+  // should render; computing it here keeps the same filter outcome
+  // available to multiple surfaces from one place.
+  const stopEventAttributesFilteredNearbyStopTimes = useMemo(() => {
+    if (!showOriginOnly && !showBoardableOnly) {
+      return routeTypesFilteredNearbyStopTimes;
+    }
+    return routeTypesFilteredNearbyStopTimes
+      .map((swc) => {
+        const filtered = applyStopEventAttributeToggles(swc.stopTimes, {
+          showOriginOnly,
+          showBoardableOnly,
+        });
+        return filtered === swc.stopTimes ? swc : { ...swc, stopTimes: filtered };
+      })
+      .filter((swc) => swc.stopTimes.length > 0);
+  }, [routeTypesFilteredNearbyStopTimes, showOriginOnly, showBoardableOnly]);
+
+  // Per-stop pre-filter `TimetableEntriesState` map. The base is
+  // `routeTypesFilteredNearbyStopTimes` (= origin/boardable filter
+  // applied *before*), so consumers can distinguish `'filter-hidden'`
+  // (entries existed pre-filter, removed by user toggles) from
+  // `'no-service'` (no entries at all).
+  const nearbyStopTimesServiceState = useMemo(() => {
+    const map = new Map<string, TimetableEntriesState>();
+    for (const swc of routeTypesFilteredNearbyStopTimes) {
+      map.set(swc.stop.stop_id, getTimetableEntriesState([...swc.stopTimes]));
+    }
+    return map;
+  }, [routeTypesFilteredNearbyStopTimes]);
 
   const handleToggleStopType = useCallback(
     (rt: number) => {
@@ -730,20 +768,24 @@ export default function App({ loadResult }: AppProps) {
   // shapes re-render is skipped for the vast majority of ticks.
   const serviceDay = useMemo(() => getServiceDay(dateTime), [dateTime]);
   const serviceDayKey = formatDateKey(serviceDay);
+  const stableServiceDay = useMemo(() => {
+    const [year, month, day] = serviceDayKey.split('-').map(Number);
+    return new Date(year, month - 1, day);
+  }, [serviceDayKey]);
+  const serviceDayWeekday = useMemo(() => {
+    return stableServiceDay.getDay();
+  }, [stableServiceDay]);
 
   useEffect(() => {
     const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    // Use serviceDay.getDay() for timezone-safe day-of-week.
-    // Do NOT reparse serviceDayKey via new Date('YYYY-MM-DD') — JS parses
+    // Do NOT parse serviceDayKey via new Date('YYYY-MM-DD') here — JS parses
     // date-only strings as UTC, which yields wrong getDay() in non-UTC timezones.
-    logger.info(`Service day: ${serviceDayKey} (${dayNames[serviceDay.getDay()]})`);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- serviceDayKey is the stable identity; serviceDay is a new Date each tick but getDay() is deterministic for the same serviceDayKey
-  }, [serviceDayKey]);
+    logger.info(`Service day: ${serviceDayKey} (${dayNames[serviceDayWeekday]})`);
+  }, [serviceDayKey, serviceDayWeekday]);
 
   const resolveRouteFreq = useCallback(
-    (routeId: string) => repo.resolveRouteFreq(routeId, serviceDay),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- serviceDay is a new Date each tick; use serviceDayKey for stable identity
-    [repo, serviceDayKey],
+    (routeId: string) => repo.resolveRouteFreq(routeId, stableServiceDay),
+    [repo, stableServiceDay],
   );
 
   const handleToggleBusShapes = useCallback(() => {
@@ -808,7 +850,7 @@ export default function App({ loadResult }: AppProps) {
           radiusStops,
           selectedStopId,
           focusPosition,
-          stopTimes,
+          stopTimes: stopEventAttributesFilteredNearbyStopTimes,
           routeTypeMap,
           routeShapes,
           selectionInfo,
@@ -847,7 +889,8 @@ export default function App({ loadResult }: AppProps) {
           lookupAnchorStopMeta,
         }}
         bottomSheetProps={{
-          stopTimes: routeTypesFilteredStopTimes,
+          stopTimes: stopEventAttributesFilteredNearbyStopTimes,
+          stopServiceState: nearbyStopTimesServiceState,
           selectedStopId,
           isNearbyLoading,
           hasNearbyLoaded,

--- a/src/components/bottom-sheet-stops.tsx
+++ b/src/components/bottom-sheet-stops.tsx
@@ -20,7 +20,7 @@ interface BottomSheetStopsProps {
    * ended" apart from "filter-hidden" when its filtered stop times are
    * empty.
    */
-  upcomingEntriesStates: ReadonlyMap<string, TimetableEntriesState>;
+  stopServiceState: ReadonlyMap<string, TimetableEntriesState>;
   selectedStopId: string | null;
   now: Date;
   mapCenter: LatLng | null;
@@ -42,7 +42,7 @@ interface BottomSheetStopsProps {
 
 export function BottomSheetStops({
   stopTimes,
-  upcomingEntriesStates,
+  stopServiceState,
   selectedStopId,
   now,
   mapCenter,
@@ -75,7 +75,7 @@ export function BottomSheetStops({
             // (shouldn't happen — the Map and this `stopTimes` prop are
             // both derived from the same upstream stops list — but stay
             // defensive in case of race conditions during rerender).
-            upcomingEntriesState: upcomingEntriesStates.get(swc.stop.stop_id) ?? 'no-service',
+            timetableEntriesState: stopServiceState.get(swc.stop.stop_id) ?? 'no-service',
             isSelected: selectedStopId === swc.stop.stop_id,
             now,
             mapCenter,

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -7,12 +7,7 @@ import type { GlobalFilter } from '../types/app/global-filter';
 import type { StopWithContext, TripInspectionTarget } from '../types/app/transit-composed';
 import { collectPresentAgencies } from '../domain/transit/collect-present-agencies';
 import { collectPresentRouteTypes } from '../domain/transit/collect-present-route-types';
-import {
-  applyStopEventAttributeToggles,
-  filterByAgency,
-  filterByRouteType,
-} from '../domain/transit/timetable-filter';
-import { getTimetableEntriesState } from '../domain/transit/timetable-utils';
+import { filterByAgency, filterByRouteType } from '../domain/transit/timetable-filter';
 import { STOP_TIMES_VIEWS, DEFAULT_VIEW_ID } from '../domain/transit/stop-time-views';
 import { getServiceDayMinutes } from '../domain/transit/service-day';
 import { APP_ROUTE_TYPES } from '../config/route-types';
@@ -63,7 +58,18 @@ export interface NearbyStopsCounts {
 }
 
 export interface BottomSheetProps {
+  /**
+   * Stops to render. Already narrowed by the app-wide filters
+   * (`globalFilter` + `enabledRouteTypes`); BottomSheet only applies
+   * its own surface-local filters (operating-only / agency / route_type).
+   */
   stopTimes: StopWithContext[];
+  /**
+   * Pre-filter `TimetableEntriesState` per stop, keyed by `stop_id`.
+   * Computed in `app.tsx` against the `globalFilter`-pre-trim base so
+   * NearbyStop can distinguish `'filter-hidden'` from `'no-service'`.
+   */
+  stopServiceState: ReadonlyMap<string, TimetableEntriesState>;
   selectedStopId: string | null;
   isNearbyLoading: boolean;
   hasNearbyLoaded: boolean;
@@ -96,6 +102,7 @@ export interface BottomSheetProps {
 
 export function BottomSheet({
   stopTimes,
+  stopServiceState,
   selectedStopId,
   isNearbyLoading: _isNearbyLoading,
   hasNearbyLoaded,
@@ -151,20 +158,6 @@ export function BottomSheet({
 
   const presentAgencies = useMemo(() => collectPresentAgencies(stopTimes), [stopTimes]);
 
-  // Per-stop state of the upcoming entries as returned by the repo,
-  // BEFORE any UI-level filter. Used by NearbyStop to distinguish
-  // "late-night / service ended" (upcoming already empty pre-filter)
-  // from "filter-hidden" (upcoming had entries but the user's active
-  // filters removed them all). Depends only on `stopTimes` so
-  // it is not recomputed when the user toggles filter pills.
-  const upcomingEntriesStates = useMemo(() => {
-    const map = new Map<string, TimetableEntriesState>();
-    for (const swc of stopTimes) {
-      map.set(swc.stop.stop_id, getTimetableEntriesState([...swc.stopTimes]));
-    }
-    return map;
-  }, [stopTimes]);
-
   const toggleRouteType = useCallback((rt: number) => {
     setHiddenRouteTypes((prev) => {
       const next = new Set(prev);
@@ -189,12 +182,16 @@ export function BottomSheet({
     });
   }, []);
 
-  // Three-stage filter pipeline. Each stage has a distinct nature, so
-  // they are kept separate and the stage order is load-bearing.
+  // Two-stage local filter pipeline. The app-wide origin / boardable
+  // filter (= `globalFilter`) is already applied upstream in `app.tsx`
+  // — by the time `stopTimes` arrives here, those entries have already
+  // been narrowed and empty stops dropped. BottomSheet only applies its
+  // own surface-local filters below.
   //
-  // Stage 1 — drop stops that have no upcoming entries today.
-  // `showOperatingStopsOnly` is a property of the stop itself and MUST be
-  // evaluated against pre-filter `stopTimes.length`.
+  // Stage 1 — drop stops with no upcoming entries (operating-only
+  // toggle). Acts on the upstream-filtered `stopTimes`, so when entry
+  // pills are active the operating filter narrows "what is left after
+  // the user's intent narrowing".
   const filteredStopTimes = useMemo(() => {
     if (!showOperatingStopsOnly) {
       return stopTimes;
@@ -202,39 +199,16 @@ export function BottomSheet({
     return stopTimes.filter((swc) => swc.stopTimes.length > 0);
   }, [stopTimes, showOperatingStopsOnly]);
 
-  // Stage 2 — trim each surviving stop's inner stopTimes by stop-event
-  // attributes (origin / boardable), and drop stops whose stopTimes
-  // become empty after the trim. This is a user-facing presence toggle
-  // (same nature as Stage 1's `showOperatingStopsOnly`): when the user
-  // enables an entry-level pill, stops with no matching entry are
-  // removed from the list. Runs before the agency / route_type trim so
-  // those non-removing filters operate on entries that have already
-  // passed the user's primary intent (= what kind of trips to see).
-  const stopEventAttributesFilteredStopTimes = useMemo(() => {
-    if (!showOriginOnly && !showBoardableOnly) {
-      return filteredStopTimes;
-    }
-    return filteredStopTimes
-      .map((swc) => {
-        const filtered = applyStopEventAttributeToggles(swc.stopTimes, {
-          showOriginOnly,
-          showBoardableOnly,
-        });
-        return filtered === swc.stopTimes ? swc : { ...swc, stopTimes: filtered };
-      })
-      .filter((swc) => swc.stopTimes.length > 0);
-  }, [filteredStopTimes, showOriginOnly, showBoardableOnly]);
-
-  // Stage 3 — trim each surviving stop's inner stopTimes by agency /
+  // Stage 2 — trim each surviving stop's inner stopTimes by agency /
   // route_type filters. This never drops stops: a stop whose stopTimes
   // are all removed stays visible and shows the "allFilteredOut"
   // fallback message. This decouples "which stops are in the list"
   // from "what is shown inside each stop".
   const trimmedStopTimes = useMemo(() => {
     if (hiddenAgencyIds.size === 0 && hiddenRouteTypes.size === 0) {
-      return stopEventAttributesFilteredStopTimes;
+      return filteredStopTimes;
     }
-    return stopEventAttributesFilteredStopTimes.map((swc) => {
+    return filteredStopTimes.map((swc) => {
       let trimmed = swc.stopTimes;
       if (hiddenAgencyIds.size > 0) {
         trimmed = filterByAgency(trimmed, hiddenAgencyIds);
@@ -244,7 +218,7 @@ export function BottomSheet({
       }
       return trimmed === swc.stopTimes ? swc : { ...swc, stopTimes: trimmed };
     });
-  }, [stopEventAttributesFilteredStopTimes, hiddenAgencyIds, hiddenRouteTypes]);
+  }, [filteredStopTimes, hiddenAgencyIds, hiddenRouteTypes]);
 
   const counts: NearbyStopsCounts = useMemo(
     () => ({
@@ -359,7 +333,7 @@ export function BottomSheet({
       />
       <BottomSheetStops
         stopTimes={trimmedStopTimes}
-        upcomingEntriesStates={upcomingEntriesStates}
+        stopServiceState={stopServiceState}
         selectedStopId={selectedStopId}
         now={now}
         mapCenter={mapCenter}

--- a/src/components/nearby-stop.stories.tsx
+++ b/src/components/nearby-stop.stories.tsx
@@ -270,7 +270,7 @@ const meta = {
   component: NearbyStop,
   args: {
     data: createStopWithContext(),
-    upcomingEntriesState: 'boardable',
+    timetableEntriesState: 'boardable',
     isSelected: false,
     now,
     mapCenter,
@@ -584,7 +584,7 @@ export const LangComparison: Story = {
           <span className="block text-[10px] text-gray-400">{label}</span>
           <NearbyStop
             data={args.data}
-            upcomingEntriesState={args.upcomingEntriesState}
+            timetableEntriesState={args.timetableEntriesState}
             isSelected={args.isSelected}
             now={args.now}
             mapCenter={args.mapCenter}

--- a/src/components/nearby-stop.tsx
+++ b/src/components/nearby-stop.tsx
@@ -26,7 +26,7 @@ export interface NearbyStopProps {
    * filtered `stopTimes` state to pick the correct empty-fallback
    * message (no-service / service-ended / filter-hidden).
    */
-  upcomingEntriesState: TimetableEntriesState;
+  timetableEntriesState: TimetableEntriesState;
   isSelected: boolean;
   now: Date;
   mapCenter: LatLng | null;
@@ -111,7 +111,7 @@ function NearbyStopActionButtons({
 
 export function NearbyStop({
   data: { stop, routeTypes, stopTimes, stopServiceState, agencies, routes, distance, stats, geo },
-  upcomingEntriesState,
+  timetableEntriesState,
   isSelected,
   now,
   mapCenter,
@@ -165,10 +165,10 @@ export function NearbyStop({
     () =>
       getFilteredTimetableEntriesState(
         stopServiceState,
-        upcomingEntriesState,
+        timetableEntriesState,
         getTimetableEntriesState([...stopTimes]),
       ),
-    [stopServiceState, upcomingEntriesState, stopTimes],
+    [stopServiceState, timetableEntriesState, stopTimes],
   );
 
   return (


### PR DESCRIPTION
## Summary

- BottomSheet 内で計算していた **`globalFilter` (showOriginOnly / showBoardableOnly) 適用後の stop list** と **per-stop \`TimetableEntriesState\` map** を \`app.tsx\` に lift。\`stopEventAttributesFilteredNearbyStopTimes\` と \`nearbyStopTimesServiceState\` を新 \`useMemo\` として上位で 1 度だけ計算する。
- \`nearbyStopTimesServiceState\` は **pre-\`globalFilter\` base** (= \`routeTypesFilteredNearbyStopTimes\`) で計算するため、\`'filter-hidden'\` (= filter 前は entries あり / filter 後は空) と \`'no-service'\` (= 元データに entries 無し) の区別を維持。
- 上位 lift の結果、**MapView も filter 適用後の stop list を受け取る** ようになり、map marker と BottomSheet list の filter 状態が同期。
- BottomSheet 内の filter pipeline は **2 stage に縮小** (\`showOperatingStopsOnly\` stop drop + agency/route_type entry trim)。origin/boardable filter の局所 useMemo は廃止、parent からの \`stopTimes\` props 自体が filter 後。
- \`pipeline/scripts/pipeline/lib/check-odpt-report.test.ts\` の \`printRemoteResources\` describe で \`vi.useFakeTimers()\` + \`vi.setSystemTime\` を使い、\`getPeriodStatus()\` の default \`new Date()\` 由来の日付依存テスト破綻を修正 (= 別 fix、本 PR にあわせ込み)。

## Behavior changes

- MapView marker が origin/boardable filter ON 時に filter 後の stop のみ描画。
- BottomSheet と MapView の表示 stop 集合が常に一致。
- TimetableModal は \`globalFilter\` props 経由で filter state を共有 (前 PR で lift 済み、本 PR では追加変更なし)。

## Test plan

- [x] BottomSheet で origin pill ON → MapView marker も origin entries を持つ stop のみに
- [x] boardable pill ON → 同様に boardable stops のみに
- [x] 両 OFF → 全 stop が地図と list で表示
- [x] BottomSheet の \`'filter-hidden'\` fallback message が引き続き正しく表示
- [x] BottomSheet の \`'no-service'\` / \`'service-ended'\` fallback message も正しく区別
- [x] BottomSheet の \`showOperatingStopsOnly\` toggle が引き続き動作
- [x] Agency / route_type filter (= entry trim only) で \`'allFilteredOut'\` fallback が出る
- [x] TimetableModal を開いた時、BottomSheet と filter 状態が同期
- [x] dark mode で表示崩れなし
- [x] CI / unit tests pass (3021 / 3021)

🤖 Generated with [Claude Code](https://claude.com/claude-code)