### PR TITLE
Refine bottom sheet filter state and count display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,60 +9,54 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `GlobalFilter` 型 (`src/types/app/global-filter.ts`) を導入。app-wide で共有する filter state (`showOriginOnly` / `showBoardableOnly` / `omitEmptyStops` / `isOmitEmptyStopsForced`) と toggle handler を 1 つの interface に集約し、BottomSheet / TimetableModal / MapBottomSheetLayout に `globalFilter: GlobalFilter` 1 props として nest 渡し。
+- `StopsCounts` 型 (`src/types/app/stop.ts`) と `computeStopsCounts` (`src/domain/transit/compute-stops-counts.ts`) を追加。`total` / `nonEmpty` / `originCount` / `boardableCount` の 4 軸を任意の stop 配列から single-pass で集計 (旧 BottomSheet 内部の `NearbyStopsCounts` を一般化 + 移動)。
+- `filterByStopEventAttributes` (`src/domain/transit/timetable-filter.ts`) を追加。`TimetableEntry[]` に対して per-stop-event 属性 (schedule range / `pickUpState` / patternPosition) を hybrid Set / range API で single-pass 合成 filter。trip-level 属性は対象外 (`filterByAgency` / `filterByRouteType` と責務分離)、empty bundle は input reference を返す fast-path 付き。
+- `applyStopEventAttributeToggles` / `applyStopEventAttributeTogglesToStops` / `omitStopsWithoutStopTimes` を追加。`showOriginOnly` / `showBoardableOnly` の AND 合成と、entry filter と empty-stop omission の独立適用を可能に。
+- `PickUpState` 型 (`'boardable' | 'nonBoardable' | 'phoneArrangement' | 'driverArrangement'`) を追加。GTFS `pickup_type` 0/1/2/3 と 1:1 mapping、`isTerminal` を混入させず position 軸と責務分離。
+- BottomSheet に origin / boardable filter pill (`OriginFilter` / `BoardabilityFilter`) を追加。`src/components/filter/` に共通配置 (旧 `TimetableOriginFilter` / `TimetableBoardabilityFilter` から rename + 移動) し、TimetableModal と BottomSheet 両方で再利用。
+- i18n key `filter.originOnly` / `filter.originOnlyTitle` / `filter.boardableOnly` / `filter.boardableOnlyTitle` を top-level `filter.*` namespace に追加 (旧 `timetable.filter.*` から re-namespace)。
+- `src/domain/transit/stop-time-display.ts` を追加。`shouldCollapseArrival` と `deriveStopTimeRoleDisplayProps` (役割 / infoLevel から `showArrivalTime` / `showDepartureTime` / `collapseToleranceMinutes` を一括導出) を提供。26 vitest cases で 8 セル真理値表 (verbose × isOrigin × isTerminal) と tolerance 入力をカバー。
+- `StopTimeTimeInfo` に `align` prop と `collapseToleranceMinutes` (`number | null`) を導入し、旧 `collapseArrivalWhenSameAsDeparture` (boolean) を置換。`null` で collapse 無効、`n` で `|dep - arr| <= n` 分以内なら collapse。
+- `src/components/stop-time-time-info.stories.tsx` を新設。各 Show 軸 / Align / Size / Verbose / tolerance 動作確認 (`ArrivalCloseToDepartureCollapsedWithTolerance`) などをカバー。
+
 ### Changed
 
-- `globalFilter` (`showOriginOnly` / `showBoardableOnly`) 適用後の stop list と、per-stop の `TimetableEntriesState` map を、BottomSheet 内部から `app.tsx` に lift。`stopEventAttributesFilteredNearbyStopTimes` (= filter 適用後 stop 配列) と `nearbyStopTimesServiceState` (= 各 stop の state map、`'filter-hidden'` を `'no-service'` から区別するため pre-`globalFilter` base で計算) を `app.tsx` で `useMemo` 化し、BottomSheet と MapView 双方に渡す。MapView の `stopTimes` prop も生 `nearbyStopTimes` から filter 適用後の値に切替、marker と BottomSheet list の filter 状態が同期。
-- BottomSheet 内の filter pipeline を 2 stage (`showOperatingStopsOnly` の stop drop + agency / route_type の entry trim) に縮小。origin / boardable 由来の Stage 1 は app.tsx 側に吸収。`upcomingEntriesStates` の局所 `useMemo` を削除し、`stopServiceState` props (= `ReadonlyMap<stop_id, TimetableEntriesState>`) を parent から受け取る形に変更 (`BottomSheetStops` / `NearbyStop` も同 prop 名で透過)。
+- `showOriginOnly` / `showBoardableOnly` / `showOperatingStopsOnly` の state を BottomSheet / TimetableModal の internal `useState` から `app.tsx` に lift し、両 component を controlled 化。`omitEmptyStops` (旧 `showOperatingStopsOnly`) は 22:00 auto-on と user override 保持を `app.tsx` で行い、`showOriginOnly` / `showBoardableOnly` ON 時は `isOmitEmptyStopsForced` で強制 ON 化 (空 stop placeholder の不整合を排除し、対応 pill は `disabled` 表示)。
+- 上記 lift により `globalFilter` 適用後の stop list と per-stop `TimetableEntriesState` map を `app.tsx` で `useMemo` 化し、BottomSheet と MapView 双方に渡す。`'filter-hidden'` を `'no-service'` から区別するため map は pre-`globalFilter` base で計算。MapView の `stopTimes` も filter 適用後に切替、marker と BottomSheet list の filter 状態が同期。
+- BottomSheet の filter pipeline を agency / route_type の entry trim のみ (= 1 stage) に縮小。`showOperatingStopsOnly` / `showOriginOnly` / `showBoardableOnly` 由来の stop drop は `app.tsx` 側に吸収。`upcomingEntriesStates` の局所 `useMemo` を削除し、`stopServiceState` props を parent から受け取る形に変更 (`BottomSheetStops` / `NearbyStop` も同 prop 名で透過)。
+- BottomSheet header の filter pill count を `nearbyStopsCounts` (`globalFilter` pre) / `filteredNearbyStopsCounts` (`globalFilter` post, BottomSheet-local pre) / `counts` (全 filter 後) の 3-tier に分離。各 pill は `filteredNearbyStopsCounts` 由来とし、`globalFilter` toggle で count が揺れないように。`MapBottomSheetLayout` にも透過 props を追加。
+- `NearbyStopsSummary` を `StopsSummary` に rename、props を `totalCount` + `filteredCount` の 2 軸に分離。`infoLevel === 'verbose'` で `LabelCountBadge` の inline 表示を追加。
+- `PillButton` の active / inactive / disabled tone と count badge style 計算を再構成。`disabled` 時は border 色を維持しつつ background / count badge を muted tone に統一。
+- TimetableModal の `boardableOnly` prop と infoLevel-based 初期値 logic (`!isDetailedEnabled` で boardable filter を自動 ON) を廃止。filter 状態は `globalFilter` を完全に反映。filter pipeline も `applyStopEventAttributeToggles` 経由に統一し、中間変数 `entriesBeforeRouteHeadsignFilter` → `stopEventAttributesFilteredEntries` に rename。
+- `prepareStopTimetable` / `prepareRouteHeadsignTimetable` / `verbose-nearby-stop-summary` の boardable filter 呼び出しを `filterByStopEventAttributes(..., { pickUpState: ['boardable'], position: ['origin', 'middle'] })` に置換。旧 `filterBoardable` (= `pickup_type === 1 || isTerminal` 除外) と挙動差: pure terminal を除外 / 1-stop trip を keep / `pickup_type=2/3` を除外。`matchesPickUpState` も `isDropOffOnly` 依存から純粋な `pickup_type` 値判定に変更 (`isTerminal` 混入を解消)。
+- `shouldCollapseArrival` 判定を domain helper に抽出。比較を `at === dt` (整形文字列) から `Math.abs(departureMinutes - arrivalMinutes) <= collapseToleranceMinutes` の整数比較に変更。`deriveStopTimeRoleDisplayProps` の tolerance default は `verbose ? null : 2` (GTFS / ODPT 全 20 source の中間 stop dwell 分布 d=1: 2.34% / d=2: 0.082% / d>=3: 0.078% から d<=2 を collapse 対象に設計)。
+- 動作仕様: 非 verbose では origin = dep のみ / terminal = arr のみ / middle = 両方 (tolerance=2) / single-stop = 両方 (tolerance=2)。verbose では全 role で両方表示し tolerance は null (= 全 dwell 開示)、terminal の operator-recorded `departure_time` (例: 京成 妙典駅 d=8、京都市バス 松尾橋 d=6) も可視化。
+- `StopTimeItem` の API を簡素化: `showArrivalTime` / `showDepartureTime` / `collapseToleranceMinutes` の 3 props を削除し、`entry.patternPosition` と `infoLevel` から内部で `deriveStopTimeRoleDisplayProps` を呼んで導出。`TripStopRow` / `TripPager` の `StopTimeTimeInfo` 呼び出しも同 helper 経由に統一 (`TripPager` には `infoLevel` prop を追加)。
+- `StopTimeTimeInfo` から `showVerbose` prop と verbose 用 `着` / `発` badge を削除 (badge が collapse 判定と独立 render されており不整合があったため)。caller (`stop-time-item.tsx` / `trip-pager.tsx` / `trip-stops.tsx`) も追従。
+- `StopTimesItem` の `dataLang` prop を `dataLangs` に rename。React key を loop index から `${patternId}__${serviceId}__${tripIndex}__${stopIndex}` 安定 ID に変更し、Issue #47 の 6-shape / circular pattern でも一意性を保つ。絶対時刻表示は `formatAbsoluteTime` 直書きから `AbsoluteStopTime` に置換し、terminal entry に `showArrivalMarker={isTerminal}` 経由で `着` suffix を表示。hardcoded `text-[#757575]` も `text-muted-foreground` に統一。
+- `DialogContent` に `showCloseButton={false}` を渡してデフォルト X を無効化 (Esc / 外側クリックで close 可能なため UX 維持)。
+- `NearbyStopsCounts` を `StopsCounts` に rename + 切り出し。`active` を `nonEmpty` に rename、`filtered` フィールドは `counts.total` から導出可能のため削除。
 
 ### Fixed
 
-- `pipeline/scripts/pipeline/lib/check-odpt-report.test.ts` の `printRemoteResources` describe を `vi.useFakeTimers()` + `vi.setSystemTime(new Date('2026-04-15'))` で時刻 pin。`getPeriodStatus()` の default `new Date()` がテスト実行日を境に "currently valid" 判定を変えていた (= fixture `start_at: 2026-05-01` を境に 2 → 3 へ drift) のを解消。
-
-### Added
-
-- `GlobalFilter` 型 (`src/types/app/global-filter.ts`) を追加。app-wide で共有する filter state (`showOriginOnly` / `showBoardableOnly`) と toggle handler を 1 つの interface に集約。BottomSheet / TimetableModal / MapBottomSheetLayout で `globalFilter: GlobalFilter` 1 props として nest 渡し (= 名前空間明確、将来 MapView / TripInspectionDialog にも展開可能)。
-- `filterByStopEventAttributes` helper (`src/domain/transit/timetable-filter.ts`) を追加。`TimetableEntry[]` に対して per-stop-event 属性 (schedule range / `pickUpState` / patternPosition) を hybrid Set / range API で single-pass 合成 filter する。trip-level 属性 (route / headsign / agency) は対象外で `filterByAgency` / `filterByRouteType` と責務分離。empty filter bundle は input reference をそのまま返す fast-path 付き。
-- `PickUpState` 型 (`'boardable' | 'nonBoardable' | 'phoneArrangement' | 'driverArrangement'`) を追加。GTFS `pickup_type` 0/1/2/3 と 1:1 mapping。`isTerminal` は判定に混入させず position 軸の責務に分離。
-- `applyStopEventAttributeToggles` helper を追加。`showOriginOnly` / `showBoardableOnly` の boolean toggle を受けて `filterByStopEventAttributes` を AND 合成する wrapper。BottomSheet と TimetableModal で同じ toggle semantics を共有。
-- BottomSheet に origin / boardable filter pill (`OriginFilter` / `BoardabilityFilter`) を追加。Stage 1 (`showOperatingStopsOnly`) と同性質の "operative presence toggle" として stop drop を行い、filter で entries が空になった stop は list から除外。
-- `NearbyStopsCounts` に `originCount` / `boardableCount` を追加。final `trimmedStopTimes` に対して仮想的に各 toggle を適用した stop 数を計算し、各 filter pill の count として表示。
-- `src/components/filter/origin-filter.tsx` / `boardability-filter.tsx` を追加 (`TimetableOriginFilter` / `TimetableBoardabilityFilter` から rename + 移動)。TimetableModal と BottomSheet 両方で再利用可能な共通 filter pill。
-- i18n key `filter.originOnly` / `filter.originOnlyTitle` / `filter.boardableOnly` / `filter.boardableOnlyTitle` を top-level `filter.*` namespace に追加 (旧 `timetable.filter.*` から re-namespace)。
-- `src/domain/transit/stop-time-display.ts` を追加。`shouldCollapseArrival` (= 表示済み arr 行を dep と冗長な場合に hide するか) と `deriveStopTimeRoleDisplayProps` (= 役割 / infoLevel から `StopTimeTimeInfo` 用の `showArrivalTime` / `showDepartureTime` / `collapseToleranceMinutes` を一括導出) を提供。26 vitest cases で 8 セル真理値表 (verbose × isOrigin × isTerminal) と各種 tolerance 入力をカバー。
-- `StopTimeTimeInfo` に `align` prop に続く `collapseToleranceMinutes` (`number | null`) を導入し、旧 `collapseArrivalWhenSameAsDeparture` (boolean) を置換。`null` で collapse 無効、`0` で厳密一致のみ collapse、`n` で `|dep - arr| <= n` 分以内なら collapse という単一軸の閾値表現に。
-- `src/components/stop-time-time-info.stories.tsx` を新設。Default / Imminent / Past / FarFuture / 各 Show 軸 / Align / Size / Verbose / TextAppearance / InspectTrip 等のストーリーと、tolerance 動作確認用の `ArrivalCloseToDepartureCollapsedWithTolerance` を含む。
-
-### Changed
-
-- `showOriginOnly` / `showBoardableOnly` の state を BottomSheet / TimetableModal の internal `useState` から app.tsx に lift。両 component を controlled component 化し、`globalFilter: GlobalFilter` 経由で受け取る。BottomSheet と TimetableModal 間で filter 状態が同期 (= 一方で boardable ON にすると他方でも反映)。`MapBottomSheetLayout` にも `globalFilter` を中継するための props を追加 (`app.tsx → MapBottomSheetLayout → BottomSheet`)。
-- TimetableModal の `boardableOnly` prop (= 初期値) と infoLevel-based 初期値 logic (`!isDetailedEnabled` で boardable filter を初期 ON する自動化) を廃止。filter 状態は app-wide `globalFilter` を完全に反映 (= simple/normal でも boardable filter は user の手動 toggle で ON)。
-- `TimetableModal` の filter pipeline を `applyStopEventAttributeToggles` 経由に統一。旧 `filterBoardable` / `filterOrigin` 直接呼び出しを廃し、BottomSheet と同一の toggle semantics を共有。中間変数 `entriesBeforeRouteHeadsignFilter` を `stopEventAttributesFilteredEntries` にリネーム (= 軸の責務を反映)。
-- BottomSheet の filter pipeline を 3-stage 構成に再編。Stage 1 (`showOperatingStopsOnly`、stop drop) → Stage 2 (`showOriginOnly` / `showBoardableOnly`、stop drop) → Stage 3 (`hiddenAgencyIds` / `hiddenRouteTypes`、entry trim only)。集合属性 trim (Stage 3) は `'allFilteredOut'` fallback 維持、user 操作の presence toggle (Stage 1/2) は stop drop。
-- BottomSheet の `counts` を全て final `trimmedStopTimes` (Stage 3 出力) base に統一。`active` の semantic を旧 "pre-filter で entries が 1 件以上の stop 数" (= filter 状態無関係の固定値) から "現在表示中で entries が 1 件以上の stop 数" (= 全 filter 操作で変動) に変更。Operating pill の count は user の filter 操作で変動するようになる。
-- 4-state `PickUpState` 設計に伴い、`matchesPickUpState` を `isDropOffOnly` 依存から純粋な `pickup_type` 値判定に変更 (`isTerminal` 混入を解消、軸の責務分離を厳密化)。`pickup_type === 1` のみ `'nonBoardable'`、`2`/`3` は `'phoneArrangement'`/`'driverArrangement'` に独立分類。
-- `prepareStopTimetable` / `prepareRouteHeadsignTimetable` の boardable filter 呼び出しを `filterByStopEventAttributes(..., { pickUpState: ['boardable'], position: ['origin', 'middle'] })` に置換。旧 `filterBoardable` (= `pickup_type === 1 || isTerminal` で除外) と挙動差: pure terminal (= `!isOrigin && isTerminal`) は除外 / 1-stop trip (= `isOrigin && isTerminal`) は keep / `pickup_type=2/3` は除外。
-- `verbose-nearby-stop-summary.tsx` の inline `boardable` filter (`pickupType !== 1 && !isTerminal`) を `filterByStopEventAttributes` 合成呼び出しに置換 (count 計算経路を新 helper に統一)。
-- `DialogContent` に `showCloseButton={false}` を渡してデフォルト X を無効化 (Esc / 外側クリックで close 可能なため UX 維持)。
-- `shouldCollapseArrival` 判定ロジックを domain helper (`src/domain/transit/stop-time-display.ts`) に抽出。比較を `at === dt` (整形文字列比較) から `Math.abs(departureMinutes - arrivalMinutes) <= collapseToleranceMinutes` の tolerance-based 整数比較に変更し、`null` で collapse 無効化を表現可能に。
-- `StopTimeItem` の API を簡素化: `showArrivalTime` / `showDepartureTime` / `collapseToleranceMinutes` の 3 props を削除し、`entry.patternPosition` (isOrigin / isTerminal) と `infoLevel` から内部で `deriveStopTimeRoleDisplayProps` を呼んで導出する形に。caller (`nearby-stop.tsx`) はこれら 3 props を渡さなくなる。
-- `TripStopRow` (`trip-stops.tsx`) と `TripPager` の `StopTimeTimeInfo` 呼び出しを `deriveStopTimeRoleDisplayProps` 経由に統一。`TripPager` には新たに `infoLevel: InfoLevel` prop を追加し、`TripInspectionDialog` から渡すよう更新。
-- `deriveStopTimeRoleDisplayProps` の tolerance default を `verbose ? null : 2` に設定。GTFS / ODPT 全 20 source の中間 stop dwell 分布 (d=1: 2.34% = 鉄道発車待ち、d=2: 0.082% = 軽 hub dwell、d>=3: 0.078% = 通過待ち / 折返し / 高速バス起点) から、d=1+d=2 を collapse 対象とし d>=3 を 2 行展開する設計。
-- 動作仕様: 非 verbose では origin = dep のみ / terminal = arr のみ / middle = 両方 (tolerance=2) / single-stop = 両方 (tolerance=2) を表示。verbose では全 role で両方表示し tolerance は null (= 全 dwell 開示)。terminal の operator-recorded `departure_time` (例: 京成 妙典駅 d=8 の折返し時間、京都市バス 松尾橋 d=6) も verbose で可視化。
-- `StopTimeTimeInfo` から `showVerbose` prop と verbose 用 `着` / `発` badge ブロックを削除。badge は collapse 判定 (`shouldCollapseArrival`) と独立に render されており、`着` badge と arrival 行の表示が連動しない不整合があったため、機能ごと撤去。caller (`stop-time-item.tsx` / `trip-pager.tsx` / `trip-stops.tsx`) も `showVerbose` の引き渡しを削除。
-- `StopTimesItem` の `dataLang` prop を `dataLangs` にリネーム (project-wide 命名規約整合)。caller (`nearby-stop.tsx`) と stories の引き渡しも併せて更新。React key を loop index (`i`) から `${patternId}__${serviceId}__${tripIndex}__${stopIndex}` ベースの安定 ID に変更し、Issue #47 の 6-shape / circular pattern (同 trip が異なる stopIndex で登場) でも一意性を保つ。
-- `StopTimesItem` の絶対時刻表示を `formatAbsoluteTime` 直書きから `AbsoluteStopTime` コンポーネントに置換。terminal entry に `着` suffix が `showArrivalMarker={isTerminal}` 経由で表示され、TERM badge と併せて到着便を一目で識別可能に (`発` suffix は compact 性維持のため非表示)。各 entry wrapper の hardcoded `text-[#757575] dark:text-gray-400` も theme token `text-muted-foreground` に統一。
+- Origin filter pill が `showOriginOnly` ON 直後に `counts.originCount === 0` で消える問題を解消 (表示条件を `showOriginOnly || nearbyStopsCounts.originCount > 0` に)。
+- Operating-stops / Boardable pill の count が他の `globalFilter` toggle で揺れる問題を解消 (`filteredNearbyStopsCounts` 参照に統一)。
+- `pipeline/scripts/pipeline/lib/check-odpt-report.test.ts` の `printRemoteResources` describe を `vi.useFakeTimers()` + `vi.setSystemTime(new Date('2026-04-15'))` で時刻 pin。`getPeriodStatus()` がテスト実行日を境に判定 drift する問題 (fixture `start_at: 2026-05-01` を境に 2 → 3) を解消。
 
 ### Removed
 
-- `filterBoardable` / `filterOrigin` 関数を削除 (`src/domain/transit/timetable-filter.ts`)。新 helper `filterByStopEventAttributes` (criteria 受け) と `applyStopEventAttributeToggles` (toggle 受け wrapper) で代替。両者の唯一の caller (`prepareStopTimetable` / `prepareRouteHeadsignTimetable` / `TimetableModal` / `verbose-nearby-stop-summary`) を全て新 helper 経由に置換済み。
-- `TimetableOriginFilter` / `TimetableBoardabilityFilter` を削除 (= `OriginFilter` / `BoardabilityFilter` に rename + `src/components/filter/` に移動)。
+- `filterBoardable` / `filterOrigin` を削除 (新 `filterByStopEventAttributes` / `applyStopEventAttributeToggles` で代替)。caller は全て新 helper 経由に置換済み。
+- `TimetableOriginFilter` / `TimetableBoardabilityFilter` を削除 (`OriginFilter` / `BoardabilityFilter` に rename + `src/components/filter/` に移動)。
 - 旧 i18n key `timetable.filter.originOnly` / `timetable.filter.originOnlyTitle` / `timetable.filter.boardableOnly` / `timetable.filter.boardableOnlyTitle` を削除 (top-level `filter.*` namespace に移行)。
 
 ### Performance
 
-- `TimetableModal` / `TripInspectionDialog` / `StopSearchModal` を `React.memo` で wrap。3 dialog はいずれも `App` に常時マウントされ (closed 時は `data: null` / `snapshot: null` / `open: false` を渡す設計)、`mapCenter` 等の親 state 変更ごとに body が再実行されていた。`React.memo` のデフォルト shallow compare により、`time={dateTime}` (15 秒 tick) や `data` / `snapshot` などの props が実際に変わった場合のみ再レンダーされるようになり、親の map pan などで props が同一のときの不要な再レンダーをスキップ。
-- `TimetableModal` の inline `computeTimetableEntryStats(...)` 呼び出し 2 箇所を `useMemo` 化。memo 後も `time` tick で body が走った際に stats 計算 (= entries 全走査 + `Set` aggregation + debug log 出力) が毎回再実行されていた問題を解消。modal 閉時の `DEBUG [TimetableStats] stopHeadsigns []` console noise も停止。
-- `app.tsx` の `onClose` / `onOpenChange` inline arrow を `closeTimetableModal` / `handleTripInspectionOpenChange` の `useCallback` 化。inline arrow は親レンダーごとに新規生成されるため `React.memo` の shallow 比較を defeat していた (= memo 単体では効果ゼロ)。各 dialog の memo 化に必要な前提条件として lift。
+- `TimetableModal` / `TripInspectionDialog` / `StopSearchModal` を `React.memo` で wrap。3 dialog はいずれも `App` に常時マウントされ、`mapCenter` 等の親 state 変更で body が再実行されていた問題を、shallow compare で `time` (15 秒 tick) や `data` / `snapshot` 変化時のみ再レンダーするよう抑制。
+- `TimetableModal` の inline `computeTimetableEntryStats(...)` 呼び出し 2 箇所を `useMemo` 化。`time` tick で stats 計算 (entries 全走査 + Set aggregation + debug log) が毎回走る問題と、modal 閉時の `DEBUG [TimetableStats]` console noise を解消。
+- `app.tsx` の `onClose` / `onOpenChange` inline arrow を `useCallback` 化 (`closeTimetableModal` / `handleTripInspectionOpenChange`)。各 dialog の `React.memo` shallow 比較を defeat する原因だったため、memo 化の前提条件として lift。
 
 ## [2026.04.29]
 

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -1,17 +1,35 @@
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from '../i18n';
 import App from '../app';
 import type { UseAnchorsReturn } from '../hooks/use-anchors';
+import type { ContextualTimetableEntry, StopWithContext } from '../types/app/transit-composed';
 
-const { mockToastError, mockUseAnchors, mockGetRouteShapes, mockClearAnchorError } = vi.hoisted(
-  () => ({
-    mockToastError: vi.fn(),
-    mockUseAnchors: vi.fn<(...args: unknown[]) => UseAnchorsReturn>(),
-    mockGetRouteShapes: vi.fn(),
-    mockClearAnchorError: vi.fn(),
-  }),
-);
+type UseDateTimeReturn = ReturnType<typeof import('../hooks/use-date-time').useDateTime>;
+type UseNearbyStopTimesReturn = ReturnType<
+  typeof import('../hooks/use-nearby-stop-times').useNearbyStopTimes
+>;
+type GetServiceDayMinutes = typeof import('../domain/transit/service-day').getServiceDayMinutes;
+
+const {
+  mockToastError,
+  mockUseAnchors,
+  mockGetRouteShapes,
+  mockClearAnchorError,
+  mockGetServiceDayMinutes,
+  mockUseDateTime,
+  mockUseNearbyStopTimes,
+  mockMapBottomSheetLayout,
+} = vi.hoisted(() => ({
+  mockToastError: vi.fn(),
+  mockUseAnchors: vi.fn<(...args: unknown[]) => UseAnchorsReturn>(),
+  mockGetRouteShapes: vi.fn(),
+  mockClearAnchorError: vi.fn(),
+  mockGetServiceDayMinutes: vi.fn<GetServiceDayMinutes>(),
+  mockUseDateTime: vi.fn<() => UseDateTimeReturn>(),
+  mockUseNearbyStopTimes: vi.fn<() => UseNearbyStopTimesReturn>(),
+  mockMapBottomSheetLayout: vi.fn(),
+}));
 
 vi.mock('sonner', () => ({
   toast: {
@@ -47,19 +65,19 @@ vi.mock('../hooks/use-user-settings', () => ({
 }));
 
 vi.mock('../hooks/use-date-time', () => ({
-  useDateTime: () => ({
-    dateTime: new Date('2026-03-28T12:00:00Z'),
-    isCustomTime: false,
-    resetToNow: vi.fn(),
-    setCustomTime: vi.fn(),
-  }),
+  useDateTime: () => mockUseDateTime(),
 }));
 
+vi.mock('../domain/transit/service-day', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../domain/transit/service-day')>();
+  return {
+    ...actual,
+    getServiceDayMinutes: (dateTime: Date) => mockGetServiceDayMinutes(dateTime),
+  };
+});
+
 vi.mock('../hooks/use-nearby-stop-times', () => ({
-  useNearbyStopTimes: () => ({
-    stopTimes: [],
-    isNearbyLoading: false,
-  }),
+  useNearbyStopTimes: () => mockUseNearbyStopTimes(),
 }));
 
 vi.mock('../hooks/use-selection', () => ({
@@ -99,6 +117,13 @@ vi.mock('../components/map/map-view', () => ({
   MapView: () => null,
 }));
 
+vi.mock('../components/map-bottom-sheet-layout', () => ({
+  MapBottomSheetLayout: (props: unknown) => {
+    mockMapBottomSheetLayout(props);
+    return null;
+  },
+}));
+
 vi.mock('../components/bottom-sheet', () => ({
   BottomSheet: () => null,
 }));
@@ -120,6 +145,78 @@ vi.mock('../components/dialog/info-dialog', () => ({
 }));
 
 describe('App anchor error toast', () => {
+  const makeEntry = (
+    overrides: { isOrigin?: boolean; isTerminal?: boolean; pickupType?: 0 | 1 | 2 | 3 } = {},
+  ): ContextualTimetableEntry =>
+    ({
+      schedule: { departureMinutes: 480, arrivalMinutes: 480 },
+      routeDirection: {
+        route: {
+          route_id: 'route-1',
+          route_type: 3,
+          agency_id: 'agency-1',
+          route_short_name: '1',
+          route_short_names: {},
+          route_long_name: 'Route 1',
+          route_long_names: {},
+          route_color: '000000',
+          route_text_color: 'FFFFFF',
+        },
+        tripHeadsign: { name: 'Terminal', names: {} },
+      },
+      boarding: { pickupType: overrides.pickupType ?? 0, dropOffType: 0 },
+      patternPosition: {
+        stopIndex: 0,
+        totalStops: 3,
+        isOrigin: overrides.isOrigin ?? false,
+        isTerminal: overrides.isTerminal ?? false,
+      },
+      tripLocator: { patternId: 'pattern-1', serviceId: 'svc-1', tripIndex: 0 },
+      serviceDate: new Date('2026-03-28T00:00:00Z'),
+    }) as ContextualTimetableEntry;
+
+  const makeNearbyStop = (
+    stopId: string,
+    entries: ContextualTimetableEntry[],
+    stopServiceState: StopWithContext['stopServiceState'] = 'boardable',
+  ): StopWithContext =>
+    ({
+      stop: {
+        stop_id: stopId,
+        stop_name: stopId,
+        stop_names: {},
+        stop_lat: 0,
+        stop_lon: 0,
+        location_type: 0,
+        agency_id: 'agency-1',
+      },
+      agencies: [],
+      routes: [],
+      routeTypes: [3],
+      stopTimes: entries,
+      stopServiceState,
+    }) as StopWithContext;
+
+  const getLastLayoutProps = () => {
+    const lastCall = mockMapBottomSheetLayout.mock.lastCall;
+    expect(lastCall).toBeTruthy();
+    return lastCall?.[0] as {
+      globalFilter: {
+        omitEmptyStops: boolean;
+        isOmitEmptyStopsForced: boolean;
+        onToggleShowOriginOnly: () => void;
+        onToggleShowBoardableOnly: () => void;
+        onToggleOmitEmptyStops: () => void;
+      };
+      filteredNearbyStopsCounts: {
+        total: number;
+        nonEmpty: number;
+        originCount: number;
+        boardableCount: number;
+      };
+    };
+  };
+
   beforeEach(async () => {
     // Fix i18n language to 'ja' so toast message assertions are deterministic.
     await i18n.changeLanguage('ja');
@@ -127,8 +224,33 @@ describe('App anchor error toast', () => {
     mockUseAnchors.mockReset();
     mockGetRouteShapes.mockReset();
     mockClearAnchorError.mockReset();
+    mockGetServiceDayMinutes.mockReset();
+    mockUseDateTime.mockReset();
+    mockUseNearbyStopTimes.mockReset();
+    mockMapBottomSheetLayout.mockReset();
 
     mockGetRouteShapes.mockResolvedValue({ success: true, data: [] });
+    mockUseAnchors.mockReturnValue({
+      anchors: [],
+      lastError: null,
+      clearError: mockClearAnchorError,
+      addStop: vi.fn(),
+      removeStop: vi.fn(),
+      updateStop: vi.fn(),
+      batchUpdateStops: vi.fn(),
+      isStopAnchor: vi.fn(() => false),
+    });
+    mockUseDateTime.mockReturnValue({
+      dateTime: new Date('2026-03-28T12:00:00Z'),
+      isCustomTime: false,
+      resetToNow: vi.fn(),
+      setCustomTime: vi.fn(),
+    });
+    mockGetServiceDayMinutes.mockReturnValue(12 * 60);
+    mockUseNearbyStopTimes.mockReturnValue({
+      stopTimes: [],
+      isNearbyLoading: false,
+    });
   });
 
   it('does not show toast when lastError is null', async () => {
@@ -172,6 +294,78 @@ describe('App anchor error toast', () => {
         duration: 4500,
       });
       expect(mockClearAnchorError).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('forces omitEmptyStops on for origin filter and keeps toggleOmitEmptyStops as a no-op while forced', async () => {
+    mockUseNearbyStopTimes.mockReturnValue({
+      stopTimes: [
+        makeNearbyStop('origin-stop', [makeEntry({ isOrigin: true })]),
+        makeNearbyStop('middle-stop', [makeEntry({ isOrigin: false })]),
+      ],
+      isNearbyLoading: false,
+    });
+
+    render(<App loadResult={{ loaded: [], failed: [] }} />);
+
+    await waitFor(() => {
+      const props = getLastLayoutProps();
+      expect(props.globalFilter.omitEmptyStops).toBe(false);
+      expect(props.globalFilter.isOmitEmptyStopsForced).toBe(false);
+      expect(props.filteredNearbyStopsCounts.total).toBe(2);
+    });
+
+    act(() => {
+      getLastLayoutProps().globalFilter.onToggleShowOriginOnly();
+    });
+
+    await waitFor(() => {
+      const props = getLastLayoutProps();
+      expect(props.globalFilter.omitEmptyStops).toBe(true);
+      expect(props.globalFilter.isOmitEmptyStopsForced).toBe(true);
+      expect(props.filteredNearbyStopsCounts.total).toBe(1);
+    });
+
+    act(() => {
+      getLastLayoutProps().globalFilter.onToggleOmitEmptyStops();
+    });
+
+    await waitFor(() => {
+      const props = getLastLayoutProps();
+      expect(props.globalFilter.omitEmptyStops).toBe(true);
+      expect(props.globalFilter.isOmitEmptyStopsForced).toBe(true);
+      expect(props.filteredNearbyStopsCounts.total).toBe(1);
+    });
+  });
+
+  it('auto-enables omitEmptyStops late at night and allows manual override off when not forced', async () => {
+    mockGetServiceDayMinutes.mockReturnValue(22 * 60 + 30);
+    mockUseNearbyStopTimes.mockReturnValue({
+      stopTimes: [
+        makeNearbyStop('active-stop', [makeEntry()]),
+        makeNearbyStop('ended-stop', [], 'no-service'),
+      ],
+      isNearbyLoading: false,
+    });
+
+    render(<App loadResult={{ loaded: [], failed: [] }} />);
+
+    await waitFor(() => {
+      const props = getLastLayoutProps();
+      expect(props.globalFilter.omitEmptyStops).toBe(true);
+      expect(props.globalFilter.isOmitEmptyStopsForced).toBe(false);
+      expect(props.filteredNearbyStopsCounts.total).toBe(1);
+    });
+
+    act(() => {
+      getLastLayoutProps().globalFilter.onToggleOmitEmptyStops();
+    });
+
+    await waitFor(() => {
+      const props = getLastLayoutProps();
+      expect(props.globalFilter.omitEmptyStops).toBe(false);
+      expect(props.globalFilter.isOmitEmptyStopsForced).toBe(false);
+      expect(props.filteredNearbyStopsCounts.total).toBe(2);
     });
   });
 });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -723,7 +723,7 @@ export default function App({ loadResult }: AppProps) {
     ],
   );
 
-  logger.debug('GlobalFilter', globalFilter);
+  // logger.debug('GlobalFilter', globalFilter);
 
   // --- Settings handlers ---
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -723,7 +723,7 @@ export default function App({ loadResult }: AppProps) {
     ],
   );
 
-  console.debug('GlobalFilter', globalFilter);
+  logger.debug('GlobalFilter', globalFilter);
 
   // --- Settings handlers ---
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -19,9 +19,10 @@ import { computeStopsCounts } from './domain/transit/compute-stops-counts';
 import { getStopDisplayNames } from './domain/transit/get-stop-display-names';
 import { resolveLangChain, type LangChain } from './domain/transit/i18n/resolve-lang-chain';
 import { resolveStopRouteTypes } from './domain/transit/resolve-stop-route-types';
-import { getServiceDay } from './domain/transit/service-day';
+import { getServiceDay, getServiceDayMinutes } from './domain/transit/service-day';
 import {
-  applyStopEventAttributeToggles,
+  applyStopEventAttributeTogglesToStops,
+  omitStopsWithoutStopTimes,
   prepareRouteHeadsignTimetable,
   prepareStopTimetable,
 } from './domain/transit/timetable-filter';
@@ -59,6 +60,7 @@ import {
 
 const logger = createLogger('App');
 const DEBOUNCE_MS = 300;
+const LATE_NIGHT_THRESHOLD_MINUTES = 22 * 60;
 
 interface AppProps {
   /**
@@ -679,6 +681,9 @@ export default function App({ loadResult }: AppProps) {
   // it given its own data shape.
   const [showOriginOnly, setShowOriginOnly] = useState(false);
   const [showBoardableOnly, setShowBoardableOnly] = useState(false);
+  const isLateNight = getServiceDayMinutes(dateTime) >= LATE_NIGHT_THRESHOLD_MINUTES;
+  const [omitEmptyStopsOverride, setOmitEmptyStopsOverride] = useState<boolean | null>(null);
+  const omitEmptyStops = omitEmptyStopsOverride ?? isLateNight;
 
   const toggleShowOriginOnly = useCallback(() => {
     setShowOriginOnly((prev) => !prev);
@@ -686,6 +691,9 @@ export default function App({ loadResult }: AppProps) {
   const toggleShowBoardableOnly = useCallback(() => {
     setShowBoardableOnly((prev) => !prev);
   }, []);
+  const toggleOmitEmptyStops = useCallback(() => {
+    setOmitEmptyStopsOverride((prev) => !(prev ?? isLateNight));
+  }, [isLateNight]);
 
   // Bundle the app-wide filter state + toggle handlers into a single
   // memoized object so consumers (BottomSheet / TimetableModal /
@@ -694,11 +702,22 @@ export default function App({ loadResult }: AppProps) {
     () => ({
       showOriginOnly,
       showBoardableOnly,
+      omitEmptyStops,
       onToggleShowOriginOnly: toggleShowOriginOnly,
       onToggleShowBoardableOnly: toggleShowBoardableOnly,
+      onToggleOmitEmptyStops: toggleOmitEmptyStops,
     }),
-    [showOriginOnly, showBoardableOnly, toggleShowOriginOnly, toggleShowBoardableOnly],
+    [
+      showOriginOnly,
+      showBoardableOnly,
+      omitEmptyStops,
+      toggleShowOriginOnly,
+      toggleShowBoardableOnly,
+      toggleOmitEmptyStops,
+    ],
   );
+
+  console.debug('GlobalFilter', globalFilter);
 
   // --- Settings handlers ---
 
@@ -713,24 +732,27 @@ export default function App({ loadResult }: AppProps) {
   );
 
   // Apply origin / boardable filter (= app-wide `globalFilter` toggles)
-  // per-stop and drop stops whose entries become empty. The result is
-  // the stop list that BottomSheet (and forthcoming MapView etc.)
-  // should render; computing it here keeps the same filter outcome
-  // available to multiple surfaces from one place.
-  const stopEventAttributesFilteredNearbyStopTimes = useMemo(() => {
-    if (!showOriginOnly && !showBoardableOnly) {
-      return routeTypesFilteredNearbyStopTimes;
-    }
-    return routeTypesFilteredNearbyStopTimes
-      .map((swc) => {
-        const filtered = applyStopEventAttributeToggles(swc.stopTimes, {
-          showOriginOnly,
-          showBoardableOnly,
-        });
-        return filtered === swc.stopTimes ? swc : { ...swc, stopTimes: filtered };
-      })
-      .filter((swc) => swc.stopTimes.length > 0);
-  }, [routeTypesFilteredNearbyStopTimes, showOriginOnly, showBoardableOnly]);
+  // per-stop while preserving the outer stop list. Empty-stop omission
+  // happens in the next memo so the two responsibilities stay distinct.
+  const stopEventAttributesAppliedNearbyStopTimes = useMemo(
+    () =>
+      applyStopEventAttributeTogglesToStops(routeTypesFilteredNearbyStopTimes, {
+        showOriginOnly,
+        showBoardableOnly,
+      }),
+    [routeTypesFilteredNearbyStopTimes, showOriginOnly, showBoardableOnly],
+  );
+
+  // Apply the app-wide empty-stop visibility policy on top of the
+  // entry-level filter result. When omitted, only non-empty stops are
+  // rendered; when disabled, empty stops remain visible for placeholder UI.
+  const stopEventAttributesNonEmptyNearbyStopTimes = useMemo(
+    () =>
+      omitEmptyStops
+        ? omitStopsWithoutStopTimes(stopEventAttributesAppliedNearbyStopTimes)
+        : stopEventAttributesAppliedNearbyStopTimes,
+    [stopEventAttributesAppliedNearbyStopTimes, omitEmptyStops],
+  );
 
   // Per-stop pre-`globalFilter` `TimetableEntriesState` map. The base
   // is intentionally `routeTypesFilteredNearbyStopTimes` (= settings
@@ -754,8 +776,8 @@ export default function App({ loadResult }: AppProps) {
   );
 
   const filteredNearbyStopsCounts: StopsCounts = useMemo(
-    () => computeStopsCounts(stopEventAttributesFilteredNearbyStopTimes),
-    [stopEventAttributesFilteredNearbyStopTimes],
+    () => computeStopsCounts(stopEventAttributesNonEmptyNearbyStopTimes),
+    [stopEventAttributesNonEmptyNearbyStopTimes],
   );
 
   const handleToggleStopType = useCallback(
@@ -880,7 +902,7 @@ export default function App({ loadResult }: AppProps) {
           radiusStops,
           selectedStopId,
           focusPosition,
-          stopTimes: stopEventAttributesFilteredNearbyStopTimes,
+          stopTimes: stopEventAttributesNonEmptyNearbyStopTimes,
           routeTypeMap,
           routeShapes,
           selectionInfo,
@@ -919,7 +941,7 @@ export default function App({ loadResult }: AppProps) {
           lookupAnchorStopMeta,
         }}
         bottomSheetProps={{
-          stopTimes: stopEventAttributesFilteredNearbyStopTimes,
+          stopTimes: stopEventAttributesNonEmptyNearbyStopTimes,
           timetableEntriesStateByStopId,
           selectedStopId,
           isNearbyLoading,

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -57,7 +57,6 @@ import {
   nextRenderMode,
   nextTileIndex,
 } from './utils/settings-cycle';
-
 const logger = createLogger('App');
 const DEBOUNCE_MS = 300;
 const LATE_NIGHT_THRESHOLD_MINUTES = 22 * 60;
@@ -684,6 +683,8 @@ export default function App({ loadResult }: AppProps) {
   const isLateNight = getServiceDayMinutes(dateTime) >= LATE_NIGHT_THRESHOLD_MINUTES;
   const [omitEmptyStopsOverride, setOmitEmptyStopsOverride] = useState<boolean | null>(null);
   const omitEmptyStops = omitEmptyStopsOverride ?? isLateNight;
+  const isOmitEmptyStopsForced = showOriginOnly || showBoardableOnly;
+  const effectiveOmitEmptyStops = omitEmptyStops || isOmitEmptyStopsForced;
 
   const toggleShowOriginOnly = useCallback(() => {
     setShowOriginOnly((prev) => !prev);
@@ -692,8 +693,11 @@ export default function App({ loadResult }: AppProps) {
     setShowBoardableOnly((prev) => !prev);
   }, []);
   const toggleOmitEmptyStops = useCallback(() => {
+    if (isOmitEmptyStopsForced) {
+      return;
+    }
     setOmitEmptyStopsOverride((prev) => !(prev ?? isLateNight));
-  }, [isLateNight]);
+  }, [isLateNight, isOmitEmptyStopsForced]);
 
   // Bundle the app-wide filter state + toggle handlers into a single
   // memoized object so consumers (BottomSheet / TimetableModal /
@@ -702,7 +706,8 @@ export default function App({ loadResult }: AppProps) {
     () => ({
       showOriginOnly,
       showBoardableOnly,
-      omitEmptyStops,
+      omitEmptyStops: effectiveOmitEmptyStops,
+      isOmitEmptyStopsForced,
       onToggleShowOriginOnly: toggleShowOriginOnly,
       onToggleShowBoardableOnly: toggleShowBoardableOnly,
       onToggleOmitEmptyStops: toggleOmitEmptyStops,
@@ -710,7 +715,8 @@ export default function App({ loadResult }: AppProps) {
     [
       showOriginOnly,
       showBoardableOnly,
-      omitEmptyStops,
+      effectiveOmitEmptyStops,
+      isOmitEmptyStopsForced,
       toggleShowOriginOnly,
       toggleShowBoardableOnly,
       toggleOmitEmptyStops,
@@ -746,13 +752,11 @@ export default function App({ loadResult }: AppProps) {
   // Apply the app-wide empty-stop visibility policy on top of the
   // entry-level filter result. When omitted, only non-empty stops are
   // rendered; when disabled, empty stops remain visible for placeholder UI.
-  const stopEventAttributesNonEmptyNearbyStopTimes = useMemo(
-    () =>
-      omitEmptyStops
-        ? omitStopsWithoutStopTimes(stopEventAttributesAppliedNearbyStopTimes)
-        : stopEventAttributesAppliedNearbyStopTimes,
-    [stopEventAttributesAppliedNearbyStopTimes, omitEmptyStops],
-  );
+  const stopEventAttributesNonEmptyNearbyStopTimes = useMemo(() => {
+    return effectiveOmitEmptyStops
+      ? omitStopsWithoutStopTimes(stopEventAttributesAppliedNearbyStopTimes)
+      : stopEventAttributesAppliedNearbyStopTimes;
+  }, [effectiveOmitEmptyStops, stopEventAttributesAppliedNearbyStopTimes]);
 
   // Per-stop pre-`globalFilter` `TimetableEntriesState` map. The base
   // is intentionally `routeTypesFilteredNearbyStopTimes` (= settings

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -15,6 +15,7 @@ import { TILE_SOURCES } from './config/tile-sources';
 import { DEFAULT_TIMEZONE, resolveAgencyLang } from './config/transit-defaults';
 import { buildAnchorRefreshUpdates, type AnchorEntry } from './domain/portal/anchor';
 import { formatDateKey } from './domain/transit/calendar-utils';
+import { computeStopsCounts } from './domain/transit/compute-stops-counts';
 import { getStopDisplayNames } from './domain/transit/get-stop-display-names';
 import { resolveLangChain, type LangChain } from './domain/transit/i18n/resolve-lang-chain';
 import { resolveStopRouteTypes } from './domain/transit/resolve-stop-route-types';
@@ -41,6 +42,7 @@ import { getStopParam } from './lib/query-params';
 import type { LoadResult } from './repositories/athenai-repository';
 import { LocalStorageUserDataRepository } from './repositories/local-storage-user-data-repository';
 import type { Bounds, LatLng, RouteShape } from './types/app/map';
+import type { StopsCounts } from './types/app/stop';
 import type { AppRouteTypeValue, Stop, TimetableEntriesState } from './types/app/transit';
 import type { StopWithContext, StopWithMeta } from './types/app/transit-composed';
 import { formatDateParts } from './utils/datetime';
@@ -746,6 +748,16 @@ export default function App({ loadResult }: AppProps) {
     return map;
   }, [routeTypesFilteredNearbyStopTimes]);
 
+  const nearbyStopsCounts: StopsCounts = useMemo(
+    () => computeStopsCounts(routeTypesFilteredNearbyStopTimes),
+    [routeTypesFilteredNearbyStopTimes],
+  );
+
+  const filteredNearbyStopsCounts: StopsCounts = useMemo(
+    () => computeStopsCounts(stopEventAttributesFilteredNearbyStopTimes),
+    [stopEventAttributesFilteredNearbyStopTimes],
+  );
+
   const handleToggleStopType = useCallback(
     (rt: number) => {
       updateSetting(
@@ -925,6 +937,8 @@ export default function App({ loadResult }: AppProps) {
           onInspectTrip: openTripInspection,
         }}
         globalFilter={globalFilter}
+        nearbyStopsCounts={nearbyStopsCounts}
+        filteredNearbyStopsCounts={filteredNearbyStopsCounts}
         mapOverlay={
           <TimeControls
             time={dateTime}

--- a/src/components/bottom-sheet-header.stories.tsx
+++ b/src/components/bottom-sheet-header.stories.tsx
@@ -53,6 +53,7 @@ const meta = {
     dataConfig: defaultDataConfig,
     dataLangs: ['ja'],
     omitEmptyStops: false,
+    isOmitEmptyStopsForced: false,
     showOriginOnly: false,
     showBoardableOnly: false,
     viewId: DEFAULT_VIEW_ID,
@@ -72,6 +73,7 @@ const meta = {
   argTypes: {
     infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
     omitEmptyStops: { control: 'boolean' },
+    isOmitEmptyStopsForced: { control: 'boolean' },
     showOriginOnly: { control: 'boolean' },
     showBoardableOnly: { control: 'boolean' },
     hasNearbyLoaded: { control: 'boolean' },

--- a/src/components/bottom-sheet-header.stories.tsx
+++ b/src/components/bottom-sheet-header.stories.tsx
@@ -27,6 +27,8 @@ import { BottomSheetHeader } from './bottom-sheet-header';
 const defaultDataConfig = PERF_PROFILES.normal.data;
 const selectView = (id: string) => STOP_TIMES_VIEWS.find((v) => v.id === id);
 const defaultSelectedView = selectView(DEFAULT_VIEW_ID);
+const defaultCounts = { total: 12, active: 7, originCount: 3, boardableCount: 5 };
+const defaultFilteredNearbyStopsCounts = { total: 7, active: 7, originCount: 3, boardableCount: 5 };
 
 /** All route type values defined in APP_ROUTE_TYPES except the `-1` unknown placeholder. */
 const ALL_PRESENT_ROUTE_TYPES: readonly number[] = APP_ROUTE_TYPES.map((rt) => rt.value).filter(
@@ -40,7 +42,9 @@ const meta = {
   component: BottomSheetHeader,
   args: {
     hasNearbyLoaded: true,
-    counts: { total: 12, active: 7, filtered: 7, originCount: 3, boardableCount: 5 },
+    counts: defaultCounts,
+    nearbyStopsCounts: defaultCounts,
+    filteredNearbyStopsCounts: defaultFilteredNearbyStopsCounts,
     dataConfig: defaultDataConfig,
     dataLangs: ['ja'],
     showOperatingStopsOnly: false,
@@ -86,13 +90,17 @@ export const Default: Story = {};
 export const Loading: Story = {
   args: {
     hasNearbyLoaded: false,
-    counts: { total: 0, active: 0, filtered: 0, originCount: 0, boardableCount: 0 },
+    counts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
+    nearbyStopsCounts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
+    filteredNearbyStopsCounts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
   },
 };
 
 export const NoStops: Story = {
   args: {
-    counts: { total: 0, active: 0, filtered: 0, originCount: 0, boardableCount: 0 },
+    counts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
+    nearbyStopsCounts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
+    filteredNearbyStopsCounts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
     presentRouteTypes: [],
     presentAgencies: [],
   },
@@ -100,7 +108,9 @@ export const NoStops: Story = {
 
 export const NoOperatingStops: Story = {
   args: {
-    counts: { total: 8, active: 0, filtered: 0, originCount: 0, boardableCount: 0 },
+    counts: { total: 8, active: 0, originCount: 0, boardableCount: 0 },
+    nearbyStopsCounts: { total: 8, active: 0, originCount: 0, boardableCount: 0 },
+    filteredNearbyStopsCounts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
     showOperatingStopsOnly: true,
     presentRouteTypes: [3],
     presentAgencies: [agencyTobus],
@@ -109,7 +119,9 @@ export const NoOperatingStops: Story = {
 
 export const OperatingOnlyActive: Story = {
   args: {
-    counts: { total: 15, active: 9, filtered: 9, originCount: 4, boardableCount: 7 },
+    counts: { total: 15, active: 9, originCount: 4, boardableCount: 7 },
+    nearbyStopsCounts: { total: 15, active: 9, originCount: 4, boardableCount: 7 },
+    filteredNearbyStopsCounts: { total: 9, active: 9, originCount: 4, boardableCount: 7 },
     showOperatingStopsOnly: true,
   },
 };

--- a/src/components/bottom-sheet-header.stories.tsx
+++ b/src/components/bottom-sheet-header.stories.tsx
@@ -133,6 +133,23 @@ export const OperatingOnlyActive: Story = {
   },
 };
 
+export const OriginFilterHidden: Story = {
+  args: {
+    counts: { total: 12, nonEmpty: 7, originCount: 0, boardableCount: 5 },
+    nearbyStopsCounts: { total: 12, nonEmpty: 7, originCount: 0, boardableCount: 5 },
+    filteredNearbyStopsCounts: { total: 7, nonEmpty: 7, originCount: 0, boardableCount: 5 },
+  },
+};
+
+export const OriginFilterActiveWithoutNearbyOrigins: Story = {
+  args: {
+    counts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    nearbyStopsCounts: { total: 12, nonEmpty: 7, originCount: 0, boardableCount: 5 },
+    filteredNearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    showOriginOnly: true,
+  },
+};
+
 // --- Route type filters ---
 
 export const SingleRouteType: Story = {

--- a/src/components/bottom-sheet-header.stories.tsx
+++ b/src/components/bottom-sheet-header.stories.tsx
@@ -27,8 +27,13 @@ import { BottomSheetHeader } from './bottom-sheet-header';
 const defaultDataConfig = PERF_PROFILES.normal.data;
 const selectView = (id: string) => STOP_TIMES_VIEWS.find((v) => v.id === id);
 const defaultSelectedView = selectView(DEFAULT_VIEW_ID);
-const defaultCounts = { total: 12, active: 7, originCount: 3, boardableCount: 5 };
-const defaultFilteredNearbyStopsCounts = { total: 7, active: 7, originCount: 3, boardableCount: 5 };
+const defaultCounts = { total: 12, nonEmpty: 7, originCount: 3, boardableCount: 5 };
+const defaultFilteredNearbyStopsCounts = {
+  total: 7,
+  nonEmpty: 7,
+  originCount: 3,
+  boardableCount: 5,
+};
 
 /** All route type values defined in APP_ROUTE_TYPES except the `-1` unknown placeholder. */
 const ALL_PRESENT_ROUTE_TYPES: readonly number[] = APP_ROUTE_TYPES.map((rt) => rt.value).filter(
@@ -47,7 +52,7 @@ const meta = {
     filteredNearbyStopsCounts: defaultFilteredNearbyStopsCounts,
     dataConfig: defaultDataConfig,
     dataLangs: ['ja'],
-    showOperatingStopsOnly: false,
+    omitEmptyStops: false,
     showOriginOnly: false,
     showBoardableOnly: false,
     viewId: DEFAULT_VIEW_ID,
@@ -57,7 +62,7 @@ const meta = {
     hiddenRouteTypes: new Set<number>(),
     presentAgencies: [agencyTobus],
     hiddenAgencyIds: new Set<string>(),
-    onToggleShowOperatingStopsOnly: fn(),
+    onToggleOmitEmptyStops: fn(),
     onToggleShowOriginOnly: fn(),
     onToggleShowBoardableOnly: fn(),
     onViewChange: fn(),
@@ -66,7 +71,7 @@ const meta = {
   },
   argTypes: {
     infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
-    showOperatingStopsOnly: { control: 'boolean' },
+    omitEmptyStops: { control: 'boolean' },
     showOriginOnly: { control: 'boolean' },
     showBoardableOnly: { control: 'boolean' },
     hasNearbyLoaded: { control: 'boolean' },
@@ -90,17 +95,17 @@ export const Default: Story = {};
 export const Loading: Story = {
   args: {
     hasNearbyLoaded: false,
-    counts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
-    nearbyStopsCounts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
-    filteredNearbyStopsCounts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
+    counts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    nearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    filteredNearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
   },
 };
 
 export const NoStops: Story = {
   args: {
-    counts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
-    nearbyStopsCounts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
-    filteredNearbyStopsCounts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
+    counts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    nearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    filteredNearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
     presentRouteTypes: [],
     presentAgencies: [],
   },
@@ -108,10 +113,10 @@ export const NoStops: Story = {
 
 export const NoOperatingStops: Story = {
   args: {
-    counts: { total: 8, active: 0, originCount: 0, boardableCount: 0 },
-    nearbyStopsCounts: { total: 8, active: 0, originCount: 0, boardableCount: 0 },
-    filteredNearbyStopsCounts: { total: 0, active: 0, originCount: 0, boardableCount: 0 },
-    showOperatingStopsOnly: true,
+    counts: { total: 8, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    nearbyStopsCounts: { total: 8, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    filteredNearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    omitEmptyStops: true,
     presentRouteTypes: [3],
     presentAgencies: [agencyTobus],
   },
@@ -119,10 +124,10 @@ export const NoOperatingStops: Story = {
 
 export const OperatingOnlyActive: Story = {
   args: {
-    counts: { total: 15, active: 9, originCount: 4, boardableCount: 7 },
-    nearbyStopsCounts: { total: 15, active: 9, originCount: 4, boardableCount: 7 },
-    filteredNearbyStopsCounts: { total: 9, active: 9, originCount: 4, boardableCount: 7 },
-    showOperatingStopsOnly: true,
+    counts: { total: 15, nonEmpty: 9, originCount: 4, boardableCount: 7 },
+    nearbyStopsCounts: { total: 15, nonEmpty: 9, originCount: 4, boardableCount: 7 },
+    filteredNearbyStopsCounts: { total: 9, nonEmpty: 9, originCount: 4, boardableCount: 7 },
+    omitEmptyStops: true,
   },
 };
 
@@ -259,10 +264,12 @@ export const InfoLevelVerbose: Story = {
 
 const kitchenSinkArgs = {
   hasNearbyLoaded: true,
-  counts: { total: 42, active: 28, filtered: 21, originCount: 6, boardableCount: 15 },
+  counts: { total: 42, nonEmpty: 28, originCount: 6, boardableCount: 15 },
+  nearbyStopsCounts: { total: 42, nonEmpty: 28, originCount: 6, boardableCount: 15 },
+  filteredNearbyStopsCounts: { total: 21, nonEmpty: 21, originCount: 6, boardableCount: 15 },
   dataConfig: defaultDataConfig,
   dataLangs: ['ja'],
-  showOperatingStopsOnly: true,
+  omitEmptyStops: true,
   viewId: 'route-headsign',
   selectedView: selectView('route-headsign'),
   presentRouteTypes: ALL_PRESENT_ROUTE_TYPES,

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -270,7 +270,7 @@ function formatStopsCountsDebugLog(counts: StopsCounts): string {
 
 const summaryLogger = createLogger('NearbyStopsSummary');
 
-interface NearbyStopsSummaryProps {
+interface StopsSummaryProps {
   label: string;
   totalCount: StopsCounts;
   filteredCount: number;
@@ -288,7 +288,7 @@ function StopsSummary({
   omitEmptyStops,
   hasLoaded,
   infoLevel,
-}: NearbyStopsSummaryProps) {
+}: StopsSummaryProps) {
   const { t, i18n } = useTranslation();
 
   summaryLogger.debug(

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -11,7 +11,7 @@ import { createLogger } from '../lib/logger';
 import { routeTypeColor } from '../utils/route-type-color';
 import { routeTypeEmoji } from '../utils/route-type-emoji';
 import { useInfoLevel } from '../hooks/use-info-level';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PillButton } from './button/pill-button';
 import { BoardabilityFilter } from './filter/boardability-filter';
@@ -53,7 +53,6 @@ interface BottomSheetHeaderProps {
 }
 
 const logger = createLogger('BottomSheetHeader');
-let lastBottomSheetHeaderDebugSnapshot: string | undefined;
 
 export function BottomSheetHeader({
   hasNearbyLoaded,
@@ -90,22 +89,27 @@ export function BottomSheetHeader({
   const nearbyStopsCountsDebugLog = formatStopsCountsDebugLog(nearbyStopsCounts);
   const filteredNearbyStopsCountsDebugLog = formatStopsCountsDebugLog(filteredNearbyStopsCounts);
   const countsDebugLog = formatStopsCountsDebugLog(counts);
+  const lastDebugSnapshotRef = useRef<string | undefined>(undefined);
 
   // const countsForFilterLabel = counts;
   const countsForFilterLabel = filteredNearbyStopsCounts;
 
   useEffect(() => {
+    if (!import.meta.env.DEV) {
+      return;
+    }
+
     const snapshot = [
       `[nearbyStopsCounts] ${nearbyStopsCountsDebugLog}`,
       `[filteredNearbyStopsCounts] ${filteredNearbyStopsCountsDebugLog}`,
       `[counts] ${countsDebugLog}`,
     ].join(' | ');
 
-    if (snapshot === lastBottomSheetHeaderDebugSnapshot) {
+    if (snapshot === lastDebugSnapshotRef.current) {
       return;
     }
 
-    lastBottomSheetHeaderDebugSnapshot = snapshot;
+    lastDebugSnapshotRef.current = snapshot;
     logger.debug(snapshot);
   }, [countsDebugLog, filteredNearbyStopsCountsDebugLog, nearbyStopsCountsDebugLog]);
 

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { PillButton } from './button/pill-button';
 import { BoardabilityFilter } from './filter/boardability-filter';
 import { OriginFilter } from './filter/origin-filter';
+import { LabelCountBadge } from './badge/label-count-badge';
 
 interface BottomSheetHeaderProps {
   hasNearbyLoaded: boolean;
@@ -53,7 +54,7 @@ interface BottomSheetHeaderProps {
 export function BottomSheetHeader({
   hasNearbyLoaded,
   nearbyStopsCounts,
-  filteredNearbyStopsCounts,
+  filteredNearbyStopsCounts: _filteredNearbyStopsCounts,
   counts,
   dataConfig,
   dataLangs,
@@ -84,28 +85,13 @@ export function BottomSheetHeader({
   return (
     <div className="shrink-0 px-4 pb-2">
       <StopsSummary
-        label={'nearbyStops -> filterd nearbyStops'}
-        hasLoaded={hasNearbyLoaded}
-        totalCount={nearbyStopsCounts}
-        filteredCount={counts.total}
-        nearbyRadius={dataConfig.stops.nearbyRadius}
-        omitEmptyStops={omitEmptyStops}
-      />
-      <StopsSummary
-        label={'filterd nearbyStops -> operating stops only'}
-        hasLoaded={hasNearbyLoaded}
-        totalCount={nearbyStopsCounts}
-        filteredCount={filteredNearbyStopsCounts.total}
-        nearbyRadius={dataConfig.stops.nearbyRadius}
-        omitEmptyStops={omitEmptyStops}
-      />
-      <StopsSummary
         label={'operating stops only'}
         hasLoaded={hasNearbyLoaded}
         totalCount={nearbyStopsCounts}
         filteredCount={counts.total}
         nearbyRadius={dataConfig.stops.nearbyRadius}
         omitEmptyStops={omitEmptyStops}
+        infoLevel={infoLevel}
       />
 
       <div className="no-scrollbar mt-1.5 flex gap-1 overflow-x-auto">
@@ -154,38 +140,6 @@ export function BottomSheetHeader({
           origin={showOriginOnly}
           onToggleOrigin={onToggleShowOriginOnly}
           count={counts.originCount}
-        />
-        {/* )} */}
-
-        {/* Operating stops filter */}
-        <PillButton
-          size={'sm'}
-          active={omitEmptyStops}
-          disabled={isOmitEmptyStopsForced}
-          activeBg={'var(--info)'}
-          activeBorder={'var(--info)'}
-          inactiveBorder={'var(--info)'}
-          onClick={onToggleOmitEmptyStops}
-          title={t('nearbyStops.showOperatingStopsOnlyTitle')}
-          count={nearbyStopsCounts.nonEmpty}
-        >
-          {t('nearbyStops.showOperatingStopsOnly')}
-        </PillButton>
-
-        {/* Boardable filter (entry-level: pickup_type === 0) */}
-        {/* {(showBoardableOnly || nearbyStopsCounts.boardableCount > 0) && ( */}
-        <BoardabilityFilter
-          boardable={showBoardableOnly}
-          onToggleBoardable={onToggleShowBoardableOnly}
-          count={nearbyStopsCounts.boardableCount}
-        />
-        {/* )} */}
-
-        {/* {(showOriginOnly || nearbyStopsCounts.originCount > 0) && ( */}
-        <OriginFilter
-          origin={showOriginOnly}
-          onToggleOrigin={onToggleShowOriginOnly}
-          count={nearbyStopsCounts.originCount}
         />
         {/* )} */}
 
@@ -256,6 +210,7 @@ function getNearbyStopsSummaryText(
   totalCounts: StopsCounts,
   filteredCount: number,
   omitEmptyStops: boolean,
+  _infoLevel: InfoLevel,
   radius: string,
   lang: string,
   t: (key: string, options?: Record<string, unknown>) => string,
@@ -263,9 +218,10 @@ function getNearbyStopsSummaryText(
   if (!hasLoaded) {
     return t('common.loading');
   }
+
   if (filteredCount > 0) {
     return t('nearbyStops.summary', {
-      count: filteredCount.toLocaleString(lang) + '/' + totalCounts.total.toLocaleString(lang),
+      count: filteredCount.toLocaleString(lang),
       radius,
     });
   }
@@ -284,6 +240,7 @@ interface NearbyStopsSummaryProps {
   nearbyRadius: number;
   omitEmptyStops: boolean;
   hasLoaded: boolean;
+  infoLevel: InfoLevel;
 }
 
 function StopsSummary({
@@ -293,6 +250,7 @@ function StopsSummary({
   nearbyRadius,
   omitEmptyStops,
   hasLoaded,
+  infoLevel,
 }: NearbyStopsSummaryProps) {
   const { t, i18n } = useTranslation();
   summaryLogger.debug(
@@ -305,6 +263,7 @@ function StopsSummary({
     totalCount,
     filteredCount,
     omitEmptyStops,
+    infoLevel,
     formatRadius(nearbyRadius),
     i18n.language,
     t,
@@ -312,6 +271,16 @@ function StopsSummary({
 
   return (
     <p className="m-0 flex items-center gap-1 text-base font-bold text-[#212121] dark:text-gray-100">
+      {infoLevel === 'verbose' && totalCount.total !== filteredCount && (
+        <LabelCountBadge
+          label={`${totalCount.total}`}
+          count={filteredCount}
+          size="sm"
+          labelClassName="bg-info text-info-foreground"
+          countClassName="bg-background text-info"
+          frameClassName="border-info"
+        />
+      )}
       {text}
     </p>
   );

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -305,7 +305,6 @@ function StopsSummary({
 
   return (
     <p className="m-0 flex items-center gap-1 text-base font-bold text-[#212121] dark:text-gray-100">
-      {/* {infoLevel === 'verbose' && totalCount.total !== filteredCount && ( */}
       {infoLevel === 'verbose' && (
         <LabelCountBadge
           label={`${totalCount.total}`}

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -31,7 +31,7 @@ interface BottomSheetHeaderProps {
   counts: StopsCounts;
   dataConfig: DataConfig;
   dataLangs: readonly string[];
-  showOperatingStopsOnly: boolean;
+  omitEmptyStops: boolean;
   showOriginOnly: boolean;
   showBoardableOnly: boolean;
   viewId: string;
@@ -41,7 +41,7 @@ interface BottomSheetHeaderProps {
   hiddenRouteTypes: Set<number>;
   presentAgencies: Agency[];
   hiddenAgencyIds: Set<string>;
-  onToggleShowOperatingStopsOnly: () => void;
+  onToggleOmitEmptyStops: () => void;
   onToggleShowOriginOnly: () => void;
   onToggleShowBoardableOnly: () => void;
   onViewChange: (viewId: string) => void;
@@ -56,7 +56,7 @@ export function BottomSheetHeader({
   counts,
   dataConfig,
   dataLangs,
-  showOperatingStopsOnly,
+  omitEmptyStops,
   showOriginOnly,
   showBoardableOnly,
   viewId,
@@ -66,7 +66,7 @@ export function BottomSheetHeader({
   hiddenRouteTypes,
   presentAgencies,
   hiddenAgencyIds,
-  onToggleShowOperatingStopsOnly,
+  onToggleOmitEmptyStops,
   onToggleShowOriginOnly,
   onToggleShowBoardableOnly,
   onViewChange,
@@ -85,9 +85,9 @@ export function BottomSheetHeader({
         label={'nearbyStops -> filterd nearbyStops'}
         hasLoaded={hasNearbyLoaded}
         totalCount={nearbyStopsCounts}
-        filteredCount={filteredNearbyStopsCounts.total}
+        filteredCount={counts.total}
         nearbyRadius={dataConfig.stops.nearbyRadius}
-        showOperatingStopsOnly={showOperatingStopsOnly}
+        omitEmptyStops={omitEmptyStops}
       />
       <StopsSummary
         label={'filterd nearbyStops -> operating stops only'}
@@ -95,7 +95,7 @@ export function BottomSheetHeader({
         totalCount={nearbyStopsCounts}
         filteredCount={filteredNearbyStopsCounts.total}
         nearbyRadius={dataConfig.stops.nearbyRadius}
-        showOperatingStopsOnly={showOperatingStopsOnly}
+        omitEmptyStops={omitEmptyStops}
       />
       <StopsSummary
         label={'operating stops only'}
@@ -103,7 +103,7 @@ export function BottomSheetHeader({
         totalCount={nearbyStopsCounts}
         filteredCount={counts.total}
         nearbyRadius={dataConfig.stops.nearbyRadius}
-        showOperatingStopsOnly={showOperatingStopsOnly}
+        omitEmptyStops={omitEmptyStops}
       />
 
       <div className="no-scrollbar mt-1.5 flex gap-1 overflow-x-auto">
@@ -143,13 +143,13 @@ export function BottomSheetHeader({
         {/* Operating stops filter */}
         <PillButton
           size={'sm'}
-          active={showOperatingStopsOnly}
+          active={omitEmptyStops}
           activeBg={'var(--info)'}
           activeBorder={'var(--info)'}
           inactiveBorder={'var(--info)'}
-          onClick={onToggleShowOperatingStopsOnly}
+          onClick={onToggleOmitEmptyStops}
           title={t('nearbyStops.showOperatingStopsOnlyTitle')}
-          count={counts.active}
+          count={counts.nonEmpty}
         >
           {t('nearbyStops.showOperatingStopsOnly')}
         </PillButton>
@@ -157,13 +157,13 @@ export function BottomSheetHeader({
         {/* Operating stops filter */}
         <PillButton
           size={'sm'}
-          active={showOperatingStopsOnly}
+          active={omitEmptyStops}
           activeBg={'var(--info)'}
           activeBorder={'var(--info)'}
           inactiveBorder={'var(--info)'}
-          onClick={onToggleShowOperatingStopsOnly}
+          onClick={onToggleOmitEmptyStops}
           title={t('nearbyStops.showOperatingStopsOnlyTitle')}
-          count={nearbyStopsCounts.active}
+          count={nearbyStopsCounts.nonEmpty}
         >
           {t('nearbyStops.showOperatingStopsOnly')}
         </PillButton>
@@ -251,7 +251,7 @@ function getNearbyStopsSummaryText(
   hasLoaded: boolean,
   totalCounts: StopsCounts,
   filteredCount: number,
-  showOperatingStopsOnly: boolean,
+  omitEmptyStops: boolean,
   radius: string,
   lang: string,
   t: (key: string, options?: Record<string, unknown>) => string,
@@ -265,7 +265,7 @@ function getNearbyStopsSummaryText(
       radius,
     });
   }
-  if (showOperatingStopsOnly && totalCounts.total > 0) {
+  if (omitEmptyStops && totalCounts.total > 0) {
     return t('nearbyStops.noOperating', { radius });
   }
   return t('nearbyStops.noStops', { radius });
@@ -278,7 +278,7 @@ interface NearbyStopsSummaryProps {
   totalCount: StopsCounts;
   filteredCount: number;
   nearbyRadius: number;
-  showOperatingStopsOnly: boolean;
+  omitEmptyStops: boolean;
   hasLoaded: boolean;
 }
 
@@ -287,20 +287,20 @@ function StopsSummary({
   totalCount,
   filteredCount,
   nearbyRadius,
-  showOperatingStopsOnly,
+  omitEmptyStops,
   hasLoaded,
 }: NearbyStopsSummaryProps) {
   const { t, i18n } = useTranslation();
   summaryLogger.debug(
     hasLoaded
-      ? `[${label}] total=${totalCount.total} active=${totalCount.active} boardable=${totalCount.boardableCount} origin=${totalCount.originCount} -> filtered=${filteredCount}`
+      ? `[${label}] total=${totalCount.total} nonEmpty=${totalCount.nonEmpty} boardable=${totalCount.boardableCount} origin=${totalCount.originCount} -> filtered=${filteredCount}`
       : 'not loaded yet',
   );
   const text = getNearbyStopsSummaryText(
     hasLoaded,
     totalCount,
     filteredCount,
-    showOperatingStopsOnly,
+    omitEmptyStops,
     formatRadius(nearbyRadius),
     i18n.language,
     t,

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -32,6 +32,7 @@ interface BottomSheetHeaderProps {
   dataConfig: DataConfig;
   dataLangs: readonly string[];
   omitEmptyStops: boolean;
+  isOmitEmptyStopsForced: boolean;
   showOriginOnly: boolean;
   showBoardableOnly: boolean;
   viewId: string;
@@ -57,6 +58,7 @@ export function BottomSheetHeader({
   dataConfig,
   dataLangs,
   omitEmptyStops,
+  isOmitEmptyStopsForced,
   showOriginOnly,
   showBoardableOnly,
   viewId,
@@ -124,26 +126,11 @@ export function BottomSheetHeader({
       </div>
       {/* Filters */}
       <div className="no-scrollbar mt-1 flex gap-1 overflow-x-auto">
-        {/* Origin filter (entry-level: patternPosition.isOrigin) */}
-        {/* {counts.total > 0 && counts.originCount > 0 && ( */}
-        <OriginFilter
-          origin={showOriginOnly}
-          onToggleOrigin={onToggleShowOriginOnly}
-          count={counts.originCount}
-        />
-        {/* )} */}
-
-        {/* Boardable filter (entry-level: pickup_type === 0) */}
-        <BoardabilityFilter
-          boardable={showBoardableOnly}
-          onToggleBoardable={onToggleShowBoardableOnly}
-          count={counts.boardableCount}
-        />
-
         {/* Operating stops filter */}
         <PillButton
           size={'sm'}
           active={omitEmptyStops}
+          disabled={isOmitEmptyStopsForced}
           activeBg={'var(--info)'}
           activeBorder={'var(--info)'}
           inactiveBorder={'var(--info)'}
@@ -154,10 +141,27 @@ export function BottomSheetHeader({
           {t('nearbyStops.showOperatingStopsOnly')}
         </PillButton>
 
+        {/* Boardable filter (entry-level: pickup_type === 0) */}
+        <BoardabilityFilter
+          boardable={showBoardableOnly}
+          onToggleBoardable={onToggleShowBoardableOnly}
+          count={counts.boardableCount}
+        />
+
+        {/* Origin filter (entry-level: patternPosition.isOrigin) */}
+        {/* {counts.total > 0 && counts.originCount > 0 && ( */}
+        <OriginFilter
+          origin={showOriginOnly}
+          onToggleOrigin={onToggleShowOriginOnly}
+          count={counts.originCount}
+        />
+        {/* )} */}
+
         {/* Operating stops filter */}
         <PillButton
           size={'sm'}
           active={omitEmptyStops}
+          disabled={isOmitEmptyStopsForced}
           activeBg={'var(--info)'}
           activeBorder={'var(--info)'}
           inactiveBorder={'var(--info)'}

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -11,6 +11,7 @@ import { createLogger } from '../lib/logger';
 import { routeTypeColor } from '../utils/route-type-color';
 import { routeTypeEmoji } from '../utils/route-type-emoji';
 import { useInfoLevel } from '../hooks/use-info-level';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PillButton } from './button/pill-button';
 import { BoardabilityFilter } from './filter/boardability-filter';
@@ -51,10 +52,13 @@ interface BottomSheetHeaderProps {
   onToggleAgency: (agency: Agency) => void;
 }
 
+const logger = createLogger('BottomSheetHeader');
+let lastBottomSheetHeaderDebugSnapshot: string | undefined;
+
 export function BottomSheetHeader({
   hasNearbyLoaded,
   nearbyStopsCounts,
-  filteredNearbyStopsCounts: _filteredNearbyStopsCounts,
+  filteredNearbyStopsCounts,
   counts,
   dataConfig,
   dataLangs,
@@ -83,9 +87,27 @@ export function BottomSheetHeader({
   const operatingStopsActiveBg = 'var(--info)';
   const operatingStopsBorder = 'var(--info)';
   const shouldShowOriginFilter = showOriginOnly || nearbyStopsCounts.originCount > 0;
+  const nearbyStopsCountsDebugLog = formatStopsCountsDebugLog(nearbyStopsCounts);
+  const filteredNearbyStopsCountsDebugLog = formatStopsCountsDebugLog(filteredNearbyStopsCounts);
+  const countsDebugLog = formatStopsCountsDebugLog(counts);
 
-  console.debug({ nearbyStopsCounts });
-  console.debug({ counts });
+  // const countsForFilterLabel = counts;
+  const countsForFilterLabel = filteredNearbyStopsCounts;
+
+  useEffect(() => {
+    const snapshot = [
+      `[nearbyStopsCounts] ${nearbyStopsCountsDebugLog}`,
+      `[filteredNearbyStopsCounts] ${filteredNearbyStopsCountsDebugLog}`,
+      `[counts] ${countsDebugLog}`,
+    ].join(' | ');
+
+    if (snapshot === lastBottomSheetHeaderDebugSnapshot) {
+      return;
+    }
+
+    lastBottomSheetHeaderDebugSnapshot = snapshot;
+    logger.debug(snapshot);
+  }, [countsDebugLog, filteredNearbyStopsCountsDebugLog, nearbyStopsCountsDebugLog]);
 
   return (
     <div className="shrink-0 px-4 pb-2">
@@ -128,7 +150,7 @@ export function BottomSheetHeader({
           inactiveBorder={operatingStopsBorder}
           onClick={onToggleOmitEmptyStops}
           title={t('nearbyStops.showOperatingStopsOnlyTitle')}
-          count={counts.nonEmpty}
+          count={countsForFilterLabel.nonEmpty}
           className={isOmitEmptyStopsForced ? 'cursor-not-allowed' : undefined}
         >
           {t('nearbyStops.showOperatingStopsOnly')}
@@ -138,7 +160,7 @@ export function BottomSheetHeader({
         <BoardabilityFilter
           boardable={showBoardableOnly}
           onToggleBoardable={onToggleShowBoardableOnly}
-          count={counts.boardableCount}
+          count={countsForFilterLabel.boardableCount}
         />
 
         {/* Origin filter: keep visibility stable against global-filter toggles. */}
@@ -146,7 +168,7 @@ export function BottomSheetHeader({
           <OriginFilter
             origin={showOriginOnly}
             onToggleOrigin={onToggleShowOriginOnly}
-            count={counts.originCount}
+            count={countsForFilterLabel.originCount}
           />
         )}
 
@@ -238,6 +260,10 @@ function getNearbyStopsSummaryText(
   return t('nearbyStops.noStops', { radius });
 }
 
+function formatStopsCountsDebugLog(counts: StopsCounts): string {
+  return `total=${counts.total} nonEmpty=${counts.nonEmpty} boardable=${counts.boardableCount} origin=${counts.originCount}`;
+}
+
 const summaryLogger = createLogger('NearbyStopsSummary');
 
 interface NearbyStopsSummaryProps {
@@ -260,9 +286,10 @@ function StopsSummary({
   infoLevel,
 }: NearbyStopsSummaryProps) {
   const { t, i18n } = useTranslation();
+
   summaryLogger.debug(
     hasLoaded
-      ? `[${label}] total=${totalCount.total} nonEmpty=${totalCount.nonEmpty} boardable=${totalCount.boardableCount} origin=${totalCount.originCount} -> filtered=${filteredCount}`
+      ? `[${label}] ${formatStopsCountsDebugLog(totalCount)} -> filtered=${filteredCount}`
       : 'not loaded yet',
   );
   const text = getNearbyStopsSummaryText(

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -76,8 +76,13 @@ export function BottomSheetHeader({
   onToggleRouteType,
   onToggleAgency,
 }: BottomSheetHeaderProps) {
-  const { t } = useTranslation();
   const info = useInfoLevel(infoLevel);
+
+  const { t } = useTranslation();
+
+  const operatingStopsActiveBg = 'var(--info)';
+  const operatingStopsBorder = 'var(--info)';
+  const shouldShowOriginFilter = showOriginOnly || nearbyStopsCounts.originCount > 0;
 
   console.debug({ nearbyStopsCounts });
   console.debug({ counts });
@@ -117,12 +122,14 @@ export function BottomSheetHeader({
           size={'sm'}
           active={omitEmptyStops}
           disabled={isOmitEmptyStopsForced}
-          activeBg={'var(--info)'}
-          activeBorder={'var(--info)'}
-          inactiveBorder={'var(--info)'}
+          activeBg={operatingStopsActiveBg}
+          activeFg={'#fff'}
+          activeBorder={operatingStopsBorder}
+          inactiveBorder={operatingStopsBorder}
           onClick={onToggleOmitEmptyStops}
           title={t('nearbyStops.showOperatingStopsOnlyTitle')}
           count={counts.nonEmpty}
+          className={isOmitEmptyStopsForced ? 'cursor-not-allowed' : undefined}
         >
           {t('nearbyStops.showOperatingStopsOnly')}
         </PillButton>
@@ -134,14 +141,14 @@ export function BottomSheetHeader({
           count={counts.boardableCount}
         />
 
-        {/* Origin filter (entry-level: patternPosition.isOrigin) */}
-        {/* {counts.total > 0 && counts.originCount > 0 && ( */}
-        <OriginFilter
-          origin={showOriginOnly}
-          onToggleOrigin={onToggleShowOriginOnly}
-          count={counts.originCount}
-        />
-        {/* )} */}
+        {/* Origin filter: keep visibility stable against global-filter toggles. */}
+        {shouldShowOriginFilter && (
+          <OriginFilter
+            origin={showOriginOnly}
+            onToggleOrigin={onToggleShowOriginOnly}
+            count={counts.originCount}
+          />
+        )}
 
         {/* Route types filter */}
         {presentRouteTypes.map((rt) => (
@@ -271,7 +278,8 @@ function StopsSummary({
 
   return (
     <p className="m-0 flex items-center gap-1 text-base font-bold text-[#212121] dark:text-gray-100">
-      {infoLevel === 'verbose' && totalCount.total !== filteredCount && (
+      {/* {infoLevel === 'verbose' && totalCount.total !== filteredCount && ( */}
+      {infoLevel === 'verbose' && (
         <LabelCountBadge
           label={`${totalCount.total}`}
           count={filteredCount}

--- a/src/components/bottom-sheet-header.tsx
+++ b/src/components/bottom-sheet-header.tsx
@@ -2,7 +2,7 @@ import type { DataConfig } from '../config/perf-profiles';
 import type { InfoLevel } from '../types/app/settings';
 import type { Agency } from '../types/app/transit';
 import type { StopTimeViewMeta } from '../types/app/transit-composed';
-import type { NearbyStopsCounts } from './bottom-sheet';
+import type { StopsCounts } from '../types/app/stop';
 import { DEFAULT_AGENCY_LANG } from '../config/transit-defaults';
 import { resolveAgencyColors } from '../domain/transit/color-resolver/agency-colors';
 import { STOP_TIMES_VIEWS } from '../domain/transit/stop-time-views';
@@ -18,7 +18,17 @@ import { OriginFilter } from './filter/origin-filter';
 
 interface BottomSheetHeaderProps {
   hasNearbyLoaded: boolean;
-  counts: NearbyStopsCounts;
+  /**
+   * Pre-`globalFilter` counts (= settings filter applied, `globalFilter`
+   * not yet, no BottomSheet-local Stage 1/2 trim). Used to drive filter
+   * pill displays that should not fluctuate when the user toggles
+   * `globalFilter` pills. The post-`globalFilter` `counts` above remains
+   * the source of truth for "what is currently visible".
+   */
+  nearbyStopsCounts: StopsCounts;
+  /** App-filtered counts before BottomSheet-local filters. */
+  filteredNearbyStopsCounts: StopsCounts;
+  counts: StopsCounts;
   dataConfig: DataConfig;
   dataLangs: readonly string[];
   showOperatingStopsOnly: boolean;
@@ -41,6 +51,8 @@ interface BottomSheetHeaderProps {
 
 export function BottomSheetHeader({
   hasNearbyLoaded,
+  nearbyStopsCounts,
+  filteredNearbyStopsCounts,
   counts,
   dataConfig,
   dataLangs,
@@ -64,11 +76,32 @@ export function BottomSheetHeader({
   const { t } = useTranslation();
   const info = useInfoLevel(infoLevel);
 
+  console.debug({ nearbyStopsCounts });
+  console.debug({ counts });
+
   return (
     <div className="shrink-0 px-4 pb-2">
-      <NearbyStopsSummary
+      <StopsSummary
+        label={'nearbyStops -> filterd nearbyStops'}
         hasLoaded={hasNearbyLoaded}
-        counts={counts}
+        totalCount={nearbyStopsCounts}
+        filteredCount={filteredNearbyStopsCounts.total}
+        nearbyRadius={dataConfig.stops.nearbyRadius}
+        showOperatingStopsOnly={showOperatingStopsOnly}
+      />
+      <StopsSummary
+        label={'filterd nearbyStops -> operating stops only'}
+        hasLoaded={hasNearbyLoaded}
+        totalCount={nearbyStopsCounts}
+        filteredCount={filteredNearbyStopsCounts.total}
+        nearbyRadius={dataConfig.stops.nearbyRadius}
+        showOperatingStopsOnly={showOperatingStopsOnly}
+      />
+      <StopsSummary
+        label={'operating stops only'}
+        hasLoaded={hasNearbyLoaded}
+        totalCount={nearbyStopsCounts}
+        filteredCount={counts.total}
         nearbyRadius={dataConfig.stops.nearbyRadius}
         showOperatingStopsOnly={showOperatingStopsOnly}
       />
@@ -92,13 +125,13 @@ export function BottomSheetHeader({
       {/* Filters */}
       <div className="no-scrollbar mt-1 flex gap-1 overflow-x-auto">
         {/* Origin filter (entry-level: patternPosition.isOrigin) */}
-        {counts.originCount > 0 && (
-          <OriginFilter
-            origin={showOriginOnly}
-            onToggleOrigin={onToggleShowOriginOnly}
-            count={counts.originCount}
-          />
-        )}
+        {/* {counts.total > 0 && counts.originCount > 0 && ( */}
+        <OriginFilter
+          origin={showOriginOnly}
+          onToggleOrigin={onToggleShowOriginOnly}
+          count={counts.originCount}
+        />
+        {/* )} */}
 
         {/* Boardable filter (entry-level: pickup_type === 0) */}
         <BoardabilityFilter
@@ -120,6 +153,37 @@ export function BottomSheetHeader({
         >
           {t('nearbyStops.showOperatingStopsOnly')}
         </PillButton>
+
+        {/* Operating stops filter */}
+        <PillButton
+          size={'sm'}
+          active={showOperatingStopsOnly}
+          activeBg={'var(--info)'}
+          activeBorder={'var(--info)'}
+          inactiveBorder={'var(--info)'}
+          onClick={onToggleShowOperatingStopsOnly}
+          title={t('nearbyStops.showOperatingStopsOnlyTitle')}
+          count={nearbyStopsCounts.active}
+        >
+          {t('nearbyStops.showOperatingStopsOnly')}
+        </PillButton>
+
+        {/* Boardable filter (entry-level: pickup_type === 0) */}
+        {/* {(showBoardableOnly || nearbyStopsCounts.boardableCount > 0) && ( */}
+        <BoardabilityFilter
+          boardable={showBoardableOnly}
+          onToggleBoardable={onToggleShowBoardableOnly}
+          count={nearbyStopsCounts.boardableCount}
+        />
+        {/* )} */}
+
+        {/* {(showOriginOnly || nearbyStopsCounts.originCount > 0) && ( */}
+        <OriginFilter
+          origin={showOriginOnly}
+          onToggleOrigin={onToggleShowOriginOnly}
+          count={nearbyStopsCounts.originCount}
+        />
+        {/* )} */}
 
         {/* Route types filter */}
         {presentRouteTypes.map((rt) => (
@@ -185,7 +249,8 @@ function formatRadius(meters: number): string {
 
 function getNearbyStopsSummaryText(
   hasLoaded: boolean,
-  counts: NearbyStopsCounts,
+  totalCounts: StopsCounts,
+  filteredCount: number,
   showOperatingStopsOnly: boolean,
   radius: string,
   lang: string,
@@ -194,10 +259,13 @@ function getNearbyStopsSummaryText(
   if (!hasLoaded) {
     return t('common.loading');
   }
-  if (counts.filtered > 0) {
-    return t('nearbyStops.summary', { count: counts.filtered.toLocaleString(lang), radius });
+  if (filteredCount > 0) {
+    return t('nearbyStops.summary', {
+      count: filteredCount.toLocaleString(lang) + '/' + totalCounts.total.toLocaleString(lang),
+      radius,
+    });
   }
-  if (showOperatingStopsOnly && counts.total > 0) {
+  if (showOperatingStopsOnly && totalCounts.total > 0) {
     return t('nearbyStops.noOperating', { radius });
   }
   return t('nearbyStops.noStops', { radius });
@@ -206,27 +274,32 @@ function getNearbyStopsSummaryText(
 const summaryLogger = createLogger('NearbyStopsSummary');
 
 interface NearbyStopsSummaryProps {
-  counts: NearbyStopsCounts;
+  label: string;
+  totalCount: StopsCounts;
+  filteredCount: number;
   nearbyRadius: number;
   showOperatingStopsOnly: boolean;
   hasLoaded: boolean;
 }
 
-function NearbyStopsSummary({
-  counts,
+function StopsSummary({
+  label,
+  totalCount,
+  filteredCount,
   nearbyRadius,
   showOperatingStopsOnly,
   hasLoaded,
 }: NearbyStopsSummaryProps) {
   const { t, i18n } = useTranslation();
-  summaryLogger.verbose(
+  summaryLogger.debug(
     hasLoaded
-      ? `found ${counts.total} nearby stops (${counts.active} active, ${counts.filtered} after filter)`
+      ? `[${label}] total=${totalCount.total} active=${totalCount.active} boardable=${totalCount.boardableCount} origin=${totalCount.originCount} -> filtered=${filteredCount}`
       : 'not loaded yet',
   );
   const text = getNearbyStopsSummaryText(
     hasLoaded,
-    counts,
+    totalCount,
+    filteredCount,
     showOperatingStopsOnly,
     formatRadius(nearbyRadius),
     i18n.language,

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -124,6 +124,7 @@ export function BottomSheet({
     showOriginOnly,
     showBoardableOnly,
     omitEmptyStops,
+    isOmitEmptyStopsForced,
     onToggleShowOriginOnly,
     onToggleShowBoardableOnly,
     onToggleOmitEmptyStops,
@@ -283,6 +284,7 @@ export function BottomSheet({
         dataConfig={dataConfig}
         dataLangs={dataLangs}
         omitEmptyStops={omitEmptyStops}
+        isOmitEmptyStopsForced={isOmitEmptyStopsForced}
         showOriginOnly={showOriginOnly}
         showBoardableOnly={showBoardableOnly}
         viewId={viewId}

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -4,9 +4,11 @@ import type { DataConfig } from '../config/perf-profiles';
 import type { InfoLevel } from '../types/app/settings';
 import type { Agency, AppRouteTypeValue, TimetableEntriesState } from '../types/app/transit';
 import type { GlobalFilter } from '../types/app/global-filter';
+import type { StopsCounts } from '../types/app/stop';
 import type { StopWithContext, TripInspectionTarget } from '../types/app/transit-composed';
 import { collectPresentAgencies } from '../domain/transit/collect-present-agencies';
 import { collectPresentRouteTypes } from '../domain/transit/collect-present-route-types';
+import { computeStopsCounts } from '../domain/transit/compute-stops-counts';
 import { filterByAgency, filterByRouteType } from '../domain/transit/timetable-filter';
 import { STOP_TIMES_VIEWS, DEFAULT_VIEW_ID } from '../domain/transit/stop-time-views';
 import { getServiceDayMinutes } from '../domain/transit/service-day';
@@ -42,21 +44,6 @@ const ROUTE_TYPE_ORDER: AppRouteTypeValue[] = [...APP_ROUTE_TYPES.map(({ value }
     (ROUTE_TYPE_PRIORITY[b] ?? Number.POSITIVE_INFINITY),
 );
 
-export interface NearbyStopsCounts {
-  /** Total number of nearby stops before any filtering (= input `stopTimes`). */
-  total: number;
-  /** Stops with at least one upcoming entry, computed against the final
-   *  `trimmedStopTimes`. Reflects the user's current filter state. */
-  active: number;
-  /** Stops remaining after all filters (= `trimmedStopTimes.length`). */
-  filtered: number;
-  /** Stops in `trimmedStopTimes` that contain at least one origin entry. */
-  originCount: number;
-  /** Stops in `trimmedStopTimes` that contain at least one boardable
-   *  entry (= `pickup_type === 0` at a non-pure-terminal position). */
-  boardableCount: number;
-}
-
 export interface BottomSheetProps {
   /**
    * Stops to render. Already narrowed by the app-wide filters
@@ -83,6 +70,18 @@ export interface BottomSheetProps {
   anchorIds: Set<string>;
   /** App-wide filter state shared across surfaces. */
   globalFilter: GlobalFilter;
+  /**
+   * Pre-`globalFilter` `NearbyStopsCounts` computed in `app.tsx` from the
+   * settings-filter-applied stop list. Used by BottomSheetHeader to display
+   * counts that stay stable as the user toggles `globalFilter` pills.
+   */
+  nearbyStopsCounts: StopsCounts;
+  /**
+   * Post-`globalFilter`, pre-BottomSheet-local-filter counts computed in
+   * `app.tsx`. Threaded to BottomSheetHeader for UI that needs the
+   * app-filtered base before operating/agency/route_type trimming.
+   */
+  filteredNearbyStopsCounts: StopsCounts;
   onStopSelected: (stopId: string) => void;
   onShowTimetable?: (stopId: string, routeId: string, headsign: string) => void;
   onShowStopTimetable?: (stopId: string) => void;
@@ -113,6 +112,8 @@ export function BottomSheet({
   dataLangs,
   anchorIds,
   globalFilter,
+  nearbyStopsCounts,
+  filteredNearbyStopsCounts,
   onStopSelected,
   onShowTimetable,
   onShowStopTimetable,
@@ -220,27 +221,9 @@ export function BottomSheet({
     });
   }, [filteredStopTimes, hiddenAgencyIds, hiddenRouteTypes]);
 
-  const counts: NearbyStopsCounts = useMemo(
-    () => ({
-      total: stopTimes.length,
-      active: trimmedStopTimes.filter((swc) => swc.stopTimes.length > 0).length,
-      filtered: trimmedStopTimes.length,
-      // Existence-only `.some(...)` predicates — semantic-equivalent to
-      // applyStopEventAttributeToggles({ showOriginOnly: true }).length > 0
-      // and applyStopEventAttributeToggles({ showBoardableOnly: true }).length > 0
-      // respectively, but without allocating a per-stop filtered array.
-      originCount: trimmedStopTimes.filter((swc) =>
-        swc.stopTimes.some((entry) => entry.patternPosition.isOrigin),
-      ).length,
-      boardableCount: trimmedStopTimes.filter((swc) =>
-        swc.stopTimes.some(
-          (entry) =>
-            entry.boarding.pickupType === 0 &&
-            (entry.patternPosition.isOrigin || !entry.patternPosition.isTerminal),
-        ),
-      ).length,
-    }),
-    [stopTimes, trimmedStopTimes],
+  const trimmedStopTimesCounts: StopsCounts = useMemo(
+    () => computeStopsCounts(trimmedStopTimes),
+    [trimmedStopTimes],
   );
 
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
@@ -309,7 +292,9 @@ export function BottomSheet({
 
       <BottomSheetHeader
         hasNearbyLoaded={hasNearbyLoaded}
-        counts={counts}
+        nearbyStopsCounts={nearbyStopsCounts}
+        filteredNearbyStopsCounts={filteredNearbyStopsCounts}
+        counts={trimmedStopTimesCounts}
         dataConfig={dataConfig}
         dataLangs={dataLangs}
         showOperatingStopsOnly={showOperatingStopsOnly}

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -11,7 +11,6 @@ import { collectPresentRouteTypes } from '../domain/transit/collect-present-rout
 import { computeStopsCounts } from '../domain/transit/compute-stops-counts';
 import { filterByAgency, filterByRouteType } from '../domain/transit/timetable-filter';
 import { STOP_TIMES_VIEWS, DEFAULT_VIEW_ID } from '../domain/transit/stop-time-views';
-import { getServiceDayMinutes } from '../domain/transit/service-day';
 import { APP_ROUTE_TYPES } from '../config/route-types';
 import { cn } from '../lib/utils';
 import { BottomSheetHeader } from './bottom-sheet-header';
@@ -20,9 +19,6 @@ import { BottomSheetStops } from './bottom-sheet-stops';
 type ExpandedStateAction = boolean | ((prevExpanded: boolean) => boolean);
 
 const DRAG_THRESHOLD = 50;
-
-/** Auto-enable "show operating stops only" filter at 22:00 in service day minutes. */
-const LATE_NIGHT_THRESHOLD_MINUTES = 22 * 60;
 
 /** Route type display order matching StopTypeFilterPanel. */
 const ROUTE_TYPE_PRIORITY: Readonly<Record<number, number>> = {
@@ -48,7 +44,7 @@ export interface BottomSheetProps {
   /**
    * Stops to render. Already narrowed by the app-wide filters
    * (`globalFilter` + `enabledRouteTypes`); BottomSheet only applies
-   * its own surface-local filters (operating-only / agency / route_type).
+   * its own surface-local filters (agency / route_type).
    */
   stopTimes: StopWithContext[];
   /**
@@ -124,8 +120,14 @@ export function BottomSheet({
   expanded: expandedProp,
   onExpandedChange,
 }: BottomSheetProps) {
-  const { showOriginOnly, showBoardableOnly, onToggleShowOriginOnly, onToggleShowBoardableOnly } =
-    globalFilter;
+  const {
+    showOriginOnly,
+    showBoardableOnly,
+    omitEmptyStops,
+    onToggleShowOriginOnly,
+    onToggleShowBoardableOnly,
+    onToggleOmitEmptyStops,
+  } = globalFilter;
   const [uncontrolledExpanded, setUncontrolledExpanded] = useState(false);
   const expanded = expandedProp ?? uncontrolledExpanded;
   const setExpanded = useCallback(
@@ -139,12 +141,6 @@ export function BottomSheet({
     [onExpandedChange],
   );
   const [viewId, setViewId] = useState(DEFAULT_VIEW_ID);
-  const isLateNight = getServiceDayMinutes(now) >= LATE_NIGHT_THRESHOLD_MINUTES;
-  // User can toggle manually; null means "use auto (isLateNight)".
-  const [showOperatingStopsOnlyOverride, setShowOperatingStopsOnlyOverride] = useState<
-    boolean | null
-  >(null);
-  const showOperatingStopsOnly = showOperatingStopsOnlyOverride ?? isLateNight;
   const [hiddenRouteTypes, setHiddenRouteTypes] = useState<Set<number>>(() => new Set());
   const [hiddenAgencyIds, setHiddenAgencyIds] = useState<Set<string>>(() => new Set());
   const selectedView = STOP_TIMES_VIEWS.find((v) => v.id === viewId);
@@ -183,33 +179,22 @@ export function BottomSheet({
     });
   }, []);
 
-  // Two-stage local filter pipeline. The app-wide origin / boardable
+  // The app-wide origin / boardable
   // filter (= `globalFilter`) is already applied upstream in `app.tsx`
-  // — by the time `stopTimes` arrives here, those entries have already
-  // been narrowed and empty stops dropped. BottomSheet only applies its
-  // own surface-local filters below.
+  // — and the app-wide empty-stop omission policy — are already applied
+  // upstream in `app.tsx`. BottomSheet only applies its own surface-local
+  // filters below.
   //
-  // Stage 1 — drop stops with no upcoming entries (operating-only
-  // toggle). Acts on the upstream-filtered `stopTimes`, so when entry
-  // pills are active the operating filter narrows "what is left after
-  // the user's intent narrowing".
-  const filteredStopTimes = useMemo(() => {
-    if (!showOperatingStopsOnly) {
-      return stopTimes;
-    }
-    return stopTimes.filter((swc) => swc.stopTimes.length > 0);
-  }, [stopTimes, showOperatingStopsOnly]);
-
-  // Stage 2 — trim each surviving stop's inner stopTimes by agency /
+  // Trim each surviving stop's inner stopTimes by agency /
   // route_type filters. This never drops stops: a stop whose stopTimes
   // are all removed stays visible and shows the "allFilteredOut"
   // fallback message. This decouples "which stops are in the list"
   // from "what is shown inside each stop".
   const trimmedStopTimes = useMemo(() => {
     if (hiddenAgencyIds.size === 0 && hiddenRouteTypes.size === 0) {
-      return filteredStopTimes;
+      return stopTimes;
     }
-    return filteredStopTimes.map((swc) => {
+    return stopTimes.map((swc) => {
       let trimmed = swc.stopTimes;
       if (hiddenAgencyIds.size > 0) {
         trimmed = filterByAgency(trimmed, hiddenAgencyIds);
@@ -219,7 +204,7 @@ export function BottomSheet({
       }
       return trimmed === swc.stopTimes ? swc : { ...swc, stopTimes: trimmed };
     });
-  }, [filteredStopTimes, hiddenAgencyIds, hiddenRouteTypes]);
+  }, [stopTimes, hiddenAgencyIds, hiddenRouteTypes]);
 
   const trimmedStopTimesCounts: StopsCounts = useMemo(
     () => computeStopsCounts(trimmedStopTimes),
@@ -297,7 +282,7 @@ export function BottomSheet({
         counts={trimmedStopTimesCounts}
         dataConfig={dataConfig}
         dataLangs={dataLangs}
-        showOperatingStopsOnly={showOperatingStopsOnly}
+        omitEmptyStops={omitEmptyStops}
         showOriginOnly={showOriginOnly}
         showBoardableOnly={showBoardableOnly}
         viewId={viewId}
@@ -307,9 +292,7 @@ export function BottomSheet({
         hiddenRouteTypes={hiddenRouteTypes}
         presentAgencies={presentAgencies}
         hiddenAgencyIds={hiddenAgencyIds}
-        onToggleShowOperatingStopsOnly={() =>
-          setShowOperatingStopsOnlyOverride((v) => !(v ?? isLateNight))
-        }
+        onToggleOmitEmptyStops={onToggleOmitEmptyStops}
         onToggleShowOriginOnly={onToggleShowOriginOnly}
         onToggleShowBoardableOnly={onToggleShowBoardableOnly}
         onViewChange={setViewId}

--- a/src/components/button/pill-button.stories.tsx
+++ b/src/components/button/pill-button.stories.tsx
@@ -272,6 +272,70 @@ export const WithCountCustomColor: Story = {
   },
 };
 
+export const WithCountDisabledComparison: Story = {
+  args: { active: true },
+  render: (args) => (
+    <div className="space-y-2">
+      <p className="text-muted-foreground text-xs">Enabled / active branch</p>
+      <div className="flex flex-wrap items-center gap-2">
+        <PillButton {...args} active count={22}>
+          Active default
+        </PillButton>
+        <PillButton {...args} active activeBg={TOEI_GREEN} activeFg="#fff" count={42}>
+          Active custom bg
+        </PillButton>
+        <PillButton
+          {...args}
+          active
+          activeBg={TOEI_GREEN}
+          activeFg="#fff"
+          activeBorder="#0b6b38"
+          count={42}
+        >
+          Active custom border
+        </PillButton>
+      </div>
+
+      <p className="text-muted-foreground text-xs">Enabled / inactive branch</p>
+      <div className="flex flex-wrap items-center gap-2">
+        <PillButton {...args} active={false} count={22}>
+          Inactive default
+        </PillButton>
+        <PillButton {...args} active={false} inactiveBorder={TOEI_GREEN} count={42}>
+          Inactive green border
+        </PillButton>
+        <PillButton {...args} active={false} inactiveBorder="#e60012" count={42}>
+          Inactive red border
+        </PillButton>
+      </div>
+
+      <p className="text-muted-foreground text-xs">Disabled branch</p>
+      <div className="flex flex-wrap items-center gap-2">
+        <PillButton {...args} active disabled count={22}>
+          Disabled active default
+        </PillButton>
+        <PillButton
+          {...args}
+          active
+          activeBg={TOEI_GREEN}
+          activeFg="#fff"
+          activeBorder="#0b6b38"
+          disabled
+          count={42}
+        >
+          Disabled active custom border
+        </PillButton>
+        <PillButton {...args} active={false} disabled count={22}>
+          Disabled inactive default
+        </PillButton>
+        <PillButton {...args} active={false} inactiveBorder={TOEI_GREEN} disabled count={42}>
+          Disabled inactive green border
+        </PillButton>
+      </div>
+    </div>
+  ),
+};
+
 export const WithCountNoCount: Story = {
   args: { active: true, children: 'カウントなし' },
 };

--- a/src/components/button/pill-button.tsx
+++ b/src/components/button/pill-button.tsx
@@ -69,21 +69,70 @@ export function PillButton({
   children,
 }: PillButtonProps) {
   const { i18n } = useTranslation();
+  const resolvedActiveBg = activeBg ?? 'var(--info)';
+  const resolvedActiveFg = activeFg ?? 'var(--info-foreground)';
+  const resolvedDisabledBorder = active ? activeBorder : inactiveBorder;
+  const resolvedInactiveBadgeBg = inactiveBorder ?? 'var(--info)';
+  const resolvedInactiveBadgeFg = activeFg ?? 'white';
+
   // All buttons get a 2px transparent border for consistent sizing.
   // Border color is overridden per state as needed.
   const style: CSSProperties = {
     borderWidth: 2,
     borderStyle: 'solid',
     borderColor: 'transparent',
-    ...(active
-      ? {
-          ...(activeBg ? { background: activeBg, color: activeFg } : {}),
-          ...(activeBorder ? { borderColor: activeBorder } : {}),
-        }
-      : {
-          ...(inactiveBorder ? { borderColor: inactiveBorder } : {}),
-        }),
   };
+
+  if (disabled) {
+    if (resolvedDisabledBorder) {
+      style.borderColor = resolvedDisabledBorder;
+    }
+  } else {
+    if (active) {
+      if (activeBg) {
+        style.background = activeBg;
+        style.color = activeFg;
+      }
+      if (activeBorder) {
+        style.borderColor = activeBorder;
+      }
+    } else if (inactiveBorder) {
+      style.borderColor = inactiveBorder;
+    }
+  }
+
+  let toneClassName: string;
+  if (disabled) {
+    toneClassName = 'bg-[#e8eaf0] text-gray-400 dark:bg-gray-700 dark:text-gray-500';
+  } else {
+    if (active) {
+      if (activeBg) {
+        toneClassName = 'text-white';
+      } else {
+        toneClassName = 'bg-info text-info-foreground';
+      }
+    } else {
+      toneClassName =
+        'bg-[#e8eaf0] text-[#555] active:bg-[#d0d3da] dark:bg-gray-700 dark:text-gray-300';
+    }
+  }
+
+  let countBadgeStyle: CSSProperties;
+  if (disabled) {
+    countBadgeStyle = {
+      color: 'var(--muted)',
+      background: 'var(--muted-foreground)',
+    };
+  } else {
+    if (active) {
+      countBadgeStyle = { background: resolvedActiveFg, color: resolvedActiveBg };
+    } else {
+      countBadgeStyle = {
+        background: resolvedInactiveBadgeBg,
+        color: resolvedInactiveBadgeFg,
+      };
+    }
+  }
 
   return (
     <button
@@ -92,14 +141,9 @@ export function PillButton({
       className={cn(
         'inline-flex shrink-0 items-center rounded-full font-medium whitespace-nowrap transition-colors select-none [-webkit-touch-callout:none]',
         onClick && !disabled && 'cursor-pointer',
+        disabled && 'cursor-not-allowed',
         sizeVariants[size] ?? sizeVariants.default,
-        active
-          ? activeBg
-            ? 'text-white'
-            : 'bg-info text-info-foreground'
-          : disabled
-            ? 'cursor-not-allowed bg-[#f0f0f0] text-[#bbb] dark:bg-gray-800 dark:text-gray-600'
-            : 'bg-[#e8eaf0] text-[#555] active:bg-[#d0d3da] dark:bg-gray-700 dark:text-gray-300',
+        toneClassName,
         className,
       )}
       style={style}
@@ -112,16 +156,7 @@ export function PillButton({
       {count != null && (
         <span
           className="ml-1 inline-flex min-h-[1.4em] min-w-[1.4em] items-center justify-center rounded-full px-1 text-[0.85em] leading-none font-bold"
-          style={
-            disabled
-              ? { background: '#bbb', color: '#f0f0f0' }
-              : active
-                ? { background: activeFg ?? 'white', color: activeBg ?? 'var(--info)' }
-                : {
-                    background: activeBg ?? inactiveBorder ?? 'var(--info)',
-                    color: activeFg ?? 'white',
-                  }
-          }
+          style={countBadgeStyle}
         >
           {count.toLocaleString(i18n.language)}
         </span>

--- a/src/components/dialog/dialog-memoization.test.tsx
+++ b/src/components/dialog/dialog-memoization.test.tsx
@@ -326,6 +326,7 @@ describe('dialog memoization regressions', () => {
       showOriginOnly: false,
       showBoardableOnly: false,
       omitEmptyStops: false,
+      isOmitEmptyStopsForced: false,
       onToggleShowOriginOnly: vi.fn(),
       onToggleShowBoardableOnly: vi.fn(),
       onToggleOmitEmptyStops: vi.fn(),

--- a/src/components/dialog/dialog-memoization.test.tsx
+++ b/src/components/dialog/dialog-memoization.test.tsx
@@ -325,8 +325,10 @@ describe('dialog memoization regressions', () => {
     const globalFilter = {
       showOriginOnly: false,
       showBoardableOnly: false,
+      omitEmptyStops: false,
       onToggleShowOriginOnly: vi.fn(),
       onToggleShowBoardableOnly: vi.fn(),
+      onToggleOmitEmptyStops: vi.fn(),
     };
     const props = {
       data,

--- a/src/components/map-bottom-sheet-layout.tsx
+++ b/src/components/map-bottom-sheet-layout.tsx
@@ -5,6 +5,7 @@ import { useViewportHeight } from '../hooks/use-viewport-height';
 import { resolveMapBottomSheetLayoutPreset } from '../utils/map-bottom-sheet-layout-preset';
 import { createLogger } from '../lib/logger';
 import type { GlobalFilter } from '../types/app/global-filter';
+import type { StopsCounts } from '../types/app/stop';
 
 const logger = createLogger('MapBottomSheetLayout');
 
@@ -17,9 +18,20 @@ interface MapBottomSheetLayoutProps {
     | 'expanded'
     | 'onExpandedChange'
     | 'globalFilter'
+    | 'nearbyStopsCounts'
+    | 'filteredNearbyStopsCounts'
   >;
   /** App-wide filter state shared with BottomSheet (and forthcoming MapView etc.). */
   globalFilter: GlobalFilter;
+  /**
+   * Pre-`globalFilter` `NearbyStopsCounts` computed in `app.tsx` from the
+   * settings-filter-applied stop list. Threaded through to BottomSheet /
+   * BottomSheetHeader so filter pills can read counts that don't fluctuate
+   * with `globalFilter` toggles.
+   */
+  nearbyStopsCounts: StopsCounts;
+  /** Post-`globalFilter`, pre-BottomSheet-local-filter counts from `app.tsx`. */
+  filteredNearbyStopsCounts: StopsCounts;
   mapOverlay?: ReactNode;
 }
 
@@ -27,6 +39,8 @@ export function MapBottomSheetLayout({
   mapViewProps,
   bottomSheetProps,
   globalFilter,
+  nearbyStopsCounts,
+  filteredNearbyStopsCounts,
   mapOverlay,
 }: MapBottomSheetLayoutProps) {
   const [expanded, setExpanded] = useState(false);
@@ -55,6 +69,8 @@ export function MapBottomSheetLayout({
       <BottomSheet
         {...bottomSheetProps}
         globalFilter={globalFilter}
+        nearbyStopsCounts={nearbyStopsCounts}
+        filteredNearbyStopsCounts={filteredNearbyStopsCounts}
         expanded={expanded}
         onExpandedChange={setExpanded}
         collapsedHeightClassName={layoutPreset.collapsedSheetHeightClassName}

--- a/src/domain/transit/__tests__/compute-stops-counts.test.ts
+++ b/src/domain/transit/__tests__/compute-stops-counts.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type { TimetableEntry } from '../../../types/app/transit-composed';
+import { computeStopsCounts } from '../compute-stops-counts';
+
+function makeEntry(
+  overrides: {
+    isOrigin?: boolean;
+    isTerminal?: boolean;
+    pickupType?: 0 | 1 | 2 | 3;
+  } = {},
+): TimetableEntry {
+  return {
+    schedule: { departureMinutes: 480, arrivalMinutes: 480 },
+    routeDirection: {
+      route: {
+        route_id: 'route-1',
+        route_type: 3,
+        agency_id: 'agency-1',
+        route_short_name: '1',
+        route_short_names: {},
+        route_long_name: 'Route 1',
+        route_long_names: {},
+        route_color: '000000',
+        route_text_color: 'FFFFFF',
+      },
+      tripHeadsign: { name: 'Terminal', names: {} },
+    },
+    boarding: { pickupType: overrides.pickupType ?? 0, dropOffType: 0 },
+    patternPosition: {
+      stopIndex: 0,
+      totalStops: 3,
+      isOrigin: overrides.isOrigin ?? false,
+      isTerminal: overrides.isTerminal ?? false,
+    },
+    tripLocator: { patternId: 'pattern-1', serviceId: 'svc-1', tripIndex: 0 },
+  } as TimetableEntry;
+}
+
+describe('computeStopsCounts', () => {
+  it('returns zero counts for empty input', () => {
+    expect(computeStopsCounts([])).toEqual({
+      total: 0,
+      nonEmpty: 0,
+      originCount: 0,
+      boardableCount: 0,
+    });
+  });
+
+  it('counts total/non-empty/origin/boardable stops across mixed stop states', () => {
+    const pureTerminal = { stopTimes: [makeEntry({ isTerminal: true, pickupType: 0 })] };
+    const oneStopTrip = {
+      stopTimes: [makeEntry({ isOrigin: true, isTerminal: true, pickupType: 0 })],
+    };
+    const middleBoardable = { stopTimes: [makeEntry({ pickupType: 0 })] };
+    const nonBoardableOrigin = { stopTimes: [makeEntry({ isOrigin: true, pickupType: 1 })] };
+    const emptyStop = { stopTimes: [] };
+
+    expect(
+      computeStopsCounts([
+        pureTerminal,
+        oneStopTrip,
+        middleBoardable,
+        nonBoardableOrigin,
+        emptyStop,
+      ]),
+    ).toEqual({
+      total: 5,
+      nonEmpty: 4,
+      originCount: 2,
+      boardableCount: 2,
+    });
+  });
+
+  it('treats boardability according to pickup_type === 0 && (isOrigin || !isTerminal)', () => {
+    const pureTerminal = {
+      stopTimes: [makeEntry({ isOrigin: false, isTerminal: true, pickupType: 0 })],
+    };
+    const oneStopTrip = {
+      stopTimes: [makeEntry({ isOrigin: true, isTerminal: true, pickupType: 0 })],
+    };
+    const middle = {
+      stopTimes: [makeEntry({ isOrigin: false, isTerminal: false, pickupType: 0 })],
+    };
+    const phoneArrangement = {
+      stopTimes: [makeEntry({ isOrigin: true, isTerminal: false, pickupType: 2 })],
+    };
+
+    expect(computeStopsCounts([pureTerminal, oneStopTrip, middle, phoneArrangement])).toEqual({
+      total: 4,
+      nonEmpty: 4,
+      originCount: 2,
+      boardableCount: 2,
+    });
+  });
+});

--- a/src/domain/transit/__tests__/timetable-filter.test.ts
+++ b/src/domain/transit/__tests__/timetable-filter.test.ts
@@ -3,9 +3,11 @@ import type { Route } from '../../../types/app/transit';
 import type { ContextualTimetableEntry, TimetableEntry } from '../../../types/app/transit-composed';
 import {
   applyStopEventAttributeToggles,
+  applyStopEventAttributeTogglesToStops,
   filterByAgency,
   filterByRouteType,
   filterByStopEventAttributes,
+  omitStopsWithoutStopTimes,
   prepareStopTimetable,
   prepareRouteHeadsignTimetable,
 } from '../timetable-filter';
@@ -645,6 +647,63 @@ describe('filterByRouteType', () => {
     const original = [...entries];
     filterByRouteType(entries, new Set([0]));
     expect(entries).toEqual(original);
+  });
+});
+
+describe('applyStopEventAttributeTogglesToStops', () => {
+  it('returns the input reference unchanged when both toggles are false', () => {
+    const stops = [{ stopTimes: [makeEntry({ isOrigin: true })] }, { stopTimes: [makeEntry()] }];
+
+    const result = applyStopEventAttributeTogglesToStops(stops, {
+      showOriginOnly: false,
+      showBoardableOnly: false,
+    });
+
+    expect(result).toBe(stops);
+  });
+
+  it('keeps unchanged entry content and empties only the stops that do not match', () => {
+    const untouched = { stopTimes: [makeEntry({ isOrigin: true })] };
+    const changed = { stopTimes: [makeEntry({ isOrigin: false })] };
+
+    const result = applyStopEventAttributeTogglesToStops([untouched, changed], {
+      showOriginOnly: true,
+      showBoardableOnly: false,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).not.toBe(untouched);
+    expect(result[0]?.stopTimes).toEqual(untouched.stopTimes);
+    expect(result[0]?.stopTimes[0]).toBe(untouched.stopTimes[0]);
+    expect(result[1]).not.toBe(changed);
+    expect(result[1]?.stopTimes).toEqual([]);
+  });
+
+  it('handles empty input', () => {
+    expect(
+      applyStopEventAttributeTogglesToStops([], {
+        showOriginOnly: true,
+        showBoardableOnly: true,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('omitStopsWithoutStopTimes', () => {
+  it('removes only empty stops and preserves surviving stop references', () => {
+    const nonEmptyA = { stopTimes: [makeEntry()] };
+    const empty = { stopTimes: [] };
+    const nonEmptyB = { stopTimes: [makeEntry({ isOrigin: true })] };
+
+    const result = omitStopsWithoutStopTimes([nonEmptyA, empty, nonEmptyB]);
+
+    expect(result).toEqual([nonEmptyA, nonEmptyB]);
+    expect(result[0]).toBe(nonEmptyA);
+    expect(result[1]).toBe(nonEmptyB);
+  });
+
+  it('returns empty when all stops are empty', () => {
+    expect(omitStopsWithoutStopTimes([{ stopTimes: [] }, { stopTimes: [] }])).toEqual([]);
   });
 });
 

--- a/src/domain/transit/compute-stops-counts.ts
+++ b/src/domain/transit/compute-stops-counts.ts
@@ -19,7 +19,7 @@ export function computeStopsCounts<T extends StopTimesCarrier>(items: readonly T
       counts.total += 1;
 
       if (item.stopTimes.length > 0) {
-        counts.active += 1;
+        counts.nonEmpty += 1;
       }
       if (item.stopTimes.some((entry) => entry.patternPosition.isOrigin)) {
         counts.originCount += 1;
@@ -32,7 +32,7 @@ export function computeStopsCounts<T extends StopTimesCarrier>(items: readonly T
     },
     {
       total: 0,
-      active: 0,
+      nonEmpty: 0,
       originCount: 0,
       boardableCount: 0,
     },

--- a/src/domain/transit/compute-stops-counts.ts
+++ b/src/domain/transit/compute-stops-counts.ts
@@ -1,0 +1,40 @@
+import type { StopsCounts } from '../../types/app/stop';
+import type { TimetableEntry } from '../../types/app/transit-composed';
+
+interface StopTimesCarrier {
+  stopTimes: readonly TimetableEntry[];
+}
+
+function hasBoardableEntry(entries: readonly TimetableEntry[]): boolean {
+  return entries.some(
+    (entry) =>
+      entry.boarding.pickupType === 0 &&
+      (entry.patternPosition.isOrigin || !entry.patternPosition.isTerminal),
+  );
+}
+
+export function computeStopsCounts<T extends StopTimesCarrier>(items: readonly T[]): StopsCounts {
+  return items.reduce<StopsCounts>(
+    (counts, item) => {
+      counts.total += 1;
+
+      if (item.stopTimes.length > 0) {
+        counts.active += 1;
+      }
+      if (item.stopTimes.some((entry) => entry.patternPosition.isOrigin)) {
+        counts.originCount += 1;
+      }
+      if (hasBoardableEntry(item.stopTimes)) {
+        counts.boardableCount += 1;
+      }
+
+      return counts;
+    },
+    {
+      total: 0,
+      active: 0,
+      originCount: 0,
+      boardableCount: 0,
+    },
+  );
+}

--- a/src/domain/transit/timetable-filter.ts
+++ b/src/domain/transit/timetable-filter.ts
@@ -281,6 +281,10 @@ export interface StopEventAttributeToggles {
   showBoardableOnly: boolean;
 }
 
+interface StopTimesCarrier<T extends TimetableEntry = TimetableEntry> {
+  stopTimes: readonly T[];
+}
+
 /**
  * Apply the user-facing entry-attribute toggles
  * (`showOriginOnly` / `showBoardableOnly`) to a list of entries.
@@ -310,4 +314,32 @@ export function applyStopEventAttributeToggles<T extends TimetableEntry>(
     });
   }
   return result;
+}
+
+/**
+ * Apply stop-event attribute toggles to each stop's inner `stopTimes`
+ * collection while preserving the outer stop list.
+ *
+ * Stops whose entries become empty are intentionally retained; callers
+ * can decide in a separate step whether empty stops should remain for
+ * placeholder rendering or be omitted from the list entirely.
+ */
+export function applyStopEventAttributeTogglesToStops<T extends StopTimesCarrier>(
+  stops: readonly T[],
+  toggles: StopEventAttributeToggles,
+): T[] {
+  if (!toggles.showOriginOnly && !toggles.showBoardableOnly) {
+    return stops as T[];
+  }
+  return stops.map((stop) => {
+    const filtered = applyStopEventAttributeToggles(stop.stopTimes, toggles);
+    return filtered === stop.stopTimes ? stop : { ...stop, stopTimes: filtered };
+  });
+}
+
+/**
+ * Omit stops whose inner `stopTimes` collection is empty.
+ */
+export function omitStopsWithoutStopTimes<T extends StopTimesCarrier>(stops: readonly T[]): T[] {
+  return stops.filter((stop) => stop.stopTimes.length > 0);
 }

--- a/src/types/app/global-filter.ts
+++ b/src/types/app/global-filter.ts
@@ -1,5 +1,5 @@
 /**
- * App-wide filter state shared across surfaces (BottomSheet,
+ * App-wide display filter state shared across surfaces (BottomSheet,
  * TimetableModal, MapView, TripInspectionDialog, etc.).
  *
  * Owned by `app.tsx` and threaded through props as a single
@@ -12,8 +12,12 @@ export interface GlobalFilter {
   showOriginOnly: boolean;
   /** When true, narrow to entries with `pickup_type === 0` at non-pure-terminal positions. */
   showBoardableOnly: boolean;
+  /** When true, omit stops whose filtered `stopTimes` collection is empty. */
+  omitEmptyStops: boolean;
   /** Toggle `showOriginOnly`. */
   onToggleShowOriginOnly: () => void;
   /** Toggle `showBoardableOnly`. */
   onToggleShowBoardableOnly: () => void;
+  /** Toggle `omitEmptyStops`. */
+  onToggleOmitEmptyStops: () => void;
 }

--- a/src/types/app/global-filter.ts
+++ b/src/types/app/global-filter.ts
@@ -12,8 +12,10 @@ export interface GlobalFilter {
   showOriginOnly: boolean;
   /** When true, narrow to entries with `pickup_type === 0` at non-pure-terminal positions. */
   showBoardableOnly: boolean;
-  /** When true, omit stops whose filtered `stopTimes` collection is empty. */
+  /** Effective empty-stop visibility policy after forced-on conditions are applied. */
   omitEmptyStops: boolean;
+  /** Whether empty-stop omission is currently forced by another app-wide toggle. */
+  isOmitEmptyStopsForced: boolean;
   /** Toggle `showOriginOnly`. */
   onToggleShowOriginOnly: () => void;
   /** Toggle `showBoardableOnly`. */

--- a/src/types/app/stop.ts
+++ b/src/types/app/stop.ts
@@ -1,6 +1,6 @@
 export interface StopsCounts {
   total: number;
-  active: number;
+  nonEmpty: number;
   originCount: number;
   boardableCount: number;
 }

--- a/src/types/app/stop.ts
+++ b/src/types/app/stop.ts
@@ -1,0 +1,6 @@
+export interface StopsCounts {
+  total: number;
+  active: number;
+  originCount: number;
+  boardableCount: number;
+}


### PR DESCRIPTION
## Summary
- lift empty-stop omission into app-level global filter state and reflect forced operating-stops behavior in the bottom sheet UI
- simplify bottom sheet stop summary handling and thread stable stop-count inputs through the header
- refine `PillButton` disabled styling and add Storybook coverage for enabled/disabled border-count combinations
- align bottom sheet filter badge counts with visible stop rows by using pre-local-filter counts
- add targeted debug logging for stop-count snapshots in app and bottom sheet header

## Validation
- `npm run format`
- `npm run lint`
- `npm run build`