### PR TITLE
feat(trip-inspection): pure helpers + stop-based open flow

### DIFF
--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -136,8 +136,8 @@ vi.mock('../components/dialog/timetable-modal', () => ({
   TimetableModal: () => null,
 }));
 
-vi.mock('../components/dialog/stop-search-modal', () => ({
-  StopSearchModal: () => null,
+vi.mock('../components/dialog/stop-search-dialog', () => ({
+  StopSearchDialog: () => null,
 }));
 
 vi.mock('../components/dialog/info-dialog', () => ({

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -552,13 +552,19 @@ export default function App({ loadResult }: AppProps) {
         now: dateTime,
         serviceDate,
       }).then((status) => {
-        if (status === 'no-data') {
-          toast.warning(t('tripInspection.noData'));
+        if (status.status === 'no-data') {
+          const messageKey =
+            status.reason === 'no-stop-data'
+              ? 'tripInspection.messages.noStopData'
+              : status.reason === 'no-service-on-this-day'
+                ? 'tripInspection.messages.noServiceOnThisDay'
+                : 'tripInspection.messages.noData';
+          toast.warning(t(messageKey));
           return;
         }
 
-        if (status === 'error') {
-          toast.error(t('tripInspection.openFailed'));
+        if (status.status === 'error') {
+          toast.error(t('tripInspection.messages.openFailed'));
         }
       });
     },
@@ -568,13 +574,19 @@ export default function App({ loadResult }: AppProps) {
   const handleInspectTrip = useCallback(
     (target: TripInspectionTarget) => {
       void openTripInspectionFromTarget(target).then((status) => {
-        if (status === 'no-data') {
-          toast.warning(t('tripInspection.noData'));
+        if (status.status === 'no-data') {
+          const messageKey =
+            status.reason === 'no-stop-data'
+              ? 'tripInspection.messages.noStopData'
+              : status.reason === 'no-service-on-this-day'
+                ? 'tripInspection.messages.noServiceOnThisDay'
+                : 'tripInspection.messages.noData';
+          toast.warning(t(messageKey));
           return;
         }
 
-        if (status === 'error') {
-          toast.error(t('tripInspection.openFailed'));
+        if (status.status === 'error') {
+          toast.error(t('tripInspection.messages.openFailed'));
         }
       });
     },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -45,7 +45,11 @@ import { LocalStorageUserDataRepository } from './repositories/local-storage-use
 import type { Bounds, LatLng, RouteShape } from './types/app/map';
 import type { StopsCounts } from './types/app/stop';
 import type { AppRouteTypeValue, Stop, TimetableEntriesState } from './types/app/transit';
-import type { StopWithContext, StopWithMeta } from './types/app/transit-composed';
+import type {
+  StopWithContext,
+  StopWithMeta,
+  TripInspectionTarget,
+} from './types/app/transit-composed';
 import { formatDateParts } from './utils/datetime';
 import { toggleGroupInList } from './utils/list-toggle';
 import { routeTypeGroup } from './utils/route-type-category';
@@ -125,7 +129,8 @@ export default function App({ loadResult }: AppProps) {
     tripInspectionSnapshot,
     tripInspectionTargets,
     currentTripInspectionTargetIndex,
-    openTripInspection,
+    openTripInspectionFromTarget,
+    openTripInspectionFromStopId,
     openPreviousTripInspection,
     openNextTripInspection,
     closeTripInspection,
@@ -538,6 +543,44 @@ export default function App({ loadResult }: AppProps) {
     [showTimetable],
   );
 
+  const handleOpenTripInspectionByStopId = useCallback(
+    (stopId: string) => {
+      const serviceDate = getServiceDay(dateTime);
+
+      void openTripInspectionFromStopId({
+        stopId,
+        now: dateTime,
+        serviceDate,
+      }).then((status) => {
+        if (status === 'no-data') {
+          toast.warning(t('tripInspection.noData'));
+          return;
+        }
+
+        if (status === 'error') {
+          toast.error(t('tripInspection.openFailed'));
+        }
+      });
+    },
+    [dateTime, openTripInspectionFromStopId, t],
+  );
+
+  const handleInspectTrip = useCallback(
+    (target: TripInspectionTarget) => {
+      void openTripInspectionFromTarget(target).then((status) => {
+        if (status === 'no-data') {
+          toast.warning(t('tripInspection.noData'));
+          return;
+        }
+
+        if (status === 'error') {
+          toast.error(t('tripInspection.openFailed'));
+        }
+      });
+    },
+    [openTripInspectionFromTarget, t],
+  );
+
   const closeTimetableModal = useCallback(() => setTimetableData(null), []);
 
   const handleTripInspectionOpenChange = useCallback(
@@ -566,8 +609,8 @@ export default function App({ loadResult }: AppProps) {
   const anchorIds = useMemo(() => new Set(anchors.map((a) => a.stopId)), [anchors]);
 
   // Toggle anchor (bookmark) status for a stop
-  const handleToggleAnchor = useCallback(
-    (stopId: string, routeTypes: AppRouteTypeValue[]) => {
+  const handleToggleAnchorByStopId = useCallback(
+    (stopId: string) => {
       if (isStopAnchor(stopId)) {
         // Capture anchor data before removal (entry won't exist after removeAnchor).
         // Resolve display name from current GTFS so the toast follows
@@ -598,41 +641,45 @@ export default function App({ loadResult }: AppProps) {
           }
         });
       } else {
-        const meta = findStopWithMeta(stopId);
-        if (meta) {
-          const displayName =
-            getStopDisplayNames(
-              meta.stop,
-              langChain,
-              resolveAgencyLang(meta.agencies, meta.stop.agency_id),
-            ).name || meta.stop.stop_name;
-          logger.debug(`handleToggleAnchor: adding stopId=${stopId}, name=${displayName}`);
-          void addAnchor({
-            stopId: meta.stop.stop_id,
-            stopName: meta.stop.stop_name,
-            stopLat: meta.stop.stop_lat,
-            stopLon: meta.stop.stop_lon,
-            routeTypes,
-          }).then((result) => {
-            if (result.success) {
-              toast.success(t('anchor.added'), {
-                description: `${routeTypesEmoji(routeTypes)} ${displayName}`,
+        void Promise.all([repo.getStopMetaById(stopId), repo.getRouteTypesForStop(stopId)]).then(
+          ([metaResult, routeTypesResult]) => {
+            if (!metaResult.success) {
+              logger.warn('handleToggleAnchorByStopId: stop metadata lookup failed', {
+                stopId,
+                error: metaResult.error,
               });
+              return;
             }
-          });
-        }
+
+            const meta = metaResult.data;
+            const routeTypes = routeTypesResult.success ? routeTypesResult.data : [-1 as const];
+            const displayName =
+              getStopDisplayNames(
+                meta.stop,
+                langChain,
+                resolveAgencyLang(meta.agencies, meta.stop.agency_id),
+              ).name || meta.stop.stop_name;
+            logger.debug(
+              `handleToggleAnchorByStopId: adding stopId=${stopId}, name=${displayName}`,
+            );
+            void addAnchor({
+              stopId: meta.stop.stop_id,
+              stopName: meta.stop.stop_name,
+              stopLat: meta.stop.stop_lat,
+              stopLon: meta.stop.stop_lon,
+              routeTypes,
+            }).then((result) => {
+              if (result.success) {
+                toast.success(t('anchor.added'), {
+                  description: `${routeTypesEmoji(routeTypes)} ${displayName}`,
+                });
+              }
+            });
+          },
+        );
       }
     },
-    [
-      isStopAnchor,
-      anchors,
-      removeAnchor,
-      addAnchor,
-      findStopWithMeta,
-      lookupAnchorStopMeta,
-      langChain,
-      t,
-    ],
+    [isStopAnchor, anchors, removeAnchor, addAnchor, repo, lookupAnchorStopMeta, langChain, t],
   );
 
   // Select + pan to a stop from Portal dropdown
@@ -959,8 +1006,9 @@ export default function App({ loadResult }: AppProps) {
           onStopSelected: handleSelectStopById,
           onShowTimetable: handleShowTimetable,
           onShowStopTimetable: handleShowStopTimetable,
-          onToggleAnchor: handleToggleAnchor,
-          onInspectTrip: openTripInspection,
+          onToggleAnchor: handleToggleAnchorByStopId,
+          onOpenTripInspectionByStopId: handleOpenTripInspectionByStopId,
+          onInspectTrip: handleInspectTrip,
         }}
         globalFilter={globalFilter}
         nearbyStopsCounts={nearbyStopsCounts}
@@ -979,6 +1027,7 @@ export default function App({ loadResult }: AppProps) {
         infoLevel={settings.infoLevel}
         dataLang={langChain}
         onSelectStop={handleSearchSelect}
+        onOpenTripInspectionByStopId={handleOpenTripInspectionByStopId}
         open={searchModalOpen}
         onOpenChange={setSearchModalOpen}
       />
@@ -1003,7 +1052,7 @@ export default function App({ loadResult }: AppProps) {
         infoLevel={settings.infoLevel}
         dataLangs={langChain}
         globalFilter={globalFilter}
-        onInspectTrip={openTripInspection}
+        onInspectTrip={handleInspectTrip}
         onClose={closeTimetableModal}
       />
       <Toaster

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { InfoDialog } from './components/dialog/info-dialog';
 import { ShortcutHelpDialog } from './components/dialog/shortcut-help-dialog';
-import { StopSearchModal } from './components/dialog/stop-search-modal';
+import { StopSearchDialog } from './components/dialog/stop-search-dialog';
 import { TimetableModal, type TimetableData } from './components/dialog/timetable-modal';
 import { TripInspectionDialog } from './components/dialog/trip-inspection-dialog';
 import { MapBottomSheetLayout } from './components/map-bottom-sheet-layout';
@@ -1034,11 +1034,14 @@ export default function App({ loadResult }: AppProps) {
           />
         }
       />
-      <StopSearchModal
+      <StopSearchDialog
         repo={repo}
         infoLevel={settings.infoLevel}
         dataLang={langChain}
+        isStopAnchor={isStopAnchor}
         onSelectStop={handleSearchSelect}
+        onToggleAnchor={handleToggleAnchorByStopId}
+        onShowStopTimetable={handleShowStopTimetable}
         onOpenTripInspectionByStopId={handleOpenTripInspectionByStopId}
         open={searchModalOpen}
         onOpenChange={setSearchModalOpen}

--- a/src/components/bottom-sheet-stops.tsx
+++ b/src/components/bottom-sheet-stops.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState, type RefObject } from 'react';
 import { useScrollFades } from '@/hooks/use-scroll-fades';
 import type { LatLng } from '../types/app/map';
 import type { InfoLevel } from '../types/app/settings';
-import type { AppRouteTypeValue, TimetableEntriesState } from '../types/app/transit';
+import type { TimetableEntriesState } from '../types/app/transit';
 import type { StopWithContext, TripInspectionTarget } from '../types/app/transit-composed';
 import { ScrollFadeEdge } from './shared/scroll-fade-edge';
 import { NearbyStop, type NearbyStopProps } from './nearby-stop';
@@ -35,7 +35,9 @@ interface BottomSheetStopsProps {
   onShowTimetable?: (stopId: string, routeId: string, headsign: string) => void;
   onShowStopTimetable?: (stopId: string) => void;
   /** Toggle anchor (bookmark) status for a stop. */
-  onToggleAnchor: (stopId: string, routeTypes: AppRouteTypeValue[]) => void;
+  onToggleAnchor: (stopId: string) => void;
+  /** Optional callback for opening trip inspection from a stop ID. */
+  onOpenTripInspectionByStopId?: (stopId: string) => void;
   /** Optional callback for inspecting one concrete trip. */
   onInspectTrip?: (target: TripInspectionTarget) => void;
 }
@@ -55,6 +57,7 @@ export function BottomSheetStops({
   onShowTimetable,
   onShowStopTimetable,
   onToggleAnchor,
+  onOpenTripInspectionByStopId,
   onInspectTrip,
 }: BottomSheetStopsProps) {
   const stopIdsKey = useMemo(() => stopTimes.map((swc) => swc.stop.stop_id).join(','), [stopTimes]);
@@ -88,6 +91,7 @@ export function BottomSheetStops({
             onShowTimetable,
             onShowStopTimetable,
             onToggleAnchor,
+            onOpenTripInspectionByStopId,
             onInspectTrip,
           };
           // Eager render: first N stops, or the selected stop (so scroll-to-selected works)

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -82,7 +82,9 @@ export interface BottomSheetProps {
   onShowTimetable?: (stopId: string, routeId: string, headsign: string) => void;
   onShowStopTimetable?: (stopId: string) => void;
   /** Toggle anchor (bookmark) status for a stop. */
-  onToggleAnchor: (stopId: string, routeTypes: AppRouteTypeValue[]) => void;
+  onToggleAnchor: (stopId: string) => void;
+  /** Optional callback for opening trip inspection from a stop ID. */
+  onOpenTripInspectionByStopId?: (stopId: string) => void;
   /** Optional callback for inspecting one concrete trip. */
   onInspectTrip?: (target: TripInspectionTarget) => void;
   /** Collapsed-state height class applied to the sheet root. */
@@ -114,6 +116,7 @@ export function BottomSheet({
   onShowTimetable,
   onShowStopTimetable,
   onToggleAnchor,
+  onOpenTripInspectionByStopId,
   onInspectTrip,
   collapsedHeightClassName = 'h-[40dvh]',
   expandedHeightClassName = 'h-[70dvh]',
@@ -316,6 +319,7 @@ export function BottomSheet({
         onShowTimetable={onShowTimetable}
         onShowStopTimetable={onShowStopTimetable}
         onToggleAnchor={onToggleAnchor}
+        onOpenTripInspectionByStopId={onOpenTripInspectionByStopId}
         onInspectTrip={onInspectTrip}
       />
     </div>

--- a/src/components/dialog/dialog-memoization.test.tsx
+++ b/src/components/dialog/dialog-memoization.test.tsx
@@ -177,7 +177,7 @@ vi.mock('../verbose/verbose-trip-stop-time', () => ({
 }));
 
 import { TimetableModal, type TimetableData } from './timetable-modal';
-import { StopSearchModal } from './stop-search-modal';
+import { StopSearchDialog } from './stop-search-dialog';
 import { TripInspectionDialog } from './trip-inspection-dialog';
 
 function makeRoute(id: string): Route {
@@ -435,7 +435,7 @@ describe('dialog memoization regressions', () => {
     expect(tripStopsRenderMock).toHaveBeenCalledTimes(initialRenderCount + 1);
   });
 
-  it('StopSearchModal skips rerender when props are identical', () => {
+  it('StopSearchDialog skips rerender when props are identical', () => {
     const repo = makeRepo();
     const props = {
       repo,
@@ -446,16 +446,16 @@ describe('dialog memoization regressions', () => {
       onOpenChange: vi.fn(),
     };
 
-    const { rerender } = render(<StopSearchModal {...props} />);
+    const { rerender } = render(<StopSearchDialog {...props} />);
     const initialRenderCount = useTranslationMock.mock.calls.length;
 
     expect(initialRenderCount).toBeGreaterThan(0);
 
-    rerender(<StopSearchModal {...props} />);
+    rerender(<StopSearchDialog {...props} />);
 
     expect(useTranslationMock).toHaveBeenCalledTimes(initialRenderCount);
 
-    rerender(<StopSearchModal {...props} infoLevel={'detailed'} />);
+    rerender(<StopSearchDialog {...props} infoLevel={'detailed'} />);
 
     expect(useTranslationMock).toHaveBeenCalledTimes(initialRenderCount + 1);
   });

--- a/src/components/dialog/stop-search-dialog.tsx
+++ b/src/components/dialog/stop-search-dialog.tsx
@@ -1,15 +1,3 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
-import { useTranslation } from 'react-i18next';
-import { DEFAULT_AGENCY_LANG } from '@/config/transit-defaults';
-import type { AppRouteTypeValue, Stop } from '@/types/app/transit';
-import type { TransitRepository } from '@/repositories/transit-repository';
-import type { InfoLevel } from '@/types/app/settings';
-import { useInfoLevel } from '@/hooks/use-info-level';
-import { katakanaToHiragana } from '@/utils/kana-normalize';
-import { getStopDisplayNames } from '@/domain/transit/get-stop-display-names';
-import { resolveStopRouteTypes } from '@/domain/transit/resolve-stop-route-types';
-import { routeTypesEmoji } from '@/utils/route-type-emoji';
-import { createLogger } from '@/lib/logger';
 import {
   Dialog,
   DialogContent,
@@ -17,6 +5,18 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { DEFAULT_AGENCY_LANG } from '@/config/transit-defaults';
+import { getStopDisplayNames } from '@/domain/transit/get-stop-display-names';
+import { resolveStopRouteTypes } from '@/domain/transit/resolve-stop-route-types';
+import { useInfoLevel } from '@/hooks/use-info-level';
+import { createLogger } from '@/lib/logger';
+import type { TransitRepository } from '@/repositories/transit-repository';
+import type { InfoLevel } from '@/types/app/settings';
+import type { AppRouteTypeValue, Stop } from '@/types/app/transit';
+import { katakanaToHiragana } from '@/utils/kana-normalize';
+import { routeTypesEmoji } from '@/utils/route-type-emoji';
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 import { IdBadge } from '../badge/id-badge';
 import { StopActionButtons } from '../stop-action-buttons';
 
@@ -27,6 +27,7 @@ const MAX_RESULTS = 20;
 interface StopSearchResultItemProps {
   stop: Stop;
   routeTypes: AppRouteTypeValue[];
+  isAnchor: boolean;
   query: string;
   normalizedQuery: string;
   infoLevel: InfoLevel;
@@ -37,12 +38,15 @@ interface StopSearchResultItemProps {
   /** Ref forwarded to the underlying button so the parent can scroll it into view. */
   buttonRef: (el: HTMLButtonElement | null) => void;
   onSelect: (stop: Stop) => void;
+  onToggleAnchor?: (stopId: string) => void;
+  onShowStopTimetable?: (stopId: string) => void;
   onOpenTripInspectionByStopId?: (stopId: string) => void;
 }
 
 function StopSearchResultItem({
   stop,
   routeTypes,
+  isAnchor,
   query,
   normalizedQuery,
   infoLevel,
@@ -50,6 +54,8 @@ function StopSearchResultItem({
   isSelected,
   buttonRef,
   onSelect,
+  onToggleAnchor,
+  onShowStopTimetable,
   onOpenTripInspectionByStopId,
 }: StopSearchResultItemProps) {
   const info = useInfoLevel(infoLevel);
@@ -101,8 +107,14 @@ function StopSearchResultItem({
       </button>
       <StopActionButtons
         stopId={stop.stop_id}
+        isAnchor={isAnchor}
         layout="horizontal"
+        onToggleAnchor={onToggleAnchor}
+        onShowStopTimetable={onShowStopTimetable}
         onOpenTripInspectionByStopId={onOpenTripInspectionByStopId}
+        showAnchorButton
+        showStopTimetableButton
+        showTripInspectionButton
       />
     </div>
   );
@@ -152,26 +164,62 @@ function HighlightedName({
   );
 }
 
-interface StopSearchModalProps {
+interface StopSearchInputSectionProps {
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  placeholder: string;
+  query: string;
+  onQueryChange: (query: string) => void;
+  onInputKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+}
+
+function StopSearchInputSection({
+  inputRef,
+  placeholder,
+  query,
+  onQueryChange,
+  onInputKeyDown,
+}: StopSearchInputSectionProps) {
+  return (
+    <div className="border-border shrink-0 border-b px-4 py-3">
+      <input
+        ref={inputRef}
+        type="text"
+        className="border-input bg-background focus:border-ring focus:ring-ring/20 w-full rounded-lg border px-3 py-2.5 text-base outline-none focus:ring-2"
+        placeholder={placeholder}
+        value={query}
+        onChange={(event) => onQueryChange(event.target.value)}
+        onKeyDown={onInputKeyDown}
+      />
+    </div>
+  );
+}
+
+interface StopSearchDialogProps {
   repo: TransitRepository;
   infoLevel: InfoLevel;
   /** Display language chain for translated GTFS/ODPT data names. */
   dataLang: readonly string[];
+  isStopAnchor?: (stopId: string) => boolean;
   onSelectStop: (stop: Stop, routeTypes: AppRouteTypeValue[]) => void;
+  onToggleAnchor?: (stopId: string) => void;
+  onShowStopTimetable?: (stopId: string) => void;
   onOpenTripInspectionByStopId?: (stopId: string) => void;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-export const StopSearchModal = memo(function StopSearchModal({
+export const StopSearchDialog = memo(function StopSearchDialog({
   repo,
   infoLevel,
   dataLang,
+  isStopAnchor,
   onSelectStop,
+  onToggleAnchor,
+  onShowStopTimetable,
   onOpenTripInspectionByStopId,
   open,
   onOpenChange,
-}: StopSearchModalProps) {
+}: StopSearchDialogProps) {
   const { t } = useTranslation();
   const [query, setQuery] = useState('');
   const [allStops, setAllStops] = useState<Stop[]>([]);
@@ -354,17 +402,13 @@ export const StopSearchModal = memo(function StopSearchModal({
           <DialogTitle className="text-[15px]">{t('search.title')}</DialogTitle>
           <DialogDescription className="sr-only">{t('search.description')}</DialogDescription>
         </DialogHeader>
-        <div className="border-border shrink-0 border-b px-4 py-3">
-          <input
-            ref={inputRef}
-            type="text"
-            className="border-input bg-background focus:border-ring focus:ring-ring/20 w-full rounded-lg border px-3 py-2.5 text-base outline-none focus:ring-2"
-            placeholder={t('search.placeholder')}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleInputKeyDown}
-          />
-        </div>
+        <StopSearchInputSection
+          inputRef={inputRef}
+          placeholder={t('search.placeholder')}
+          query={query}
+          onQueryChange={setQuery}
+          onInputKeyDown={handleInputKeyDown}
+        />
         <div className="flex-1 overflow-y-auto">
           {filteredStops.length > 0
             ? filteredStops.map((stop, index) => (
@@ -377,6 +421,7 @@ export const StopSearchModal = memo(function StopSearchModal({
                     routes: null,
                     unknownPolicy: 'include-unknown',
                   })}
+                  isAnchor={isStopAnchor?.(stop.stop_id) ?? false}
                   query={trimmedQuery}
                   normalizedQuery={normalizedQuery}
                   infoLevel={infoLevel}
@@ -386,6 +431,8 @@ export const StopSearchModal = memo(function StopSearchModal({
                     itemRefs.current[index] = el;
                   }}
                   onSelect={handleSelect}
+                  onToggleAnchor={onToggleAnchor}
+                  onShowStopTimetable={onShowStopTimetable}
                   onOpenTripInspectionByStopId={onOpenTripInspectionByStopId}
                 />
               ))

--- a/src/components/dialog/stop-search-modal.tsx
+++ b/src/components/dialog/stop-search-modal.tsx
@@ -18,6 +18,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { IdBadge } from '../badge/id-badge';
+import { StopActionButtons } from '../stop-action-buttons';
 
 const logger = createLogger('StopSearch');
 
@@ -36,6 +37,7 @@ interface StopSearchResultItemProps {
   /** Ref forwarded to the underlying button so the parent can scroll it into view. */
   buttonRef: (el: HTMLButtonElement | null) => void;
   onSelect: (stop: Stop) => void;
+  onOpenTripInspectionByStopId?: (stopId: string) => void;
 }
 
 function StopSearchResultItem({
@@ -48,6 +50,7 @@ function StopSearchResultItem({
   isSelected,
   buttonRef,
   onSelect,
+  onOpenTripInspectionByStopId,
 }: StopSearchResultItemProps) {
   const info = useInfoLevel(infoLevel);
   // Always show subNames in search results for discoverability.
@@ -64,31 +67,44 @@ function StopSearchResultItem({
   const stopNames = getStopDisplayNames(stop, dataLang, DEFAULT_AGENCY_LANG);
 
   return (
-    <button
-      ref={buttonRef}
-      className={`border-border active:bg-accent flex w-full cursor-pointer items-center gap-2.5 border-t-0 border-r-0 border-b border-l-0 px-4 py-3 text-left font-[inherit] last:border-b-0 ${
+    <div
+      className={`border-border flex items-stretch gap-2 border-t-0 border-r-0 border-b border-l-0 px-4 py-3 last:border-b-0 ${
         isSelected ? 'bg-accent' : 'bg-transparent'
       }`}
-      onClick={() => onSelect(stop)}
     >
-      <div className="flex min-w-0 flex-col gap-0.5">
-        {info.isVerboseEnabled && <IdBadge>{stop.stop_id}</IdBadge>}
-        <span className="text-foreground text-[15px]">
-          {routeTypesEmoji(routeTypes)}{' '}
-          <HighlightedName name={stopNames.name} query={query} normalizedQuery={normalizedQuery} />
-        </span>
-        {stopNames.subNames.length > 0 && (
-          <span className="text-muted-foreground text-xs leading-snug">
-            {stopNames.subNames.map((name, i) => (
-              <span key={`${i}-${name}`}>
-                {i > 0 && ' / '}
-                <HighlightedName name={name} query={query} normalizedQuery={normalizedQuery} />
-              </span>
-            ))}
+      <button
+        ref={buttonRef}
+        className="active:bg-accent flex min-w-0 flex-1 cursor-pointer items-center gap-2.5 text-left font-[inherit]"
+        onClick={() => onSelect(stop)}
+      >
+        <div className="flex min-w-0 flex-col gap-0.5">
+          {info.isVerboseEnabled && <IdBadge>{stop.stop_id}</IdBadge>}
+          <span className="text-foreground text-[15px]">
+            {routeTypesEmoji(routeTypes)}{' '}
+            <HighlightedName
+              name={stopNames.name}
+              query={query}
+              normalizedQuery={normalizedQuery}
+            />
           </span>
-        )}
-      </div>
-    </button>
+          {stopNames.subNames.length > 0 && (
+            <span className="text-muted-foreground text-xs leading-snug">
+              {stopNames.subNames.map((name, i) => (
+                <span key={`${i}-${name}`}>
+                  {i > 0 && ' / '}
+                  <HighlightedName name={name} query={query} normalizedQuery={normalizedQuery} />
+                </span>
+              ))}
+            </span>
+          )}
+        </div>
+      </button>
+      <StopActionButtons
+        stopId={stop.stop_id}
+        layout="horizontal"
+        onOpenTripInspectionByStopId={onOpenTripInspectionByStopId}
+      />
+    </div>
   );
 }
 
@@ -142,6 +158,7 @@ interface StopSearchModalProps {
   /** Display language chain for translated GTFS/ODPT data names. */
   dataLang: readonly string[];
   onSelectStop: (stop: Stop, routeTypes: AppRouteTypeValue[]) => void;
+  onOpenTripInspectionByStopId?: (stopId: string) => void;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -151,6 +168,7 @@ export const StopSearchModal = memo(function StopSearchModal({
   infoLevel,
   dataLang,
   onSelectStop,
+  onOpenTripInspectionByStopId,
   open,
   onOpenChange,
 }: StopSearchModalProps) {
@@ -330,7 +348,7 @@ export const StopSearchModal = memo(function StopSearchModal({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="top-12 flex max-h-[80dvh] max-w-[90vw] translate-y-0 flex-col gap-0 overflow-hidden border-4 p-0"
+        className="top-12 flex max-h-[80dvh] max-w-[80vw] translate-y-0 flex-col gap-0 overflow-hidden border-4 p-0"
       >
         <DialogHeader className="border-border shrink-0 border-b p-4">
           <DialogTitle className="text-[15px]">{t('search.title')}</DialogTitle>
@@ -368,6 +386,7 @@ export const StopSearchModal = memo(function StopSearchModal({
                     itemRefs.current[index] = el;
                   }}
                   onSelect={handleSelect}
+                  onOpenTripInspectionByStopId={onOpenTripInspectionByStopId}
                 />
               ))
             : query.trim() !== '' && (

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -316,7 +316,7 @@ export const TimetableModal = memo(function TimetableModal({
       {/* border-4: intentional thick border to visually distinguish the timetable modal from the map background */}
       <DialogContent
         showCloseButton={false}
-        className="flex max-h-[80dvh] max-w-[90dvw] flex-col gap-0 overflow-hidden border-4 p-0 sm:max-w-[90dvw]"
+        className="flex max-h-[80dvh] w-[90dvw] max-w-5xl flex-col gap-0 overflow-hidden border-4 p-2 sm:max-w-3xl"
       >
         <div
           ref={headerContainerRef}

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -682,7 +682,7 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="flex max-h-[80dvh] max-w-[90vw] flex-col gap-0 overflow-hidden border-4 p-2"
+        className="flex max-h-[80dvh] w-[90dvw] max-w-5xl flex-col gap-0 overflow-hidden border-4 p-2 sm:max-w-2xl"
         style={{ borderColor: adjustedRouteColors.color }}
       >
         <DialogHeader

--- a/src/components/nearby-stop.tsx
+++ b/src/components/nearby-stop.tsx
@@ -154,6 +154,9 @@ export function NearbyStop({
           onToggleAnchor={onToggleAnchor}
           onShowStopTimetable={onShowStopTimetable}
           onOpenTripInspectionByStopId={onOpenTripInspectionByStopId}
+          showAnchorButton
+          showStopTimetableButton
+          showTripInspectionButton={false}
         />
       </div>
 

--- a/src/components/nearby-stop.tsx
+++ b/src/components/nearby-stop.tsx
@@ -1,4 +1,3 @@
-import { Clock, Signpost } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getEffectiveHeadsign } from '../domain/transit/get-effective-headsign';
@@ -10,9 +9,10 @@ import {
 import { useInfoLevel } from '../hooks/use-info-level';
 import type { LatLng } from '../types/app/map';
 import type { InfoLevel } from '../types/app/settings';
-import type { AppRouteTypeValue, TimetableEntriesState } from '../types/app/transit';
+import type { TimetableEntriesState } from '../types/app/transit';
 import type { StopWithContext, TripInspectionTarget } from '../types/app/transit-composed';
 import { StopInfo } from './stop-info';
+import { StopActionButtons } from './stop-action-buttons';
 import { StopTimeItem } from './stop-time-item';
 import { StopTimesItem } from './stop-times-item';
 import { VerboseNearbyStopSummary } from './verbose/verbose-nearby-stop-summary';
@@ -43,72 +43,11 @@ export interface NearbyStopProps {
   onShowTimetable?: (stopId: string, routeId: string, headsign: string) => void;
   onShowStopTimetable?: (stopId: string) => void;
   /** Toggle anchor (bookmark) status for this stop. */
-  onToggleAnchor: (stopId: string, routeTypes: AppRouteTypeValue[]) => void;
+  onToggleAnchor: (stopId: string) => void;
+  /** Optional callback for opening trip inspection from a stop ID. */
+  onOpenTripInspectionByStopId?: (stopId: string) => void;
   /** Optional callback for inspecting one concrete trip. */
   onInspectTrip?: (target: TripInspectionTarget) => void;
-}
-
-interface NearbyStopActionButtonsProps {
-  stopId: string;
-  routeTypes: AppRouteTypeValue[];
-  isAnchor: boolean;
-  layout?: 'horizontal' | 'vertical';
-  onToggleAnchor: (stopId: string, routeTypes: AppRouteTypeValue[]) => void;
-  onShowStopTimetable?: (stopId: string) => void;
-}
-
-function NearbyStopActionButtons({
-  stopId,
-  routeTypes,
-  isAnchor,
-  layout = 'vertical',
-  onToggleAnchor,
-  onShowStopTimetable,
-}: NearbyStopActionButtonsProps) {
-  const { t } = useTranslation();
-  const layoutClassName =
-    layout === 'horizontal'
-      ? 'ml-auto flex shrink-0 self-stretch flex-row items-start justify-end'
-      : 'ml-auto flex shrink-0 self-stretch flex-col items-end justify-start';
-
-  return (
-    <div className={`${layoutClassName} gap-1`}>
-      <button
-        type="button"
-        className="shrink-0 cursor-pointer rounded border border-amber-400 bg-transparent px-1.5 py-0.5 active:bg-amber-50 dark:border-amber-500 dark:active:bg-amber-950"
-        onClick={(e) => {
-          e.stopPropagation();
-          onToggleAnchor(stopId, routeTypes);
-        }}
-        title={isAnchor ? t('anchor.remove') : t('anchor.add')}
-        aria-label={isAnchor ? t('anchor.remove') : t('anchor.add')}
-        aria-pressed={isAnchor}
-      >
-        <Signpost
-          size={16}
-          strokeWidth={2}
-          className={isAnchor ? 'text-amber-500' : 'text-gray-400'}
-        />
-      </button>
-      {onShowStopTimetable && (
-        <>
-          <button
-            type="button"
-            className="shrink-0 cursor-pointer rounded border border-teal-600 bg-transparent px-1.5 py-0.5 text-teal-600 active:bg-teal-600/10 dark:border-teal-400 dark:text-teal-400 dark:active:bg-teal-400/10"
-            // className="shrink-0 cursor-pointer rounded border border-slate-600 bg-transparent px-1.5 py-0.5 text-slate-600 active:bg-slate-600/10 dark:border-slate-300 dark:text-slate-300 dark:active:bg-slate-300/10"
-            onClick={(e) => {
-              e.stopPropagation();
-              onShowStopTimetable(stopId);
-            }}
-            title={t('showTimetable')}
-            aria-label={t('showTimetable')}
-          >
-            <Clock size={16} strokeWidth={2} />
-          </button>
-        </>
-      )}
-    </div>
-  );
 }
 
 export function NearbyStop({
@@ -125,6 +64,7 @@ export function NearbyStop({
   onShowTimetable,
   onShowStopTimetable,
   onToggleAnchor,
+  onOpenTripInspectionByStopId,
   onInspectTrip,
 }: NearbyStopProps) {
   const { t } = useTranslation();
@@ -207,13 +147,13 @@ export function NearbyStop({
           agencyBadgeSize={'md'}
           routeBadgeSize={'sm'}
         />
-        <NearbyStopActionButtons
+        <StopActionButtons
           stopId={stop.stop_id}
-          routeTypes={routeTypes}
           isAnchor={isAnchor}
           layout={'vertical'}
           onToggleAnchor={onToggleAnchor}
           onShowStopTimetable={onShowStopTimetable}
+          onOpenTripInspectionByStopId={onOpenTripInspectionByStopId}
         />
       </div>
 

--- a/src/components/stop-action-buttons.stories.tsx
+++ b/src/components/stop-action-buttons.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { baseStop } from '../stories/fixtures';
+import { StopActionButtons } from './stop-action-buttons';
+
+const meta = {
+  title: 'Stop/StopActionButtons',
+  component: StopActionButtons,
+  args: {
+    stopId: baseStop.stop_id,
+    isAnchor: false,
+    layout: 'vertical',
+    showAnchorButton: true,
+    showStopTimetableButton: true,
+    showTripInspectionButton: true,
+    onToggleAnchor: fn(),
+    onShowStopTimetable: fn(),
+    onOpenTripInspectionByStopId: fn(),
+  },
+  argTypes: {
+    layout: { control: 'inline-radio', options: ['horizontal', 'vertical'] },
+    isAnchor: { control: 'boolean' },
+    showAnchorButton: { control: 'boolean' },
+    showStopTimetableButton: { control: 'boolean' },
+    showTripInspectionButton: { control: 'boolean' },
+  },
+  decorators: [
+    (Story) => (
+      <div className="rounded-lg bg-[#f5f7fa] p-3 dark:bg-gray-800">
+        <div className="flex min-h-24 w-32 rounded border border-dashed border-gray-300 bg-white p-2 dark:border-gray-600 dark:bg-gray-900">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof StopActionButtons>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// --- Basic ---
+
+export const Default: Story = {};
+
+export const Anchored: Story = {
+  args: {
+    isAnchor: true,
+  },
+};
+
+// --- Layout ---
+
+export const Horizontal: Story = {
+  args: {
+    layout: 'horizontal',
+  },
+};
+
+export const LayoutComparison: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-3">
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">Vertical</span>
+        <div className="flex min-h-24 w-32 rounded border border-dashed border-gray-300 bg-white p-2 dark:border-gray-600 dark:bg-gray-900">
+          <StopActionButtons {...args} layout="vertical" />
+        </div>
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">Horizontal</span>
+        <div className="flex min-h-16 w-40 rounded border border-dashed border-gray-300 bg-white p-2 dark:border-gray-600 dark:bg-gray-900">
+          <StopActionButtons {...args} layout="horizontal" />
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+// --- Visibility ---
+
+export const TimetableOnly: Story = {
+  args: {
+    showAnchorButton: false,
+    showTripInspectionButton: false,
+  },
+};
+
+export const TripInspectionOnly: Story = {
+  args: {
+    showAnchorButton: false,
+    showStopTimetableButton: false,
+  },
+};
+
+export const VisibilityComparison: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-3">
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">All actions</span>
+        <div className="flex min-h-24 w-32 rounded border border-dashed border-gray-300 bg-white p-2 dark:border-gray-600 dark:bg-gray-900">
+          <StopActionButtons {...args} />
+        </div>
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">Timetable only</span>
+        <div className="flex min-h-24 w-32 rounded border border-dashed border-gray-300 bg-white p-2 dark:border-gray-600 dark:bg-gray-900">
+          <StopActionButtons {...args} showAnchorButton={false} showTripInspectionButton={false} />
+        </div>
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">Trip inspection only</span>
+        <div className="flex min-h-24 w-32 rounded border border-dashed border-gray-300 bg-white p-2 dark:border-gray-600 dark:bg-gray-900">
+          <StopActionButtons {...args} showAnchorButton={false} showStopTimetableButton={false} />
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+// --- Kitchen sink ---
+
+export const KitchenSink: Story = {
+  args: {
+    isAnchor: true,
+    layout: 'vertical',
+    showAnchorButton: true,
+    showStopTimetableButton: true,
+    showTripInspectionButton: true,
+  },
+};

--- a/src/components/stop-action-buttons.tsx
+++ b/src/components/stop-action-buttons.tsx
@@ -1,76 +1,102 @@
+import type { ReactNode } from 'react';
 import { Clock, Route, Signpost } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
 
 interface StopActionButtonsProps {
   stopId: string;
   isAnchor?: boolean;
   layout?: 'horizontal' | 'vertical';
+  showAnchorButton?: boolean;
+  showStopTimetableButton?: boolean;
+  showTripInspectionButton?: boolean;
   onToggleAnchor?: (stopId: string) => void;
   onShowStopTimetable?: (stopId: string) => void;
   onOpenTripInspectionByStopId?: (stopId: string) => void;
+}
+
+interface ActionButtonProps {
+  title: string;
+  className?: string;
+  onClick: () => void;
+  children: ReactNode;
+}
+
+function ActionButton({ title, className, onClick, children }: ActionButtonProps) {
+  const baseClassName = 'bg-background shrink-0 cursor-pointer rounded border px-1.5 py-0.5';
+
+  return (
+    <button
+      type="button"
+      className={cn(baseClassName, className)}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      title={title}
+      aria-label={title}
+    >
+      {children}
+    </button>
+  );
 }
 
 export function StopActionButtons({
   stopId,
   isAnchor,
   layout = 'vertical',
+  showAnchorButton = false,
+  showStopTimetableButton = false,
+  showTripInspectionButton = false,
   onToggleAnchor,
   onShowStopTimetable,
   onOpenTripInspectionByStopId,
 }: StopActionButtonsProps) {
   const { t } = useTranslation();
-  const layoutClassName =
+  const layoutClassName = cn(
+    'ml-auto flex shrink-0 self-stretch',
     layout === 'horizontal'
-      ? 'ml-auto flex shrink-0 self-stretch flex-row items-start justify-end'
-      : 'ml-auto flex shrink-0 self-stretch flex-col items-end justify-start';
+      ? 'flex-row items-start justify-end'
+      : 'flex-col items-end justify-start',
+  );
 
   return (
-    <div className={`${layoutClassName} gap-1`}>
-      {onToggleAnchor && isAnchor !== undefined && (
-        <button
-          type="button"
-          className="shrink-0 cursor-pointer rounded border border-amber-400 bg-transparent px-1.5 py-0.5 active:bg-amber-50 dark:border-amber-500 dark:active:bg-amber-950"
-          onClick={(event) => {
-            event.stopPropagation();
-            onToggleAnchor(stopId);
-          }}
+    <div className={cn(layoutClassName, 'gap-1')}>
+      {/* Anchor Button */}
+      {showAnchorButton && onToggleAnchor && isAnchor !== undefined && (
+        <ActionButton
+          className={cn(
+            'border-amber-400 active:bg-amber-50 dark:border-amber-500 dark:active:bg-amber-950',
+            isAnchor
+              ? 'bg-amber-300 text-white dark:bg-amber-400'
+              : 'text-amber-400 dark:text-amber-500',
+          )}
+          onClick={() => onToggleAnchor(stopId)}
           title={isAnchor ? t('anchor.remove') : t('anchor.add')}
-          aria-label={isAnchor ? t('anchor.remove') : t('anchor.add')}
         >
-          <Signpost
-            size={16}
-            strokeWidth={2}
-            className={isAnchor ? 'text-amber-500' : 'text-gray-400'}
-          />
-        </button>
+          <Signpost size={16} strokeWidth={2} />
+        </ActionButton>
       )}
-      {onShowStopTimetable && (
-        <button
-          type="button"
-          className="shrink-0 cursor-pointer rounded border border-teal-600 bg-transparent px-1.5 py-0.5 text-teal-600 active:bg-teal-600/10 dark:border-teal-400 dark:text-teal-400 dark:active:bg-teal-400/10"
-          onClick={(event) => {
-            event.stopPropagation();
-            onShowStopTimetable(stopId);
-          }}
+      {/* Timetable Button */}
+      {showStopTimetableButton && onShowStopTimetable && (
+        <ActionButton
+          className="border-teal-600 text-teal-600 active:bg-teal-600/10 dark:border-teal-400 dark:text-teal-400 dark:active:bg-teal-400/10"
+          onClick={() => onShowStopTimetable(stopId)}
           title={t('showTimetable')}
-          aria-label={t('showTimetable')}
         >
           <Clock size={16} strokeWidth={2} />
-        </button>
+        </ActionButton>
       )}
-      {onOpenTripInspectionByStopId && (
-        <button
-          type="button"
-          className="shrink-0 cursor-pointer rounded border border-sky-600 bg-transparent px-1.5 py-1 text-sky-600 active:bg-sky-600/10 dark:border-sky-400 dark:text-sky-400 dark:active:bg-sky-400/10"
-          onClick={(event) => {
-            event.stopPropagation();
-            onOpenTripInspectionByStopId(stopId);
-          }}
+      {/* Trip Inspection Button */}
+      {showTripInspectionButton && onOpenTripInspectionByStopId && (
+        <ActionButton
+          className="border-sky-600 text-sky-600 active:bg-sky-600/10 dark:border-sky-400 dark:text-sky-400 dark:active:bg-sky-400/10"
+          onClick={() => onOpenTripInspectionByStopId(stopId)}
           title={t('tripInspection.title')}
-          aria-label={t('tripInspection.title')}
         >
           <Route size={16} strokeWidth={2} />
-        </button>
+        </ActionButton>
       )}
     </div>
   );

--- a/src/components/stop-action-buttons.tsx
+++ b/src/components/stop-action-buttons.tsx
@@ -1,0 +1,77 @@
+import { Clock, Route, Signpost } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+interface StopActionButtonsProps {
+  stopId: string;
+  isAnchor?: boolean;
+  layout?: 'horizontal' | 'vertical';
+  onToggleAnchor?: (stopId: string) => void;
+  onShowStopTimetable?: (stopId: string) => void;
+  onOpenTripInspectionByStopId?: (stopId: string) => void;
+}
+
+export function StopActionButtons({
+  stopId,
+  isAnchor,
+  layout = 'vertical',
+  onToggleAnchor,
+  onShowStopTimetable,
+  onOpenTripInspectionByStopId,
+}: StopActionButtonsProps) {
+  const { t } = useTranslation();
+  const layoutClassName =
+    layout === 'horizontal'
+      ? 'ml-auto flex shrink-0 self-stretch flex-row items-start justify-end'
+      : 'ml-auto flex shrink-0 self-stretch flex-col items-end justify-start';
+
+  return (
+    <div className={`${layoutClassName} gap-1`}>
+      {onToggleAnchor && isAnchor !== undefined && (
+        <button
+          type="button"
+          className="shrink-0 cursor-pointer rounded border border-amber-400 bg-transparent px-1.5 py-0.5 active:bg-amber-50 dark:border-amber-500 dark:active:bg-amber-950"
+          onClick={(event) => {
+            event.stopPropagation();
+            onToggleAnchor(stopId);
+          }}
+          title={isAnchor ? t('anchor.remove') : t('anchor.add')}
+          aria-label={isAnchor ? t('anchor.remove') : t('anchor.add')}
+        >
+          <Signpost
+            size={16}
+            strokeWidth={2}
+            className={isAnchor ? 'text-amber-500' : 'text-gray-400'}
+          />
+        </button>
+      )}
+      {onShowStopTimetable && (
+        <button
+          type="button"
+          className="shrink-0 cursor-pointer rounded border border-teal-600 bg-transparent px-1.5 py-0.5 text-teal-600 active:bg-teal-600/10 dark:border-teal-400 dark:text-teal-400 dark:active:bg-teal-400/10"
+          onClick={(event) => {
+            event.stopPropagation();
+            onShowStopTimetable(stopId);
+          }}
+          title={t('showTimetable')}
+          aria-label={t('showTimetable')}
+        >
+          <Clock size={16} strokeWidth={2} />
+        </button>
+      )}
+      {onOpenTripInspectionByStopId && (
+        <button
+          type="button"
+          className="shrink-0 cursor-pointer rounded border border-sky-600 bg-transparent px-1.5 py-1 text-sky-600 active:bg-sky-600/10 dark:border-sky-400 dark:text-sky-400 dark:active:bg-sky-400/10"
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenTripInspectionByStopId(stopId);
+          }}
+          title={t('tripInspection.title')}
+          aria-label={t('tripInspection.title')}
+        >
+          <Route size={16} strokeWidth={2} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/domain/transit/__tests__/trip-inspection-target.test.ts
+++ b/src/domain/transit/__tests__/trip-inspection-target.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isSameTripInspectionTarget,
+  resolveSnapshotStopIndex,
+  resolveTripInspectionTarget,
+  selectTripInspectionTargetByReferenceTime,
+} from '../trip-inspection-target';
+import type {
+  TripInspectionTarget,
+  TripLocator,
+  TripStopTime,
+} from '../../../types/app/transit-composed';
+import type { Route } from '../../../types/app/transit';
+
+function makeRoute(routeId = 'test:R1'): Route {
+  return {
+    route_id: routeId,
+    route_short_name: routeId,
+    route_short_names: {},
+    route_long_name: routeId,
+    route_long_names: {},
+    route_type: 3,
+    route_color: '000000',
+    route_text_color: 'FFFFFF',
+    agency_id: 'test:agency',
+  };
+}
+
+function makeLocator(overrides: Partial<TripLocator> = {}): TripLocator {
+  return { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 0, ...overrides };
+}
+
+function makeTarget(overrides: Partial<TripInspectionTarget> = {}): TripInspectionTarget {
+  const { tripLocator, ...rest } = overrides;
+  return {
+    tripLocator: makeLocator(tripLocator),
+    serviceDate: new Date(2026, 4, 2),
+    stopIndex: 3,
+    departureMinutes: 600,
+    ...rest,
+  };
+}
+
+function makeStopTime(
+  stopIndex: number,
+  departureMinutes: number,
+  arrivalMinutes = departureMinutes,
+): TripStopTime {
+  return {
+    routeTypes: [],
+    timetableEntry: {
+      tripLocator: makeLocator(),
+      schedule: { departureMinutes, arrivalMinutes },
+      routeDirection: {
+        route: makeRoute(),
+        tripHeadsign: { name: 'Terminal', names: {} },
+      },
+      boarding: { pickupType: 0, dropOffType: 0 },
+      patternPosition: {
+        stopIndex,
+        totalStops: 10,
+        isTerminal: false,
+        isOrigin: false,
+      },
+    },
+  };
+}
+
+describe('isSameTripInspectionTarget', () => {
+  it('treats targets with the same trip/service-day/stop-index tuple as identical', () => {
+    const left = makeTarget({ departureMinutes: 600 });
+    const right = makeTarget({ departureMinutes: 605 });
+
+    expect(isSameTripInspectionTarget(left, right)).toBe(true);
+  });
+
+  it('returns false when stopIndex differs', () => {
+    const left = makeTarget({ stopIndex: 3 });
+    const right = makeTarget({ stopIndex: 4 });
+
+    expect(isSameTripInspectionTarget(left, right)).toBe(false);
+  });
+
+  it.each<[string, Partial<TripInspectionTarget>]>([
+    ['patternId', { tripLocator: { patternId: 'pattern-b' } }],
+    ['serviceId', { tripLocator: { serviceId: 'saturday' } }],
+    ['tripIndex', { tripLocator: { tripIndex: 1 } }],
+    ['serviceDate', { serviceDate: new Date(2026, 4, 3) }],
+  ])('returns false when %s differs', (_label, override) => {
+    expect(isSameTripInspectionTarget(makeTarget(), makeTarget(override))).toBe(false);
+  });
+
+  it('compares serviceDate by value, not by Date instance reference', () => {
+    // Two distinct Date instances representing the same moment must be equal.
+    // Guards against accidental `===` regression on the serviceDate field.
+    const moment = new Date(2026, 4, 2).getTime();
+    expect(
+      isSameTripInspectionTarget(
+        makeTarget({ serviceDate: new Date(moment) }),
+        makeTarget({ serviceDate: new Date(moment) }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('selectTripInspectionTargetByReferenceTime', () => {
+  it('returns null for an empty candidate list', () => {
+    expect(selectTripInspectionTargetByReferenceTime([], 600)).toBeNull();
+  });
+
+  it('selects the first departure at or after the reference time', () => {
+    const candidates = [
+      makeTarget({ stopIndex: 1, departureMinutes: 540 }),
+      makeTarget({ stopIndex: 2, departureMinutes: 600 }),
+      makeTarget({ stopIndex: 3, departureMinutes: 660 }),
+    ];
+
+    expect(selectTripInspectionTargetByReferenceTime(candidates, 590)).toEqual({
+      target: candidates[1],
+      index: 1,
+      matchType: 'reference-time',
+    });
+  });
+
+  it('falls back to the final candidate when all departures are before the reference time', () => {
+    const candidates = [
+      makeTarget({ stopIndex: 1, departureMinutes: 540 }),
+      makeTarget({ stopIndex: 2, departureMinutes: 600 }),
+    ];
+
+    expect(selectTripInspectionTargetByReferenceTime(candidates, 800)).toEqual({
+      target: candidates[1],
+      index: 1,
+      matchType: 'reference-time',
+    });
+  });
+
+  it('selects the boundary candidate when reference equals its departure time', () => {
+    // Pins the `>=` boundary: a candidate departing exactly at the reference
+    // time must be selected over later ones. Guards against `>=` → `>` regression.
+    const candidates = [
+      makeTarget({ stopIndex: 1, departureMinutes: 540 }),
+      makeTarget({ stopIndex: 2, departureMinutes: 600 }),
+      makeTarget({ stopIndex: 3, departureMinutes: 660 }),
+    ];
+
+    expect(selectTripInspectionTargetByReferenceTime(candidates, 600)).toEqual({
+      target: candidates[1],
+      index: 1,
+      matchType: 'reference-time',
+    });
+  });
+
+  it('selects the first candidate when reference is before all departures', () => {
+    const candidates = [
+      makeTarget({ stopIndex: 1, departureMinutes: 540 }),
+      makeTarget({ stopIndex: 2, departureMinutes: 600 }),
+    ];
+
+    expect(selectTripInspectionTargetByReferenceTime(candidates, 400)).toEqual({
+      target: candidates[0],
+      index: 0,
+      matchType: 'reference-time',
+    });
+  });
+});
+
+describe('resolveTripInspectionTarget', () => {
+  it('returns null for an empty candidate list', () => {
+    expect(resolveTripInspectionTarget([], makeTarget())).toBeNull();
+  });
+
+  it('returns the exact matching candidate when one exists', () => {
+    const requestedTarget = makeTarget({ stopIndex: 4, departureMinutes: 620 });
+    const candidates = [
+      makeTarget({ stopIndex: 1, departureMinutes: 500 }),
+      makeTarget({ stopIndex: 4, departureMinutes: 630 }),
+      makeTarget({
+        tripLocator: {
+          patternId: 'pattern-b',
+          serviceId: 'weekday',
+          tripIndex: 0,
+        },
+        stopIndex: 4,
+        departureMinutes: 620,
+      }),
+    ];
+
+    expect(resolveTripInspectionTarget(candidates, requestedTarget)).toEqual({
+      target: candidates[1],
+      index: 1,
+      matchType: 'exact',
+    });
+  });
+
+  it('returns the first exact match when multiple exact candidates exist', () => {
+    const requestedTarget = makeTarget({ stopIndex: 4, departureMinutes: 620 });
+    const candidates = [
+      makeTarget({ stopIndex: 4, departureMinutes: 610 }),
+      makeTarget({ stopIndex: 4, departureMinutes: 630 }),
+      makeTarget({ stopIndex: 7, departureMinutes: 700 }),
+    ];
+
+    expect(resolveTripInspectionTarget(candidates, requestedTarget)).toEqual({
+      target: candidates[0],
+      index: 0,
+      matchType: 'exact',
+    });
+  });
+
+  it('falls back to the closest candidate within the same trip when no exact stop-event match exists', () => {
+    const requestedTarget = makeTarget({ stopIndex: 5, departureMinutes: 620 });
+    const candidates = [
+      makeTarget({ stopIndex: 2, departureMinutes: 580 }),
+      makeTarget({ stopIndex: 4, departureMinutes: 618 }),
+      makeTarget({ stopIndex: 7, departureMinutes: 640 }),
+    ];
+
+    expect(resolveTripInspectionTarget(candidates, requestedTarget)).toEqual({
+      target: candidates[1],
+      index: 1,
+      matchType: 'fallback',
+    });
+  });
+
+  it('prefers the smaller stopIndex distance when fallback candidates have the same departure distance', () => {
+    const requestedTarget = makeTarget({ stopIndex: 5, departureMinutes: 620 });
+    const candidates = [
+      makeTarget({ stopIndex: 1, departureMinutes: 610 }),
+      makeTarget({ stopIndex: 4, departureMinutes: 630 }),
+      makeTarget({ stopIndex: 8, departureMinutes: 630 }),
+    ];
+
+    expect(resolveTripInspectionTarget(candidates, requestedTarget)).toEqual({
+      target: candidates[1],
+      index: 1,
+      matchType: 'fallback',
+    });
+  });
+
+  it('breaks combined ties by the earlier raw departure time', () => {
+    // Both candidates are equidistant in departure (|620-618|=|620-622|=2) and
+    // stopIndex (|5-4|=|5-6|=1) from the reference. Tertiary tie-break must
+    // pick the smaller raw `departureMinutes` (= the earlier departure).
+    const requestedTarget = makeTarget({ stopIndex: 5, departureMinutes: 620 });
+    const candidates = [
+      makeTarget({ stopIndex: 6, departureMinutes: 622 }),
+      makeTarget({ stopIndex: 4, departureMinutes: 618 }),
+    ];
+
+    expect(resolveTripInspectionTarget(candidates, requestedTarget)).toEqual({
+      target: candidates[1],
+      index: 1,
+      matchType: 'fallback',
+    });
+  });
+
+  it('returns null when no candidate belongs to the same trip locator', () => {
+    const requestedTarget = makeTarget();
+    const candidates = [
+      makeTarget({
+        tripLocator: {
+          patternId: 'pattern-b',
+          serviceId: 'weekday',
+          tripIndex: 0,
+        },
+      }),
+    ];
+
+    expect(resolveTripInspectionTarget(candidates, requestedTarget)).toBeNull();
+  });
+});
+
+describe('resolveSnapshotStopIndex', () => {
+  it('returns the exact stopIndex match when present', () => {
+    const stopTimes = [makeStopTime(1, 540), makeStopTime(3, 600), makeStopTime(5, 660)];
+
+    expect(
+      resolveSnapshotStopIndex(stopTimes, makeTarget({ stopIndex: 3, departureMinutes: 601 })),
+    ).toBe(1);
+  });
+
+  it('falls back to the stop row with the nearest departure time and then nearest stopIndex', () => {
+    const stopTimes = [makeStopTime(1, 540), makeStopTime(4, 618), makeStopTime(8, 618)];
+
+    expect(
+      resolveSnapshotStopIndex(stopTimes, makeTarget({ stopIndex: 5, departureMinutes: 620 })),
+    ).toBe(1);
+  });
+
+  it('keeps the first fallback row when departure and stopIndex distances are tied', () => {
+    const stopTimes = [makeStopTime(4, 618), makeStopTime(6, 622)];
+
+    expect(
+      resolveSnapshotStopIndex(stopTimes, makeTarget({ stopIndex: 5, departureMinutes: 620 })),
+    ).toBe(0);
+  });
+
+  it('returns -1 when the snapshot has no stop rows', () => {
+    expect(resolveSnapshotStopIndex([], makeTarget())).toBe(-1);
+  });
+
+  it('returns the first match when multiple stop rows share the same stopIndex', () => {
+    // Defensive: circular / 6-shape patterns may legitimately reuse the same
+    // physical stop_id, but `stopIndex` is the unique positional identifier
+    // so a duplicate here would indicate malformed snapshot data. Guarantee
+    // deterministic first-match behavior so consumers can rely on the index.
+    const stopTimes = [makeStopTime(3, 540), makeStopTime(3, 600)];
+
+    expect(
+      resolveSnapshotStopIndex(stopTimes, makeTarget({ stopIndex: 3, departureMinutes: 590 })),
+    ).toBe(0);
+  });
+});

--- a/src/domain/transit/__tests__/trip-inspection-target.test.ts
+++ b/src/domain/transit/__tests__/trip-inspection-target.test.ts
@@ -31,7 +31,11 @@ function makeLocator(overrides: Partial<TripLocator> = {}): TripLocator {
   return { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 0, ...overrides };
 }
 
-function makeTarget(overrides: Partial<TripInspectionTarget> = {}): TripInspectionTarget {
+type TripInspectionTargetOverrides = Omit<Partial<TripInspectionTarget>, 'tripLocator'> & {
+  tripLocator?: Partial<TripLocator>;
+};
+
+function makeTarget(overrides: TripInspectionTargetOverrides = {}): TripInspectionTarget {
   const { tripLocator, ...rest } = overrides;
   return {
     tripLocator: makeLocator(tripLocator),
@@ -82,7 +86,7 @@ describe('isSameTripInspectionTarget', () => {
     expect(isSameTripInspectionTarget(left, right)).toBe(false);
   });
 
-  it.each<[string, Partial<TripInspectionTarget>]>([
+  it.each<[string, TripInspectionTargetOverrides]>([
     ['patternId', { tripLocator: { patternId: 'pattern-b' } }],
     ['serviceId', { tripLocator: { serviceId: 'saturday' } }],
     ['tripIndex', { tripLocator: { tripIndex: 1 } }],

--- a/src/domain/transit/__tests__/trip-inspection-target.test.ts
+++ b/src/domain/transit/__tests__/trip-inspection-target.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import {
   isSameTripInspectionTarget,
+  resolveSelectedTripInspectionSnapshot,
   resolveSnapshotStopIndex,
+  resolveTripInspectionDisplayState,
   resolveTripInspectionTarget,
   selectTripInspectionTargetByReferenceTime,
 } from '../trip-inspection-target';
 import type {
+  TripSnapshot,
   TripInspectionTarget,
   TripLocator,
   TripStopTime,
@@ -68,6 +71,16 @@ function makeStopTime(
         isOrigin: false,
       },
     },
+  };
+}
+
+function makeTripSnapshot(stopTimes: TripStopTime[]): TripSnapshot {
+  return {
+    locator: makeLocator(),
+    route: makeRoute(),
+    tripHeadsign: { name: 'Terminal', names: {} },
+    serviceDate: new Date(2026, 4, 2),
+    stopTimes,
   };
 }
 
@@ -315,5 +328,124 @@ describe('resolveSnapshotStopIndex', () => {
     expect(
       resolveSnapshotStopIndex(stopTimes, makeTarget({ stopIndex: 3, departureMinutes: 590 })),
     ).toBe(0);
+  });
+});
+
+describe('resolveSelectedTripInspectionSnapshot', () => {
+  it('returns a selected snapshot and stopId when the target stop row exists', () => {
+    const stopTimes = [
+      makeStopTime(1, 540),
+      {
+        ...makeStopTime(3, 600),
+        stopMeta: {
+          stop: {
+            stop_id: 'test:stop-3',
+            stop_name: 'Stop 3',
+            stop_names: {},
+            stop_lat: 35,
+            stop_lon: 139,
+            location_type: 0,
+            agency_id: 'test:agency',
+          },
+          agencies: [],
+          routes: [],
+        },
+      },
+    ];
+
+    expect(
+      resolveSelectedTripInspectionSnapshot(
+        makeTripSnapshot(stopTimes),
+        makeTarget({ stopIndex: 3, departureMinutes: 601 }),
+      ),
+    ).toEqual({
+      ok: true,
+      data: {
+        snapshot: {
+          ...makeTripSnapshot(stopTimes),
+          currentStopIndex: 1,
+          selectedStop: stopTimes[1],
+        },
+        selectedStopId: 'test:stop-3',
+      },
+    });
+  });
+
+  it('returns a missing-pattern-position reason when the snapshot has no matching stop row', () => {
+    expect(resolveSelectedTripInspectionSnapshot(makeTripSnapshot([]), makeTarget())).toEqual({
+      ok: false,
+      reason: 'pattern-position-missing',
+    });
+  });
+});
+
+describe('resolveTripInspectionDisplayState', () => {
+  it('returns the snapshot unchanged when the target resolves exactly', () => {
+    const stopTimes = [makeStopTime(1, 540), makeStopTime(3, 600), makeStopTime(5, 660)];
+    const snapshot = {
+      ...makeTripSnapshot(stopTimes),
+      currentStopIndex: 1,
+      selectedStop: stopTimes[1],
+    };
+    const candidates = [makeTarget({ stopIndex: 1, departureMinutes: 540 }), makeTarget()];
+
+    expect(resolveTripInspectionDisplayState(snapshot, candidates, makeTarget())).toEqual({
+      ok: true,
+      data: {
+        snapshot,
+        targets: candidates,
+        targetIndex: 1,
+      },
+    });
+  });
+
+  it('rebuilds the snapshot around the fallback target when only a same-trip fallback exists', () => {
+    const stopTimes = [makeStopTime(1, 540), makeStopTime(4, 618), makeStopTime(8, 700)];
+    const snapshot = {
+      ...makeTripSnapshot(stopTimes),
+      currentStopIndex: 0,
+      selectedStop: stopTimes[0],
+    };
+    const candidates = [makeTarget({ stopIndex: 4, departureMinutes: 620 })];
+
+    expect(
+      resolveTripInspectionDisplayState(
+        snapshot,
+        candidates,
+        makeTarget({ stopIndex: 5, departureMinutes: 620 }),
+      ),
+    ).toEqual({
+      ok: true,
+      data: {
+        snapshot: {
+          ...snapshot,
+          currentStopIndex: 1,
+          selectedStop: stopTimes[1],
+        },
+        targets: candidates,
+        targetIndex: 0,
+      },
+    });
+  });
+
+  it('returns a target-not-found reason when no candidate can be resolved', () => {
+    const stopTimes = [makeStopTime(1, 540)];
+    const snapshot = {
+      ...makeTripSnapshot(stopTimes),
+      currentStopIndex: 0,
+      selectedStop: stopTimes[0],
+    };
+
+    expect(
+      resolveTripInspectionDisplayState(
+        snapshot,
+        [
+          makeTarget({
+            tripLocator: { patternId: 'pattern-b' },
+          }),
+        ],
+        makeTarget(),
+      ),
+    ).toEqual({ ok: false, reason: 'target-not-found' });
   });
 });

--- a/src/domain/transit/trip-inspection-target.ts
+++ b/src/domain/transit/trip-inspection-target.ts
@@ -1,0 +1,229 @@
+import type { TripInspectionTarget, TripStopTime } from '../../types/app/transit-composed';
+
+export interface ResolvedTripInspectionTarget {
+  target: TripInspectionTarget;
+  index: number;
+  matchType: 'exact' | 'fallback' | 'reference-time';
+}
+
+/**
+ * Returns whether two trip-inspection targets refer to the same stop event.
+ *
+ * This comparison intentionally ignores `departureMinutes`. The current
+ * model treats `(tripLocator, serviceDate, stopIndex)` as the primary exact
+ * identity, while departure time is used later as a distance/tie-break signal
+ * when multiple nearby candidates must be resolved.
+ *
+ * @param left - First target to compare.
+ * @param right - Second target to compare.
+ * @returns `true` when both targets point at the same trip / service day /
+ *          stop-index tuple.
+ */
+export function isSameTripInspectionTarget(
+  left: TripInspectionTarget,
+  right: TripInspectionTarget,
+): boolean {
+  return (
+    left.tripLocator.patternId === right.tripLocator.patternId &&
+    left.tripLocator.serviceId === right.tripLocator.serviceId &&
+    left.tripLocator.tripIndex === right.tripLocator.tripIndex &&
+    left.stopIndex === right.stopIndex &&
+    left.serviceDate.getTime() === right.serviceDate.getTime()
+  );
+}
+
+/**
+ * Returns whether two targets belong to the same reconstructed trip instance.
+ *
+ * This is weaker than {@link isSameTripInspectionTarget}: it ignores the
+ * selected stop position and therefore groups all stop events that belong to
+ * the same concrete trip on the same service day.
+ *
+ * @param left - First target to compare.
+ * @param right - Second target to compare.
+ * @returns `true` when both targets share the same trip locator and service day.
+ */
+function isSameTripLocator(left: TripInspectionTarget, right: TripInspectionTarget): boolean {
+  return (
+    left.tripLocator.patternId === right.tripLocator.patternId &&
+    left.tripLocator.serviceId === right.tripLocator.serviceId &&
+    left.tripLocator.tripIndex === right.tripLocator.tripIndex &&
+    left.serviceDate.getTime() === right.serviceDate.getTime()
+  );
+}
+
+/**
+ * Orders two candidates by how close they are to a reference target.
+ *
+ * The comparison is intentionally narrow: departure-time distance is the
+ * primary signal, stop-index distance is the tie-break, and raw departure time
+ * is the final deterministic tie-break. Callers should already have filtered
+ * candidates to a compatible subset (for example the same trip locator) before
+ * using this comparator.
+ *
+ * @param left - First candidate.
+ * @param right - Second candidate.
+ * @param reference - Reference target the candidates are being compared against.
+ * @returns Negative when `left` is closer, positive when `right` is closer,
+ *          or `0` when they are equivalent under this ordering.
+ */
+function compareCandidateDistance(
+  left: TripInspectionTarget,
+  right: TripInspectionTarget,
+  reference: TripInspectionTarget,
+): number {
+  const leftDepartureDistance = Math.abs(left.departureMinutes - reference.departureMinutes);
+  const rightDepartureDistance = Math.abs(right.departureMinutes - reference.departureMinutes);
+  if (leftDepartureDistance !== rightDepartureDistance) {
+    return leftDepartureDistance - rightDepartureDistance;
+  }
+
+  const leftStopIndexDistance = Math.abs(left.stopIndex - reference.stopIndex);
+  const rightStopIndexDistance = Math.abs(right.stopIndex - reference.stopIndex);
+  if (leftStopIndexDistance !== rightStopIndexDistance) {
+    return leftStopIndexDistance - rightStopIndexDistance;
+  }
+
+  return left.departureMinutes - right.departureMinutes;
+}
+
+/**
+ * Selects one trip-inspection target from an ordered candidate list using a
+ * reference service-day time.
+ *
+ * The input is expected to preserve repository ordering (`departureMinutes`
+ * ascending, then `stopIndex`, then route ordering). The selector returns the
+ * first candidate whose departure is at or after the reference service-day
+ * minutes. If no such candidate exists, it falls back to the final candidate
+ * in the list.
+ *
+ * @param candidates - Ordered trip-inspection candidates to choose from.
+ * @param serviceDayMinutes - Reference time expressed as service-day minutes.
+ * @returns The selected candidate and its original index, or `null` when the
+ *          input is empty.
+ */
+export function selectTripInspectionTargetByReferenceTime(
+  candidates: TripInspectionTarget[],
+  serviceDayMinutes: number,
+): ResolvedTripInspectionTarget | null {
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const index = candidates.findIndex(
+    (candidate) => candidate.departureMinutes >= serviceDayMinutes,
+  );
+  const resolvedIndex = index >= 0 ? index : candidates.length - 1;
+  const resolvedTarget = candidates[resolvedIndex];
+  if (!resolvedTarget) {
+    return null;
+  }
+
+  return {
+    target: resolvedTarget,
+    index: resolvedIndex,
+    matchType: 'reference-time',
+  };
+}
+
+/**
+ * Resolves one trip-inspection target from an ordered candidate list using an
+ * existing target as the reference.
+ *
+ * The input is expected to preserve repository ordering (`departureMinutes`
+ * ascending, then `stopIndex`, then route ordering). This helper does not sort
+ * the full input itself; it only sorts the narrowed same-trip fallback subset.
+ *
+ * @param candidates - Ordered trip-inspection candidates to choose from.
+ * @param target - Reference target that should be matched or approximated.
+ * @returns The resolved candidate and its original index, or `null` when no
+ *          candidate can be selected from the input.
+ */
+export function resolveTripInspectionTarget(
+  candidates: TripInspectionTarget[],
+  target: TripInspectionTarget,
+): ResolvedTripInspectionTarget | null {
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const exactIndex = candidates.findIndex((candidate) =>
+    isSameTripInspectionTarget(candidate, target),
+  );
+  if (exactIndex >= 0) {
+    const exactTarget = candidates[exactIndex];
+    if (!exactTarget) {
+      return null;
+    }
+
+    return {
+      target: exactTarget,
+      index: exactIndex,
+      matchType: 'exact',
+    };
+  }
+
+  const sameTripCandidates = candidates
+    .map((candidate, index) => ({ candidate, index }))
+    .filter(({ candidate }) => isSameTripLocator(candidate, target))
+    .sort((left, right) => compareCandidateDistance(left.candidate, right.candidate, target));
+
+  const fallback = sameTripCandidates[0];
+  if (!fallback) {
+    return null;
+  }
+
+  return {
+    target: fallback.candidate,
+    index: fallback.index,
+    matchType: 'fallback',
+  };
+}
+
+/**
+ * Resolves the most suitable stop row inside a reconstructed trip snapshot.
+ *
+ * The function prefers an exact `stopIndex` match. If that pattern-position is
+ * missing from the sparse snapshot, it falls back to the stop row with the
+ * smallest departure-time distance and then the smallest stop-index distance.
+ *
+ * @param stopTimes - Sparse stop rows reconstructed for one trip snapshot.
+ * @param target - Target whose selected stop should be located.
+ * @returns The array index of the best matching stop row, or `-1` when the
+ *          snapshot contains no stop rows at all.
+ */
+export function resolveSnapshotStopIndex(
+  stopTimes: TripStopTime[],
+  target: TripInspectionTarget,
+): number {
+  const exactIndex = stopTimes.findIndex(
+    (stop) => stop.timetableEntry.patternPosition.stopIndex === target.stopIndex,
+  );
+  if (exactIndex >= 0) {
+    return exactIndex;
+  }
+
+  let bestArrayIndex = -1;
+  let bestDepartureDistance = Number.POSITIVE_INFINITY;
+  let bestStopIndexDistance = Number.POSITIVE_INFINITY;
+
+  for (const [index, stop] of stopTimes.entries()) {
+    const departureDistance = Math.abs(
+      stop.timetableEntry.schedule.departureMinutes - target.departureMinutes,
+    );
+    const stopIndexDistance = Math.abs(
+      stop.timetableEntry.patternPosition.stopIndex - target.stopIndex,
+    );
+
+    if (
+      departureDistance < bestDepartureDistance ||
+      (departureDistance === bestDepartureDistance && stopIndexDistance < bestStopIndexDistance)
+    ) {
+      bestArrayIndex = index;
+      bestDepartureDistance = departureDistance;
+      bestStopIndexDistance = stopIndexDistance;
+    }
+  }
+
+  return bestArrayIndex;
+}

--- a/src/domain/transit/trip-inspection-target.ts
+++ b/src/domain/transit/trip-inspection-target.ts
@@ -1,10 +1,46 @@
-import type { TripInspectionTarget, TripStopTime } from '../../types/app/transit-composed';
+import type {
+  SelectedTripSnapshot,
+  TripInspectionTarget,
+  TripSnapshot,
+  TripStopTime,
+} from '../../types/app/transit-composed';
 
 export interface ResolvedTripInspectionTarget {
   target: TripInspectionTarget;
   index: number;
   matchType: 'exact' | 'fallback' | 'reference-time';
 }
+
+export interface ResolvedSelectedTripInspectionSnapshot {
+  snapshot: SelectedTripSnapshot;
+  selectedStopId?: string;
+}
+
+export type ResolveSelectedTripInspectionSnapshotResult =
+  | {
+      ok: true;
+      data: ResolvedSelectedTripInspectionSnapshot;
+    }
+  | {
+      ok: false;
+      reason: 'pattern-position-missing' | 'stop-row-missing';
+    };
+
+export interface ResolvedTripInspectionDisplayState {
+  snapshot: SelectedTripSnapshot;
+  targets: TripInspectionTarget[];
+  targetIndex: number;
+}
+
+export type ResolveTripInspectionDisplayStateResult =
+  | {
+      ok: true;
+      data: ResolvedTripInspectionDisplayState;
+    }
+  | {
+      ok: false;
+      reason: 'target-not-found';
+    };
 
 /**
  * Returns whether two trip-inspection targets refer to the same stop event.
@@ -226,4 +262,92 @@ export function resolveSnapshotStopIndex(
   }
 
   return bestArrayIndex;
+}
+
+/**
+ * Rebuilds the selected stop row inside one reconstructed trip snapshot.
+ *
+ * This helper applies the same sparse-safe stop-index resolution used by trip
+ * inspection, then returns a {@link SelectedTripSnapshot} enriched with the
+ * resolved stop row and its `stop_id` when available.
+ *
+ * @param trip - Reconstructed trip snapshot returned by the repository.
+ * @param target - Target whose selected stop should be located.
+ * @returns The selected snapshot plus optional `stop_id`, or `null` when no
+ *          suitable stop row can be resolved from the snapshot.
+ */
+export function resolveSelectedTripInspectionSnapshot(
+  trip: TripSnapshot,
+  target: TripInspectionTarget,
+): ResolveSelectedTripInspectionSnapshotResult {
+  const selectedStopIndex = resolveSnapshotStopIndex(trip.stopTimes, target);
+  if (selectedStopIndex < 0) {
+    return { ok: false, reason: 'pattern-position-missing' };
+  }
+
+  const selectedStop = trip.stopTimes[selectedStopIndex];
+  if (!selectedStop) {
+    return { ok: false, reason: 'stop-row-missing' };
+  }
+
+  return {
+    ok: true,
+    data: {
+      snapshot: {
+        ...trip,
+        currentStopIndex: selectedStopIndex,
+        selectedStop,
+      },
+      selectedStopId: selectedStop.stopMeta?.stop.stop_id,
+    },
+  };
+}
+
+/**
+ * Resolves the final trip-inspection display state from one snapshot and a set
+ * of stop-level trip-inspection candidates.
+ *
+ * The helper resolves the requested target against the candidate list and, when
+ * needed, rebuilds the snapshot around the fallback target's stop row.
+ *
+ * @param snapshot - Initial selected snapshot reconstructed for the requested target.
+ * @param candidates - Ordered trip-inspection candidates for the selected stop.
+ * @param target - Requested target that should be matched or approximated.
+ * @returns The final snapshot, candidate list, and selected index, or `null`
+ *          when no candidate or fallback snapshot can be resolved.
+ */
+export function resolveTripInspectionDisplayState(
+  snapshot: SelectedTripSnapshot,
+  candidates: TripInspectionTarget[],
+  target: TripInspectionTarget,
+): ResolveTripInspectionDisplayStateResult {
+  const resolvedTarget = resolveTripInspectionTarget(candidates, target);
+  if (!resolvedTarget) {
+    return { ok: false, reason: 'target-not-found' };
+  }
+
+  let resolvedSnapshot = snapshot;
+  if (resolvedTarget.matchType === 'fallback') {
+    const fallbackStopIndex = resolveSnapshotStopIndex(snapshot.stopTimes, resolvedTarget.target);
+    const fallbackSelectedStop =
+      fallbackStopIndex >= 0 ? snapshot.stopTimes[fallbackStopIndex] : undefined;
+    if (!fallbackSelectedStop) {
+      return { ok: false, reason: 'target-not-found' };
+    }
+
+    resolvedSnapshot = {
+      ...snapshot,
+      currentStopIndex: fallbackStopIndex,
+      selectedStop: fallbackSelectedStop,
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      snapshot: resolvedSnapshot,
+      targets: candidates,
+      targetIndex: resolvedTarget.index,
+    },
+  };
 }

--- a/src/hooks/__tests__/use-trip-inspection.test.ts
+++ b/src/hooks/__tests__/use-trip-inspection.test.ts
@@ -1,0 +1,93 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeRepo } from '../../__tests__/helpers';
+import { getServiceDay } from '../../domain/transit/service-day';
+import { useTripInspection } from '../use-trip-inspection';
+
+const mockWarn = vi.fn();
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({
+    isEnabled: vi.fn().mockReturnValue(false),
+    verbose: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: (...args: unknown[]) => {
+      mockWarn(...args);
+    },
+    error: vi.fn(),
+  }),
+}));
+
+describe('useTripInspection', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockWarn.mockReset();
+  });
+
+  it('logs no-service-on-this-day when stopId lookup returns an empty result for the service day', async () => {
+    const now = new Date('2026-05-02T14:59:36+09:00');
+    const serviceDate = getServiceDay(now);
+    const repo = makeRepo({
+      getTripInspectionTargets: vi.fn().mockResolvedValue({
+        success: true,
+        data: [],
+        meta: { emptyReason: 'no-service-on-this-day' },
+      }),
+    });
+
+    const { result } = renderHook(() => useTripInspection(repo));
+
+    let status: Awaited<ReturnType<typeof result.current.openTripInspectionFromStopId>>;
+    await act(async () => {
+      status = await result.current.openTripInspectionFromStopId({
+        stopId: 'sbbus:20023-15',
+        now,
+        serviceDate,
+      });
+    });
+
+    expect(status!).toBe('no-data');
+    expect(mockWarn).toHaveBeenCalledWith(
+      'openTripInspectionFromStopId: empty trip inspection target result',
+      expect.objectContaining({
+        stopId: 'sbbus:20023-15',
+        emptyReason: 'no-service-on-this-day',
+        note: 'The stop has trip-inspection data, but no services on the selected service day.',
+      }),
+    );
+  });
+
+  it('logs no-stop-data when stopId lookup returns no trip-inspection stop data', async () => {
+    const now = new Date('2026-05-02T14:59:36+09:00');
+    const serviceDate = getServiceDay(now);
+    const repo = makeRepo({
+      getTripInspectionTargets: vi.fn().mockResolvedValue({
+        success: true,
+        data: [],
+        meta: { emptyReason: 'no-stop-data' },
+      }),
+    });
+
+    const { result } = renderHook(() => useTripInspection(repo));
+
+    let status: Awaited<ReturnType<typeof result.current.openTripInspectionFromStopId>>;
+    await act(async () => {
+      status = await result.current.openTripInspectionFromStopId({
+        stopId: 'missing_stop',
+        now,
+        serviceDate,
+      });
+    });
+
+    expect(status!).toBe('no-data');
+    expect(mockWarn).toHaveBeenCalledWith(
+      'openTripInspectionFromStopId: empty trip inspection target result',
+      expect.objectContaining({
+        stopId: 'missing_stop',
+        emptyReason: 'no-stop-data',
+        note: 'The stop has no trip-inspection stop data.',
+      }),
+    );
+  });
+});

--- a/src/hooks/__tests__/use-trip-inspection.test.ts
+++ b/src/hooks/__tests__/use-trip-inspection.test.ts
@@ -47,7 +47,10 @@ describe('useTripInspection', () => {
       });
     });
 
-    expect(status!).toBe('no-data');
+    expect(status!).toEqual({
+      status: 'no-data',
+      reason: 'no-service-on-this-day',
+    });
     expect(mockWarn).toHaveBeenCalledWith(
       'openTripInspectionFromStopId: empty trip inspection target result',
       expect.objectContaining({
@@ -80,7 +83,10 @@ describe('useTripInspection', () => {
       });
     });
 
-    expect(status!).toBe('no-data');
+    expect(status!).toEqual({
+      status: 'no-data',
+      reason: 'no-stop-data',
+    });
     expect(mockWarn).toHaveBeenCalledWith(
       'openTripInspectionFromStopId: empty trip inspection target result',
       expect.objectContaining({

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
+import { formatDateKey } from '../domain/transit/calendar-utils';
 import { getServiceDayMinutes } from '../domain/transit/service-day';
 import {
   isSameTripInspectionTarget,
@@ -8,6 +9,7 @@ import {
 } from '../domain/transit/trip-inspection-target';
 import { createLogger, type Logger } from '../lib/logger';
 import type { TransitRepository } from '../repositories/transit-repository';
+import type { TripInspectionTargetsResult } from '../types/app/repository';
 import type {
   SelectedTripSnapshot,
   TripInspectionTarget,
@@ -337,7 +339,10 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
       const currentServiceDayMinutes = getServiceDayMinutes(now);
 
       try {
-        const result = await repo.getTripInspectionTargets({ stopId, serviceDate });
+        const result: TripInspectionTargetsResult = await repo.getTripInspectionTargets({
+          stopId,
+          serviceDate,
+        });
 
         if (lookupRequestIdRef.current !== lookupRequestId) {
           return 'cancelled' satisfies TripInspectionOpenResult;
@@ -352,17 +357,41 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
           return 'error' satisfies TripInspectionOpenResult;
         }
 
+        if (result.data.length === 0) {
+          const emptyReason = result.meta.emptyReason;
+          logger.warn('openTripInspectionFromStopId: empty trip inspection target result', {
+            stopId,
+            now: now.toISOString(),
+            serviceDate: serviceDate.toISOString(),
+            serviceDayKey: formatDateKey(serviceDate),
+            currentServiceDayMinutes,
+            emptyReason,
+            note:
+              emptyReason === 'no-stop-data'
+                ? 'The stop has no trip-inspection stop data.'
+                : 'The stop has trip-inspection data, but no services on the selected service day.',
+          });
+          return 'no-data' satisfies TripInspectionOpenResult;
+        }
+
         const selectedTarget = selectTripInspectionTargetByReferenceTime(
           result.data,
           currentServiceDayMinutes,
         );
 
         if (selectedTarget === null) {
-          logger.warn('openTripInspectionFromStopId: no trip inspection targets', {
-            stopId,
-            serviceDate: serviceDate.toISOString(),
-          });
-          return 'no-data' satisfies TripInspectionOpenResult;
+          logger.warn(
+            'openTripInspectionFromStopId: failed to resolve target from non-empty candidate list',
+            {
+              stopId,
+              now: now.toISOString(),
+              serviceDate: serviceDate.toISOString(),
+              serviceDayKey: formatDateKey(serviceDate),
+              currentServiceDayMinutes,
+              candidateCount: result.data.length,
+            },
+          );
+          return 'error' satisfies TripInspectionOpenResult;
         }
 
         return openTripInspectionInternal(selectedTarget.target, false);

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -1,31 +1,36 @@
 import { useCallback, useRef, useState } from 'react';
+import { getServiceDayMinutes } from '../domain/transit/service-day';
+import {
+  isSameTripInspectionTarget,
+  resolveSnapshotStopIndex,
+  resolveTripInspectionTarget,
+  selectTripInspectionTargetByReferenceTime,
+} from '../domain/transit/trip-inspection-target';
 import { createLogger } from '../lib/logger';
 import type { TransitRepository } from '../repositories/transit-repository';
 import type { SelectedTripSnapshot, TripInspectionTarget } from '../types/app/transit-composed';
 
 const logger = createLogger('TripInspection');
 
+interface OpenTripInspectionByStopIdParams {
+  stopId: string;
+  now: Date;
+  serviceDate: Date;
+}
+
+type TripInspectionOpenResult = 'opened' | 'no-data' | 'error' | 'cancelled';
+
 interface UseTripInspectionReturn {
   tripInspectionSnapshot: SelectedTripSnapshot | null;
   tripInspectionTargets: TripInspectionTarget[];
   currentTripInspectionTargetIndex: number;
-  openTripInspection: (target: TripInspectionTarget) => void;
+  openTripInspectionFromTarget: (target: TripInspectionTarget) => Promise<TripInspectionOpenResult>;
+  openTripInspectionFromStopId: (
+    params: OpenTripInspectionByStopIdParams,
+  ) => Promise<TripInspectionOpenResult>;
   openPreviousTripInspection: () => void;
   openNextTripInspection: () => void;
   closeTripInspection: () => void;
-}
-
-function isSameTripInspectionTarget(
-  left: TripInspectionTarget,
-  right: TripInspectionTarget,
-): boolean {
-  return (
-    left.tripLocator.patternId === right.tripLocator.patternId &&
-    left.tripLocator.serviceId === right.tripLocator.serviceId &&
-    left.tripLocator.tripIndex === right.tripLocator.tripIndex &&
-    left.stopIndex === right.stopIndex &&
-    left.serviceDate.getTime() === right.serviceDate.getTime()
-  );
 }
 
 function summarizeTripInspectionTarget(target: TripInspectionTarget) {
@@ -114,24 +119,25 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
   }, [updateTripInspectionTargets]);
 
   const openTripInspectionInternal = useCallback(
-    (target: TripInspectionTarget, refreshTargets: boolean) => {
+    async (
+      target: TripInspectionTarget,
+      refreshTargets: boolean,
+    ): Promise<TripInspectionOpenResult> => {
       const lookupRequestId = lookupRequestIdRef.current + 1;
       lookupRequestIdRef.current = lookupRequestId;
 
       const trip = repo.getTripSnapshot(target.tripLocator, target.serviceDate);
       if (!trip.success) {
         logger.warn('openTripInspection: failed to resolve trip snapshot', trip.error);
-        return;
+        return 'error';
       }
 
-      const selectedStopIndex = trip.data.stopTimes.findIndex(
-        (stop) => stop.timetableEntry.patternPosition.stopIndex === target.stopIndex,
-      );
+      const selectedStopIndex = resolveSnapshotStopIndex(trip.data.stopTimes, target);
       if (selectedStopIndex < 0) {
         logger.warn(
           `openTripInspection: selected stop index ${target.stopIndex} is missing from reconstructed trip snapshot`,
         );
-        return;
+        return 'no-data';
       }
 
       const selectedStop = trip.data.stopTimes[selectedStopIndex];
@@ -139,7 +145,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         logger.warn(
           `openTripInspection: selected stop array index ${selectedStopIndex} is missing from reconstructed trip snapshot`,
         );
-        return;
+        return 'no-data';
       }
 
       const snapshot: SelectedTripSnapshot = {
@@ -151,15 +157,14 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
       // logger.debug(buildTripInspectionSummaryLog(snapshot), snapshot);
       // logger.debug(buildTripInspectionStopsLog(snapshot));
 
-      setTripInspectionSnapshot(snapshot);
-
       if (!refreshTargets) {
         const currentIndex = tripInspectionTargetsRef.current.findIndex((candidate) =>
           isSameTripInspectionTarget(candidate, target),
         );
         if (currentIndex >= 0) {
+          setTripInspectionSnapshot(snapshot);
           setCurrentTripInspectionTargetIndex(currentIndex);
-          return;
+          return 'opened';
         }
 
         logger.warn('openTripInspection: target missing from cached trip-inspection targets', {
@@ -168,108 +173,186 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         });
       }
 
-      updateTripInspectionTargets([target]);
-      setCurrentTripInspectionTargetIndex(0);
-
       const selectedStopId = selectedStop.stopMeta?.stop.stop_id;
       if (selectedStopId === undefined) {
         logger.warn(
           'openTripInspection: selected stop metadata missing; skip trip-inspection target lookup',
         );
-        return;
+        return 'no-data';
       }
 
-      void repo
-        .getTripInspectionTargets({
+      try {
+        const result = await repo.getTripInspectionTargets({
           serviceDate: target.serviceDate,
           stopId: selectedStopId,
-        })
-        .then((result) => {
-          if (lookupRequestIdRef.current !== lookupRequestId) {
-            return;
-          }
-
-          // logger.debug(
-          //   `openTripInspection: getTripInspectionTargets result serviceDate=${formatTripInspectionServiceDate(target.serviceDate)} stopId=${selectedStopId}`,
-          //   result,
-          // );
-
-          if (!result.success) {
-            logger.warn(
-              'openTripInspection: trip-inspection target lookup failed',
-              result.error,
-              target,
-            );
-            return;
-          }
-
-          if (result.data.length === 0) {
-            updateTripInspectionTargets([target]);
-            setCurrentTripInspectionTargetIndex(0);
-            // logger.debug('openTripInspection: trip-inspection target lookup returned no targets');
-            return;
-          }
-
-          const currentIndex = result.data.findIndex((candidate) =>
-            isSameTripInspectionTarget(candidate, target),
-          );
-          if (currentIndex < 0) {
-            const diagnostics = buildTripInspectionMatchDiagnostics(target, result.data);
-            // logger.debug('openTripInspection: target lookup mismatch', {
-            //   requestedStopId: selectedStopId,
-            //   target: summarizeTripInspectionTarget(target),
-            //   sampleCandidates: result.data.slice(0, 10).map(summarizeTripInspectionTarget),
-            // });
-            // logger.debug('openTripInspection: target lookup mismatch counts', diagnostics.counts);
-            // logger.debug(
-            //   'openTripInspection: target lookup mismatch sampleSamePattern',
-            //   diagnostics.sampleSamePattern,
-            // );
-            logger.debug(
-              'openTripInspection: target lookup mismatch sampleSameService',
-              diagnostics.sampleSameService,
-            );
-            logger.debug(
-              'openTripInspection: target lookup mismatch sampleSameTripIndex',
-              diagnostics.sampleSameTripIndex,
-            );
-            logger.debug(
-              'openTripInspection: target lookup mismatch sampleSameStopIndex',
-              diagnostics.sampleSameStopIndex,
-            );
-            logger.debug('openTripInspection: target lookup mismatch diagnostics', diagnostics);
-            updateTripInspectionTargets([target]);
-            setCurrentTripInspectionTargetIndex(0);
-            logger.warn('openTripInspection: current target missing from trip-inspection targets', {
-              target,
-              targets: result.data,
-            });
-            return;
-          }
-
-          updateTripInspectionTargets(result.data);
-          setCurrentTripInspectionTargetIndex(currentIndex);
-
-          // logger.debug(
-          //   `openTripInspection: serviceDate=${formatTripInspectionServiceDate(target.serviceDate)} trip-inspection targets=${result.data.length} currentIndex=${currentIndex} stopId=${selectedStopId}`,
-          //   result.data,
-          // );
-        })
-        .catch((error: unknown) => {
-          if (lookupRequestIdRef.current !== lookupRequestId) {
-            return;
-          }
-          logger.warn('openTripInspection: trip-inspection target lookup threw', error, target);
         });
+
+        if (lookupRequestIdRef.current !== lookupRequestId) {
+          return 'cancelled';
+        }
+
+        // logger.debug(
+        //   `openTripInspection: getTripInspectionTargets result serviceDate=${formatTripInspectionServiceDate(target.serviceDate)} stopId=${selectedStopId}`,
+        //   result,
+        // );
+
+        if (!result.success) {
+          logger.warn(
+            'openTripInspection: trip-inspection target lookup failed',
+            result.error,
+            target,
+          );
+          return 'error';
+        }
+
+        if (result.data.length === 0) {
+          // logger.debug('openTripInspection: trip-inspection target lookup returned no targets');
+          return 'no-data';
+        }
+
+        const resolvedTarget = resolveTripInspectionTarget(result.data, target);
+        if (resolvedTarget === null) {
+          const diagnostics = buildTripInspectionMatchDiagnostics(target, result.data);
+          // logger.debug('openTripInspection: target lookup mismatch', {
+          //   requestedStopId: selectedStopId,
+          //   target: summarizeTripInspectionTarget(target),
+          //   sampleCandidates: result.data.slice(0, 10).map(summarizeTripInspectionTarget),
+          // });
+          // logger.debug('openTripInspection: target lookup mismatch counts', diagnostics.counts);
+          // logger.debug(
+          //   'openTripInspection: target lookup mismatch sampleSamePattern',
+          //   diagnostics.sampleSamePattern,
+          // );
+          logger.debug(
+            'openTripInspection: target lookup mismatch sampleSameService',
+            diagnostics.sampleSameService,
+          );
+          logger.debug(
+            'openTripInspection: target lookup mismatch sampleSameTripIndex',
+            diagnostics.sampleSameTripIndex,
+          );
+          logger.debug(
+            'openTripInspection: target lookup mismatch sampleSameStopIndex',
+            diagnostics.sampleSameStopIndex,
+          );
+          logger.debug('openTripInspection: target lookup mismatch diagnostics', diagnostics);
+          logger.warn('openTripInspection: current target missing from trip-inspection targets', {
+            target,
+            targets: result.data,
+          });
+          return 'no-data';
+        }
+
+        let resolvedSnapshot = snapshot;
+
+        if (resolvedTarget.matchType === 'fallback') {
+          const fallbackStopIndex = resolveSnapshotStopIndex(
+            trip.data.stopTimes,
+            resolvedTarget.target,
+          );
+          let fallbackSelectedStop;
+          if (fallbackStopIndex >= 0) {
+            fallbackSelectedStop = trip.data.stopTimes[fallbackStopIndex];
+          }
+          if (!fallbackSelectedStop) {
+            logger.warn(
+              'openTripInspection: fallback target resolved but snapshot stop is missing',
+              {
+                requestedTarget: target,
+                resolvedTarget: resolvedTarget.target,
+              },
+            );
+            return 'no-data';
+          }
+
+          resolvedSnapshot = {
+            ...trip.data,
+            currentStopIndex: fallbackStopIndex,
+            selectedStop: fallbackSelectedStop,
+          };
+          logger.warn('openTripInspection: using fallback trip-inspection target', {
+            requestedTarget: target,
+            resolvedTarget: resolvedTarget.target,
+          });
+        }
+
+        updateTripInspectionTargets(result.data);
+        setCurrentTripInspectionTargetIndex(resolvedTarget.index);
+        setTripInspectionSnapshot(resolvedSnapshot);
+
+        // logger.debug(
+        //   `openTripInspection: serviceDate=${formatTripInspectionServiceDate(target.serviceDate)} trip-inspection targets=${result.data.length} currentIndex=${resolvedTarget.index} stopId=${selectedStopId}`,
+        //   result.data,
+        // );
+        return 'opened';
+      } catch (error: unknown) {
+        if (lookupRequestIdRef.current !== lookupRequestId) {
+          return 'cancelled';
+        }
+        logger.warn('openTripInspection: trip-inspection target lookup threw', error, target);
+        return 'error';
+      }
     },
     [repo, updateTripInspectionTargets],
   );
 
-  const openTripInspection = useCallback(
+  const openTripInspectionFromTarget = useCallback(
     (target: TripInspectionTarget) => {
-      openTripInspectionInternal(target, true);
+      return openTripInspectionInternal(target, true);
     },
     [openTripInspectionInternal],
+  );
+
+  const openTripInspectionFromStopId = useCallback(
+    async ({ stopId, now, serviceDate }: OpenTripInspectionByStopIdParams) => {
+      const lookupRequestId = lookupRequestIdRef.current + 1;
+      lookupRequestIdRef.current = lookupRequestId;
+      const currentServiceDayMinutes = getServiceDayMinutes(now);
+
+      try {
+        const result = await repo.getTripInspectionTargets({ stopId, serviceDate });
+
+        if (lookupRequestIdRef.current !== lookupRequestId) {
+          return 'cancelled' satisfies TripInspectionOpenResult;
+        }
+
+        if (!result.success) {
+          logger.warn('openTripInspectionByStopId: failed to load trip inspection targets', {
+            stopId,
+            serviceDate: serviceDate.toISOString(),
+            error: result.error,
+          });
+          return 'error' satisfies TripInspectionOpenResult;
+        }
+
+        const selectedTarget = selectTripInspectionTargetByReferenceTime(
+          result.data,
+          currentServiceDayMinutes,
+        );
+
+        if (selectedTarget === null) {
+          logger.warn('openTripInspectionByStopId: no trip inspection targets', {
+            stopId,
+            serviceDate: serviceDate.toISOString(),
+          });
+          return 'no-data' satisfies TripInspectionOpenResult;
+        }
+
+        return openTripInspectionInternal(selectedTarget.target, true);
+      } catch (error: unknown) {
+        if (lookupRequestIdRef.current !== lookupRequestId) {
+          return 'cancelled' satisfies TripInspectionOpenResult;
+        }
+
+        logger.warn('openTripInspectionByStopId: unexpected error', {
+          stopId,
+          serviceDate: serviceDate.toISOString(),
+          error,
+        });
+        return 'error' satisfies TripInspectionOpenResult;
+      }
+    },
+    [openTripInspectionInternal, repo],
   );
 
   const openPreviousTripInspection = useCallback(() => {
@@ -279,7 +362,14 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
 
     const previousTarget = tripInspectionTargets[currentTripInspectionTargetIndex - 1];
     if (previousTarget) {
-      openTripInspectionInternal(previousTarget, false);
+      void openTripInspectionInternal(previousTarget, false).then((status) => {
+        if (status === 'no-data' || status === 'error') {
+          logger.warn('openTripInspection: failed to open previous target', {
+            status,
+            target: previousTarget,
+          });
+        }
+      });
     }
   }, [currentTripInspectionTargetIndex, openTripInspectionInternal, tripInspectionTargets]);
 
@@ -290,7 +380,14 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
 
     const nextTarget = tripInspectionTargets[currentTripInspectionTargetIndex + 1];
     if (nextTarget) {
-      openTripInspectionInternal(nextTarget, false);
+      void openTripInspectionInternal(nextTarget, false).then((status) => {
+        if (status === 'no-data' || status === 'error') {
+          logger.warn('openTripInspection: failed to open next target', {
+            status,
+            target: nextTarget,
+          });
+        }
+      });
     }
   }, [currentTripInspectionTargetIndex, openTripInspectionInternal, tripInspectionTargets]);
 
@@ -298,7 +395,8 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
     tripInspectionSnapshot,
     tripInspectionTargets,
     currentTripInspectionTargetIndex,
-    openTripInspection,
+    openTripInspectionFromTarget,
+    openTripInspectionFromStopId,
     openPreviousTripInspection,
     openNextTripInspection,
     closeTripInspection,

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -2,15 +2,19 @@ import { useCallback, useRef, useState } from 'react';
 import { getServiceDayMinutes } from '../domain/transit/service-day';
 import {
   isSameTripInspectionTarget,
-  resolveSnapshotStopIndex,
-  resolveTripInspectionTarget,
+  resolveSelectedTripInspectionSnapshot,
+  resolveTripInspectionDisplayState,
   selectTripInspectionTargetByReferenceTime,
 } from '../domain/transit/trip-inspection-target';
-import { createLogger } from '../lib/logger';
+import { createLogger, type Logger } from '../lib/logger';
 import type { TransitRepository } from '../repositories/transit-repository';
-import type { SelectedTripSnapshot, TripInspectionTarget } from '../types/app/transit-composed';
+import type {
+  SelectedTripSnapshot,
+  TripInspectionTarget,
+  TripSnapshot,
+} from '../types/app/transit-composed';
 
-const logger = createLogger('TripInspection');
+const logger: Logger = createLogger('TripInspection');
 
 interface OpenTripInspectionByStopIdParams {
   stopId: string;
@@ -19,6 +23,40 @@ interface OpenTripInspectionByStopIdParams {
 }
 
 type TripInspectionOpenResult = 'opened' | 'no-data' | 'error' | 'cancelled';
+
+type TripInspectionLoadResult = Extract<TripInspectionOpenResult, 'error' | 'no-data'>;
+type RefineFailureStatus = Extract<TripInspectionOpenResult, 'no-data' | 'error' | 'cancelled'>;
+
+interface LoadedTripInspectionSnapshot {
+  snapshot: SelectedTripSnapshot;
+  selectedStopId: string;
+}
+
+type LoadedTripInspectionSnapshotResult =
+  | {
+      ok: true;
+      data: LoadedTripInspectionSnapshot;
+    }
+  | {
+      ok: false;
+      status: TripInspectionLoadResult;
+    };
+
+interface RefinedTripInspectionState {
+  snapshot: SelectedTripSnapshot;
+  targets: TripInspectionTarget[];
+  targetIndex: number;
+}
+
+type RefinedTripInspectionStateResult =
+  | {
+      ok: true;
+      data: RefinedTripInspectionState;
+    }
+  | {
+      ok: false;
+      status: RefineFailureStatus;
+    };
 
 interface UseTripInspectionReturn {
   tripInspectionSnapshot: SelectedTripSnapshot | null;
@@ -33,26 +71,23 @@ interface UseTripInspectionReturn {
   closeTripInspection: () => void;
 }
 
-function summarizeTripInspectionTarget(target: TripInspectionTarget) {
-  return {
-    patternId: target.tripLocator.patternId,
-    serviceId: target.tripLocator.serviceId,
-    tripIndex: target.tripLocator.tripIndex,
-    stopIndex: target.stopIndex,
-    departureMinutes: target.departureMinutes,
-    serviceDate: target.serviceDate.toISOString(),
-  };
-}
-
 function buildTripInspectionMatchDiagnostics(
   target: TripInspectionTarget,
   candidates: TripInspectionTarget[],
 ) {
-  const samePattern = candidates.filter(
-    (candidate) => candidate.tripLocator.patternId === target.tripLocator.patternId,
-  );
-  const sameService = samePattern.filter(
-    (candidate) => candidate.tripLocator.serviceId === target.tripLocator.serviceId,
+  const summarizeTarget = (candidate: TripInspectionTarget) => ({
+    patternId: candidate.tripLocator.patternId,
+    serviceId: candidate.tripLocator.serviceId,
+    tripIndex: candidate.tripLocator.tripIndex,
+    stopIndex: candidate.stopIndex,
+    departureMinutes: candidate.departureMinutes,
+    serviceDate: candidate.serviceDate.toISOString(),
+  });
+
+  const sameService = candidates.filter(
+    (candidate) =>
+      candidate.tripLocator.patternId === target.tripLocator.patternId &&
+      candidate.tripLocator.serviceId === target.tripLocator.serviceId,
   );
   const sameTripIndex = sameService.filter(
     (candidate) => candidate.tripLocator.tripIndex === target.tripLocator.tripIndex,
@@ -60,12 +95,6 @@ function buildTripInspectionMatchDiagnostics(
   const sameStopIndex = sameTripIndex.filter(
     (candidate) => candidate.stopIndex === target.stopIndex,
   );
-  const sameServiceDate = sameStopIndex.filter(
-    (candidate) => candidate.serviceDate.getTime() === target.serviceDate.getTime(),
-  );
-  const sameDepartureMinutes = sameStopIndex.filter(
-    (candidate) => candidate.departureMinutes === target.departureMinutes,
-  );
 
   return {
     patternId: target.tripLocator.patternId,
@@ -74,20 +103,137 @@ function buildTripInspectionMatchDiagnostics(
     stopIndex: target.stopIndex,
     departureMinutes: target.departureMinutes,
     serviceDate: target.serviceDate.toISOString(),
-    counts: {
-      total: candidates.length,
-      samePattern: samePattern.length,
-      sameService: sameService.length,
-      sameTripIndex: sameTripIndex.length,
-      sameStopIndex: sameStopIndex.length,
-      sameServiceDate: sameServiceDate.length,
-      sameDepartureMinutesAfterStopIndex: sameDepartureMinutes.length,
-    },
-    sampleSamePattern: samePattern.slice(0, 5).map(summarizeTripInspectionTarget),
-    sampleSameService: sameService.slice(0, 5).map(summarizeTripInspectionTarget),
-    sampleSameTripIndex: sameTripIndex.slice(0, 5).map(summarizeTripInspectionTarget),
-    sampleSameStopIndex: sameStopIndex.slice(0, 5).map(summarizeTripInspectionTarget),
+    sampleSameService: sameService.slice(0, 5).map(summarizeTarget),
+    sampleSameTripIndex: sameTripIndex.slice(0, 5).map(summarizeTarget),
+    sampleSameStopIndex: sameStopIndex.slice(0, 5).map(summarizeTarget),
   };
+}
+
+function loadTripInspectionSnapshot(
+  trip: TripSnapshot,
+  target: TripInspectionTarget,
+): LoadedTripInspectionSnapshotResult {
+  const resolvedSnapshot = resolveSelectedTripInspectionSnapshot(trip, target);
+  if (!resolvedSnapshot.ok) {
+    switch (resolvedSnapshot.reason) {
+      case 'pattern-position-missing':
+        logger.warn(
+          `openTripInspection: selected stop index ${target.stopIndex} is missing from reconstructed trip snapshot`,
+        );
+        break;
+      case 'stop-row-missing':
+        logger.warn(
+          'openTripInspection: selected stop row is missing from reconstructed trip snapshot',
+          {
+            target,
+          },
+        );
+        break;
+      default: {
+        const exhaustiveReason: never = resolvedSnapshot.reason;
+        logger.warn('openTripInspection: unexpected snapshot resolution failure', {
+          target,
+          reason: exhaustiveReason,
+        });
+      }
+    }
+
+    return { ok: false, status: 'no-data' };
+  }
+
+  if (resolvedSnapshot.data.selectedStopId === undefined) {
+    logger.warn(
+      'openTripInspection: selected stop metadata missing; skip trip-inspection target lookup',
+    );
+    return { ok: false, status: 'no-data' };
+  }
+
+  return {
+    ok: true,
+    data: {
+      snapshot: resolvedSnapshot.data.snapshot,
+      selectedStopId: resolvedSnapshot.data.selectedStopId,
+    },
+  };
+}
+
+async function refineTripInspectionState(
+  repo: TransitRepository,
+  target: TripInspectionTarget,
+  snapshot: SelectedTripSnapshot,
+  selectedStopId: string,
+  isCancelled: () => boolean,
+): Promise<RefinedTripInspectionStateResult> {
+  try {
+    const result = await repo.getTripInspectionTargets({
+      serviceDate: target.serviceDate,
+      stopId: selectedStopId,
+    });
+
+    if (isCancelled()) {
+      return { ok: false, status: 'cancelled' };
+    }
+
+    if (!result.success) {
+      logger.warn('openTripInspection: trip-inspection target lookup failed', result.error, target);
+      return { ok: false, status: 'error' };
+    }
+
+    if (result.data.length === 0) {
+      return { ok: false, status: 'no-data' };
+    }
+
+    const resolvedState = resolveTripInspectionDisplayState(snapshot, result.data, target);
+    if (!resolvedState.ok) {
+      if (logger.isEnabled('debug')) {
+        const diagnostics = buildTripInspectionMatchDiagnostics(target, result.data);
+        logger.debug(
+          'openTripInspection: target lookup mismatch sampleSameService',
+          diagnostics.sampleSameService,
+        );
+        logger.debug(
+          'openTripInspection: target lookup mismatch sampleSameTripIndex',
+          diagnostics.sampleSameTripIndex,
+        );
+        logger.debug(
+          'openTripInspection: target lookup mismatch sampleSameStopIndex',
+          diagnostics.sampleSameStopIndex,
+        );
+        logger.debug('openTripInspection: target lookup mismatch diagnostics', diagnostics);
+      }
+      logger.warn('openTripInspection: current target missing from trip-inspection targets', {
+        target,
+        targets: result.data,
+      });
+      return { ok: false, status: 'no-data' };
+    }
+
+    if (
+      resolvedState.data.snapshot.currentStopIndex !== snapshot.currentStopIndex ||
+      resolvedState.data.snapshot.selectedStop !== snapshot.selectedStop
+    ) {
+      logger.warn('openTripInspection: using fallback trip-inspection target', {
+        requestedTarget: target,
+        resolvedTarget: resolvedState.data.targets[resolvedState.data.targetIndex],
+      });
+    }
+
+    return {
+      ok: true,
+      data: {
+        snapshot: resolvedState.data.snapshot,
+        targets: resolvedState.data.targets,
+        targetIndex: resolvedState.data.targetIndex,
+      },
+    };
+  } catch (error: unknown) {
+    if (isCancelled()) {
+      return { ok: false, status: 'cancelled' };
+    }
+
+    logger.warn('openTripInspection: trip-inspection target lookup threw', error, target);
+    return { ok: false, status: 'error' };
+  }
 }
 
 /**
@@ -121,7 +267,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
   const openTripInspectionInternal = useCallback(
     async (
       target: TripInspectionTarget,
-      refreshTargets: boolean,
+      preferCachedTargets: boolean,
     ): Promise<TripInspectionOpenResult> => {
       const lookupRequestId = lookupRequestIdRef.current + 1;
       lookupRequestIdRef.current = lookupRequestId;
@@ -132,32 +278,17 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         return 'error';
       }
 
-      const selectedStopIndex = resolveSnapshotStopIndex(trip.data.stopTimes, target);
-      if (selectedStopIndex < 0) {
-        logger.warn(
-          `openTripInspection: selected stop index ${target.stopIndex} is missing from reconstructed trip snapshot`,
-        );
-        return 'no-data';
+      const loadedSnapshot = loadTripInspectionSnapshot(trip.data, target);
+      if (!loadedSnapshot.ok) {
+        return loadedSnapshot.status;
       }
 
-      const selectedStop = trip.data.stopTimes[selectedStopIndex];
-      if (!selectedStop) {
-        logger.warn(
-          `openTripInspection: selected stop array index ${selectedStopIndex} is missing from reconstructed trip snapshot`,
-        );
-        return 'no-data';
-      }
+      const { snapshot, selectedStopId } = loadedSnapshot.data;
 
-      const snapshot: SelectedTripSnapshot = {
-        ...trip.data,
-        currentStopIndex: selectedStopIndex,
-        selectedStop,
-      };
-
-      // logger.debug(buildTripInspectionSummaryLog(snapshot), snapshot);
-      // logger.debug(buildTripInspectionStopsLog(snapshot));
-
-      if (!refreshTargets) {
+      if (preferCachedTargets) {
+        // Prev/next navigation prefers the cached target list for a fast local
+        // move, but it intentionally falls through to a fresh lookup when the
+        // requested target is missing from that cache.
         const currentIndex = tripInspectionTargetsRef.current.findIndex((candidate) =>
           isSameTripInspectionTarget(candidate, target),
         );
@@ -169,136 +300,32 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
 
         logger.warn('openTripInspection: target missing from cached trip-inspection targets', {
           target,
-          tripInspectionTargets: tripInspectionTargetsRef.current,
+          cachedTargets: tripInspectionTargetsRef.current,
         });
       }
 
-      const selectedStopId = selectedStop.stopMeta?.stop.stop_id;
-      if (selectedStopId === undefined) {
-        logger.warn(
-          'openTripInspection: selected stop metadata missing; skip trip-inspection target lookup',
-        );
-        return 'no-data';
+      const refinedState = await refineTripInspectionState(
+        repo,
+        target,
+        snapshot,
+        selectedStopId,
+        () => lookupRequestIdRef.current !== lookupRequestId,
+      );
+      if (!refinedState.ok) {
+        return refinedState.status;
       }
 
-      try {
-        const result = await repo.getTripInspectionTargets({
-          serviceDate: target.serviceDate,
-          stopId: selectedStopId,
-        });
-
-        if (lookupRequestIdRef.current !== lookupRequestId) {
-          return 'cancelled';
-        }
-
-        // logger.debug(
-        //   `openTripInspection: getTripInspectionTargets result serviceDate=${formatTripInspectionServiceDate(target.serviceDate)} stopId=${selectedStopId}`,
-        //   result,
-        // );
-
-        if (!result.success) {
-          logger.warn(
-            'openTripInspection: trip-inspection target lookup failed',
-            result.error,
-            target,
-          );
-          return 'error';
-        }
-
-        if (result.data.length === 0) {
-          // logger.debug('openTripInspection: trip-inspection target lookup returned no targets');
-          return 'no-data';
-        }
-
-        const resolvedTarget = resolveTripInspectionTarget(result.data, target);
-        if (resolvedTarget === null) {
-          const diagnostics = buildTripInspectionMatchDiagnostics(target, result.data);
-          // logger.debug('openTripInspection: target lookup mismatch', {
-          //   requestedStopId: selectedStopId,
-          //   target: summarizeTripInspectionTarget(target),
-          //   sampleCandidates: result.data.slice(0, 10).map(summarizeTripInspectionTarget),
-          // });
-          // logger.debug('openTripInspection: target lookup mismatch counts', diagnostics.counts);
-          // logger.debug(
-          //   'openTripInspection: target lookup mismatch sampleSamePattern',
-          //   diagnostics.sampleSamePattern,
-          // );
-          logger.debug(
-            'openTripInspection: target lookup mismatch sampleSameService',
-            diagnostics.sampleSameService,
-          );
-          logger.debug(
-            'openTripInspection: target lookup mismatch sampleSameTripIndex',
-            diagnostics.sampleSameTripIndex,
-          );
-          logger.debug(
-            'openTripInspection: target lookup mismatch sampleSameStopIndex',
-            diagnostics.sampleSameStopIndex,
-          );
-          logger.debug('openTripInspection: target lookup mismatch diagnostics', diagnostics);
-          logger.warn('openTripInspection: current target missing from trip-inspection targets', {
-            target,
-            targets: result.data,
-          });
-          return 'no-data';
-        }
-
-        let resolvedSnapshot = snapshot;
-
-        if (resolvedTarget.matchType === 'fallback') {
-          const fallbackStopIndex = resolveSnapshotStopIndex(
-            trip.data.stopTimes,
-            resolvedTarget.target,
-          );
-          let fallbackSelectedStop;
-          if (fallbackStopIndex >= 0) {
-            fallbackSelectedStop = trip.data.stopTimes[fallbackStopIndex];
-          }
-          if (!fallbackSelectedStop) {
-            logger.warn(
-              'openTripInspection: fallback target resolved but snapshot stop is missing',
-              {
-                requestedTarget: target,
-                resolvedTarget: resolvedTarget.target,
-              },
-            );
-            return 'no-data';
-          }
-
-          resolvedSnapshot = {
-            ...trip.data,
-            currentStopIndex: fallbackStopIndex,
-            selectedStop: fallbackSelectedStop,
-          };
-          logger.warn('openTripInspection: using fallback trip-inspection target', {
-            requestedTarget: target,
-            resolvedTarget: resolvedTarget.target,
-          });
-        }
-
-        updateTripInspectionTargets(result.data);
-        setCurrentTripInspectionTargetIndex(resolvedTarget.index);
-        setTripInspectionSnapshot(resolvedSnapshot);
-
-        // logger.debug(
-        //   `openTripInspection: serviceDate=${formatTripInspectionServiceDate(target.serviceDate)} trip-inspection targets=${result.data.length} currentIndex=${resolvedTarget.index} stopId=${selectedStopId}`,
-        //   result.data,
-        // );
-        return 'opened';
-      } catch (error: unknown) {
-        if (lookupRequestIdRef.current !== lookupRequestId) {
-          return 'cancelled';
-        }
-        logger.warn('openTripInspection: trip-inspection target lookup threw', error, target);
-        return 'error';
-      }
+      updateTripInspectionTargets(refinedState.data.targets);
+      setCurrentTripInspectionTargetIndex(refinedState.data.targetIndex);
+      setTripInspectionSnapshot(refinedState.data.snapshot);
+      return 'opened';
     },
     [repo, updateTripInspectionTargets],
   );
 
   const openTripInspectionFromTarget = useCallback(
     (target: TripInspectionTarget) => {
-      return openTripInspectionInternal(target, true);
+      return openTripInspectionInternal(target, false);
     },
     [openTripInspectionInternal],
   );
@@ -317,7 +344,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         }
 
         if (!result.success) {
-          logger.warn('openTripInspectionByStopId: failed to load trip inspection targets', {
+          logger.warn('openTripInspectionFromStopId: failed to load trip inspection targets', {
             stopId,
             serviceDate: serviceDate.toISOString(),
             error: result.error,
@@ -331,20 +358,20 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         );
 
         if (selectedTarget === null) {
-          logger.warn('openTripInspectionByStopId: no trip inspection targets', {
+          logger.warn('openTripInspectionFromStopId: no trip inspection targets', {
             stopId,
             serviceDate: serviceDate.toISOString(),
           });
           return 'no-data' satisfies TripInspectionOpenResult;
         }
 
-        return openTripInspectionInternal(selectedTarget.target, true);
+        return openTripInspectionInternal(selectedTarget.target, false);
       } catch (error: unknown) {
         if (lookupRequestIdRef.current !== lookupRequestId) {
           return 'cancelled' satisfies TripInspectionOpenResult;
         }
 
-        logger.warn('openTripInspectionByStopId: unexpected error', {
+        logger.warn('openTripInspectionFromStopId: unexpected error', {
           stopId,
           serviceDate: serviceDate.toISOString(),
           error,
@@ -362,9 +389,9 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
 
     const previousTarget = tripInspectionTargets[currentTripInspectionTargetIndex - 1];
     if (previousTarget) {
-      void openTripInspectionInternal(previousTarget, false).then((status) => {
-        if (status === 'no-data' || status === 'error') {
-          logger.warn('openTripInspection: failed to open previous target', {
+      void openTripInspectionInternal(previousTarget, true).then((status) => {
+        if ((status === 'no-data' || status === 'error') && logger.isEnabled('debug')) {
+          logger.debug('openTripInspection: previous target open failed after inner warning', {
             status,
             target: previousTarget,
           });
@@ -380,9 +407,9 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
 
     const nextTarget = tripInspectionTargets[currentTripInspectionTargetIndex + 1];
     if (nextTarget) {
-      void openTripInspectionInternal(nextTarget, false).then((status) => {
-        if (status === 'no-data' || status === 'error') {
-          logger.warn('openTripInspection: failed to open next target', {
+      void openTripInspectionInternal(nextTarget, true).then((status) => {
+        if ((status === 'no-data' || status === 'error') && logger.isEnabled('debug')) {
+          logger.debug('openTripInspection: next target open failed after inner warning', {
             status,
             target: nextTarget,
           });

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -9,7 +9,10 @@ import {
 } from '../domain/transit/trip-inspection-target';
 import { createLogger, type Logger } from '../lib/logger';
 import type { TransitRepository } from '../repositories/transit-repository';
-import type { TripInspectionTargetsResult } from '../types/app/repository';
+import type {
+  TripInspectionTargetsEmptyReason,
+  TripInspectionTargetsResult,
+} from '../types/app/repository';
 import type {
   SelectedTripSnapshot,
   TripInspectionTarget,
@@ -25,6 +28,20 @@ interface OpenTripInspectionByStopIdParams {
 }
 
 type TripInspectionOpenResult = 'opened' | 'no-data' | 'error' | 'cancelled';
+
+export type TripInspectionNoDataReason =
+  | TripInspectionTargetsEmptyReason
+  | 'snapshot-unavailable'
+  | 'target-missing';
+
+type TripInspectionOpenOutcome =
+  | { status: 'opened' }
+  | { status: 'cancelled' }
+  | { status: 'error' }
+  | {
+      status: 'no-data';
+      reason: TripInspectionNoDataReason;
+    };
 
 type TripInspectionLoadResult = Extract<TripInspectionOpenResult, 'error' | 'no-data'>;
 type RefineFailureStatus = Extract<TripInspectionOpenResult, 'no-data' | 'error' | 'cancelled'>;
@@ -64,10 +81,12 @@ interface UseTripInspectionReturn {
   tripInspectionSnapshot: SelectedTripSnapshot | null;
   tripInspectionTargets: TripInspectionTarget[];
   currentTripInspectionTargetIndex: number;
-  openTripInspectionFromTarget: (target: TripInspectionTarget) => Promise<TripInspectionOpenResult>;
+  openTripInspectionFromTarget: (
+    target: TripInspectionTarget,
+  ) => Promise<TripInspectionOpenOutcome>;
   openTripInspectionFromStopId: (
     params: OpenTripInspectionByStopIdParams,
-  ) => Promise<TripInspectionOpenResult>;
+  ) => Promise<TripInspectionOpenOutcome>;
   openPreviousTripInspection: () => void;
   openNextTripInspection: () => void;
   closeTripInspection: () => void;
@@ -270,19 +289,21 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
     async (
       target: TripInspectionTarget,
       preferCachedTargets: boolean,
-    ): Promise<TripInspectionOpenResult> => {
+    ): Promise<TripInspectionOpenOutcome> => {
       const lookupRequestId = lookupRequestIdRef.current + 1;
       lookupRequestIdRef.current = lookupRequestId;
 
       const trip = repo.getTripSnapshot(target.tripLocator, target.serviceDate);
       if (!trip.success) {
         logger.warn('openTripInspection: failed to resolve trip snapshot', trip.error);
-        return 'error';
+        return { status: 'error' };
       }
 
       const loadedSnapshot = loadTripInspectionSnapshot(trip.data, target);
       if (!loadedSnapshot.ok) {
-        return loadedSnapshot.status;
+        return loadedSnapshot.status === 'no-data'
+          ? { status: 'no-data', reason: 'snapshot-unavailable' }
+          : { status: loadedSnapshot.status };
       }
 
       const { snapshot, selectedStopId } = loadedSnapshot.data;
@@ -297,7 +318,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         if (currentIndex >= 0) {
           setTripInspectionSnapshot(snapshot);
           setCurrentTripInspectionTargetIndex(currentIndex);
-          return 'opened';
+          return { status: 'opened' };
         }
 
         logger.warn('openTripInspection: target missing from cached trip-inspection targets', {
@@ -314,13 +335,15 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         () => lookupRequestIdRef.current !== lookupRequestId,
       );
       if (!refinedState.ok) {
-        return refinedState.status;
+        return refinedState.status === 'no-data'
+          ? { status: 'no-data', reason: 'target-missing' }
+          : { status: refinedState.status };
       }
 
       updateTripInspectionTargets(refinedState.data.targets);
       setCurrentTripInspectionTargetIndex(refinedState.data.targetIndex);
       setTripInspectionSnapshot(refinedState.data.snapshot);
-      return 'opened';
+      return { status: 'opened' };
     },
     [repo, updateTripInspectionTargets],
   );
@@ -345,7 +368,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         });
 
         if (lookupRequestIdRef.current !== lookupRequestId) {
-          return 'cancelled' satisfies TripInspectionOpenResult;
+          return { status: 'cancelled' } satisfies TripInspectionOpenOutcome;
         }
 
         if (!result.success) {
@@ -354,11 +377,19 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
             serviceDate: serviceDate.toISOString(),
             error: result.error,
           });
-          return 'error' satisfies TripInspectionOpenResult;
+          return { status: 'error' } satisfies TripInspectionOpenOutcome;
         }
 
         if (result.data.length === 0) {
           const emptyReason = result.meta.emptyReason;
+          if (emptyReason === undefined) {
+            logger.warn('openTripInspectionFromStopId: empty result missing emptyReason metadata', {
+              stopId,
+              serviceDate: serviceDate.toISOString(),
+            });
+            return { status: 'error' } satisfies TripInspectionOpenOutcome;
+          }
+
           logger.warn('openTripInspectionFromStopId: empty trip inspection target result', {
             stopId,
             now: now.toISOString(),
@@ -371,7 +402,10 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
                 ? 'The stop has no trip-inspection stop data.'
                 : 'The stop has trip-inspection data, but no services on the selected service day.',
           });
-          return 'no-data' satisfies TripInspectionOpenResult;
+          return {
+            status: 'no-data',
+            reason: emptyReason,
+          } satisfies TripInspectionOpenOutcome;
         }
 
         const selectedTarget = selectTripInspectionTargetByReferenceTime(
@@ -391,13 +425,13 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
               candidateCount: result.data.length,
             },
           );
-          return 'error' satisfies TripInspectionOpenResult;
+          return { status: 'error' } satisfies TripInspectionOpenOutcome;
         }
 
         return openTripInspectionInternal(selectedTarget.target, false);
       } catch (error: unknown) {
         if (lookupRequestIdRef.current !== lookupRequestId) {
-          return 'cancelled' satisfies TripInspectionOpenResult;
+          return { status: 'cancelled' } satisfies TripInspectionOpenOutcome;
         }
 
         logger.warn('openTripInspectionFromStopId: unexpected error', {
@@ -405,7 +439,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
           serviceDate: serviceDate.toISOString(),
           error,
         });
-        return 'error' satisfies TripInspectionOpenResult;
+        return { status: 'error' } satisfies TripInspectionOpenOutcome;
       }
     },
     [openTripInspectionInternal, repo],
@@ -419,7 +453,10 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
     const previousTarget = tripInspectionTargets[currentTripInspectionTargetIndex - 1];
     if (previousTarget) {
       void openTripInspectionInternal(previousTarget, true).then((status) => {
-        if ((status === 'no-data' || status === 'error') && logger.isEnabled('debug')) {
+        if (
+          (status.status === 'no-data' || status.status === 'error') &&
+          logger.isEnabled('debug')
+        ) {
           logger.debug('openTripInspection: previous target open failed after inner warning', {
             status,
             target: previousTarget,
@@ -437,7 +474,10 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
     const nextTarget = tripInspectionTargets[currentTripInspectionTargetIndex + 1];
     if (nextTarget) {
       void openTripInspectionInternal(nextTarget, true).then((status) => {
-        if ((status === 'no-data' || status === 'error') && logger.isEnabled('debug')) {
+        if (
+          (status.status === 'no-data' || status.status === 'error') &&
+          logger.isEnabled('debug')
+        ) {
           logger.debug('openTripInspection: next target open failed after inner warning', {
             status,
             target: nextTarget,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -191,6 +191,9 @@
     "titleWithNoHeadsign": "(No headsign)",
     "unknownStop": "(Unknown stop)",
     "description": "Show the stop sequence and times for the selected trip",
+    "noData": "No data is available",
+    "openFailed": "Could not load trip information",
+    "noUpcomingTrips": "No departures are available after the current time",
     "sections": {
       "summary": "Summary",
       "selectedStop": "Selected stop",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -191,9 +191,13 @@
     "titleWithNoHeadsign": "(No headsign)",
     "unknownStop": "(Unknown stop)",
     "description": "Show the stop sequence and times for the selected trip",
-    "noData": "No data is available",
-    "openFailed": "Could not load trip information",
-    "noUpcomingTrips": "No departures are available after the current time",
+    "messages": {
+      "noData": "Trip information is unavailable for this selection.",
+      "noStopData": "No trip information is available for this stop",
+      "noServiceOnThisDay": "No services run on the selected day",
+      "openFailed": "Could not load trip information",
+      "noUpcomingTrips": "No departures are available after the current time"
+    },
     "sections": {
       "summary": "Summary",
       "selectedStop": "Selected stop",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -191,6 +191,9 @@
     "titleWithNoHeadsign": "(行先情報なし)",
     "unknownStop": "(情報なし)",
     "description": "選択した便の停車順と時刻を表示します",
+    "noData": "データがありません",
+    "openFailed": "便情報を取得できませんでした",
+    "noUpcomingTrips": "現在時刻以降の便がありません",
     "sections": {
       "summary": "概要",
       "selectedStop": "選択中の stop",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -191,9 +191,13 @@
     "titleWithNoHeadsign": "(行先情報なし)",
     "unknownStop": "(情報なし)",
     "description": "選択した便の停車順と時刻を表示します",
-    "noData": "データがありません",
-    "openFailed": "便情報を取得できませんでした",
-    "noUpcomingTrips": "現在時刻以降の便がありません",
+    "messages": {
+      "noData": "便情報がありません",
+      "noStopData": "この停留所の便情報データがありません",
+      "noServiceOnThisDay": "この運行日には便がありません",
+      "openFailed": "便情報を取得できませんでした",
+      "noUpcomingTrips": "現在時刻以降の便がありません"
+    },
     "sections": {
       "summary": "概要",
       "selectedStop": "選択中の stop",

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -13,6 +13,7 @@ export type LogLevel = 'verbose' | 'debug' | 'info' | 'warn' | 'error';
 
 /** Logger instance bound to a specific tag. */
 export interface Logger {
+  isEnabled: (level: LogLevel) => boolean;
   verbose: (...args: unknown[]) => void;
   debug: (...args: unknown[]) => void;
   info: (...args: unknown[]) => void;
@@ -160,6 +161,7 @@ export function createLogger(tag: string): Logger {
   }
 
   return {
+    isEnabled: (level: LogLevel) => shouldLog(level, tag),
     verbose: (...args: unknown[]) => emit('verbose', args),
     debug: (...args: unknown[]) => emit('debug', args),
     info: (...args: unknown[]) => emit('info', args),

--- a/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
@@ -708,6 +708,7 @@ describe('getTripInspectionTargets', () => {
 
     assertSuccess(result);
     assertSuccess(timetable);
+    expect(result.truncated).toBe(false);
     expect(result.data).toEqual(
       timetable.data.map((entry) => ({
         tripLocator: entry.tripLocator,
@@ -738,6 +739,7 @@ describe('getTripInspectionTargets', () => {
     });
 
     assertSuccess(result);
+    expect(result.truncated).toBe(false);
     expect(
       result.data
         .filter(
@@ -763,6 +765,7 @@ describe('getTripInspectionTargets', () => {
 
     assertSuccess(result);
     assertSuccess(timetable);
+    expect(result.truncated).toBe(false);
     expect(result.data).toEqual(
       timetable.data.map((entry) => ({
         tripLocator: entry.tripLocator,
@@ -787,6 +790,7 @@ describe('getTripInspectionTargets', () => {
 
     assertSuccess(result);
     assertSuccess(timetable);
+    expect(result.truncated).toBe(false);
     expect(result.data).toEqual(
       timetable.data.map((entry) => ({
         tripLocator: entry.tripLocator,
@@ -798,6 +802,100 @@ describe('getTripInspectionTargets', () => {
     expect(new Set(result.data.map((target) => target.tripLocator.serviceId))).toEqual(
       new Set(['svc_holiday']),
     );
+    expect(result.meta).toEqual({});
+  });
+
+  it('reports no-stop-data when the stop has no trip-inspection stop data', async () => {
+    const fixture = createFixtureV2();
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    const result = await repository.getTripInspectionTargets({
+      serviceDate: WEEKDAY,
+      stopId: 'missing_stop',
+    });
+
+    assertSuccess(result);
+    expect(result.truncated).toBe(false);
+    expect(result.data).toEqual([]);
+    expect(result.meta).toEqual({ emptyReason: 'no-stop-data' });
+  });
+
+  it('reports no-service-on-this-day when a stop has trip-inspection data but none run on the service day', async () => {
+    const fixture = createFixtureV2();
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    const result = await repository.getTripInspectionTargets({
+      serviceDate: SATURDAY,
+      stopId: 'bus_01',
+    });
+
+    assertSuccess(result);
+    expect(result.truncated).toBe(false);
+    expect(result.data).toEqual([]);
+    expect(result.meta).toEqual({ emptyReason: 'no-service-on-this-day' });
+  });
+
+  it('fails when all active timetable groups reference missing patterns', async () => {
+    const fixture = createFixtureV2();
+    const groups = fixture.data.timetable.data['bus_01'];
+    if (!groups) {
+      throw new Error('Expected bus_01 timetable fixture');
+    }
+
+    for (const group of groups) {
+      group.tp = `missing:${group.tp}`;
+    }
+
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    const result = await repository.getTripInspectionTargets({
+      serviceDate: WEEKDAY,
+      stopId: 'bus_01',
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error(
+        'Expected failure when all active timetable groups reference missing patterns',
+      );
+    }
+
+    expect(result.error).toContain('all active timetable groups reference missing patterns');
+    expect(result.error).toContain('bus_01');
+  });
+
+  it('returns resolved targets when active timetable groups mix resolved and missing patterns', async () => {
+    const fixture = createFixtureV2();
+    const groups = fixture.data.timetable.data['bus_01'];
+    if (!groups || groups.length < 2) {
+      throw new Error('Expected bus_01 timetable fixture with multiple groups');
+    }
+
+    const firstGroup = groups[0];
+    if (!firstGroup) {
+      throw new Error('Expected first bus_01 timetable group');
+    }
+
+    firstGroup.tp = `missing:${firstGroup.tp}`;
+
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    const result = await repository.getTripInspectionTargets({
+      serviceDate: WEEKDAY,
+      stopId: 'bus_01',
+    });
+
+    assertSuccess(result);
+    expect(result.truncated).toBe(false);
+    expect(result.meta).toEqual({});
+    expect(result.data.length).toBeGreaterThan(0);
+    expect(
+      result.data.every((target) => !target.tripLocator.patternId.startsWith('missing:')),
+    ).toBe(true);
   });
 });
 

--- a/src/repositories/athenai-repository/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository/athenai-repository-v2.ts
@@ -38,6 +38,7 @@ import type {
   Result,
   TimetableQueryMeta,
   TimetableResult,
+  TripInspectionTargetsResult,
   TripSnapshotResult,
   UpcomingTimetableResult,
 } from '../../types/app/repository';
@@ -649,27 +650,42 @@ export class AthenaiRepositoryV2 implements TransitRepository {
   }
 
   /** {@inheritDoc TransitRepository.getTripInspectionTargets} */
-  getTripInspectionTargets(
-    query: TripInspectionGroupQuery,
-  ): Promise<Result<TripInspectionTarget[]>> {
+  getTripInspectionTargets(query: TripInspectionGroupQuery): Promise<TripInspectionTargetsResult> {
     const timetableGroups = this.timetable[query.stopId];
     if (!timetableGroups) {
-      return Promise.resolve({ success: true, data: [] });
+      return Promise.resolve({
+        success: true,
+        data: [],
+        truncated: false,
+        meta: { emptyReason: 'no-stop-data' },
+      });
     }
 
     const activeServiceIds = this.getActiveServiceIds(query.serviceDate);
     const targets: Array<TripInspectionTarget & { routeId: string }> = [];
+    const missingPatternIds = new Set<string>();
+    let sawActiveDeparturesForResolvedPattern = false;
+    let sawActiveDeparturesForMissingPattern = false;
 
     for (const group of timetableGroups) {
       const pattern = this.tripPatterns.get(group.tp);
-      if (!pattern) {
-        continue;
-      }
 
       for (const [serviceId, times] of Object.entries(group.d)) {
         if (!activeServiceIds.has(serviceId)) {
           continue;
         }
+
+        if (times.length === 0) {
+          continue;
+        }
+
+        if (!pattern) {
+          missingPatternIds.add(group.tp);
+          sawActiveDeparturesForMissingPattern = true;
+          continue;
+        }
+
+        sawActiveDeparturesForResolvedPattern = true;
 
         for (let i = 0; i < times.length; i++) {
           targets.push({
@@ -697,9 +713,42 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       return left.routeId.localeCompare(right.routeId);
     });
 
+    if (
+      targets.length === 0 &&
+      sawActiveDeparturesForMissingPattern &&
+      !sawActiveDeparturesForResolvedPattern
+    ) {
+      return Promise.resolve({
+        success: false,
+        error: `Trip inspection targets unavailable: all active timetable groups reference missing patterns for stop ${query.stopId} (${[...missingPatternIds].join(', ')})`,
+      });
+    }
+
+    if (targets.length === 0) {
+      return Promise.resolve({
+        success: true,
+        data: [],
+        truncated: false,
+        meta: { emptyReason: 'no-service-on-this-day' },
+      });
+    }
+
+    const [firstTarget, ...remainingTargets] = targets;
+    if (!firstTarget) {
+      return Promise.resolve({
+        success: false,
+        error: `Trip inspection targets unavailable: failed to resolve non-empty candidate list for stop ${query.stopId}`,
+      });
+    }
+
     return Promise.resolve({
       success: true,
-      data: targets.map(({ routeId: _routeId, ...target }) => target),
+      data: [
+        (({ routeId: _routeId, ...target }) => target)(firstTarget),
+        ...remainingTargets.map(({ routeId: _routeId, ...target }) => target),
+      ],
+      truncated: false,
+      meta: {},
     });
   }
 

--- a/src/repositories/mock-repository/__tests__/mock-repository.test.ts
+++ b/src/repositories/mock-repository/__tests__/mock-repository.test.ts
@@ -107,6 +107,7 @@ describe('MockRepository contract compatibility', () => {
 
     assertSuccess(timetable);
     assertSuccess(result);
+    expect(result.truncated).toBe(false);
     expect(result.data).toEqual(
       timetable.data.map((entry) => ({
         tripLocator: entry.tripLocator,
@@ -115,6 +116,22 @@ describe('MockRepository contract compatibility', () => {
         departureMinutes: entry.schedule.departureMinutes,
       })),
     );
+    expect(result.meta).toEqual({});
+  });
+
+  it('reports no-stop-data when no trip-inspection targets exist for the stop', async () => {
+    const repository = new MockRepository();
+    const serviceDate = new Date('2026-04-07T12:00:00+09:00');
+
+    const result = await repository.getTripInspectionTargets({
+      serviceDate,
+      stopId: 'missing_stop',
+    });
+
+    assertSuccess(result);
+    expect(result.truncated).toBe(false);
+    expect(result.data).toEqual([]);
+    expect(result.meta).toEqual({ emptyReason: 'no-stop-data' });
   });
 
   it('returns all upcoming entries when limit is omitted', async () => {

--- a/src/repositories/mock-repository/mock-repository.ts
+++ b/src/repositories/mock-repository/mock-repository.ts
@@ -23,7 +23,6 @@ import type {
   StopWithMeta,
   TimetableEntry,
   TripInspectionGroupQuery,
-  TripInspectionTarget,
   TripLocator,
   TripStopTime,
   TripSnapshot,
@@ -33,6 +32,7 @@ import type {
   Result,
   TimetableQueryMeta,
   TimetableResult,
+  TripInspectionTargetsResult,
   TripSnapshotResult,
   UpcomingTimetableResult,
 } from '../../types/app/repository';
@@ -387,19 +387,37 @@ export class MockRepository implements TransitRepository {
     return { success: true, data: snapshot };
   }
 
-  getTripInspectionTargets(
-    query: TripInspectionGroupQuery,
-  ): Promise<Result<TripInspectionTarget[]>> {
+  getTripInspectionTargets(query: TripInspectionGroupQuery): Promise<TripInspectionTargetsResult> {
     const entries = this.buildFullDayTimetableEntries(query.stopId);
+    const data = entries.map((entry) => ({
+      tripLocator: entry.tripLocator,
+      serviceDate: query.serviceDate,
+      stopIndex: entry.patternPosition.stopIndex,
+      departureMinutes: entry.schedule.departureMinutes,
+    }));
+
+    if (data.length === 0) {
+      return Promise.resolve({
+        success: true,
+        data: [],
+        truncated: false,
+        meta: { emptyReason: 'no-stop-data' },
+      });
+    }
+
+    const [firstTarget, ...remainingTargets] = data;
+    if (!firstTarget) {
+      return Promise.resolve({
+        success: false,
+        error: `Trip inspection targets unavailable: failed to resolve non-empty mock candidate list for stop ${query.stopId}`,
+      });
+    }
 
     return Promise.resolve({
       success: true,
-      data: entries.map((entry) => ({
-        tripLocator: entry.tripLocator,
-        serviceDate: query.serviceDate,
-        stopIndex: entry.patternPosition.stopIndex,
-        departureMinutes: entry.schedule.departureMinutes,
-      })),
+      data: [firstTarget, ...remainingTargets],
+      truncated: false,
+      meta: {},
     });
   }
 

--- a/src/repositories/transit-repository.ts
+++ b/src/repositories/transit-repository.ts
@@ -12,12 +12,12 @@ import type {
   SourceMeta,
   StopWithMeta,
   TripInspectionGroupQuery,
-  TripInspectionTarget,
 } from '../types/app/transit-composed';
 import type {
   CollectionResult,
   Result,
   TimetableResult,
+  TripInspectionTargetsResult,
   TripSnapshotResult,
   UpcomingTimetableResult,
 } from '../types/app/repository';
@@ -385,13 +385,13 @@ export interface TransitRepository {
    * Implementations use it as the service-day context for calendar filtering;
    * callers should not pass a raw real-world datetime here.
    *
+   * On empty success results, `meta.emptyReason` is always defined.
+   *
    * @param query - Stop and service-day context. `query.serviceDate` is a
    *                pre-normalized service day, not a reference datetime.
    * @returns Trip-inspection targets with lightweight comparison data.
    */
-  getTripInspectionTargets(
-    query: TripInspectionGroupQuery,
-  ): Promise<Result<TripInspectionTarget[]>>;
+  getTripInspectionTargets(query: TripInspectionGroupQuery): Promise<TripInspectionTargetsResult>;
 
   /**
    * Returns a single stop with metadata by its GTFS stop_id, against

--- a/src/types/app/repository.ts
+++ b/src/types/app/repository.ts
@@ -5,7 +5,12 @@
  * {@link TransitRepository} methods.
  */
 
-import type { ContextualTimetableEntry, TimetableEntry, TripSnapshot } from './transit-composed';
+import type {
+  ContextualTimetableEntry,
+  TimetableEntry,
+  TripInspectionTarget,
+  TripSnapshot,
+} from './transit-composed';
 
 /**
  * Result for single-value queries.
@@ -102,3 +107,79 @@ export type UpcomingTimetableResult =
 
 /** Result for repository-provided whole-trip reconstruction. */
 export type TripSnapshotResult = Result<TripSnapshot>;
+
+/** Programmatic reason for an empty trip-inspection target result. */
+export type TripInspectionTargetsEmptyReason = 'no-stop-data' | 'no-service-on-this-day';
+
+/** Non-empty trip-inspection target list. */
+type NonEmptyTripInspectionTargets = [TripInspectionTarget, ...TripInspectionTarget[]];
+
+/** Metadata returned alongside trip-inspection targets. */
+export interface TripInspectionTargetsMeta {
+  /**
+   * Present when the query succeeds but yields no candidates.
+   *
+   * This property remains optional for ergonomic destructuring on the non-empty
+   * path, but callers handling `data.length === 0` can rely on it being
+   * defined.
+   */
+  emptyReason?: TripInspectionTargetsEmptyReason;
+}
+
+/**
+ * Metadata for an empty trip-inspection target result.
+ *
+ * `emptyReason` is required here, unlike in
+ * {@link TripInspectionTargetsMeta}, because the empty success branch of
+ * {@link TripInspectionTargetsResult} guarantees a programmatic reason for the
+ * absence of candidates. Used only when `data: []`.
+ */
+export interface EmptyTripInspectionTargetsMeta extends TripInspectionTargetsMeta {
+  emptyReason: TripInspectionTargetsEmptyReason;
+}
+
+/**
+ * Result for stop-level trip-inspection target queries.
+ *
+ * Empty results are reported as success, not failure. When no candidates exist
+ * for the queried stop / service day, the repository returns
+ * `{ success: true, data: [], truncated: false, meta: { emptyReason } }`.
+ * Callers are expected to use {@link TripInspectionTargetsMeta.emptyReason} to
+ * distinguish normal empty outcomes such as "no stop data" and
+ * "no service on this day".
+ *
+ * **Invariant**: when `data.length === 0`, `meta.emptyReason` is always
+ * defined. The optional marker on {@link TripInspectionTargetsMeta.emptyReason}
+ * is only for ergonomic destructuring on the non-empty path.
+ *
+ * `{ success: false, error }` is reserved for repository-level failures such
+ * as internal lookup or data integrity errors, not for normal "no matches"
+ * outcomes.
+ *
+ * @example
+ * ```ts
+ * if (result.success) {
+ *   if (result.data.length === 0) {
+ *     handleEmpty(result.meta.emptyReason);
+ *   } else {
+ *     handleNonEmpty(result.data);
+ *   }
+ * }
+ * ```
+ */
+export type TripInspectionTargetsResult =
+  | {
+      success: true;
+      data: [];
+      /** Always `false`: this API returns the full candidate set. */
+      truncated: false;
+      meta: EmptyTripInspectionTargetsMeta;
+    }
+  | {
+      success: true;
+      data: NonEmptyTripInspectionTargets;
+      /** Always `false`: this API returns the full candidate set. */
+      truncated: false;
+      meta: TripInspectionTargetsMeta;
+    }
+  | { success: false; error: string };


### PR DESCRIPTION
## Summary
- Extract trip-inspection target selection / resolution into a dedicated domain module (`src/domain/transit/trip-inspection-target.ts`) covered by unit tests for boundary values, tie-breaks, and identity comparison
- Refactor `useTripInspection` by splitting the open flow into `loadTripInspectionSnapshot` + `refineTripInspectionState` + thin orchestration; add `isCancelled` opaque token so cancellation is decoupled from React refs and unit-testable
- Add stop-based open flow (`openTripInspectionFromStopId`) wired into BottomSheet / Map markers / StopSearchModal via a shared `StopActionButtons` component
- Tighten `TripInspectionTargetsResult` with discriminated `data: [] | NonEmptyTripInspectionTargets` + `EmptyTripInspectionTargetsMeta` (required `emptyReason`); add `truncated: false` for shape consistency with sibling result types
- Detect data-integrity failures (= all active timetable groups reference missing patterns) and surface as `success: false` with diagnostic error
- Add `StopActionButtons` Storybook coverage and per-action visibility toggles; refine Anchor toggle visual (chip + `currentColor` inheritance for atomic paint timing)
- Add empty-state messages for trip inspection lookup failures (`no-stop-data` / `no-service-on-this-day`)

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] Browser-verify trip inspection open from stop tap (BottomSheet / Map marker / StopSearchModal)
- [x] Browser-verify Anchor button toggle in light + dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)