### PR TITLE
feat(timetable): extract useTimetable hook and surface failures

### DIFF
--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from '../i18n';
 import App from '../app';
 import type { UseAnchorsReturn } from '../hooks/use-anchors';
+import type { UseTimetableReturn } from '../hooks/use-timetable';
 import type { ContextualTimetableEntry, StopWithContext } from '../types/app/transit-composed';
 
 type UseDateTimeReturn = ReturnType<typeof import('../hooks/use-date-time').useDateTime>;
@@ -13,6 +14,7 @@ type GetServiceDayMinutes = typeof import('../domain/transit/service-day').getSe
 
 const {
   mockToastError,
+  mockToastWarning,
   mockUseAnchors,
   mockGetRouteShapes,
   mockClearAnchorError,
@@ -20,8 +22,12 @@ const {
   mockUseDateTime,
   mockUseNearbyStopTimes,
   mockMapBottomSheetLayout,
+  mockUseTimetable,
+  mockOpenStopTimetable,
+  mockOpenRouteHeadsignTimetable,
 } = vi.hoisted(() => ({
   mockToastError: vi.fn(),
+  mockToastWarning: vi.fn(),
   mockUseAnchors: vi.fn<(...args: unknown[]) => UseAnchorsReturn>(),
   mockGetRouteShapes: vi.fn(),
   mockClearAnchorError: vi.fn(),
@@ -29,11 +35,15 @@ const {
   mockUseDateTime: vi.fn<() => UseDateTimeReturn>(),
   mockUseNearbyStopTimes: vi.fn<() => UseNearbyStopTimesReturn>(),
   mockMapBottomSheetLayout: vi.fn(),
+  mockUseTimetable: vi.fn<() => UseTimetableReturn>(),
+  mockOpenStopTimetable: vi.fn(),
+  mockOpenRouteHeadsignTimetable: vi.fn(),
 }));
 
 vi.mock('sonner', () => ({
   toast: {
     error: mockToastError,
+    warning: mockToastWarning,
   },
 }));
 
@@ -78,6 +88,10 @@ vi.mock('../domain/transit/service-day', async (importOriginal) => {
 
 vi.mock('../hooks/use-nearby-stop-times', () => ({
   useNearbyStopTimes: () => mockUseNearbyStopTimes(),
+}));
+
+vi.mock('../hooks/use-timetable', () => ({
+  useTimetable: () => mockUseTimetable(),
 }));
 
 vi.mock('../hooks/use-selection', () => ({
@@ -221,6 +235,7 @@ describe('App anchor error toast', () => {
     // Fix i18n language to 'ja' so toast message assertions are deterministic.
     await i18n.changeLanguage('ja');
     mockToastError.mockReset();
+    mockToastWarning.mockReset();
     mockUseAnchors.mockReset();
     mockGetRouteShapes.mockReset();
     mockClearAnchorError.mockReset();
@@ -228,6 +243,9 @@ describe('App anchor error toast', () => {
     mockUseDateTime.mockReset();
     mockUseNearbyStopTimes.mockReset();
     mockMapBottomSheetLayout.mockReset();
+    mockUseTimetable.mockReset();
+    mockOpenStopTimetable.mockReset();
+    mockOpenRouteHeadsignTimetable.mockReset();
 
     mockGetRouteShapes.mockResolvedValue({ success: true, data: [] });
     mockUseAnchors.mockReturnValue({
@@ -251,6 +269,14 @@ describe('App anchor error toast', () => {
       stopTimes: [],
       isNearbyLoading: false,
     });
+    mockUseTimetable.mockReturnValue({
+      timetableData: null,
+      openStopTimetable: mockOpenStopTimetable,
+      openRouteHeadsignTimetable: mockOpenRouteHeadsignTimetable,
+      closeTimetable: vi.fn(),
+    });
+    mockOpenStopTimetable.mockResolvedValue({ status: 'opened' });
+    mockOpenRouteHeadsignTimetable.mockResolvedValue({ status: 'opened' });
   });
 
   it('does not show toast when lastError is null', async () => {
@@ -366,6 +392,56 @@ describe('App anchor error toast', () => {
       expect(props.globalFilter.omitEmptyStops).toBe(false);
       expect(props.globalFilter.isOmitEmptyStopsForced).toBe(false);
       expect(props.filteredNearbyStopsCounts.total).toBe(2);
+    });
+  });
+
+  it('shows an error toast when stop timetable loading fails', async () => {
+    mockOpenStopTimetable.mockResolvedValue({ status: 'error' });
+
+    render(<App loadResult={{ loaded: [], failed: [] }} />);
+
+    await waitFor(() => {
+      expect(mockMapBottomSheetLayout).toHaveBeenCalled();
+    });
+
+    const lastCall = mockMapBottomSheetLayout.mock.lastCall;
+    const props = lastCall?.[0] as {
+      bottomSheetProps: {
+        onShowStopTimetable: (stopId: string) => void;
+      };
+    };
+
+    act(() => {
+      props.bottomSheetProps.onShowStopTimetable('stop-error');
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('時刻表を取得できませんでした');
+    });
+  });
+
+  it('shows a warning toast when route timetable is unavailable at a stop', async () => {
+    mockOpenRouteHeadsignTimetable.mockResolvedValue({ status: 'route-not-found' });
+
+    render(<App loadResult={{ loaded: [], failed: [] }} />);
+
+    await waitFor(() => {
+      expect(mockMapBottomSheetLayout).toHaveBeenCalled();
+    });
+
+    const lastCall = mockMapBottomSheetLayout.mock.lastCall;
+    const props = lastCall?.[0] as {
+      bottomSheetProps: {
+        onShowTimetable: (stopId: string, routeId: string, headsign: string) => void;
+      };
+    };
+
+    act(() => {
+      props.bottomSheetProps.onShowTimetable('stop-1', 'route-1', 'Headsign');
+    });
+
+    await waitFor(() => {
+      expect(mockToastWarning).toHaveBeenCalledWith('この路線の時刻表を表示できません');
     });
   });
 });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 import { InfoDialog } from './components/dialog/info-dialog';
 import { ShortcutHelpDialog } from './components/dialog/shortcut-help-dialog';
 import { StopSearchDialog } from './components/dialog/stop-search-dialog';
-import { TimetableModal, type TimetableData } from './components/dialog/timetable-modal';
+import { TimetableModal } from './components/dialog/timetable-modal';
 import { TripInspectionDialog } from './components/dialog/trip-inspection-dialog';
 import { MapBottomSheetLayout } from './components/map-bottom-sheet-layout';
 import { TimeControls } from './components/time-controls';
@@ -23,8 +23,6 @@ import { getServiceDay, getServiceDayMinutes } from './domain/transit/service-da
 import {
   applyStopEventAttributeTogglesToStops,
   omitStopsWithoutStopTimes,
-  prepareRouteHeadsignTimetable,
-  prepareStopTimetable,
 } from './domain/transit/timetable-filter';
 import { getStopServiceState, getTimetableEntriesState } from './domain/transit/timetable-utils';
 import { useAnchors } from './hooks/use-anchors';
@@ -34,6 +32,7 @@ import { useNearbyStopTimes } from './hooks/use-nearby-stop-times';
 import { useRouteStops } from './hooks/use-route-stops';
 import { useSelection } from './hooks/use-selection';
 import { useStopHistory } from './hooks/use-stop-history';
+import { useTimetable } from './hooks/use-timetable';
 import { useTransitRepository } from './hooks/use-transit-repository';
 import { useTripInspection } from './hooks/use-trip-inspection';
 import { useUserSettings } from './hooks/use-user-settings';
@@ -79,6 +78,7 @@ export default function App({ loadResult }: AppProps) {
   const repo = useTransitRepository();
   const [userDataRepo] = useState(() => new LocalStorageUserDataRepository());
   const { settings, updateSetting, updateSettings } = useUserSettings();
+  const { dateTime, isCustomTime, resetToNow, setCustomTime } = useDateTime();
 
   // Sync i18next language with user setting.
   useEffect(() => {
@@ -120,7 +120,6 @@ export default function App({ loadResult }: AppProps) {
   const [radiusStops, setNearbyStops] = useState<StopWithMeta[]>([]);
   const [mapCenter, setMapCenter] = useState<LatLng | null>(null);
   const [routeShapes, setRouteShapes] = useState<RouteShape[]>([]);
-  const [timetableData, setTimetableData] = useState<TimetableData | null>(null);
   const [hasNearbyLoaded, setHasNearbyLoaded] = useState(false);
   const [searchModalOpen, setSearchModalOpen] = useState(false);
   const [infoDialogOpen, setInfoDialogOpen] = useState(false);
@@ -135,6 +134,8 @@ export default function App({ loadResult }: AppProps) {
     openNextTripInspection,
     closeTripInspection,
   } = useTripInspection(repo);
+  const { timetableData, openRouteHeadsignTimetable, openStopTimetable, closeTimetable } =
+    useTimetable(repo);
 
   // Global keyboard shortcuts. Suppressed while any of the four primary
   // modals owned by app.tsx is open (search / info / help / timetable),
@@ -159,8 +160,6 @@ export default function App({ loadResult }: AppProps) {
   });
 
   // --- Custom Hooks ---
-
-  const { dateTime, isCustomTime, resetToNow, setCustomTime } = useDateTime();
 
   const { stopTimes: nearbyStopTimes, isNearbyLoading } = useNearbyStopTimes(
     radiusStops,
@@ -469,78 +468,26 @@ export default function App({ loadResult }: AppProps) {
     [repo, dateTime, inBoundStops, radiusStops],
   );
 
-  /** Fetch full-day timetable entries for a stop (no filtering). */
-  const fetchTimetableEntries = useCallback(
-    async (stopId: string) => {
-      const result = await repo.getFullDayTimetableEntries(stopId, dateTime);
-      const allEntries = result.success ? result.data : [];
-      const isBoardableOnServiceDay = result.success ? result.meta.isBoardableOnServiceDay : false;
-      return { allEntries, isBoardableOnServiceDay };
-    },
-    [repo, dateTime],
-  );
-
-  const showTimetable = useCallback(
-    async (
-      stopId: string,
-      filter: { type: 'route-headsign'; routeId: string; headsign: string } | { type: 'stop' },
-    ) => {
-      const meta = radiusStops.find((s) => s.stop.stop_id === stopId);
-      if (!meta) {
-        return;
-      }
-
-      // Resolve routes: single matched route for route-headsign, all for stop.
-      const routes =
-        filter.type === 'route-headsign'
-          ? meta.routes.filter((r) => r.route_id === filter.routeId)
-          : meta.routes;
-      if (filter.type === 'route-headsign' && routes.length === 0) {
-        return;
-      }
-
-      const { allEntries, isBoardableOnServiceDay } = await fetchTimetableEntries(stopId);
-      const { entries, omitted } =
-        filter.type === 'route-headsign'
-          ? prepareRouteHeadsignTimetable(allEntries, filter.routeId, filter.headsign, true)
-          : prepareStopTimetable(allEntries, true);
-
-      const headsign = filter.type === 'route-headsign' ? filter.headsign : undefined;
-
-      logger.debug(
-        `timetable(${filter.type}) [${settings.infoLevel}]: ${stopId}${filter.type === 'route-headsign' ? ` ${filter.routeId} "${headsign}"` : ''} → entries=${entries.length} omitted.nonBoardable=${omitted.nonBoardable} total=${allEntries.length}`,
-      );
-
-      setTimetableData({
-        type: filter.type,
-        stop: meta.stop,
-        routes,
-        headsign,
-        serviceDate: getServiceDay(dateTime),
-        timetableEntries: entries,
-        omitted,
-        stopServiceState: getStopServiceState({
-          totalEntries: allEntries.length,
-          isBoardableOnServiceDay,
-        }),
-        agencies: meta.agencies,
-      });
-    },
-    [dateTime, radiusStops, fetchTimetableEntries, settings.infoLevel],
-  );
-
   const handleShowTimetable = useCallback(
     (stopId: string, routeId: string, headsign: string) => {
-      void showTimetable(stopId, { type: 'route-headsign', routeId, headsign });
+      void openRouteHeadsignTimetable({
+        stopId,
+        routeId,
+        headsign,
+        dateTime,
+      });
     },
-    [showTimetable],
+    [dateTime, openRouteHeadsignTimetable],
   );
 
   const handleShowStopTimetable = useCallback(
     (stopId: string) => {
-      void showTimetable(stopId, { type: 'stop' });
+      void openStopTimetable({
+        stopId,
+        dateTime,
+      });
     },
-    [showTimetable],
+    [dateTime, openStopTimetable],
   );
 
   const handleOpenTripInspectionByStopId = useCallback(
@@ -592,8 +539,6 @@ export default function App({ loadResult }: AppProps) {
     },
     [openTripInspectionFromTarget, t],
   );
-
-  const closeTimetableModal = useCallback(() => setTimetableData(null), []);
 
   const handleTripInspectionOpenChange = useCallback(
     (open: boolean) => {
@@ -1068,7 +1013,7 @@ export default function App({ loadResult }: AppProps) {
         dataLangs={langChain}
         globalFilter={globalFilter}
         onInspectTrip={handleInspectTrip}
-        onClose={closeTimetableModal}
+        onClose={closeTimetable}
       />
       <Toaster
         theme={settings.theme}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -475,9 +475,23 @@ export default function App({ loadResult }: AppProps) {
         routeId,
         headsign,
         dateTime,
+      }).then((status) => {
+        if (status.status === 'not-found') {
+          toast.warning(t('timetable.messages.stopNotFound'));
+          return;
+        }
+
+        if (status.status === 'route-not-found') {
+          toast.warning(t('timetable.messages.routeNotFound'));
+          return;
+        }
+
+        if (status.status === 'error') {
+          toast.error(t('timetable.messages.openFailed'));
+        }
       });
     },
-    [dateTime, openRouteHeadsignTimetable],
+    [dateTime, openRouteHeadsignTimetable, t],
   );
 
   const handleShowStopTimetable = useCallback(
@@ -485,9 +499,18 @@ export default function App({ loadResult }: AppProps) {
       void openStopTimetable({
         stopId,
         dateTime,
+      }).then((status) => {
+        if (status.status === 'not-found') {
+          toast.warning(t('timetable.messages.stopNotFound'));
+          return;
+        }
+
+        if (status.status === 'error') {
+          toast.error(t('timetable.messages.openFailed'));
+        }
       });
     },
-    [dateTime, openStopTimetable],
+    [dateTime, openStopTimetable, t],
   );
 
   const handleOpenTripInspectionByStopId = useCallback(

--- a/src/components/dialog/dialog-memoization.test.tsx
+++ b/src/components/dialog/dialog-memoization.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Agency, Route, Stop } from '@/types/app/transit';
 import type { TransitRepository } from '@/repositories/transit-repository';
+import type { TimetableData } from '@/types/app/timetable';
 import type {
   SelectedTripSnapshot,
   TimetableEntry,
@@ -176,7 +177,7 @@ vi.mock('../verbose/verbose-trip-stop-time', () => ({
   VerboseTripStopTime: () => null,
 }));
 
-import { TimetableModal, type TimetableData } from './timetable-modal';
+import { TimetableModal } from './timetable-modal';
 import { StopSearchDialog } from './stop-search-dialog';
 import { TripInspectionDialog } from './trip-inspection-dialog';
 

--- a/src/components/dialog/timetable-modal.tsx
+++ b/src/components/dialog/timetable-modal.tsx
@@ -21,9 +21,9 @@ import { computeTimetableEntryStats } from '@/domain/transit/timetable-stats';
 import { useInfoLevel } from '@/hooks/use-info-level';
 import { useScrollFades } from '@/hooks/use-scroll-fades';
 import type { GlobalFilter } from '@/types/app/global-filter';
-import type { TimetableOmitted } from '@/types/app/repository';
 import type { InfoLevel } from '@/types/app/settings';
-import type { Agency, Route, Stop, StopServiceState } from '@/types/app/transit';
+import type { TimetableData } from '@/types/app/timetable';
+import type { Agency } from '@/types/app/transit';
 import type { TimetableEntry, TripInspectionTarget } from '@/types/app/transit-composed';
 import { formatDateParts } from '@/utils/datetime';
 import { DAY_COLOR_CATEGORY_CLASSES } from '@/utils/day-of-week';
@@ -36,24 +36,6 @@ import { TimetableGrid } from '../timetable/timetable-grid';
 import { TimetableHeader } from '../timetable/timetable-header';
 import { TimetableHeadsignFilter } from '../timetable/timetable-headsign-filter';
 import { TimetableMetadata } from '../timetable/timetable-metadata';
-
-/** Data needed to render the timetable modal. */
-export interface TimetableData {
-  type: 'route-headsign' | 'stop';
-  stop: Stop;
-  /** Routes serving this stop in this timetable context.
-   *  For route-headsign: single route. For stop: all routes. */
-  routes: Route[];
-  /** Headsign filter. Present only for route-headsign type. */
-  headsign?: string;
-  /** GTFS service date for this timetable (not real-world time). */
-  serviceDate: Date;
-  timetableEntries: TimetableEntry[];
-  omitted: TimetableOmitted;
-  /** Service state derived from the full service day before filtering. */
-  stopServiceState: StopServiceState;
-  agencies: Agency[];
-}
 
 interface TimetableModalProps {
   /** Pass null when the modal should be closed. */

--- a/src/hooks/__tests__/use-timetable.test.ts
+++ b/src/hooks/__tests__/use-timetable.test.ts
@@ -1,0 +1,104 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { makeRepo, makeRoute, makeStop } from '../../__tests__/helpers';
+import type { TimetableEntry } from '../../types/app/transit-composed';
+import { useTimetable } from '../use-timetable';
+
+function makeStopMeta(stopId: string, routeIds: string[] = ['route-1']) {
+  return {
+    stop: makeStop(stopId),
+    agencies: [],
+    routes: routeIds.map((routeId) => makeRoute(routeId)),
+  };
+}
+
+function makeTimetableEntry(routeId = 'route-1', headsign = 'Headsign'): TimetableEntry {
+  return {
+    tripLocator: { patternId: `${routeId}__pattern`, serviceId: 'weekday', tripIndex: 0 },
+    schedule: { departureMinutes: 480, arrivalMinutes: 480 },
+    routeDirection: {
+      route: makeRoute(routeId),
+      tripHeadsign: { name: headsign, names: {} },
+      direction: 0,
+    },
+    boarding: { pickupType: 0, dropOffType: 0 },
+    patternPosition: { stopIndex: 0, totalStops: 1, isOrigin: true, isTerminal: true },
+  };
+}
+
+describe('useTimetable', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens stop timetable by falling back to full-dataset stop lookup', async () => {
+    const stopMeta = makeStopMeta('stop-remote');
+    const getStopMetaById = vi.fn().mockResolvedValue({ success: true, data: stopMeta });
+    const repo = makeRepo({
+      getStopMetaById,
+      getFullDayTimetableEntries: vi.fn().mockResolvedValue({
+        success: true,
+        data: [makeTimetableEntry()],
+        truncated: false,
+        meta: { isBoardableOnServiceDay: true, totalEntries: 1 },
+      }),
+    });
+
+    const { result } = renderHook(() => useTimetable(repo));
+
+    let status: Awaited<ReturnType<typeof result.current.openStopTimetable>>;
+    await act(async () => {
+      status = await result.current.openStopTimetable({
+        stopId: 'stop-remote',
+        dateTime: new Date('2026-05-02T12:00:00+09:00'),
+      });
+    });
+
+    expect(status!).toEqual({ status: 'opened' });
+    expect(getStopMetaById).toHaveBeenCalledWith('stop-remote');
+    expect(result.current.timetableData).toEqual(
+      expect.objectContaining({
+        type: 'stop',
+        stop: stopMeta.stop,
+        routes: stopMeta.routes,
+        agencies: stopMeta.agencies,
+      }),
+    );
+  });
+
+  it('uses repository stop metadata for route-headsign timetable', async () => {
+    const stopMeta = makeStopMeta('stop-visible', ['route-visible']);
+    const getStopMetaById = vi.fn().mockResolvedValue({ success: true, data: stopMeta });
+    const repo = makeRepo({
+      getStopMetaById,
+      getFullDayTimetableEntries: vi.fn().mockResolvedValue({
+        success: true,
+        data: [makeTimetableEntry('route-visible')],
+        truncated: false,
+        meta: { isBoardableOnServiceDay: true, totalEntries: 1 },
+      }),
+    });
+
+    const { result } = renderHook(() => useTimetable(repo));
+
+    await act(async () => {
+      await result.current.openRouteHeadsignTimetable({
+        stopId: 'stop-visible',
+        routeId: 'route-visible',
+        headsign: 'Headsign',
+        dateTime: new Date('2026-05-02T12:00:00+09:00'),
+      });
+    });
+
+    expect(getStopMetaById).toHaveBeenCalledWith('stop-visible');
+    expect(result.current.timetableData).toEqual(
+      expect.objectContaining({
+        type: 'route-headsign',
+        stop: stopMeta.stop,
+        routes: stopMeta.routes,
+        headsign: 'Headsign',
+      }),
+    );
+  });
+});

--- a/src/hooks/__tests__/use-timetable.test.ts
+++ b/src/hooks/__tests__/use-timetable.test.ts
@@ -5,6 +5,22 @@ import { makeRepo, makeRoute, makeStop } from '../../__tests__/helpers';
 import type { TimetableEntry } from '../../types/app/transit-composed';
 import { useTimetable } from '../use-timetable';
 
+// All tests use this single fixed UTC instant. Tests never assert on the
+// derived `serviceDate`, so the local-timezone interpretation done by
+// `getServiceDay` inside the hook does not influence any assertion.
+const FIXED_DATETIME = new Date('2026-05-02T12:00:00.000Z');
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
 function makeStopMeta(stopId: string, routeIds: string[] = ['route-1']) {
   return {
     stop: makeStop(stopId),
@@ -51,7 +67,7 @@ describe('useTimetable', () => {
     await act(async () => {
       status = await result.current.openStopTimetable({
         stopId: 'stop-remote',
-        dateTime: new Date('2026-05-02T12:00:00+09:00'),
+        dateTime: FIXED_DATETIME,
       });
     });
 
@@ -87,7 +103,7 @@ describe('useTimetable', () => {
         stopId: 'stop-visible',
         routeId: 'route-visible',
         headsign: 'Headsign',
-        dateTime: new Date('2026-05-02T12:00:00+09:00'),
+        dateTime: FIXED_DATETIME,
       });
     });
 
@@ -100,5 +116,211 @@ describe('useTimetable', () => {
         headsign: 'Headsign',
       }),
     );
+  });
+
+  it('returns error and keeps timetable closed when timetable lookup fails', async () => {
+    const stopMeta = makeStopMeta('stop-error');
+    const repo = makeRepo({
+      getStopMetaById: vi.fn().mockResolvedValue({ success: true, data: stopMeta }),
+      getFullDayTimetableEntries: vi.fn().mockResolvedValue({
+        success: false,
+        error: 'broken timetable source',
+      }),
+    });
+
+    const { result } = renderHook(() => useTimetable(repo));
+
+    let status: Awaited<ReturnType<typeof result.current.openStopTimetable>>;
+    await act(async () => {
+      status = await result.current.openStopTimetable({
+        stopId: 'stop-error',
+        dateTime: FIXED_DATETIME,
+      });
+    });
+
+    expect(status!).toEqual({ status: 'error' });
+    expect(result.current.timetableData).toBeNull();
+  });
+
+  it('returns not-found and keeps timetable closed when stop metadata lookup fails', async () => {
+    const repo = makeRepo({
+      getStopMetaById: vi.fn().mockResolvedValue({ success: false, error: 'Unknown stop' }),
+    });
+
+    const { result } = renderHook(() => useTimetable(repo));
+
+    let status: Awaited<ReturnType<typeof result.current.openStopTimetable>>;
+    await act(async () => {
+      status = await result.current.openStopTimetable({
+        stopId: 'missing-stop',
+        dateTime: FIXED_DATETIME,
+      });
+    });
+
+    expect(status!).toEqual({ status: 'not-found' });
+    expect(result.current.timetableData).toBeNull();
+  });
+
+  it('returns route-not-found when the route does not belong to the stop', async () => {
+    const stopMeta = makeStopMeta('stop-visible', ['route-visible']);
+    const repo = makeRepo({
+      getStopMetaById: vi.fn().mockResolvedValue({ success: true, data: stopMeta }),
+    });
+
+    const { result } = renderHook(() => useTimetable(repo));
+
+    let status: Awaited<ReturnType<typeof result.current.openRouteHeadsignTimetable>>;
+    await act(async () => {
+      status = await result.current.openRouteHeadsignTimetable({
+        stopId: 'stop-visible',
+        routeId: 'route-missing',
+        headsign: 'Headsign',
+        dateTime: FIXED_DATETIME,
+      });
+    });
+
+    expect(status!).toEqual({ status: 'route-not-found' });
+    expect(result.current.timetableData).toBeNull();
+  });
+
+  it('uses repository meta.totalEntries when deriving stopServiceState', async () => {
+    const stopMeta = makeStopMeta('stop-dropoff');
+    const repo = makeRepo({
+      getStopMetaById: vi.fn().mockResolvedValue({ success: true, data: stopMeta }),
+      getFullDayTimetableEntries: vi.fn().mockResolvedValue({
+        success: true,
+        data: [],
+        truncated: false,
+        meta: { isBoardableOnServiceDay: false, totalEntries: 1 },
+      }),
+    });
+
+    const { result } = renderHook(() => useTimetable(repo));
+
+    await act(async () => {
+      await result.current.openStopTimetable({
+        stopId: 'stop-dropoff',
+        dateTime: FIXED_DATETIME,
+      });
+    });
+
+    expect(result.current.timetableData?.stopServiceState).toBe('drop-off-only');
+  });
+
+  it('cancels the older request when a newer open request finishes first', async () => {
+    // Hold the first stop-meta lookup pending so the older request stalls
+    // before reaching getFullDayTimetableEntries. The newer request resolves
+    // synchronously and updates `requestIdRef`, which causes the older one
+    // to short-circuit on the post-await cancellation check.
+    const slowFirstStopMeta = createDeferred<{
+      success: true;
+      data: ReturnType<typeof makeStopMeta>;
+    }>();
+    const repo = makeRepo({
+      getStopMetaById: vi
+        .fn()
+        .mockReturnValueOnce(slowFirstStopMeta.promise)
+        .mockImplementation((stopId: string) =>
+          Promise.resolve({ success: true, data: makeStopMeta(stopId) }),
+        ),
+      getFullDayTimetableEntries: vi.fn().mockResolvedValue({
+        success: true,
+        data: [makeTimetableEntry('route-2')],
+        truncated: false,
+        meta: { isBoardableOnServiceDay: true, totalEntries: 1 },
+      }),
+    });
+
+    const { result } = renderHook(() => useTimetable(repo));
+
+    let firstOpenPromise!: ReturnType<typeof result.current.openStopTimetable>;
+    act(() => {
+      firstOpenPromise = result.current.openStopTimetable({
+        stopId: 'stop-1',
+        dateTime: FIXED_DATETIME,
+      });
+    });
+
+    let secondStatus: Awaited<ReturnType<typeof result.current.openStopTimetable>>;
+    await act(async () => {
+      secondStatus = await result.current.openStopTimetable({
+        stopId: 'stop-2',
+        dateTime: FIXED_DATETIME,
+      });
+    });
+
+    await act(async () => {
+      slowFirstStopMeta.resolve({ success: true, data: makeStopMeta('stop-1') });
+      await slowFirstStopMeta.promise;
+    });
+
+    const firstStatus = await firstOpenPromise;
+
+    expect(secondStatus!).toEqual({ status: 'opened' });
+    expect(firstStatus).toEqual({ status: 'cancelled' });
+    expect(result.current.timetableData?.stop.stop_id).toBe('stop-2');
+  });
+
+  it('cancels an in-flight request when closeTimetable is called', async () => {
+    const deferredTimetable = createDeferred<{
+      success: true;
+      data: TimetableEntry[];
+      truncated: false;
+      meta: { isBoardableOnServiceDay: true; totalEntries: number };
+    }>();
+    const repo = makeRepo({
+      getStopMetaById: vi.fn().mockResolvedValue({ success: true, data: makeStopMeta('stop-1') }),
+      getFullDayTimetableEntries: vi.fn().mockImplementation(() => deferredTimetable.promise),
+    });
+
+    const { result } = renderHook(() => useTimetable(repo));
+
+    let openPromise!: ReturnType<typeof result.current.openStopTimetable>;
+    act(() => {
+      openPromise = result.current.openStopTimetable({
+        stopId: 'stop-1',
+        dateTime: FIXED_DATETIME,
+      });
+    });
+
+    act(() => {
+      result.current.closeTimetable();
+    });
+
+    await act(async () => {
+      deferredTimetable.resolve({
+        success: true,
+        data: [makeTimetableEntry()],
+        truncated: false,
+        meta: { isBoardableOnServiceDay: true, totalEntries: 1 },
+      });
+      await deferredTimetable.promise;
+    });
+
+    const status = await openPromise;
+
+    expect(status).toEqual({ status: 'cancelled' });
+    expect(result.current.timetableData).toBeNull();
+  });
+
+  it('returns error when timetable lookup rejects', async () => {
+    const stopMeta = makeStopMeta('stop-reject');
+    const repo = makeRepo({
+      getStopMetaById: vi.fn().mockResolvedValue({ success: true, data: stopMeta }),
+      getFullDayTimetableEntries: vi.fn().mockRejectedValue(new Error('network down')),
+    });
+
+    const { result } = renderHook(() => useTimetable(repo));
+
+    let status: Awaited<ReturnType<typeof result.current.openStopTimetable>>;
+    await act(async () => {
+      status = await result.current.openStopTimetable({
+        stopId: 'stop-reject',
+        dateTime: FIXED_DATETIME,
+      });
+    });
+
+    expect(status!).toEqual({ status: 'error' });
+    expect(result.current.timetableData).toBeNull();
   });
 });

--- a/src/hooks/use-timetable.ts
+++ b/src/hooks/use-timetable.ts
@@ -8,7 +8,7 @@ import {
 import { getStopServiceState } from '@/domain/transit/timetable-utils';
 import { createLogger } from '@/lib/logger';
 import type { TransitRepository } from '@/repositories/transit-repository';
-import type { TimetableResult } from '@/types/app/repository';
+import type { Result, TimetableResult } from '@/types/app/repository';
 import type { Route } from '@/types/app/transit';
 import type { StopWithMeta } from '@/types/app/transit-composed';
 import type { TimetableData } from '@/types/app/timetable';
@@ -36,7 +36,7 @@ export type TimetableOpenOutcome =
   | { status: 'route-not-found' }
   | { status: 'error' };
 
-interface UseTimetableReturn {
+export interface UseTimetableReturn {
   timetableData: TimetableData | null;
   openStopTimetable: (params: OpenStopTimetableParams) => Promise<TimetableOpenOutcome>;
   openRouteHeadsignTimetable: (
@@ -48,13 +48,8 @@ interface UseTimetableReturn {
 async function loadTimetableStopMeta(
   repo: TransitRepository,
   stopId: string,
-): Promise<StopWithMeta | null> {
-  const result = await repo.getStopMetaById(stopId);
-  if (!result.success) {
-    return null;
-  }
-
-  return result.data;
+): Promise<Result<StopWithMeta>> {
+  return repo.getStopMetaById(stopId);
 }
 
 function resolveTimetableRoutes(filter: TimetableFilter, meta: StopWithMeta): Route[] {
@@ -65,22 +60,46 @@ function resolveTimetableRoutes(filter: TimetableFilter, meta: StopWithMeta): Ro
   return meta.routes.filter((route) => route.route_id === filter.routeId);
 }
 
-function normalizeTimetableResult(result: TimetableResult) {
-  if (!result.success) {
+function resolveTimetableRoutesResult(
+  filter: TimetableFilter,
+  meta: StopWithMeta,
+):
+  | { ok: true; routes: Route[] }
+  | {
+      ok: false;
+      routeId: string;
+      headsign: string;
+    } {
+  const routes = resolveTimetableRoutes(filter, meta);
+
+  if (filter.type !== 'route-headsign') {
+    return { ok: true, routes };
+  }
+
+  if (routes.length === 0) {
     return {
-      allEntries: [],
-      isBoardableOnServiceDay: false,
+      ok: false,
+      routeId: filter.routeId,
+      headsign: filter.headsign,
     };
   }
 
+  return { ok: true, routes };
+}
+
+function normalizeTimetableResult(result: Extract<TimetableResult, { success: true }>) {
   return {
     allEntries: result.data,
     isBoardableOnServiceDay: result.meta.isBoardableOnServiceDay,
+    totalEntries: result.meta.totalEntries,
   };
 }
 
-function buildTimetableEntries(filter: TimetableFilter, result: TimetableResult) {
-  const { allEntries, isBoardableOnServiceDay } = normalizeTimetableResult(result);
+function buildTimetableEntries(
+  filter: TimetableFilter,
+  result: Extract<TimetableResult, { success: true }>,
+) {
+  const { allEntries, isBoardableOnServiceDay, totalEntries } = normalizeTimetableResult(result);
 
   if (filter.type === 'route-headsign') {
     const prepared = prepareRouteHeadsignTimetable(
@@ -90,38 +109,48 @@ function buildTimetableEntries(filter: TimetableFilter, result: TimetableResult)
       true,
     );
     return {
-      allEntries,
       isBoardableOnServiceDay,
+      totalEntries,
       entries: prepared.entries,
       omitted: prepared.omitted,
-      headsign: filter.headsign,
     };
   }
 
   const prepared = prepareStopTimetable(allEntries, true);
   return {
-    allEntries,
     isBoardableOnServiceDay,
+    totalEntries,
     entries: prepared.entries,
     omitted: prepared.omitted,
-    headsign: undefined,
   };
 }
 
 function formatTimetableDebugMessage(params: {
   filter: TimetableFilter;
   stopId: string;
-  headsign?: string;
   entriesCount: number;
   omittedNonBoardable: number;
   totalEntries: number;
 }): string {
   let routeSuffix = '';
   if (params.filter.type === 'route-headsign') {
-    routeSuffix = ` ${params.filter.routeId} "${params.headsign}"`;
+    routeSuffix = ` ${params.filter.routeId} "${params.filter.headsign}"`;
   }
 
   return `timetable(${params.filter.type}): ${params.stopId}${routeSuffix} → entries=${params.entriesCount} omitted.nonBoardable=${params.omittedNonBoardable} total=${params.totalEntries}`;
+}
+
+function formatUnknownError(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    message: String(error),
+  };
 }
 
 export function useTimetable(repo: TransitRepository): UseTimetableReturn {
@@ -138,44 +167,65 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
       requestIdRef.current = requestId;
 
       try {
-        const meta = await loadTimetableStopMeta(repo, stopId);
+        // Resolve stop metadata first so unknown stops short-circuit before the
+        // full timetable scan for that stop/service day runs.
+        const stopMetaResult = await loadTimetableStopMeta(repo, stopId);
         if (requestIdRef.current !== requestId) {
           return { status: 'cancelled' };
         }
 
-        if (!meta) {
-          logger.warn('openTimetable: stop metadata not found', { stopId, filter });
+        if (!stopMetaResult.success) {
+          logger.warn('openTimetable: stop metadata not found', {
+            stopId,
+            filter,
+            error: stopMetaResult.error,
+          });
           return { status: 'not-found' };
         }
+        const meta = stopMetaResult.data;
 
-        const routes = resolveTimetableRoutes(filter, meta);
-        if (filter.type === 'route-headsign' && routes.length === 0) {
+        const routesResult = resolveTimetableRoutesResult(filter, meta);
+        if (!routesResult.ok) {
           logger.warn('openTimetable: route metadata not found for stop', {
             stopId,
-            routeId: filter.routeId,
-            headsign: filter.headsign,
+            routeId: routesResult.routeId,
+            headsign: routesResult.headsign,
           });
           return { status: 'route-not-found' };
         }
+        const { routes } = routesResult;
 
-        const result = await repo.getFullDayTimetableEntries(stopId, dateTime);
+        const timetableResult = await repo.getFullDayTimetableEntries(stopId, dateTime);
         if (requestIdRef.current !== requestId) {
           return { status: 'cancelled' };
         }
 
-        const { allEntries, isBoardableOnServiceDay, entries, omitted, headsign } =
-          buildTimetableEntries(filter, result);
-
-        logger.debug(
-          formatTimetableDebugMessage({
-            filter,
+        if (!timetableResult.success) {
+          logger.warn('openTimetable: timetable lookup failed', {
             stopId,
-            headsign,
-            entriesCount: entries.length,
-            omittedNonBoardable: omitted.nonBoardable,
-            totalEntries: allEntries.length,
-          }),
+            filter,
+            error: timetableResult.error,
+          });
+          return { status: 'error' };
+        }
+
+        const { isBoardableOnServiceDay, totalEntries, entries, omitted } = buildTimetableEntries(
+          filter,
+          timetableResult,
         );
+        const headsign = filter.type === 'route-headsign' ? filter.headsign : undefined;
+
+        if (logger.isEnabled('debug')) {
+          logger.debug(
+            formatTimetableDebugMessage({
+              filter,
+              stopId,
+              entriesCount: entries.length,
+              omittedNonBoardable: omitted.nonBoardable,
+              totalEntries,
+            }),
+          );
+        }
 
         setTimetableData({
           type: filter.type,
@@ -186,7 +236,7 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
           timetableEntries: entries,
           omitted,
           stopServiceState: getStopServiceState({
-            totalEntries: allEntries.length,
+            totalEntries,
             isBoardableOnServiceDay,
           }),
           agencies: meta.agencies,
@@ -198,7 +248,11 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
           return { status: 'cancelled' };
         }
 
-        logger.warn('openTimetable: unexpected error', { stopId, filter, error });
+        logger.warn('openTimetable: unexpected error', {
+          stopId,
+          filter,
+          error: formatUnknownError(error),
+        });
         return { status: 'error' };
       }
     },

--- a/src/hooks/use-timetable.ts
+++ b/src/hooks/use-timetable.ts
@@ -1,0 +1,234 @@
+import { useCallback, useRef, useState } from 'react';
+
+import { getServiceDay } from '@/domain/transit/service-day';
+import {
+  prepareRouteHeadsignTimetable,
+  prepareStopTimetable,
+} from '@/domain/transit/timetable-filter';
+import { getStopServiceState } from '@/domain/transit/timetable-utils';
+import { createLogger } from '@/lib/logger';
+import type { TransitRepository } from '@/repositories/transit-repository';
+import type { TimetableResult } from '@/types/app/repository';
+import type { Route } from '@/types/app/transit';
+import type { StopWithMeta } from '@/types/app/transit-composed';
+import type { TimetableData } from '@/types/app/timetable';
+
+const logger = createLogger('Timetable');
+
+interface OpenStopTimetableParams {
+  dateTime: Date;
+  stopId: string;
+}
+
+interface OpenRouteHeadsignTimetableParams extends OpenStopTimetableParams {
+  routeId: string;
+  headsign: string;
+}
+
+type TimetableFilter =
+  | { type: 'route-headsign'; routeId: string; headsign: string }
+  | { type: 'stop' };
+
+export type TimetableOpenOutcome =
+  | { status: 'opened' }
+  | { status: 'cancelled' }
+  | { status: 'not-found' }
+  | { status: 'route-not-found' }
+  | { status: 'error' };
+
+interface UseTimetableReturn {
+  timetableData: TimetableData | null;
+  openStopTimetable: (params: OpenStopTimetableParams) => Promise<TimetableOpenOutcome>;
+  openRouteHeadsignTimetable: (
+    params: OpenRouteHeadsignTimetableParams,
+  ) => Promise<TimetableOpenOutcome>;
+  closeTimetable: () => void;
+}
+
+async function loadTimetableStopMeta(
+  repo: TransitRepository,
+  stopId: string,
+): Promise<StopWithMeta | null> {
+  const result = await repo.getStopMetaById(stopId);
+  if (!result.success) {
+    return null;
+  }
+
+  return result.data;
+}
+
+function resolveTimetableRoutes(filter: TimetableFilter, meta: StopWithMeta): Route[] {
+  if (filter.type !== 'route-headsign') {
+    return meta.routes;
+  }
+
+  return meta.routes.filter((route) => route.route_id === filter.routeId);
+}
+
+function normalizeTimetableResult(result: TimetableResult) {
+  if (!result.success) {
+    return {
+      allEntries: [],
+      isBoardableOnServiceDay: false,
+    };
+  }
+
+  return {
+    allEntries: result.data,
+    isBoardableOnServiceDay: result.meta.isBoardableOnServiceDay,
+  };
+}
+
+function buildTimetableEntries(filter: TimetableFilter, result: TimetableResult) {
+  const { allEntries, isBoardableOnServiceDay } = normalizeTimetableResult(result);
+
+  if (filter.type === 'route-headsign') {
+    const prepared = prepareRouteHeadsignTimetable(
+      allEntries,
+      filter.routeId,
+      filter.headsign,
+      true,
+    );
+    return {
+      allEntries,
+      isBoardableOnServiceDay,
+      entries: prepared.entries,
+      omitted: prepared.omitted,
+      headsign: filter.headsign,
+    };
+  }
+
+  const prepared = prepareStopTimetable(allEntries, true);
+  return {
+    allEntries,
+    isBoardableOnServiceDay,
+    entries: prepared.entries,
+    omitted: prepared.omitted,
+    headsign: undefined,
+  };
+}
+
+function formatTimetableDebugMessage(params: {
+  filter: TimetableFilter;
+  stopId: string;
+  headsign?: string;
+  entriesCount: number;
+  omittedNonBoardable: number;
+  totalEntries: number;
+}): string {
+  let routeSuffix = '';
+  if (params.filter.type === 'route-headsign') {
+    routeSuffix = ` ${params.filter.routeId} "${params.headsign}"`;
+  }
+
+  return `timetable(${params.filter.type}): ${params.stopId}${routeSuffix} → entries=${params.entriesCount} omitted.nonBoardable=${params.omittedNonBoardable} total=${params.totalEntries}`;
+}
+
+export function useTimetable(repo: TransitRepository): UseTimetableReturn {
+  const [timetableData, setTimetableData] = useState<TimetableData | null>(null);
+  const requestIdRef = useRef(0);
+
+  const openTimetable = useCallback(
+    async (
+      params: OpenStopTimetableParams,
+      filter: TimetableFilter,
+    ): Promise<TimetableOpenOutcome> => {
+      const { dateTime, stopId } = params;
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+
+      try {
+        const meta = await loadTimetableStopMeta(repo, stopId);
+        if (requestIdRef.current !== requestId) {
+          return { status: 'cancelled' };
+        }
+
+        if (!meta) {
+          logger.warn('openTimetable: stop metadata not found', { stopId, filter });
+          return { status: 'not-found' };
+        }
+
+        const routes = resolveTimetableRoutes(filter, meta);
+        if (filter.type === 'route-headsign' && routes.length === 0) {
+          logger.warn('openTimetable: route metadata not found for stop', {
+            stopId,
+            routeId: filter.routeId,
+            headsign: filter.headsign,
+          });
+          return { status: 'route-not-found' };
+        }
+
+        const result = await repo.getFullDayTimetableEntries(stopId, dateTime);
+        if (requestIdRef.current !== requestId) {
+          return { status: 'cancelled' };
+        }
+
+        const { allEntries, isBoardableOnServiceDay, entries, omitted, headsign } =
+          buildTimetableEntries(filter, result);
+
+        logger.debug(
+          formatTimetableDebugMessage({
+            filter,
+            stopId,
+            headsign,
+            entriesCount: entries.length,
+            omittedNonBoardable: omitted.nonBoardable,
+            totalEntries: allEntries.length,
+          }),
+        );
+
+        setTimetableData({
+          type: filter.type,
+          stop: meta.stop,
+          routes,
+          headsign,
+          serviceDate: getServiceDay(dateTime),
+          timetableEntries: entries,
+          omitted,
+          stopServiceState: getStopServiceState({
+            totalEntries: allEntries.length,
+            isBoardableOnServiceDay,
+          }),
+          agencies: meta.agencies,
+        });
+
+        return { status: 'opened' };
+      } catch (error: unknown) {
+        if (requestIdRef.current !== requestId) {
+          return { status: 'cancelled' };
+        }
+
+        logger.warn('openTimetable: unexpected error', { stopId, filter, error });
+        return { status: 'error' };
+      }
+    },
+    [repo],
+  );
+
+  const openStopTimetable = useCallback(
+    (params: OpenStopTimetableParams) => openTimetable(params, { type: 'stop' }),
+    [openTimetable],
+  );
+
+  const openRouteHeadsignTimetable = useCallback(
+    (params: OpenRouteHeadsignTimetableParams) =>
+      openTimetable(params, {
+        type: 'route-headsign',
+        routeId: params.routeId,
+        headsign: params.headsign,
+      }),
+    [openTimetable],
+  );
+
+  const closeTimetable = useCallback(() => {
+    requestIdRef.current += 1;
+    setTimetableData(null);
+  }, []);
+
+  return {
+    timetableData,
+    openStopTimetable,
+    openRouteHeadsignTimetable,
+    closeTimetable,
+  };
+}

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -92,6 +92,14 @@ interface UseTripInspectionReturn {
   closeTripInspection: () => void;
 }
 
+function getEmptyTripInspectionTargetsNote(emptyReason: TripInspectionTargetsEmptyReason): string {
+  if (emptyReason === 'no-stop-data') {
+    return 'The stop has no trip-inspection stop data.';
+  }
+
+  return 'The stop has trip-inspection data, but no services on the selected service day.';
+}
+
 function buildTripInspectionMatchDiagnostics(
   target: TripInspectionTarget,
   candidates: TripInspectionTarget[],
@@ -397,10 +405,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
             serviceDayKey: formatDateKey(serviceDate),
             currentServiceDayMinutes,
             emptyReason,
-            note:
-              emptyReason === 'no-stop-data'
-                ? 'The stop has no trip-inspection stop data.'
-                : 'The stop has trip-inspection data, but no services on the selected service day.',
+            note: getEmptyTripInspectionTargetsNote(emptyReason),
           });
           return {
             status: 'no-data',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -95,6 +95,11 @@
   "showTimetable": "Show timetable",
   "timetable": {
     "title": "Timetable",
+    "messages": {
+      "stopNotFound": "No timetable data is available",
+      "routeNotFound": "This route timetable is not available",
+      "openFailed": "Could not load timetable"
+    },
     "entry": {
       "terminal": "Terminal",
       "origin": "Origin",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -95,6 +95,11 @@
   "showTimetable": "時刻表を表示",
   "timetable": {
     "title": "時刻表",
+    "messages": {
+      "stopNotFound": "時刻表データがありません",
+      "routeNotFound": "この路線の時刻表を表示できません",
+      "openFailed": "時刻表を取得できませんでした"
+    },
     "entry": {
       "terminal": "終点",
       "origin": "始発",

--- a/src/types/app/timetable.ts
+++ b/src/types/app/timetable.ts
@@ -1,0 +1,15 @@
+import type { TimetableOmitted } from '@/types/app/repository';
+import type { Agency, Route, Stop, StopServiceState } from '@/types/app/transit';
+import type { TimetableEntry } from '@/types/app/transit-composed';
+
+export interface TimetableData {
+  type: 'route-headsign' | 'stop';
+  stop: Stop;
+  routes: Route[];
+  headsign?: string;
+  serviceDate: Date;
+  timetableEntries: TimetableEntry[];
+  omitted: TimetableOmitted;
+  stopServiceState: StopServiceState;
+  agencies: Agency[];
+}


### PR DESCRIPTION
## Summary

- Extract timetable open/close orchestration from `app.tsx` into a dedicated `useTimetable` hook with race-condition-safe request tracking, then apply review feedback to tighten its error / log paths.
- Surface `useTimetable` failure outcomes (`not-found`, `route-not-found`, `error`) to the user via `toast.warning` / `toast.error`, with new `timetable.messages.*` i18n keys (en / ja).
- Small drive-by: extract the inline empty-targets note ternary in `useTripInspection` into a named helper.

### Notable design points

- `requestIdRef` cancels stale lookups when a newer request arrives or `closeTimetable` is called, so older results never overwrite state.
- `getStopMetaById` short-circuits unknown stops before the heavier `getFullDayTimetableEntries` call. For `route-headsign`, the route is also verified to belong to the stop before the timetable scan.
- `Result.error` from both lookups is propagated into structured `logger.warn` payloads. Try/catch errors are flattened by `formatUnknownError` so `Error.message` and `Error.stack` survive.
- Debug message construction is guarded by `logger.isEnabled('debug')`.
- `stopServiceState` input now uses `result.meta.totalEntries` (API contract), not `allEntries.length`.

### Tests added

- `useTimetable`: opened (stop / route-headsign), error, not-found, route-not-found, drop-off-only stopServiceState, cancellation by a newer request, cancellation by closeTimetable, try/catch rejection. All datetimes are TZ-independent fixed UTC instants.
- `App`: stop-timetable error renders `toast.error`, route-timetable `route-not-found` renders `toast.warning`.

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx vitest run src/hooks/__tests__/use-timetable.test.ts src/__tests__/app.test.tsx`
- [x] `npm run build`
- [x] Manual browser check: open the timetable from a stop and from a route+headsign; trigger error path (e.g. via DevTools network throttling / forcing a repo error) and confirm the correct toast variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)