### PR TITLE
feat(portal): extract StopDropdownItem and add orphan-anchor removal

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1039,6 +1039,7 @@ export default function App({ loadResult }: AppProps) {
           onHistorySelect: handleHistorySelect,
           anchors,
           onPortalSelect: handlePortalSelect,
+          onPortalRemove: (entry) => handleToggleAnchorByStopId(entry.stopId),
           lookupAnchorStopMeta,
           autoLocateEnabled,
           onEnableAutoLocate: enableAutoLocate,

--- a/src/components/map/map-overlay-panels.tsx
+++ b/src/components/map/map-overlay-panels.tsx
@@ -53,6 +53,9 @@ interface MapOverlayPanelsProps {
   onDeselectStop: () => void;
   onHistorySelect: (stop: Stop, routeTypes: AppRouteTypeValue[]) => void;
   onPortalSelect: (entry: AnchorEntry) => void;
+  /** Removes the anchor for a Portal entry whose stop_id is no longer
+   *  resolvable in the current GTFS dataset. */
+  onPortalRemove: (entry: AnchorEntry) => void;
   /**
    * Looks up an anchored stop's current `StopWithMeta` from the
    * repository's full dataset. Forwarded to `Portals` so anchor
@@ -94,6 +97,7 @@ export function MapOverlayPanels({
   onDeselectStop,
   onHistorySelect,
   onPortalSelect,
+  onPortalRemove,
   lookupAnchorStopMeta,
   tileIndex,
 }: MapOverlayPanelsProps) {
@@ -153,6 +157,7 @@ export function MapOverlayPanels({
           dataLang={dataLang}
           lookupAnchorStopMeta={lookupAnchorStopMeta}
           onSelect={onPortalSelect}
+          onRemove={onPortalRemove}
         />
       </div>
     </>

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -266,6 +266,9 @@ export interface MapViewProps {
   anchors: AnchorEntry[];
   /** Called when an anchor is chosen from the Portal dropdown. */
   onPortalSelect: (entry: AnchorEntry) => void;
+  /** Removes the anchor for a Portal entry whose stop_id is no longer
+   *  resolvable in the current GTFS dataset. */
+  onPortalRemove: (entry: AnchorEntry) => void;
   /**
    * Looks up an anchored stop's current `StopWithMeta` from the
    * repository's full dataset. Forwarded to the Portal dropdown so
@@ -333,6 +336,7 @@ export function MapView({
   onHistorySelect,
   anchors,
   onPortalSelect,
+  onPortalRemove,
   heightClassName,
   autoLocateEnabled,
   onEnableAutoLocate,
@@ -704,6 +708,7 @@ export function MapView({
         onDeselectStop={onDeselectStop}
         onHistorySelect={onHistorySelect}
         onPortalSelect={onPortalSelect}
+        onPortalRemove={onPortalRemove}
         lookupAnchorStopMeta={lookupAnchorStopMeta}
       />
       {mapInstance && (

--- a/src/components/portals.tsx
+++ b/src/components/portals.tsx
@@ -2,14 +2,10 @@ import { useState } from 'react';
 import type { InfoLevel } from '../types/app/settings';
 import type { AnchorEntry } from '../domain/portal/anchor';
 import type { StopWithMeta } from '../types/app/transit-composed';
-import { resolveAgencyLang } from '../config/transit-defaults';
-import { getStopDisplayNames } from '../domain/transit/get-stop-display-names';
-import { useInfoLevel } from '../hooks/use-info-level';
-import { routeTypesEmoji } from '../utils/route-type-emoji';
 import { DoorOpen } from 'lucide-react';
 import { createLogger } from '../lib/logger';
-import { Badge } from './ui/badge';
-import { Select, SelectContent, SelectItem, SelectTrigger } from './ui/select';
+import { StopDropdownItem } from './stop/stop-dropdown-item';
+import { Select, SelectContent, SelectTrigger } from './ui/select';
 
 const logger = createLogger('Portals');
 
@@ -28,6 +24,17 @@ interface PortalsProps {
    */
   lookupAnchorStopMeta: (stopId: string) => StopWithMeta | null;
   onSelect: (entry: AnchorEntry) => void;
+  /**
+   * Removes the anchor for an entry whose stop_id is no longer
+   * resolvable in the current GTFS dataset (`lookupAnchorStopMeta`
+   * returned `null`). The trash button is rendered inline on the
+   * orphan row and only those rows; rows with valid `meta` do not
+   * surface a delete affordance.
+   *
+   * Caller decides the appropriate UX (toast, undo, confirm step) —
+   * this prop just forwards the click.
+   */
+  onRemove: (entry: AnchorEntry) => void;
 }
 
 /**
@@ -47,8 +54,8 @@ export function Portals({
   dataLang,
   lookupAnchorStopMeta,
   onSelect,
+  onRemove,
 }: PortalsProps) {
-  const il = useInfoLevel(infoLevel);
   const [open, setOpen] = useState(false);
 
   if (anchors.length === 0) {
@@ -83,31 +90,18 @@ export function Portals({
           position="popper"
           className="z-1002 max-h-[40dvh] min-w-48 border-none bg-white/80 text-black backdrop-blur-sm dark:bg-black/80 dark:text-white"
         >
-          {anchors.map((entry) => {
-            const meta = lookupAnchorStopMeta(entry.stopId);
-            const displayName = meta
-              ? getStopDisplayNames(
-                  meta.stop,
-                  dataLang,
-                  resolveAgencyLang(meta.agencies, meta.stop.agency_id),
-                ).name || entry.stopName
-              : entry.stopName;
-            return (
-              <SelectItem
-                key={entry.stopId}
-                value={entry.stopId}
-                className="overflow-hidden focus:bg-black/10 focus:text-black dark:focus:bg-white/20 dark:focus:text-white"
-              >
-                <span className="shrink-0 text-base">{routeTypesEmoji(entry.routeTypes)}</span>
-                <span className="max-w-[60dvw] truncate">{displayName}</span>
-                {il.isVerboseEnabled && (
-                  <Badge variant="secondary" className="ml-1 text-[10px]">
-                    {entry.stopId}
-                  </Badge>
-                )}
-              </SelectItem>
-            );
-          })}
+          {anchors.map((entry) => (
+            <StopDropdownItem
+              key={entry.stopId}
+              stopId={entry.stopId}
+              routeTypes={entry.routeTypes}
+              meta={lookupAnchorStopMeta(entry.stopId)}
+              fallbackName={entry.stopName}
+              infoLevel={infoLevel}
+              dataLang={dataLang}
+              onRemove={() => onRemove(entry)}
+            />
+          ))}
         </SelectContent>
       </Select>
     </div>

--- a/src/components/stop-history.tsx
+++ b/src/components/stop-history.tsx
@@ -5,12 +5,11 @@ import type { Stop } from '../types/app/transit';
 import type { StopHistoryEntry } from '../domain/transit/stop-history';
 import { resolveAgencyLang } from '../config/transit-defaults';
 import { getStopDisplayNames } from '../domain/transit/get-stop-display-names';
-import { useInfoLevel } from '../hooks/use-info-level';
 import { routeTypesEmoji } from '../utils/route-type-emoji';
 import { History } from 'lucide-react';
 import { createLogger } from '../lib/logger';
-import { Badge } from './ui/badge';
-import { Select, SelectContent, SelectItem, SelectTrigger } from './ui/select';
+import { StopDropdownItem } from './stop/stop-dropdown-item';
+import { Select, SelectContent, SelectTrigger } from './ui/select';
 
 const logger = createLogger('StopHistory');
 
@@ -48,7 +47,6 @@ export function StopHistory({
   onSelect,
 }: StopHistoryProps) {
   const { t } = useTranslation();
-  const il = useInfoLevel(infoLevel);
   const [open, setOpen] = useState(false);
 
   if (history.length === 0) {
@@ -115,27 +113,17 @@ export function StopHistory({
           position="popper"
           className="z-1002 max-h-[40dvh] min-w-48 border-none bg-white/80 text-black backdrop-blur-sm dark:bg-black/80 dark:text-white"
         >
-          {history.map((entry) => {
-            const { stop, agencies } = entry.stopWithMeta;
-            const displayName =
-              getStopDisplayNames(stop, dataLang, resolveAgencyLang(agencies, stop.agency_id))
-                .name || stop.stop_name;
-            return (
-              <SelectItem
-                key={stop.stop_id}
-                value={stop.stop_id}
-                className="overflow-hidden focus:bg-black/10 focus:text-black dark:focus:bg-white/20 dark:focus:text-white"
-              >
-                <span className="shrink-0 text-base">{routeTypesEmoji(entry.routeTypes)}</span>
-                <span className="max-w-[60dvw] truncate">{displayName}</span>
-                {il.isVerboseEnabled && (
-                  <Badge variant="secondary" className="ml-1 text-[10px]">
-                    {stop.stop_id}
-                  </Badge>
-                )}
-              </SelectItem>
-            );
-          })}
+          {history.map((entry) => (
+            <StopDropdownItem
+              key={entry.stopWithMeta.stop.stop_id}
+              stopId={entry.stopWithMeta.stop.stop_id}
+              routeTypes={entry.routeTypes}
+              meta={entry.stopWithMeta}
+              fallbackName={entry.stopWithMeta.stop.stop_name}
+              infoLevel={infoLevel}
+              dataLang={dataLang}
+            />
+          ))}
         </SelectContent>
       </Select>
     </div>

--- a/src/components/stop/stop-dropdown-item.stories.tsx
+++ b/src/components/stop/stop-dropdown-item.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import {
+  agencyGx,
+  agencyOretetsu,
+  agencyTobus,
+  baseStop,
+  longNameStop,
+} from '../../stories/fixtures';
+import type { AppRouteTypeValue } from '../../types/app/transit';
+import type { StopWithMeta } from '../../types/app/transit-composed';
+import { Select, SelectContent } from '../ui/select';
+import { StopDropdownItem } from './stop-dropdown-item';
+
+function makeMeta(stop = baseStop, agencies = [agencyTobus]): StopWithMeta {
+  return { stop, agencies, routes: [] };
+}
+
+const meta = {
+  title: 'Stop/StopDropdownItem',
+  component: StopDropdownItem,
+  args: {
+    stopId: baseStop.stop_id,
+    routeTypes: [3] as AppRouteTypeValue[],
+    meta: makeMeta(),
+    fallbackName: baseStop.stop_name,
+    infoLevel: 'normal',
+    dataLang: ['ja'],
+  },
+  argTypes: {
+    infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-background w-[360px] rounded-lg border-4 p-2">
+        <Select value="" onValueChange={() => {}} open>
+          <SelectContent
+            position="item-aligned"
+            className="z-1002 min-w-48 border-none bg-white/80 text-black backdrop-blur-sm dark:bg-black/80 dark:text-white"
+          >
+            <Story />
+          </SelectContent>
+        </Select>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof StopDropdownItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const NoMeta: Story = {
+  args: { meta: null, fallbackName: 'Snapshot Name (no meta)' },
+};
+
+export const WithPlatformCode: Story = {
+  args: {
+    meta: makeMeta({ ...baseStop, platform_code: '2A' }),
+  },
+};
+
+export const MultipleAgencies: Story = {
+  args: {
+    routeTypes: [0, 1, 2, 3] as AppRouteTypeValue[],
+    meta: makeMeta(baseStop, [agencyGx, agencyOretetsu, agencyTobus]),
+  },
+};
+
+export const Verbose: Story = {
+  args: { infoLevel: 'verbose' },
+};
+
+export const LongName: Story = {
+  args: {
+    meta: makeMeta(longNameStop, [agencyGx]),
+    fallbackName: longNameStop.stop_name,
+  },
+};
+
+export const KitchenSink: Story = {
+  args: {
+    routeTypes: [0, 1, 2, 3] as AppRouteTypeValue[],
+    meta: makeMeta({ ...longNameStop, platform_code: '12B' }, [
+      agencyGx,
+      agencyOretetsu,
+      agencyTobus,
+    ]),
+    fallbackName: longNameStop.stop_name,
+    infoLevel: 'verbose',
+  },
+};

--- a/src/components/stop/stop-dropdown-item.tsx
+++ b/src/components/stop/stop-dropdown-item.tsx
@@ -1,0 +1,134 @@
+import { Trash2 } from 'lucide-react';
+import { resolveAgencyLang } from '../../config/transit-defaults';
+import { getStopDisplayNames } from '../../domain/transit/get-stop-display-names';
+import { useInfoLevel } from '../../hooks/use-info-level';
+import type { InfoLevel } from '../../types/app/settings';
+import type { AppRouteTypeValue } from '../../types/app/transit';
+import type { StopWithMeta } from '../../types/app/transit-composed';
+import { routeTypesEmoji } from '../../utils/route-type-emoji';
+import { AgencyBadge } from '../badge/agency-badge';
+import { Badge } from '../ui/badge';
+import { SelectItem } from '../ui/select';
+import { PlatformCodeLabel } from './platform-code-label';
+
+interface StopDropdownItemProps {
+  /** GTFS `stop_id` — used as the underlying `<SelectItem value>`. */
+  stopId: string;
+  /** Route types served by the stop, rendered as the lead emoji. */
+  routeTypes: AppRouteTypeValue[];
+  /**
+   * Latest `StopWithMeta` resolved from the repository's full dataset.
+   * `null` when the stop is no longer present in any active source — the
+   * row falls back to {@link fallbackName} and skips platform / agency
+   * chips.
+   */
+  meta: StopWithMeta | null;
+  /**
+   * Stop name to use when {@link meta} is null (e.g. the persisted name
+   * stored on an anchor entry, or the snapshot name on a history entry).
+   */
+  fallbackName: string;
+  /** Active information density level. */
+  infoLevel: InfoLevel;
+  /** Display language fallback chain for translated names. */
+  dataLang: readonly string[];
+  /**
+   * Optional removal handler. When provided AND `meta` is null (the
+   * underlying stop_id is no longer in the active GTFS dataset), an
+   * inline trash button appears on the row. Tapping it invokes
+   * `onRemove` without selecting the row.
+   *
+   * Mainly used by Portals to let users prune anchors whose stop_id is
+   * not resolvable. Caller decides whether the orphan is from a
+   * removed stop or a renamed stop_id; this component only surfaces
+   * the affordance.
+   */
+  onRemove?: () => void;
+}
+
+/**
+ * Shared `<SelectItem>` row for stop-pick navigation dropdowns
+ * ({@link Portals}, {@link StopHistory}).
+ *
+ * Renders a single dropdown entry built from a {@link StopWithMeta}
+ * snapshot:
+ *
+ * ```text
+ * [route-type emoji] [display name (truncated)] [platform code?]
+ * [agency badge × N] [stop_id badge (verbose only)]
+ * ```
+ *
+ * Display name resolution prefers the latest GTFS-translated name from
+ * `meta`; when `meta` is null (stop dropped from the loaded dataset),
+ * it falls back to `fallbackName`.
+ */
+export function StopDropdownItem({
+  stopId,
+  routeTypes,
+  meta,
+  fallbackName,
+  infoLevel,
+  dataLang,
+  onRemove,
+}: StopDropdownItemProps) {
+  const info = useInfoLevel(infoLevel);
+  const displayName = meta
+    ? getStopDisplayNames(
+        meta.stop,
+        dataLang,
+        resolveAgencyLang(meta.agencies, meta.stop.agency_id),
+      ).name || fallbackName
+    : fallbackName;
+  const platformCode = meta?.stop.platform_code;
+  const agencies = meta?.agencies ?? [];
+  const showRemove = meta === null && onRemove !== undefined;
+
+  return (
+    <SelectItem
+      value={stopId}
+      className="overflow-hidden focus:bg-black/10 focus:text-black dark:focus:bg-white/20 dark:focus:text-white"
+    >
+      <span className="shrink-0 text-base">{routeTypesEmoji(routeTypes)}</span>
+      <span className="max-w-[60dvw] truncate">{displayName}</span>
+      {platformCode && <PlatformCodeLabel code={platformCode} size="sm" />}
+      {agencies.map((agency) => (
+        <AgencyBadge
+          key={agency.agency_id}
+          agency={agency}
+          size="sm"
+          dataLang={dataLang}
+          agencyLangs={resolveAgencyLang(agencies, agency.agency_id)}
+          infoLevel={infoLevel}
+          showBorder
+        />
+      ))}
+      {info.isVerboseEnabled && (
+        <Badge variant="secondary" className="ml-1 text-[10px]">
+          {stopId}
+        </Badge>
+      )}
+      {showRemove && (
+        <button
+          type="button"
+          aria-label="Remove orphan entry"
+          title="Remove orphan entry"
+          className="ml-auto inline-flex shrink-0 items-center justify-center rounded bg-red-100 p-1 text-red-700 hover:bg-red-200 dark:bg-red-900 dark:text-red-300 dark:hover:bg-red-800"
+          // Radix SelectItem reacts on pointerdown/pointerup to commit the
+          // selection. The button's `onClick` would fire too late — by then
+          // the dropdown has already closed and treated the tap as a row
+          // activation. Stopping propagation on pointerdown / pointerup
+          // (and click as a fallback) prevents the row from being selected
+          // so the trash tap acts purely as a delete.
+          onPointerDown={(event) => event.stopPropagation()}
+          onPointerUp={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRemove?.();
+          }}
+        >
+          <Trash2 size={14} strokeWidth={2} aria-hidden="true" focusable="false" />
+        </button>
+      )}
+    </SelectItem>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract a shared `StopDropdownItem` component used by both `Portals` and `StopHistory` — both dropdowns surface the same stop info now (platform code, agencies)
- Add an orphan-anchor removal affordance to Portals: anchors whose `stop_id` can no longer be resolved in the active GTFS dataset (typically because the source regenerated stop_id values) get an inline trash button on their row. Healthy anchors show no delete affordance.
- StopHistory inherits the new metadata (agency badges, platform code) for free; history is FIFO-pruned so no delete UI is wired there.

## Why orphan-only?

If a stop_id changes upstream (data source switch, regenerated IDs), the anchor lives on in localStorage but `lookupAnchorStopMeta` returns null and the stop disappears from the map. Without an in-app delete path, the user has no way to clean up the entry. Restricting the trash to orphan rows keeps the destructive action narrow — anchors with valid `meta` cannot be deleted from the dropdown at all.

## Click handling

The trash button sits inside a Radix `<SelectItem>`, which would otherwise treat the tap as a row activation (= navigate to a stop that no longer exists). The button stops propagation on `pointerdown`, `pointerup`, and `click`, so the tap reaches the button only.

## Commits

- `237c7cf` — `feat(portal): extract StopDropdownItem and add orphan-anchor removal`

## Test plan

- [x] Open the Portal dropdown with a healthy anchor → no trash button shown; tap → row navigates as before
- [x] Open the Portal dropdown with an anchor whose `stop_id` is no longer in any active GTFS source (e.g., switch / disable a data source so the anchored stop_id stops resolving) → trash button visible on that row only
- [x] Tap the trash button → anchor is removed, warning toast surfaces, dropdown stays / re-renders the rest
- [x] Confirm tap on the trash does not navigate the map (= row activation suppressed)
- [x] StopHistory dropdown shows the same agency badges / platform code as Portals; no trash button anywhere on history rows
- [x] Storybook: `Stop/StopDropdownItem` stories cover Default / NoMeta / WithPlatformCode / MultipleAgencies / Verbose / LongName / KitchenSink

🤖 Generated with [Claude Code](https://claude.com/claude-code)