### PR TITLE
refactor(distance): split webapp and pipeline geo utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ### Changed
 
+- 距離・方角 utility を整理。webapp 側で使う `getDistanceM` / `getBearingDeg` を `src/domain/transit/distance.ts` に戻し、`src` から `pipeline` を直接 import しない構成に修正。`src/components/search/stop-search-result-item.tsx`、`src/components/stop-info.tsx`、`src/components/stop-summary.stories.tsx` の参照先を更新し、`src/domain/transit/__tests__/distance.test.ts` に geolib ベースの距離・dateline crossing・方角テストを追加。
+- Pipeline の距離 utility を `pipeline/src/lib/geo-utils.ts` の `getDistanceKm` 1 本に整理。旧 Haversine 実装と比較用 helper、未使用の meter / bearing API を削除し、`build-trip-pattern-geo.ts` と `build-stop-geo.ts` は `getDistanceKm` を使う構成に統一。`pipeline/src/lib/__tests__/geo-utils.test.ts` も km API 中心のテストへ更新。
+- 距離計算ライブラリとして `geolib` を導入。webapp (`src/domain/transit/distance.ts`) と pipeline (`pipeline/src/lib/geo-utils.ts`) の距離・方角計算で同じ実装基盤を使うようにした。
 - `useListKeyboardNavigation` の reset 駆動を `items` reference 変化から **明示 `resetKey`** に切り替え。 ページネーションで `items` が伸びても resetKey が同じなら selectedIndex を保持、 scrollIntoView も再発火しないため scroll 位置が先頭に巻き戻る不具合を回避。 resetKey が変わったとき (= 新クエリ) のみ selectedIndex を 0 にリセット + 1 件目を `block: 'nearest'` で表示。 caller (`StopSearchDialog`) は `resetKey: deferredQuery` を渡す。 既存テストを resetKey ベースに更新、 「pagination 中は selection を保持する」 regression test を追加。
-
 - 検索ダイアログのタイプ中の体感を改善: `useDeferredValue(query)` で input echo (raw `query`) と filter / highlight / no-results pipeline (`deferredQuery`) を分離。 連続入力 / Backspace 連打時に React が中間値の filter / re-render を破棄し、 最終クエリのみ commit。 `<mark>` ハイライトと結果リストは常に同じ query 由来で整合。
 - `filterStopsByQuery` を 3 段の matching path (raw / blob / normalized) から 1 path に集約。 `SearchIndexEntry` の `rawNamesBlob` / `normalizedNamesBlob` を撤去し `normalizedNames: string[]` 1 本に。 prefix bonus も `stop.stop_name` 限定だったのを `normalizedNames` ベースに切り替え、 romaji クエリでの prefix 評価が機能 (e.g., `naka` → `Nakai` / `Nakanobu` が prefix 扱い)。 length tiebreaker も raw `stop_name` length から「マッチした name のうち最短長」 に揃え、 多言語 stops の比較粒度を統一。 NAME_SEP injection guard は撤去 (blob を使わないため不要)。
 - `src/utils/stop-search-index.ts` を `src/domain/transit/stop-search-index.ts` へ移設。 GTFS 固有の判断 (stop.stop_names の言語キー前提、 `ja-Hrkt` ソート等) を含むため、 generic utils ではなく domain/transit 配下が適切。 既存 caller の import path を更新。

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "geolib": "^3.3.14",
         "i18next": "^26.0.3",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.577.0",
@@ -9512,6 +9513,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/geolib": {
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/geolib/-/geolib-3.3.14.tgz",
+      "integrity": "sha512-uQ1772h3OjhWvL/HhSRZTMjBKIKoc4wFksLDqzqOkuG/2TgBbTwFamU0Disx3sNFk/BOweHyhKoVaYDuLIpsxQ==",
+      "license": "MIT"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "geolib": "^3.3.14",
     "i18next": "^26.0.3",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.577.0",

--- a/pipeline/src/lib/__tests__/geo-utils.test.ts
+++ b/pipeline/src/lib/__tests__/geo-utils.test.ts
@@ -1,132 +1,63 @@
 /**
- * Tests for geo-utils.ts (Haversine distance).
+ * Tests for geo-utils.ts.
  *
  * @vitest-environment node
  */
 
 import { describe, expect, it } from 'vitest';
 
-import { haversineKm } from '../geo-utils';
+import { getDistanceKm } from '../geo-utils';
 
-describe('haversineKm', () => {
+describe('getDistanceKm', () => {
   it('returns 0 for identical points', () => {
-    expect(haversineKm(35.6812, 139.7671, 35.6812, 139.7671)).toBe(0);
+    const a = { lat: 35.0, lng: 139.0 };
+    const b = { stop_lat: 35.0, stop_lon: 139.0 };
+    expect(getDistanceKm(a, b)).toBe(0);
   });
 
-  it('computes Tokyo Station → Shinjuku Station (~6.4 km)', () => {
-    // Tokyo Station: 35.6812, 139.7671
-    // Shinjuku Station: 35.6896, 139.7006
-    const d = haversineKm(35.6812, 139.7671, 35.6896, 139.7006);
-    expect(d).toBeCloseTo(6.4, 0); // within ~0.5 km
+  it('returns kilometers for short urban distances', () => {
+    const tokyo = { lat: 35.6812, lng: 139.7671 };
+    const shinjuku = { stop_lat: 35.6896, stop_lon: 139.7006 };
+    const distanceKm = getDistanceKm(tokyo, shinjuku);
+
+    expect(distanceKm).toBeGreaterThan(5.5);
+    expect(distanceKm).toBeLessThan(7.5);
   });
 
-  it('computes Tokyo → Osaka (~400 km)', () => {
-    // Tokyo Station: 35.6812, 139.7671
-    // Osaka Station: 34.7024, 135.4959
-    const d = haversineKm(35.6812, 139.7671, 34.7024, 135.4959);
-    expect(d).toBeCloseTo(400, -1); // within ~10 km
+  it('stays consistent with getDistanceM on intercontinental distances', () => {
+    const tokyo = { lat: 35.681236, lng: 139.767125 };
+    const berlin = { stop_lat: 52.52, stop_lon: 13.405 };
+    const distanceKm = getDistanceKm(tokyo, berlin);
+
+    expect(distanceKm).toBeGreaterThan(8_800);
+    expect(distanceKm).toBeLessThan(9_100);
+    expect(distanceKm).toBeGreaterThan(8_800);
+    expect(distanceKm).toBeLessThan(9_100);
   });
 
   it('is symmetric (a→b equals b→a)', () => {
-    const ab = haversineKm(35.6812, 139.7671, 35.6896, 139.7006);
-    const ba = haversineKm(35.6896, 139.7006, 35.6812, 139.7671);
-    expect(ab).toBe(ba);
+    const a = { lat: 35.6812, lng: 139.7671 };
+    const b = { stop_lat: 35.6895, stop_lon: 139.6917 };
+    const ab = getDistanceKm(a, b);
+    const ba = getDistanceKm(
+      { lat: b.stop_lat, lng: b.stop_lon },
+      { stop_lat: a.lat, stop_lon: a.lng },
+    );
+    expect(ab).toBeCloseTo(ba, 10);
   });
 
-  it('handles antipodal points (~20000 km)', () => {
-    // North pole to south pole
-    const d = haversineKm(90, 0, -90, 0);
-    expect(d).toBeCloseTo(20015, -1); // half the Earth's circumference
+  it('matches the expected dateline-crossing distance in kilometers', () => {
+    const westOfDateline = { lat: 0, lng: 179 };
+    const eastAcrossDateline = { stop_lat: 0, stop_lon: -179 };
+    const d = getDistanceKm(westOfDateline, eastAcrossDateline);
+    expect(d).toBeGreaterThan(220);
+    expect(d).toBeLessThan(223);
   });
 
-  it('does not return NaN for nearly antipodal points (floating-point guard)', () => {
-    // Points very close to antipodal can cause a > 1 due to floating-point error,
-    // which makes Math.asin(Math.sqrt(a)) return NaN without clamping.
-    const d = haversineKm(89.999999, 0, -89.999999, 179.999999);
-    expect(Number.isNaN(d)).toBe(false);
-    expect(d).toBeGreaterThan(20000);
-  });
-
-  it('handles equator crossing', () => {
-    const d = haversineKm(1, 0, -1, 0);
-    // 2 degrees of latitude ≈ 222 km
-    expect(d).toBeCloseTo(222, 0);
-  });
-
-  it('handles meridian crossing', () => {
-    const d = haversineKm(0, -1, 0, 1);
-    // 2 degrees of longitude at equator ≈ 222 km
-    expect(d).toBeCloseTo(222, 0);
-  });
-
-  it('handles dateline crossing (179° to -179°)', () => {
-    const d = haversineKm(0, 179, 0, -179);
-    // 2 degrees of longitude at equator ≈ 222 km, not ~40000 km
-    expect(d).toBeCloseTo(222, 0);
-  });
-
-  it('returns a very small distance for nearby points', () => {
-    // ~100 meters apart
-    const d = haversineKm(35.6812, 139.7671, 35.6821, 139.7671);
-    expect(d).toBeGreaterThan(0.05);
-    expect(d).toBeLessThan(0.15);
-  });
-
-  it('computes pure latitude distance (1 degree ≈ 111 km)', () => {
-    const d = haversineKm(0, 0, 1, 0);
-    expect(d).toBeCloseTo(111, 0);
-  });
-
-  it('computes pure longitude distance at equator (1 degree ≈ 111 km)', () => {
-    const d = haversineKm(0, 0, 0, 1);
-    expect(d).toBeCloseTo(111, 0);
-  });
-
-  it('returns 0 for longitude change at north pole (meridians converge)', () => {
-    const d = haversineKm(90, 0, 90, 180);
-    expect(d).toBeCloseTo(0, 5);
-  });
-
-  it('handles Southern hemisphere coordinates', () => {
-    // Canberra area: (-35.27, 149.13) to (-36.23, 148.23)
-    const d = haversineKm(-35.27, 149.13, -36.23, 148.23);
-    expect(d).toBeGreaterThan(100);
-    expect(d).toBeLessThan(150);
-  });
-
-  it('computes opposite points on equator (half circumference)', () => {
-    const d = haversineKm(0, 0, 0, 180);
-    // π * R ≈ 20015 km
-    expect(d).toBeCloseTo(20015, 0);
-  });
-
-  it('normalizes large positive longitude difference', () => {
-    // lon2 - lon1 = 350° should normalize to -10° (same as 10° apart)
-    const direct = haversineKm(0, 0, 0, 10);
-    const wrapped = haversineKm(0, 0, 0, 350);
-    expect(wrapped).toBeCloseTo(direct, 5);
-  });
-
-  it('normalizes large negative longitude difference', () => {
-    // lon2 - lon1 = -350° should normalize to 10°
-    const direct = haversineKm(0, 0, 0, 10);
-    const wrapped = haversineKm(0, 350, 0, 0);
-    expect(wrapped).toBeCloseTo(direct, 5);
-  });
-
-  it('returns non-negative finite distance for any valid coordinates', () => {
-    const cases: [number, number, number, number][] = [
-      [0, 0, 45, 90],
-      [45, 0, -45, 90],
-      [-90, 0, 90, 180],
-      [60, 120, -60, -120],
-      [0, -180, 0, 180],
-    ];
-    for (const [lat1, lon1, lat2, lon2] of cases) {
-      const d = haversineKm(lat1, lon1, lat2, lon2);
-      expect(Number.isFinite(d)).toBe(true);
-      expect(d).toBeGreaterThanOrEqual(0);
-      expect(d).toBeLessThanOrEqual(20016); // half circumference
-    }
+  it('matches getDistanceM conversion for a simple 1 degree latitude delta', () => {
+    const a = { lat: 0, lng: 0 };
+    const b = { stop_lat: 1, stop_lon: 0 };
+    expect(getDistanceKm(a, b)).toBeGreaterThan(111);
+    expect(getDistanceKm(a, b)).toBeLessThan(112);
   });
 });

--- a/pipeline/src/lib/geo-utils.ts
+++ b/pipeline/src/lib/geo-utils.ts
@@ -1,36 +1,30 @@
+import { getDistance } from 'geolib';
+
 /**
  * Geographic utility functions for the pipeline.
  *
- * These are Node.js pipeline utilities, separate from the client-side
- * distance functions in `src/domain/transit/distance.ts`.
+ * These are geographic utilities used by the pipeline.
  */
-
-/** Mean Earth radius in kilometers (spherical approximation). */
-const EARTH_RADIUS_KM = 6371;
-
 /**
- * Compute the great-circle distance between two points using the
- * Haversine formula.
+ * Compute the distance between two points in kilometers.
  *
- * @param lat1 - Latitude of point 1 (degrees).
- * @param lon1 - Longitude of point 1 (degrees).
- * @param lat2 - Latitude of point 2 (degrees).
- * @param lon2 - Longitude of point 2 (degrees).
- * @returns Distance in kilometers (always >= 0).
+ * @param a - First point with `lat` / `lng` fields.
+ * @param b - Second point with `stop_lat` / `stop_lon` fields.
+ * @returns Distance in kilometers.
  */
-export function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const toRad = Math.PI / 180;
-  const dLat = (lat2 - lat1) * toRad;
-  // Normalize longitude difference to [-180, 180] for dateline crossing.
-  const dLon = (((lon2 - lon1 + 540) % 360) - 180) * toRad;
+export function getDistanceKm(
+  a: { lat: number; lng: number },
+  b: { stop_lat: number; stop_lon: number },
+): number {
+  if (a.lat === b.stop_lat && a.lng === b.stop_lon) {
+    return 0;
+  }
 
-  // Clamp to [0, 1] to guard against floating-point overshoot near
-  // antipodal points, which would make Math.asin return NaN.
-  const a = Math.min(
-    1,
-    Math.sin(dLat / 2) ** 2 +
-      Math.cos(lat1 * toRad) * Math.cos(lat2 * toRad) * Math.sin(dLon / 2) ** 2,
+  return (
+    getDistance(
+      { latitude: a.lat, longitude: a.lng },
+      { latitude: b.stop_lat, longitude: b.stop_lon },
+      0.01,
+    ) / 1000
   );
-
-  return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(a));
 }

--- a/pipeline/src/lib/pipeline/app-data-v2/build-stop-geo.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/build-stop-geo.ts
@@ -30,7 +30,7 @@
  */
 
 import type { StopGeoJson } from '../../../../../src/types/data/transit-v2-json';
-import { haversineKm } from '../../geo-utils';
+import { getDistanceKm } from '../../geo-utils';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -106,7 +106,10 @@ function computeConnectivity(target: StopEntry, allStops: StopEntry[]): Connecti
     if (s.id === target.id) {
       continue;
     }
-    const d = haversineKm(target.lat, target.lon, s.lat, s.lon);
+    const d = getDistanceKm(
+      { lat: target.lat, lng: target.lon },
+      { stop_lat: s.lat, stop_lon: s.lon },
+    );
     if (d > CONNECTIVITY_RADIUS_KM) {
       continue;
     }
@@ -150,7 +153,10 @@ function computeAllMetrics(
       continue;
     }
 
-    const d = haversineKm(target.lat, target.lon, s.lat, s.lon);
+    const d = getDistanceKm(
+      { lat: target.lat, lng: target.lon },
+      { stop_lat: s.lat, stop_lon: s.lon },
+    );
 
     // nr: nearest stop with a route not in target's route set
     if (bestNr === undefined || d < bestNr) {

--- a/pipeline/src/lib/pipeline/app-data-v2/build-trip-pattern-geo.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/build-trip-pattern-geo.ts
@@ -14,7 +14,7 @@ import type {
   TripPatternGeoJson,
   TripPatternJson,
 } from '../../../../../src/types/data/transit-v2-json';
-import { haversineKm } from '../../geo-utils';
+import { getDistanceKm } from '../../geo-utils';
 
 /**
  * Build per-pattern geographic metrics from trip patterns and stop coordinates.
@@ -56,7 +56,10 @@ export function buildTripPatternGeo(
       const first = stopCoords.get(stops[0].id);
       const last = stopCoords.get(stops[stops.length - 1].id);
       if (first && last) {
-        dist = haversineKm(first.lat, first.lon, last.lat, last.lon);
+        dist = getDistanceKm(
+          { lat: first.lat, lng: first.lon },
+          { stop_lat: last.lat, stop_lon: last.lon },
+        );
       }
     }
 
@@ -66,7 +69,7 @@ export function buildTripPatternGeo(
       const a = stopCoords.get(stops[i].id);
       const b = stopCoords.get(stops[i + 1].id);
       if (a && b) {
-        pathDist += haversineKm(a.lat, a.lon, b.lat, b.lon);
+        pathDist += getDistanceKm({ lat: a.lat, lng: a.lon }, { stop_lat: b.lat, stop_lon: b.lon });
       }
     }
 

--- a/src/components/search/stop-search-result-item.tsx
+++ b/src/components/search/stop-search-result-item.tsx
@@ -5,15 +5,15 @@ import { RouteBadge } from '@/components/badge/route-badge';
 import { StopActionButtons } from '@/components/stop-action-buttons';
 import { StopMetrics } from '@/components/stop-metrics';
 import { DEFAULT_AGENCY_LANG, resolveAgencyLang } from '@/config/transit-defaults';
-import { bearingDeg, distanceM } from '@/domain/transit/distance';
 import { getStopDisplayNames } from '@/domain/transit/get-stop-display-names';
+import { normalizeForSearch } from '@/domain/transit/stop-search-index';
 import { useInfoLevel } from '@/hooks/use-info-level';
 import type { LatLng } from '@/types/app/map';
 import type { InfoLevel } from '@/types/app/settings';
 import type { Agency, AppRouteTypeValue, Route, Stop } from '@/types/app/transit';
 import type { StopWithMeta } from '@/types/app/transit-composed';
-import { normalizeForSearch } from '@/domain/transit/stop-search-index';
 import { routeTypesEmoji } from '@/utils/route-type-emoji';
+import { getBearingDeg, getDistanceM } from '@/domain/transit/distance';
 import { AccessibilityLabel } from '../stop/accessibility-label';
 import { PlatformCodeLabel } from '../stop/platform-code-label';
 
@@ -136,9 +136,9 @@ export function StopSearchResultItem({
   // Suppress sub-10m noise to match the StopInfo / StopSummary convention:
   // a "0m" / "3m" badge is just visual jitter when the user is effectively
   // standing on the stop already.
-  const distanceRounded = mapCenter ? Math.round(distanceM(mapCenter, stop)) : null;
+  const distanceRounded = mapCenter ? Math.round(getDistanceM(mapCenter, stop)) : null;
   const showDistance = distanceRounded != null && distanceRounded >= 10;
-  const bearing = mapCenter ? bearingDeg(mapCenter, stop) : null;
+  const bearing = mapCenter ? getBearingDeg(mapCenter, stop) : null;
   // Display-name resolution. When agencies (from useStopSearchMeta) are
   // available we use the matching agency's lang to bias subName ordering,
   // matching StopSummary's behavior. Otherwise we fall back to the default

--- a/src/components/stop-info.tsx
+++ b/src/components/stop-info.tsx
@@ -1,4 +1,4 @@
-import { bearingDeg } from '../domain/transit/distance';
+import { getBearingDeg } from '../domain/transit/distance';
 import type { LatLng } from '../types/app/map';
 import type { StopWithContext, StopWithMeta } from '../types/app/transit-composed';
 import { DistanceBadge } from './badge/distance-badge';
@@ -41,7 +41,7 @@ export function StopInfo({
   geo,
 }: StopInfoProps) {
   const distanceRounded = distance != null ? Math.round(distance) : null;
-  const bearing = mapCenter ? bearingDeg(mapCenter, stop) : null;
+  const bearing = mapCenter ? getBearingDeg(mapCenter, stop) : null;
 
   return (
     <div className="flex min-w-0 flex-1 flex-col justify-center self-stretch">

--- a/src/components/stop-summary.stories.tsx
+++ b/src/components/stop-summary.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { bearingDeg } from '../domain/transit/distance';
+import { getBearingDeg } from '../domain/transit/distance';
 import {
   agencyGx,
   agencyOretetsu,
@@ -186,7 +186,7 @@ export const WithDistanceBadge: Story = {
       distanceBadge={
         <DistanceBadge
           meters={235}
-          bearingDeg={bearingDeg(storyMapCenter, args.stop)}
+          bearingDeg={getBearingDeg(storyMapCenter, args.stop)}
           showDirection
           size="xl"
         />

--- a/src/domain/transit/__tests__/distance.test.ts
+++ b/src/domain/transit/__tests__/distance.test.ts
@@ -1,48 +1,47 @@
 import { describe, expect, it } from 'vitest';
-import { bearingDeg, distanceM, formatDistance, formatDistanceCompact } from '../distance';
+import { formatDistance, formatDistanceCompact, getBearingDeg, getDistanceM } from '../distance';
 
-describe('distanceM', () => {
+describe('getDistanceM', () => {
   it('returns 0 for identical points', () => {
     const a = { lat: 35.0, lng: 139.0 };
     const b = { stop_lat: 35.0, stop_lon: 139.0 };
-    expect(distanceM(a, b)).toBe(0);
+    expect(getDistanceM(a, b)).toBe(0);
   });
 
-  it('calculates ~111 km for 1 degree latitude difference', () => {
-    const a = { lat: 35.0, lng: 139.0 };
-    const b = { stop_lat: 36.0, stop_lon: 139.0 };
-    const d = distanceM(a, b);
-    // 1 degree lat ≈ 111,000 m
-    expect(d).toBeCloseTo(111_000, -2);
-  });
-
-  it('calculates correct distance for 1 degree longitude at ~35N', () => {
-    const a = { lat: 35.0, lng: 139.0 };
-    const b = { stop_lat: 35.0, stop_lon: 140.0 };
-    const d = distanceM(a, b);
-    // 1 degree lng at 35°N ≈ 111_000 * cos(35°) ≈ 90,932 m
-    const expected = 111_000 * Math.cos(35 * (Math.PI / 180));
-    expect(d).toBeCloseTo(expected, -2);
-  });
-
-  it('is symmetric (a→b equals b→a)', () => {
-    const a = { lat: 35.6812, lng: 139.7671 };
-    const b = { stop_lat: 35.6895, stop_lon: 139.6917 };
-    const ab = distanceM(a, b);
-    const ba = distanceM(
-      { lat: b.stop_lat, lng: b.stop_lon },
-      { stop_lat: a.lat, stop_lon: a.lng },
-    );
-    expect(ab).toBeCloseTo(ba, 5);
-  });
-
-  it('returns a reasonable distance for Tokyo Station to Shinjuku Station (~6.4 km)', () => {
+  it('returns a reasonable distance for Tokyo Station to Shinjuku Station', () => {
     const tokyo = { lat: 35.6812, lng: 139.7671 };
     const shinjuku = { stop_lat: 35.6896, stop_lon: 139.7006 };
-    const d = distanceM(tokyo, shinjuku);
-    // Roughly 6–7 km
+    const d = getDistanceM(tokyo, shinjuku);
     expect(d).toBeGreaterThan(5_500);
     expect(d).toBeLessThan(7_500);
+  });
+
+  it('handles dateline crossing without taking the long way around', () => {
+    const westOfDateline = { lat: 0, lng: 179 };
+    const eastAcrossDateline = { stop_lat: 0, stop_lon: -179 };
+    const d = getDistanceM(westOfDateline, eastAcrossDateline);
+    expect(d).toBeGreaterThan(220_000);
+    expect(d).toBeLessThan(223_000);
+  });
+});
+
+describe('getBearingDeg', () => {
+  const origin = { lat: 35.0, lng: 139.0 };
+
+  it('returns 90 for due east', () => {
+    const east = { stop_lat: 35.0, stop_lon: 140.0 };
+    expect(getBearingDeg(origin, east)).toBeCloseTo(90, 0);
+  });
+
+  it('handles dateline crossing without flipping to the long way around', () => {
+    const westOfDateline = { lat: 0, lng: 179 };
+    const eastAcrossDateline = { stop_lat: 0, stop_lon: -179 };
+    expect(getBearingDeg(westOfDateline, eastAcrossDateline)).toBeCloseTo(90, 0);
+  });
+
+  it('returns 0 for identical points', () => {
+    const same = { stop_lat: 35.0, stop_lon: 139.0 };
+    expect(getBearingDeg(origin, same)).toBe(0);
   });
 });
 
@@ -99,8 +98,6 @@ describe('formatDistance', () => {
   });
 
   it('stays in meter branch when raw value < 1000 even if rounded to 1000', () => {
-    // 999.5 < 1000, so enters sub-km branch; Math.round(999.5) = 1000.
-    // en locale formats 1000 with a thousands separator.
     expect(formatDistance(999.5, 'en')).toBe('1,000m');
   });
 
@@ -111,59 +108,12 @@ describe('formatDistance', () => {
   });
 
   it('uses locale-specific thousands separator in meter branch', () => {
-    // Raw 1500 ≥ 1000, so the meter branch is skipped and km is used.
-    // Pick 999.5 so rounding lands on 1000 within the meter branch.
     expect(formatDistance(999.5, 'de')).toBe('1.000m');
     expect(formatDistance(999.5, 'ja')).toBe('1,000m');
   });
 });
 
-describe('bearingDeg', () => {
-  const origin = { lat: 35.0, lng: 139.0 };
-
-  it('returns 0 for due north', () => {
-    const north = { stop_lat: 36.0, stop_lon: 139.0 };
-    expect(bearingDeg(origin, north)).toBeCloseTo(0, 0);
-  });
-
-  it('returns 90 for due east', () => {
-    const east = { stop_lat: 35.0, stop_lon: 140.0 };
-    expect(bearingDeg(origin, east)).toBeCloseTo(90, 0);
-  });
-
-  it('returns 180 for due south', () => {
-    const south = { stop_lat: 34.0, stop_lon: 139.0 };
-    expect(bearingDeg(origin, south)).toBeCloseTo(180, 0);
-  });
-
-  it('returns 270 for due west', () => {
-    const west = { stop_lat: 35.0, stop_lon: 138.0 };
-    expect(bearingDeg(origin, west)).toBeCloseTo(270, 0);
-  });
-
-  it('returns ~45 for northeast', () => {
-    // Use latitude-adjusted offset so bearing is close to 45°
-    const midLat = 35.0 * (Math.PI / 180);
-    const lngOffset = 1 / Math.cos(midLat); // compensate for longitude shrinkage
-    const ne = { stop_lat: 36.0, stop_lon: 139.0 + lngOffset };
-    expect(bearingDeg(origin, ne)).toBeCloseTo(45, 0);
-  });
-
-  it('returns value in [0, 360) range', () => {
-    const sw = { stop_lat: 34.0, stop_lon: 138.0 };
-    const bearing = bearingDeg(origin, sw);
-    expect(bearing).toBeGreaterThanOrEqual(0);
-    expect(bearing).toBeLessThan(360);
-  });
-
-  it('returns 0 for identical points (degenerate case)', () => {
-    const same = { stop_lat: 35.0, stop_lon: 139.0 };
-    // atan2(0, 0) = 0 → bearing = 0
-    expect(bearingDeg(origin, same)).toBe(0);
-  });
-});
-
-describe('formatDistanceCompact', () => {
+describe('distance formatter formatDistanceCompact', () => {
   it('formats sub-km distance as integer without unit', () => {
     expect(formatDistanceCompact(450, 'en')).toBe('450');
   });
@@ -186,7 +136,6 @@ describe('formatDistanceCompact', () => {
   });
 
   it('uses comma separator for values that round to >= 1000 but are < 1000m', () => {
-    // 999.5 rounds to 1000, but 999.5 < 1000 so enters sub-km branch
     expect(formatDistanceCompact(999.5, 'en')).toBe('1,000');
   });
 

--- a/src/domain/transit/distance.ts
+++ b/src/domain/transit/distance.ts
@@ -1,22 +1,48 @@
-import type { LatLng } from '../../types/app/map';
-
-/** Meters per degree of latitude (constant worldwide). */
-const METERS_PER_DEGREE_LAT = 111_000;
+import { getDistance, getGreatCircleBearing } from 'geolib';
 
 /**
- * Calculate the approximate distance in meters between two points
- * using a flat-earth approximation with latitude-adjusted longitude.
+ * Compute the distance between two points in meters.
  *
- * @param a - First point as {@link LatLng}.
+ * This is the src-side distance helper used by UI code. It intentionally
+ * accepts the app's common `LatLng`-like shapes used around stop rendering.
+ *
+ * @param a - First point with `lat` / `lng` fields.
  * @param b - Second point with `stop_lat` / `stop_lon` fields.
- * @returns Distance in meters (may include decimals).
+ * @returns Distance in meters.
  */
-export function distanceM(a: LatLng, b: { stop_lat: number; stop_lon: number }): number {
-  const midLat = ((a.lat + b.stop_lat) / 2) * (Math.PI / 180);
-  const metersPerDegreeLng = METERS_PER_DEGREE_LAT * Math.cos(midLat);
-  const dlat = b.stop_lat - a.lat;
-  const dlng = b.stop_lon - a.lng;
-  return Math.sqrt((dlat * METERS_PER_DEGREE_LAT) ** 2 + (dlng * metersPerDegreeLng) ** 2);
+export function getDistanceM(
+  a: { lat: number; lng: number },
+  b: { stop_lat: number; stop_lon: number },
+): number {
+  if (a.lat === b.stop_lat && a.lng === b.stop_lon) {
+    return 0;
+  }
+
+  return getDistance(
+    { latitude: a.lat, longitude: a.lng },
+    { latitude: b.stop_lat, longitude: b.stop_lon },
+    0.01,
+  );
+}
+
+/**
+ * Calculate the geographic initial bearing (azimuth) from point `a` to point `b`.
+ *
+ * Returns degrees clockwise from north: 0 = north, 90 = east,
+ * 180 = south, 270 = west.
+ *
+ * @param a - Origin point with `lat` / `lng` fields.
+ * @param b - Destination point with `stop_lat` / `stop_lon` fields.
+ * @returns Bearing in degrees [0, 360).
+ */
+export function getBearingDeg(
+  a: { lat: number; lng: number },
+  b: { stop_lat: number; stop_lon: number },
+): number {
+  return getGreatCircleBearing(
+    { latitude: a.lat, longitude: a.lng },
+    { latitude: b.stop_lat, longitude: b.stop_lon },
+  );
 }
 
 /**
@@ -64,26 +90,6 @@ export function formatDistance(meters: number, lang: string, unit = true): strin
     maximumFractionDigits: 1,
   });
   return `${km}km`;
-}
-
-/**
- * Calculate the geographic bearing (azimuth) from point `a` to point `b`
- * using a flat-earth approximation with latitude-adjusted longitude.
- *
- * Returns degrees clockwise from north: 0 = north, 90 = east, 180 = south, 270 = west.
- *
- * @param a - Origin point as {@link LatLng}.
- * @param b - Destination point with `stop_lat` / `stop_lon` fields.
- * @returns Bearing in degrees [0, 360).
- */
-export function bearingDeg(a: LatLng, b: { stop_lat: number; stop_lon: number }): number {
-  const midLat = ((a.lat + b.stop_lat) / 2) * (Math.PI / 180);
-  const metersPerDegreeLng = METERS_PER_DEGREE_LAT * Math.cos(midLat);
-  const dy = (b.stop_lat - a.lat) * METERS_PER_DEGREE_LAT;
-  const dx = (b.stop_lon - a.lng) * metersPerDegreeLng;
-  // atan2(dx, dy) gives angle from north (Y-axis), clockwise positive
-  const rad = Math.atan2(dx, dy);
-  return ((rad * 180) / Math.PI + 360) % 360;
 }
 
 /**


### PR DESCRIPTION
## Summary
- move webapp-facing distance and bearing helpers back into `src/domain/transit/distance.ts`
- simplify pipeline geo helpers to a single `getDistanceKm` API and switch pipeline callers to it
- adopt `geolib` for shared distance/bearing calculations and update tests/changelog

## Validation
- `npm run format`
- `npm run lint:fix`
- `npm run build`
- `runTests` on `src/domain/transit/__tests__/distance.test.ts`
- `runTests` on `pipeline/src/lib/__tests__/geo-utils.test.ts`