### PR TITLE
feat(i18n): treat zh region tags as script-tag aliases in translation lookup

### DIFF
--- a/src/config/supported-langs.ts
+++ b/src/config/supported-langs.ts
@@ -60,10 +60,17 @@ export const SUPPORTED_LANG_CODES: readonly string[] = SUPPORTED_LANGS.map((l) =
 
 /**
  * Region-to-script mapping for Chinese locale variants.
+ *
  * navigator.language returns region-based codes (zh-CN, zh-TW, zh-HK)
- * but SUPPORTED_LANGS uses script-based codes (zh-Hans, zh-Hant).
+ * but SUPPORTED_LANGS uses script-based codes (zh-Hans, zh-Hant). This
+ * map is also reused by the i18n layer (`lang-key-equivalence.ts`) so
+ * that translations.txt entries shipped under region tags (e.g. Kyoto
+ * Bus's `zh-cn` / `zh-tw`) are matched against user-selected canonical
+ * script codes.
+ *
+ * Keys are lowercase per BCP 47 §2.1.1 case-insensitive comparison.
  */
-const REGION_TO_LANG: Record<string, string> = {
+export const REGION_TO_LANG: Record<string, string> = {
   'zh-cn': 'zh-Hans',
   'zh-sg': 'zh-Hans',
   'zh-tw': 'zh-Hant',

--- a/src/domain/transit/i18n/__tests__/inject-origin-lang.test.ts
+++ b/src/domain/transit/i18n/__tests__/inject-origin-lang.test.ts
@@ -147,4 +147,23 @@ describe('injectOriginLang', () => {
       expect(result).toEqual({ DE: 'Bertoldsbrunnen' });
     });
   });
+
+  describe('region/script alias (zh-cn ↔ zh-Hans, zh-tw ↔ zh-Hant)', () => {
+    // Hypothetical scenarios — current ferry feeds use feed_lang="ja",
+    // so this corner-case primarily guards against future Chinese-feed
+    // ingestion where translations.txt uses one alias form and the
+    // feed_lang declares the other.
+
+    it('does not inject zh-Hans when names already has zh-cn (alias coverage)', () => {
+      const names = { 'zh-cn': '北京站' };
+      const result = injectOriginLang(names, '北京站', 'zh-Hans');
+      expect(result).toBe(names);
+    });
+
+    it('does not inject zh-Hant when names already has zh-tw', () => {
+      const names = { 'zh-tw': '臺北車站' };
+      const result = injectOriginLang(names, '臺北車站', 'zh-Hant');
+      expect(result).toBe(names);
+    });
+  });
 });

--- a/src/domain/transit/i18n/__tests__/lang-key-equivalence.test.ts
+++ b/src/domain/transit/i18n/__tests__/lang-key-equivalence.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import { REGION_TO_LANG } from '../../../../config/supported-langs';
+import { langKeysEquivalent } from '../lang-key-equivalence';
+
+describe('REGION_TO_LANG (alias map invariants)', () => {
+  it('all keys are lowercase', () => {
+    // langKeysEquivalent depends on this — callers always lowercase the
+    // input before lookup, so an uppercase key in the map would be dead.
+    for (const key of Object.keys(REGION_TO_LANG)) {
+      expect(key).toBe(key.toLowerCase());
+    }
+  });
+
+  it('all values are non-empty', () => {
+    for (const value of Object.values(REGION_TO_LANG)) {
+      expect(value).not.toBe('');
+    }
+  });
+});
+
+describe('langKeysEquivalent', () => {
+  describe('identity', () => {
+    it('returns true for identical keys', () => {
+      expect(langKeysEquivalent('en', 'en')).toBe(true);
+      expect(langKeysEquivalent('ja-Hrkt', 'ja-Hrkt')).toBe(true);
+    });
+
+    it('returns true for empty strings (degenerate match)', () => {
+      expect(langKeysEquivalent('', '')).toBe(true);
+    });
+  });
+
+  describe('case-insensitive (BCP 47 §2.1.1)', () => {
+    it('treats different casings as equivalent', () => {
+      expect(langKeysEquivalent('ja-Hrkt', 'ja-HrKt')).toBe(true);
+      expect(langKeysEquivalent('JA-HRKT', 'ja-hrkt')).toBe(true);
+      expect(langKeysEquivalent('EN', 'en')).toBe(true);
+      expect(langKeysEquivalent('Zh-Hans', 'ZH-HANS')).toBe(true);
+    });
+  });
+
+  describe('Chinese region → script alias', () => {
+    it('treats zh-cn and zh-Hans as equivalent', () => {
+      expect(langKeysEquivalent('zh-cn', 'zh-Hans')).toBe(true);
+      expect(langKeysEquivalent('zh-Hans', 'zh-cn')).toBe(true);
+    });
+
+    it('treats zh-CN (uppercase region) and zh-Hans as equivalent', () => {
+      expect(langKeysEquivalent('zh-CN', 'zh-Hans')).toBe(true);
+    });
+
+    it('treats zh-tw and zh-Hant as equivalent', () => {
+      expect(langKeysEquivalent('zh-tw', 'zh-Hant')).toBe(true);
+      expect(langKeysEquivalent('zh-Hant', 'zh-tw')).toBe(true);
+    });
+
+    it('treats zh-hk and zh-mo as Traditional aliases', () => {
+      expect(langKeysEquivalent('zh-hk', 'zh-Hant')).toBe(true);
+      expect(langKeysEquivalent('zh-mo', 'zh-Hant')).toBe(true);
+    });
+
+    it('treats zh-sg as a Simplified alias', () => {
+      expect(langKeysEquivalent('zh-sg', 'zh-Hans')).toBe(true);
+    });
+
+    it('treats two region tags pointing at the same script as equivalent', () => {
+      // zh-cn and zh-sg both map to zh-Hans.
+      expect(langKeysEquivalent('zh-cn', 'zh-sg')).toBe(true);
+      // zh-tw / zh-hk / zh-mo all map to zh-Hant.
+      expect(langKeysEquivalent('zh-tw', 'zh-hk')).toBe(true);
+    });
+  });
+
+  describe('non-equivalent variants', () => {
+    it('keeps zh-Hans and zh-Hant distinct (different scripts)', () => {
+      expect(langKeysEquivalent('zh-Hans', 'zh-Hant')).toBe(false);
+    });
+
+    it('keeps zh-cn and zh-tw distinct (different target scripts)', () => {
+      expect(langKeysEquivalent('zh-cn', 'zh-tw')).toBe(false);
+    });
+
+    it('does NOT alias bare zh to either script', () => {
+      // 'zh' alone is genuinely ambiguous; rely on resolveLangChain's
+      // parent-prefix expansion instead of aliasing here.
+      expect(langKeysEquivalent('zh', 'zh-Hans')).toBe(false);
+      expect(langKeysEquivalent('zh', 'zh-Hant')).toBe(false);
+      expect(langKeysEquivalent('zh', 'zh-cn')).toBe(false);
+    });
+
+    it('rejects unrelated languages', () => {
+      expect(langKeysEquivalent('en', 'ja')).toBe(false);
+      expect(langKeysEquivalent('ja', 'ko')).toBe(false);
+      expect(langKeysEquivalent('zh-Hans', 'ja')).toBe(false);
+    });
+  });
+
+  describe('unknown codes', () => {
+    it('compares case-insensitively without an alias entry', () => {
+      expect(langKeysEquivalent('xx-yy', 'XX-YY')).toBe(true);
+      expect(langKeysEquivalent('xx-yy', 'xx-zz')).toBe(false);
+    });
+  });
+});

--- a/src/domain/transit/i18n/__tests__/lang-priority.test.ts
+++ b/src/domain/transit/i18n/__tests__/lang-priority.test.ts
@@ -198,4 +198,31 @@ describe('sortLangKeysByPriority', () => {
       });
     });
   });
+
+  describe('region/script alias (zh-cn ↔ zh-Hans, zh-tw ↔ zh-Hant)', () => {
+    it('treats zh-cn as an exact match when preferred contains zh-Hans', () => {
+      // Without alias awareness, zh-cn would land in "agency variant
+      // not in LANG_PRIORITY" (-1000); with alias it gets exact-match
+      // priority (-3000+0).
+      expect(sortLangKeysByPriority(['zh-cn', 'en', 'ja'], ['zh-Hans'])).toEqual([
+        'zh-cn',
+        'en',
+        'ja',
+      ]);
+    });
+
+    it('treats zh-tw as an exact match when preferred contains zh-Hant', () => {
+      expect(sortLangKeysByPriority(['zh-tw', 'en', 'ja'], ['zh-Hant'])).toEqual([
+        'zh-tw',
+        'en',
+        'ja',
+      ]);
+    });
+
+    it('treats zh-cn as a LANG_PRIORITY variant of zh-Hans even without preferred', () => {
+      // zh-Hans is listed in LANG_PRIORITY; zh-cn should sort in the
+      // same family slot.
+      expect(sortLangKeysByPriority(['zh-cn', 'en', 'ja'], [])).toEqual(['en', 'zh-cn', 'ja']);
+    });
+  });
 });

--- a/src/domain/transit/i18n/__tests__/resolve-lang-chain.test.ts
+++ b/src/domain/transit/i18n/__tests__/resolve-lang-chain.test.ts
@@ -101,4 +101,26 @@ describe('resolveLangChain (custom langs)', () => {
     ];
     expect(resolveLangChain('x', circular)).toEqual(['x', 'y']);
   });
+
+  // --- Region/script alias (zh-cn ↔ zh-Hans, zh-tw ↔ zh-Hant) ---
+
+  it('region alias: zh-cn input resolves to zh-Hans canonical chain', () => {
+    const langs: SupportedLang[] = [
+      { code: 'zh-Hans', label: '', shortLabel: '', fallback: 'en' },
+      { code: 'en', label: '', shortLabel: '' },
+    ];
+    // Starting from `zh-cn` (a region tag), resolveLangChain should
+    // canonicalize to the script-tag entry `zh-Hans` and follow its
+    // fallback chain.
+    expect(resolveLangChain('zh-cn', langs)).toEqual(['zh-Hans', 'zh', 'en']);
+  });
+
+  it('region alias: zh-tw input resolves to zh-Hant canonical chain', () => {
+    const langs: SupportedLang[] = [
+      { code: 'zh-Hant', label: '', shortLabel: '', fallback: 'zh-Hans' },
+      { code: 'zh-Hans', label: '', shortLabel: '', fallback: 'en' },
+      { code: 'en', label: '', shortLabel: '' },
+    ];
+    expect(resolveLangChain('zh-tw', langs)).toEqual(['zh-Hant', 'zh-Hans', 'zh', 'en']);
+  });
 });

--- a/src/domain/transit/i18n/__tests__/resolve-translatable-text.test.ts
+++ b/src/domain/transit/i18n/__tests__/resolve-translatable-text.test.ts
@@ -282,6 +282,35 @@ describe('resolveTranslatableText', () => {
     });
   });
 
+  describe('supports zh region/script alias lookup', () => {
+    it('matches a zh-cn key when the request is zh-Hans', () => {
+      expect(
+        resolveTranslatableText({ name: '渋谷駅', names: { 'zh-cn': '涩谷站' } }, ['zh-Hans']),
+      ).toEqual({
+        resolved: { lang: 'zh-Hans', value: '涩谷站' },
+        others: { origin: '渋谷駅' },
+      });
+    });
+
+    it('matches a zh-tw key when the request is zh-Hant', () => {
+      expect(
+        resolveTranslatableText({ name: '渋谷駅', names: { 'zh-tw': '澀谷站' } }, ['zh-Hant']),
+      ).toEqual({
+        resolved: { lang: 'zh-Hant', value: '澀谷站' },
+        others: { origin: '渋谷駅' },
+      });
+    });
+
+    it('does not match zh-cn when requesting zh-Hant (different scripts)', () => {
+      expect(
+        resolveTranslatableText({ name: '渋谷駅', names: { 'zh-cn': '涩谷站' } }, ['zh-Hant']),
+      ).toEqual({
+        resolved: { lang: 'origin', value: '渋谷駅' },
+        others: { 'zh-cn': '涩谷站' },
+      });
+    });
+  });
+
   describe('deduplicates case-variant keys with first-wins semantics', () => {
     it('excludes duplicate case variants from others after a direct match', () => {
       expect(

--- a/src/domain/transit/i18n/__tests__/translate-stop-name.test.ts
+++ b/src/domain/transit/i18n/__tests__/translate-stop-name.test.ts
@@ -77,4 +77,27 @@ describe('translateStopName', () => {
   it('case-insensitive in chain', () => {
     expect(translateStopName(makeStop(), ['KO', 'EN'])).toBe('Akebonobashi');
   });
+
+  // --- Region/script alias (zh-cn ↔ zh-Hans, zh-tw ↔ zh-Hant) ---
+
+  it('region alias: requesting zh-Hans matches zh-cn key in stop_names', () => {
+    const stop = makeStop({
+      stop_names: { ja: '曙橋', 'zh-cn': '曙桥' },
+    });
+    expect(translateStopName(stop, 'zh-Hans')).toBe('曙桥');
+  });
+
+  it('region alias: requesting zh-Hant matches zh-tw key in stop_names', () => {
+    const stop = makeStop({
+      stop_names: { ja: '曙橋', 'zh-tw': '曙橋' },
+    });
+    expect(translateStopName(stop, 'zh-Hant')).toBe('曙橋');
+  });
+
+  it('region alias: zh-Hans request does NOT match zh-tw (different script)', () => {
+    const stop = makeStop({
+      stop_names: { ja: '曙橋', 'zh-tw': '曙橋' },
+    });
+    expect(translateStopName(stop, 'zh-Hans')).toBe('曙橋'); // falls back to stop_name
+  });
 });

--- a/src/domain/transit/i18n/inject-origin-lang.ts
+++ b/src/domain/transit/i18n/inject-origin-lang.ts
@@ -12,12 +12,17 @@ import { langKeysEquivalent } from './lang-key-equivalence';
  * (e.g. English shown when Japanese is expected).
  *
  * This function bridges the gap: if `originLang` is a concrete
- * language code and `names` does not already contain that key, the
- * base value is injected so the resolver treats it as a candidate
- * for that language.
+ * language code and `names` does not already contain an equivalent
+ * key, the base value is injected so the resolver treats it as a
+ * candidate for that language.
+ *
+ * Equivalence is checked via {@link langKeysEquivalent}: case-
+ * insensitive per BCP 47, **plus** zh region/script aliases. So a
+ * `names` entry under `"zh-cn"` already covers an `originLang` of
+ * `"zh-Hans"`, and the record is returned unchanged in that case.
  *
  * Explicit translations (from `translations.txt`) always take
- * priority — if `names` already has a matching key, the record is
+ * priority — if `names` already has an equivalent key, the record is
  * returned unchanged.
  *
  * ### `"mul"` (multilingual) handling

--- a/src/domain/transit/i18n/inject-origin-lang.ts
+++ b/src/domain/transit/i18n/inject-origin-lang.ts
@@ -1,3 +1,5 @@
+import { langKeysEquivalent } from './lang-key-equivalence';
+
 /**
  * Inject the base value into a translation names record under its
  * feed language key.
@@ -60,11 +62,12 @@ export function injectOriginLang(
     return names;
   }
 
-  // Case-insensitive check: do not overwrite an explicit translation.
-  // BCP 47 language tags are case-insensitive (RFC 5646 §2.1.1).
-  const originLangLower = originLang.toLowerCase();
+  // Case-insensitive + region-alias check: do not overwrite an explicit
+  // translation, including aliases such as `zh-cn` for an `originLang`
+  // of `zh-Hans`. BCP 47 §2.1.1 case-insensitivity is handled inside
+  // langKeysEquivalent.
   for (const key of Object.keys(names)) {
-    if (key.toLowerCase() === originLangLower) {
+    if (langKeysEquivalent(key, originLang)) {
       return names;
     }
   }

--- a/src/domain/transit/i18n/lang-key-equivalence.ts
+++ b/src/domain/transit/i18n/lang-key-equivalence.ts
@@ -1,0 +1,37 @@
+import { REGION_TO_LANG } from '../../../config/supported-langs';
+
+/**
+ * Compare two BCP 47-ish language keys, treating known
+ * script/region aliases as equivalent.
+ *
+ * The base relation is case-insensitive comparison per BCP 47
+ * §2.1.1 (so `ja-HrKt` ≡ `ja-Hrkt`). On top of that, region-based
+ * Chinese subtags are mapped to their script-based canonical form
+ * (`zh-cn` ≡ `zh-Hans`, `zh-tw` ≡ `zh-Hant`, etc.) using
+ * {@link REGION_TO_LANG}.
+ *
+ * Unknown codes pass through unchanged, so unrelated languages stay
+ * non-equivalent (e.g. `zh-Hans` and `zh-Hant` are NOT equivalent —
+ * they are different scripts, intentionally distinct).
+ *
+ * Designed for use inside translation lookup paths where the source
+ * data (`translations.txt`) and the user-selected language may use
+ * different conformant-but-non-canonical spellings of the same
+ * language.
+ *
+ * @example
+ * langKeysEquivalent('ja-Hrkt', 'ja-HrKt'); // true (case)
+ * langKeysEquivalent('zh-cn', 'zh-Hans');   // true (region → script)
+ * langKeysEquivalent('zh-Hans', 'zh-Hant'); // false (different scripts)
+ * langKeysEquivalent('en', 'ja');            // false (different languages)
+ */
+export function langKeysEquivalent(a: string, b: string): boolean {
+  const aLower = a.toLowerCase();
+  const bLower = b.toLowerCase();
+  if (aLower === bLower) {
+    return true;
+  }
+  const aCanonical = (REGION_TO_LANG[aLower] ?? aLower).toLowerCase();
+  const bCanonical = (REGION_TO_LANG[bLower] ?? bLower).toLowerCase();
+  return aCanonical === bCanonical;
+}

--- a/src/domain/transit/i18n/lang-priority.ts
+++ b/src/domain/transit/i18n/lang-priority.ts
@@ -1,3 +1,5 @@
+import { langKeysEquivalent } from './lang-key-equivalence';
+
 /**
  * International language priority order for display purposes.
  *
@@ -80,24 +82,24 @@ function langPrefix(key: string): string {
  * ```
  */
 export function sortLangKeysByPriority(keys: string[], preferred: readonly string[]): string[] {
-  // Case-insensitive comparisons per BCP 47 (RFC 5646 §2.1.1).
-  const preferredLower = preferred.map((p) => p.toLowerCase());
-  const preferredPrefixes = new Set(preferredLower.map(langPrefix));
-  const priorityLower = LANG_PRIORITY.map((p) => p.toLowerCase());
+  // Case-insensitive + region-alias comparisons via langKeysEquivalent
+  // (BCP 47 §2.1.1 + zh region/script equivalence so that source keys
+  // like `zh-cn` cluster with `preferred` of `zh-Hans`).
+  const preferredPrefixes = new Set(preferred.map((p) => langPrefix(p.toLowerCase())));
 
   function sortKey(key: string): number {
     const keyLower = key.toLowerCase();
     const prefix = langPrefix(keyLower);
     const isAgencyVariant = preferredPrefixes.has(prefix);
-    const priorityIndex = priorityLower.indexOf(keyLower);
+    const priorityIndex = LANG_PRIORITY.findIndex((p) => langKeysEquivalent(p, key));
 
     if (isAgencyVariant) {
-      // Agency lang exact match → top priority in preferred order
-      const preferredIndex = preferredLower.indexOf(keyLower);
+      // Agency lang exact match (or alias) → top priority in preferred order
+      const preferredIndex = preferred.findIndex((p) => langKeysEquivalent(p, key));
       if (preferredIndex !== -1) {
         return -3000 + preferredIndex;
       }
-      // Agency variant defined in LANG_PRIORITY
+      // Agency variant defined in LANG_PRIORITY (or alias)
       if (priorityIndex !== -1) {
         return -2000 + priorityIndex;
       }
@@ -105,7 +107,7 @@ export function sortLangKeysByPriority(keys: string[], preferred: readonly strin
       return -1000;
     }
 
-    // LANG_PRIORITY order
+    // LANG_PRIORITY order (or alias)
     if (priorityIndex !== -1) {
       return priorityIndex;
     }

--- a/src/domain/transit/i18n/lang-priority.ts
+++ b/src/domain/transit/i18n/lang-priority.ts
@@ -56,7 +56,11 @@ function langPrefix(key: string): string {
  * 3. Keys not in any list (original relative order preserved)
  *
  * Comparison rules:
- * - Matching is case-insensitive per BCP 47.
+ * - Matching uses {@link langKeysEquivalent}: case-insensitive per
+ *   BCP 47 **plus** zh region/script aliasing (`zh-cn` clusters with
+ *   `zh-Hans`, `zh-tw` with `zh-Hant`, etc.). A `preferred` of
+ *   `['zh-Hans']` therefore treats a key of `'zh-cn'` as an exact
+ *   match in the same precedence slot.
  * - `preferred` is treated as an ordered precedence list, not an
  *   unordered set.
  * - Even when `preferred` is empty, keys in {@link LANG_PRIORITY}

--- a/src/domain/transit/i18n/resolve-lang-chain.ts
+++ b/src/domain/transit/i18n/resolve-lang-chain.ts
@@ -1,4 +1,5 @@
 import type { SupportedLang } from '../../../config/supported-langs';
+import { langKeysEquivalent } from './lang-key-equivalence';
 
 /** Ordered language fallback chain (e.g. `['zh-Hant', 'zh-Hans', 'en']`). */
 export type LangChain = readonly string[];
@@ -31,14 +32,15 @@ export function resolveLangChain(lang: string, langs: readonly SupportedLang[]):
   const seen = new Set<string>();
   let current: string | undefined = lang;
 
-  // Case-insensitive comparison per BCP 47 (RFC 5646 §2.1.1).
-  // All entries use canonical codes from langs (not raw input casing).
+  // Case-insensitive + region-alias comparison via langKeysEquivalent
+  // (BCP 47 §2.1.1 + zh region/script equivalence). All entries use
+  // canonical codes from langs (not raw input casing).
   while (current != null) {
     const lower: string = current.toLowerCase();
     if (seen.has(lower)) {
       break;
     }
-    const match: SupportedLang | undefined = langs.find((l) => l.code.toLowerCase() === lower);
+    const match: SupportedLang | undefined = langs.find((l) => langKeysEquivalent(l.code, lower));
     chain.push(match?.code ?? current);
     seen.add(lower);
     current = match?.fallback;

--- a/src/domain/transit/i18n/resolve-translatable-text.ts
+++ b/src/domain/transit/i18n/resolve-translatable-text.ts
@@ -67,8 +67,15 @@ export interface ResolvedTranslatableText {
  * If `data.names` contains an `'origin'` key, `data.name` takes priority.
  * The reserved keyword is the exact lowercase string `'origin'`.
  *
- * Language lookup is **case-insensitive** per BCP 47 (RFC 5646 §2.1.1).
- * `"ja-Hrkt"` matches a key `"ja-HrKt"` in `data.names`.
+ * Language lookup uses {@link langKeysEquivalent}: case-insensitive
+ * per BCP 47 (RFC 5646 §2.1.1) **plus** zh region/script aliasing
+ * (`zh-cn` ≡ `zh-Hans`, `zh-tw` ≡ `zh-Hant`, etc.). For example,
+ * `"ja-Hrkt"` matches a key `"ja-HrKt"`, and `"zh-Hans"` matches a
+ * key `"zh-cn"`. When a match is found, `resolved.lang` echoes the
+ * requested preferred-lang value (not the actual key in
+ * `data.names`); the matched source key is excluded from `others`
+ * via the same equivalence check so the alias does not appear twice.
+ *
  * If `data.names` contains duplicate keys that differ only in case
  * (e.g. both `"ja-Hrkt"` and `"ja-HrKt"`), the first match is used
  * and the duplicate is ignored.

--- a/src/domain/transit/i18n/resolve-translatable-text.ts
+++ b/src/domain/transit/i18n/resolve-translatable-text.ts
@@ -1,4 +1,5 @@
 import type { TranslatableText } from '../../../types/app/transit-composed';
+import { langKeysEquivalent } from './lang-key-equivalence';
 
 const RESERVED_ORIGIN_KEY = 'origin';
 
@@ -10,9 +11,8 @@ function findMatchingTranslation(
   names: Record<string, string>,
   preferredLang: string,
 ): { key: string; value: string } | undefined {
-  const preferredLangLower = preferredLang.toLowerCase();
   for (const [key, value] of Object.entries(names)) {
-    if (!isOriginKey(key) && key.toLowerCase() === preferredLangLower) {
+    if (!isOriginKey(key) && langKeysEquivalent(key, preferredLang)) {
       return { key, value };
     }
   }
@@ -128,7 +128,8 @@ export function resolveTranslatableText(
       ? { lang: matchedLang!, value: translation }
       : { lang: 'origin', value: data.name };
 
-  // Build others: all translations except the resolved language key.
+  // Build others: all translations except the resolved language key
+  // (and its aliases — see langKeysEquivalent).
   // Deduplicate by lowercase key to prevent case-variant duplicates
   // (e.g. "ja-Hrkt" and "ja-HrKt") from appearing twice.
   // Values are never compared — value deduplication is the caller's
@@ -136,16 +137,21 @@ export function resolveTranslatableText(
   // 'origin' always maps to text.name, overwriting any 'origin' in text.names.
   const others: Record<string, string> = {};
   const seen = new Set<string>();
-  if (matchedLang) {
-    seen.add(matchedLang.toLowerCase());
-  }
   seen.add(RESERVED_ORIGIN_KEY);
   for (const [key, value] of Object.entries(data.names)) {
     const keyLower = key.toLowerCase();
-    if (!seen.has(keyLower)) {
-      others[key] = value;
-      seen.add(keyLower);
+    if (seen.has(keyLower)) {
+      continue;
     }
+    // Skip the resolved language key — including aliases such as
+    // `zh-cn` when `matchedLang === 'zh-Hans'` — so the same value is
+    // not duplicated as both `resolved` and an `others` entry.
+    if (matchedLang && langKeysEquivalent(key, matchedLang)) {
+      seen.add(keyLower);
+      continue;
+    }
+    others[key] = value;
+    seen.add(keyLower);
   }
   // Add origin (data.name) only when resolved is NOT origin.
   // When resolved is origin, data.name is already the resolved value.

--- a/src/domain/transit/i18n/translate-stop-name.ts
+++ b/src/domain/transit/i18n/translate-stop-name.ts
@@ -1,4 +1,5 @@
 import type { Stop } from '../../../types/app/transit';
+import { langKeysEquivalent } from './lang-key-equivalence';
 
 /**
  * Translate the display name of a stop for a given language.
@@ -21,9 +22,9 @@ export function translateStopName(stop: Stop, lang?: string | readonly string[])
     const langs = typeof lang === 'string' ? [lang] : lang;
     const keys = Object.keys(stop.stop_names);
     for (const l of langs) {
-      // Case-insensitive match per BCP 47 (RFC 5646 §2.1.1).
-      const lLower = l.toLowerCase();
-      const key = keys.find((k) => k.toLowerCase() === lLower);
+      // Case-insensitive + region-alias match per BCP 47 (RFC 5646 §2.1.1)
+      // and zh region/script equivalence (zh-cn ≡ zh-Hans, zh-tw ≡ zh-Hant).
+      const key = keys.find((k) => langKeysEquivalent(k, l));
       if (key != null && stop.stop_names[key]) {
         return stop.stop_names[key];
       }


### PR DESCRIPTION
## Summary

- Bridge BCP 47 **region-tag ↔ script-tag** equivalence in the i18n layer so that Chinese translations shipped under region tags (e.g. `zh-cn`, `zh-tw`) are matched against the canonical script tags (`zh-Hans`, `zh-Hant`) the app uses.
- No data mutation: per the data-viewer philosophy, source values are preserved end-to-end and the new equivalence is applied only at translation lookup / sort time.

## Why

A survey of `translations.txt` across the existing 32 sources turned up two non-canonical patterns:

| Source key | How it's currently handled |
| --- | --- |
| `ja-HrKt` (kseiw) | already covered by case-insensitive comparison (`ja-Hrkt` ≡ `ja-HrKt`) |
| `zh` (kseiw, prefix-only) | covered by `resolveLangChain` parent-prefix expansion |
| `zh-cn` / `zh-tw` (Kyoto Bus, anticipated) | **not covered** — different strings even after lowercasing |

A future Kyoto Bus ingestion (separate work) ships translations under `zh-cn` / `zh-tw`. Without this PR, a user who selects `zh-Hans` would not see those translations even though they are clearly meant for the same audience.

## What

### Helper

`src/domain/transit/i18n/lang-key-equivalence.ts`

```ts
export function langKeysEquivalent(a: string, b: string): boolean {
  const aLower = a.toLowerCase();
  const bLower = b.toLowerCase();
  if (aLower === bLower) return true;
  const aCanonical = (REGION_TO_LANG[aLower] ?? aLower).toLowerCase();
  const bCanonical = (REGION_TO_LANG[bLower] ?? bLower).toLowerCase();
  return aCanonical === bCanonical;
}
```

Reuses the `REGION_TO_LANG` map already exported (newly) from `src/config/supported-langs.ts` so user-side `normalizeLang` and source-side translation lookup share one source of truth.

### Application sites (5 files / 7 sites)

| Site | What it now does |
| --- | --- |
| `resolve-translatable-text.ts` (`findMatchingTranslation`) | matches `zh-cn` keys when a `zh-Hans`-only chain is requested |
| `resolve-translatable-text.ts` (`others` dedup) | excludes the resolved alias from the alternative list (no double display) |
| `translate-stop-name.ts` | stop_names lookup, same coverage |
| `resolve-lang-chain.ts` | starting from `zh-cn` resolves to the canonical `zh-Hans` chain |
| `lang-priority.ts` (preferred match) | sorts `zh-cn` as if `preferred = ['zh-Hans']` had matched it exactly |
| `lang-priority.ts` (LANG_PRIORITY match) | clusters `zh-cn` with the canonical `zh-Hans` family slot |
| `inject-origin-lang.ts` | does not clobber an existing `zh-cn` entry when the feed declares `feed_lang=zh-Hans` |

### Intentionally NOT aliased

- **`zh` (bare prefix)** — genuinely ambiguous (Simplified or Traditional); the existing `resolveLangChain` parent-prefix expansion already places it correctly in the chain.
- Anything else in the survey — only Chinese region tags carry the script-equivalence meaning we want to formalize.

## Test plan

- [x] CI green
- [x] Existing 5 i18n test files still pass — they each got 2-3 alias cases added (`zh-cn` ↔ `zh-Hans`, `zh-tw` ↔ `zh-Hant`, plus the negative `zh-Hans` ↛ `zh-tw` case)
- [x] New `lang-key-equivalence.test.ts` covers identity / case / aliases (both directions) / map invariants (all keys lowercase, all values non-empty) / non-equivalence cases (different scripts, different languages, bare `zh`)
- [x] Local: `npm run typecheck && npm run format:check && npm run lint && npm run test && npm run build` — pass (217 test files / 3306 tests)

## Notes

- This PR introduces the i18n primitive only — there is no data-source addition here. The Kyoto Bus ingestion that motivated the survey is intentionally a separate change.
- `langKeysEquivalent` is a small enough primitive (15 lines) that I did not wrap it in further helpers like `findEquivalentKey(record, lang)`. Each call site uses it directly inside its existing `keys.find(...)` / `findIndex(...)` idiom. If a clear duplication pattern emerges later, that wrapper can be added without changing the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)