### PR TITLE
chore(data): refresh iyotetsu-bus to ODPT 20260430 resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Pipeline: 伊予鉄バスの ODPT resource を最新版にリフレッシュ (`4e0f3da7-04a3-4335-ae56-2f4a213d3631` 20260415版 → `1c786fb7-532d-4052-9de4-e51340555b64` 20260430版、 valid 2026-05-01〜2026-05-31)。 1.5 ヶ月単位で更新される短期 schedule のため定期的なリフレッシュが必要。
+
 ### Added
 
 - Pipeline: 横浜市営地下鉄 (Yokohama Municipal Subway / 横浜市交通局) の GTFS-JP データソースを追加 (prefix `yht`, route_type 1 subway)。

--- a/pipeline/config/resources/NOTES.md
+++ b/pipeline/config/resources/NOTES.md
@@ -132,7 +132,7 @@ stop_name の差異パターン (渋66 の調査結果):
 
 - Resource definition: `pipeline/config/resources/gtfs/iyotetsu-bus.ts`
 - CKAN: <https://ckan.odpt.org/dataset/iyotetsu_bus_all_lines>
-- Resource ID (使用中): `4e0f3da7-04a3-4335-ae56-2f4a213d3631` (20260415版)
+- Resource ID (使用中): `1c786fb7-532d-4052-9de4-e51340555b64` (20260430版、 valid 2026-05-01〜2026-05-31)
 
 ### iyotetsu-bus route_color
 
@@ -153,7 +153,8 @@ stop_name の差異パターン (渋66 の調査結果):
 ### iyotetsu-bus CKAN リソースの date パラメータ
 
 - downloadUrl に `?date=YYYYMMDD` が必須
-- CKAN の 20260415 版リソースと対応
+- CKAN の 20260430版リソースと対応 (前回 20260415版から refresh)
+- 1.5 ヶ月単位で短期 schedule を更新する事業者 (memory `project_new_gtfs_data_update`)、 5 月末頃に再 refresh 必要
 
 ## kyoto-city-bus
 

--- a/pipeline/config/resources/gtfs/iyotetsu-bus.ts
+++ b/pipeline/config/resources/gtfs/iyotetsu-bus.ts
@@ -16,8 +16,8 @@ const iyotetsuBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/iyotetsu_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/iyotetsu_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/iyotetsu_bus_all_lines/resource/4e0f3da7-04a3-4335-ae56-2f4a213d3631',
-      resourceId: '4e0f3da7-04a3-4335-ae56-2f4a213d3631',
+        'https://ckan.odpt.org/dataset/iyotetsu_bus_all_lines/resource/1c786fb7-532d-4052-9de4-e51340555b64',
+      resourceId: '1c786fb7-532d-4052-9de4-e51340555b64',
     },
     provider: {
       name: {
@@ -37,7 +37,7 @@ const iyotetsuBus: GtfsSourceDefinition = {
     routeTypes: ['bus'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/IyotetsuBus/AllLines.zip?date=20260415',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/IyotetsuBus/AllLines.zip?date=20260430',
   },
   pipeline: {
     outDir: 'iyotetsu-bus',


### PR DESCRIPTION
## Summary

Refresh iyotetsu-bus to the latest ODPT-published resource (`1c786fb7-532d-4052-9de4-e51340555b64`, date=`20260430`, valid `2026-05-01 → 2026-05-31`). Detected by the periodic Check Transit Resources workflow as `REMOTE_KNOWN_IN_PERIOD`.

## Why

Iyotetsu Bus publishes GTFS-JP feeds in roughly 1.5-month cycles (memory `project_new_gtfs_data_update`). The previously adopted `4e0f3da7-04a3-4335-ae56-2f4a213d3631` (date=`20260415`) covered only `2026-04-15 → 2026-04-30`. From `2026-05-01` onwards the WebApp would have served empty timetables until this refresh lands.

## Changes

- `pipeline/config/resources/gtfs/iyotetsu-bus.ts`: bumped the three-field set per the standard data-update workflow
  - `resourceId`: `4e0f3da7…` → `1c786fb7…`
  - `resourceUrl`: corresponding CKAN resource URL
  - `downloadUrl`: `?date=20260415` → `?date=20260430`
- `pipeline/config/resources/NOTES.md`: updated the iyotetsu-bus section with the new resource id and a reminder that the next refresh is expected at the end of May
- `CHANGELOG.md` Unreleased: added a `### Changed` entry summarising the refresh

## Pipeline rebuild verification

- download → build-db → build-from-gtfs → build-insights → build-global-insights → data:sync → validate:v2 all clean
- 46 routes / 1,093 stops / 3,388 trips / 80,741 stop_times rebuilt with the new schedule
- Validity now spans the current date (today is 2026-05-10), so timetables render

## Test plan

- [x] `npx tsc --noEmit && npm run lint:fix && npm run format` clean
- [x] iyotetsu-bus pipeline rebuild OK (Exit code 0 for every step)
- [x] `npm run pipeline:validate:v2` clean for `iyt2`
- [x] CI green
- [x] Update Transit Data workflow re-run after merge to refresh `public/data-v2/iyt2/`

## Other sources surveyed (no action needed)

The same Check Transit Resources run flagged `kyoto-bus` / `chiyoda-bus` / `kagoshima-maritime-bureau` / `keio-bus` / `yokohama-municipal-bus` with `REMOTE_KNOWN_IN_PERIOD` warnings, but the locally adopted `?date=` values are already newer than every entry in those WARN lists — these are noise per the documented behaviour. `chuo-bus` remains `ADOPTED_EXPIRED` (no new ODPT resource yet). `kanto-bus` deliberately skipped per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)