### PR TITLE
fix(pipeline): align fare-v2 schema (columns / NOT NULL / Spec PK comment) with the GTFS spec

### DIFF
--- a/pipeline/src/lib/pipeline/gtfs-schema.ts
+++ b/pipeline/src/lib/pipeline/gtfs-schema.ts
@@ -498,6 +498,7 @@ export const SCHEMA: string[] = [
     duration_limit_type INTEGER,
     fare_transfer_type  INTEGER NOT NULL,
     fare_product_id     TEXT
+    -- FK for fare_product_id omitted (see design decision 4)
   )`,
 ];
 

--- a/pipeline/src/lib/pipeline/gtfs-schema.ts
+++ b/pipeline/src/lib/pipeline/gtfs-schema.ts
@@ -459,9 +459,8 @@ export const SCHEMA: string[] = [
   )`,
 
   // fare_leg_rules.txt
-  // Spec PK: (leg_group_id, network_id, from_area_id, to_area_id,
-  //   from_timeframe_group_id, to_timeframe_group_id) — omitted
-  // (see design decision 1)
+  // Spec PK: (network_id, from_area_id, to_area_id, from_timeframe_group_id,
+  //   to_timeframe_group_id, fare_product_id) — omitted (see design decision 1)
   `CREATE TABLE IF NOT EXISTS fare_leg_rules (
     leg_group_id             TEXT,
     network_id               TEXT,

--- a/pipeline/src/lib/pipeline/gtfs-schema.ts
+++ b/pipeline/src/lib/pipeline/gtfs-schema.ts
@@ -477,25 +477,28 @@ export const SCHEMA: string[] = [
   )`,
 
   // fare_leg_join_rules.txt
-  // Spec PK: (from_leg_group_id, to_leg_group_id) — omitted
-  // (see design decision 1)
+  // Spec PK: (from_network_id, to_network_id, from_stop_id, to_stop_id) —
+  // omitted (see design decision 1)
   `CREATE TABLE IF NOT EXISTS fare_leg_join_rules (
-    from_leg_group_id TEXT,
-    to_leg_group_id   TEXT,
-    fare_product_id   TEXT,
-    rule_priority     INTEGER
+    from_network_id TEXT,
+    to_network_id   TEXT,
+    from_stop_id    TEXT,
+    to_stop_id      TEXT,
+    FOREIGN KEY (from_stop_id) REFERENCES stops(stop_id),
+    FOREIGN KEY (to_stop_id) REFERENCES stops(stop_id)
   )`,
 
   // fare_transfer_rules.txt
-  // Spec PK: (from_leg_group_id, to_leg_group_id, fare_transfer_type) —
-  // omitted (see design decision 1)
+  // Spec PK: (from_leg_group_id, to_leg_group_id, fare_product_id,
+  // transfer_count, duration_limit) — omitted (see design decision 1)
   `CREATE TABLE IF NOT EXISTS fare_transfer_rules (
-    from_leg_group_id        TEXT,
-    to_leg_group_id          TEXT,
-    transfer_fare_product_id TEXT,
-    duration_limit           INTEGER,
-    duration_limit_type      INTEGER,
-    fare_transfer_type       INTEGER
+    from_leg_group_id   TEXT,
+    to_leg_group_id     TEXT,
+    transfer_count      INTEGER,
+    duration_limit      INTEGER,
+    duration_limit_type INTEGER,
+    fare_transfer_type  INTEGER,
+    fare_product_id     TEXT
   )`,
 ];
 

--- a/pipeline/src/lib/pipeline/gtfs-schema.ts
+++ b/pipeline/src/lib/pipeline/gtfs-schema.ts
@@ -480,8 +480,8 @@ export const SCHEMA: string[] = [
   // Spec PK: (from_network_id, to_network_id, from_stop_id, to_stop_id) —
   // omitted (see design decision 1)
   `CREATE TABLE IF NOT EXISTS fare_leg_join_rules (
-    from_network_id TEXT,
-    to_network_id   TEXT,
+    from_network_id TEXT NOT NULL,
+    to_network_id   TEXT NOT NULL,
     from_stop_id    TEXT,
     to_stop_id      TEXT,
     FOREIGN KEY (from_stop_id) REFERENCES stops(stop_id),
@@ -497,7 +497,7 @@ export const SCHEMA: string[] = [
     transfer_count      INTEGER,
     duration_limit      INTEGER,
     duration_limit_type INTEGER,
-    fare_transfer_type  INTEGER,
+    fare_transfer_type  INTEGER NOT NULL,
     fare_product_id     TEXT
   )`,
 ];


### PR DESCRIPTION
## Summary

Schema audit follow-up for Issue #193. After fetching the GTFS Schedule reference (`reference.md`) verbatim and diffing against `pipeline/src/lib/pipeline/gtfs-schema.ts` mechanically, three corrections to the fare-v2 area were applied. All changes are confined to one file and to the fare-v2 tables; no source feed currently in the project uses fare-v2, so the rebuild produces no rows and behaviour is unchanged.

## Spec source

- [gtfs.org reference](https://gtfs.org/documentation/schedule/reference/)
- raw markdown: <https://raw.githubusercontent.com/google/transit/master/gtfs/spec/en/reference.md> (used directly via `curl + awk + grep` to avoid AI-fetch interpretation errors)

## Changes (per commit)

### `3d2df2fe` — fare_leg_join_rules / fare_transfer_rules column lists rewritten

Two tables had column sets that did not match the spec at all.

`fare_leg_join_rules`

| | column |
| --- | --- |
| **Spec** | `from_network_id` (Required), `to_network_id` (Required), `from_stop_id` (Cond. Req.), `to_stop_id` (Cond. Req.) |
| **Was** | `from_leg_group_id`, `to_leg_group_id`, `fare_product_id`, `rule_priority` |

The previous column list is the spec for `fare_leg_rules`, not `fare_leg_join_rules` — the two had been confused at definition time. Replaced with the spec definition; FK references to `stops(stop_id)` added.

`fare_transfer_rules`

| | column |
| --- | --- |
| **Spec** | `from_leg_group_id`, `to_leg_group_id`, `transfer_count`, `duration_limit`, `duration_limit_type`, `fare_transfer_type`, `fare_product_id` |
| **Was** | `from_leg_group_id`, `to_leg_group_id`, `transfer_fare_product_id`, `duration_limit`, `duration_limit_type`, `fare_transfer_type` |

- `transfer_fare_product_id` is not a spec column → renamed to `fare_product_id`
- `transfer_count` was missing → added

### `d20094ef` — NOT NULL added to spec-Required columns missed in the first commit

Three columns the spec marks **Required** were left nullable in commit `3d2df2fe`. Tightened the NOT NULL constraints so the schema enforces the spec contract:

- `fare_leg_join_rules.from_network_id`
- `fare_leg_join_rules.to_network_id`
- `fare_transfer_rules.fare_transfer_type`

### `44ef2732` — fare_leg_rules Spec PK comment refreshed

`fare_leg_rules` column list already matches the spec. Only the `// Spec PK:` comment above the table definition was outdated:

| | content |
| --- | --- |
| was | `(leg_group_id, network_id, from_area_id, to_area_id, from_timeframe_group_id, to_timeframe_group_id)` |
| now | `(network_id, from_area_id, to_area_id, from_timeframe_group_id, to_timeframe_group_id, fare_product_id)` |

Comment-only update, no SQL change.

## Impact

Zero behavioural change.

- A repository-wide grep confirms the four removed / renamed column names (`from_leg_group_id` / `to_leg_group_id` of the join-rules variant, `transfer_fare_product_id`, `rule_priority`) had **no consumers** in the pipeline or WebApp.
- No source feed currently in the project uses fare-v2 tables, so the new column lists and NOT NULL constraints can never fire on existing data.
- The full test suite (3,352 tests) continues to pass.
- `npm run build` produces an unchanged production bundle.

## Test plan

- [x] `npx tsc --noEmit && npm run lint:fix && npm run format` clean
- [x] `npm test` — 3,352 / 3,352 tests pass
- [x] `npm run build` clean
- [x] `pipeline:build:db` for `iyotetsu-bus` clean (= NOT NULL additions do not break DDL)
- [x] Mechanical schema-vs-spec diff confirms `fare_leg_rules` / `fare_leg_join_rules` / `fare_transfer_rules` now match the spec column list and PK comment
- [x] CI green

## Out of scope (= follow-up to be decided)

The audit also surfaced unrelated drift outside the fare-v2 area (column additions in `routes` / `trips`, NOT NULL polarity on `stops` / `stop_times` / `fare_media` / `fare_products` / `fare_attributes` / `timeframes` / `rider_categories`, `locations.geojson` not yet modelled, `translations.record_sequence` GTFS-JP extension, audit-script automation). None of those are touched by this PR; how to handle each one is still under discussion.

Refs: #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)