### PR TITLE
chore(logger): apply isEnabled() guard to non-trivial debug calls

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -189,6 +189,34 @@ Tags are comma-separated patterns set via `VITE_LOG_TAGS`.
 
 **Note:** `warn` and `error` logs always bypass tag filtering.
 
+### Performance: gating expensive arguments
+
+`logger.debug(...)` / `logger.verbose(...)` short-circuit internally when their level is filtered out, but **arguments are evaluated before the call**. Template literals, array iterations, function calls, and `.toFixed()` formatting all run even when the log is suppressed.
+
+For non-trivial argument evaluation, gate the call with `logger.isEnabled(level)`:
+
+```typescript
+if (logger.isEnabled('debug')) {
+    const elapsed = Math.round(performance.now() - t0);
+    logger.debug(`getStopsNearby: ${data.length}/${sorted.length} in ${elapsed}ms`);
+}
+```
+
+When to gate:
+
+- Function calls (`.toFixed()`, `.join()`, helper builders like `formatLoc()`)
+- Array iteration (`.map`, `.filter`, `.reduce`, spread `[...x]`)
+- Multi-variable template interpolation, especially with `.length` / `.size` aggregates
+- Any computation that exists only to feed the log
+
+When NOT to gate (cold paths):
+
+- Single-variable interpolation, e.g. `` `stopId=${stopId}` `` only
+- String literals, e.g. `'cancelled'`
+- `info` / `warn` / `error` — always emitted, gating provides no benefit
+
+Group consecutive `debug` calls under one `if` block so the gate cost is paid once.
+
 ### DevTools Helper (development only)
 
 In development builds, `window.__log` is available in the browser console:

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -114,7 +114,9 @@ export default function App({ loadResult }: AppProps) {
   );
 
   useEffect(() => {
-    logger.debug(`LangChain: ${settings.lang} → [${langChain.join(' → ')}]`);
+    if (logger.isEnabled('debug')) {
+      logger.debug(`LangChain: ${settings.lang} → [${langChain.join(' → ')}]`);
+    }
   }, [settings.lang, langChain]);
 
   const [inBoundStops, setInBoundStops] = useState<StopWithMeta[]>([]);
@@ -702,9 +704,11 @@ export default function App({ loadResult }: AppProps) {
                 langChain,
                 resolveAgencyLang(meta.agencies, meta.stop.agency_id),
               ).name || meta.stop.stop_name;
-            logger.debug(
-              `handleToggleAnchorByStopId: adding stopId=${stopId}, name=${displayName}`,
-            );
+            if (logger.isEnabled('debug')) {
+              logger.debug(
+                `handleToggleAnchorByStopId: adding stopId=${stopId}, name=${displayName}`,
+              );
+            }
             void addAnchor({
               stopId: meta.stop.stop_id,
               stopName: meta.stop.stop_name,
@@ -961,15 +965,19 @@ export default function App({ loadResult }: AppProps) {
   const handleCycleTile = useCallback(() => {
     const prevTileIndex = settings.tileIndex;
     const nextTile = nextTileIndex(prevTileIndex, TILE_SOURCES.length);
-    const prevTileLabel =
-      prevTileIndex == null
-        ? 'none'
-        : (TILE_SOURCES[prevTileIndex]?.label ?? `unknown(${String(prevTileIndex)})`);
-    const nextTileLabel =
-      nextTile == null ? 'none' : (TILE_SOURCES[nextTile]?.label ?? `unknown(${String(nextTile)})`);
-    logger.debug(
-      `tile: ${prevTileLabel} (${String(prevTileIndex)}) -> ${nextTileLabel} (${String(nextTile)})`,
-    );
+    if (logger.isEnabled('debug')) {
+      const prevTileLabel =
+        prevTileIndex == null
+          ? 'none'
+          : (TILE_SOURCES[prevTileIndex]?.label ?? `unknown(${String(prevTileIndex)})`);
+      const nextTileLabel =
+        nextTile == null
+          ? 'none'
+          : (TILE_SOURCES[nextTile]?.label ?? `unknown(${String(nextTile)})`);
+      logger.debug(
+        `tile: ${prevTileLabel} (${String(prevTileIndex)}) -> ${nextTileLabel} (${String(nextTile)})`,
+      );
+    }
     updateSetting('tileIndex', nextTile);
   }, [settings.tileIndex, updateSetting]);
 

--- a/src/components/map-bottom-sheet-layout.tsx
+++ b/src/components/map-bottom-sheet-layout.tsx
@@ -48,9 +48,11 @@ export function MapBottomSheetLayout({
   const layoutPreset = resolveMapBottomSheetLayoutPreset(viewportHeight);
 
   useEffect(() => {
-    logger.debug(
-      `viewportHeight=${viewportHeight}, collapsedMap=${layoutPreset.collapsedMapHeightClassName}, expandedMap=${layoutPreset.expandedMapHeightClassName}, collapsedSheet=${layoutPreset.collapsedSheetHeightClassName}, expandedSheet=${layoutPreset.expandedSheetHeightClassName}`,
-    );
+    if (logger.isEnabled('debug')) {
+      logger.debug(
+        `viewportHeight=${viewportHeight}, collapsedMap=${layoutPreset.collapsedMapHeightClassName}, expandedMap=${layoutPreset.expandedMapHeightClassName}, collapsedSheet=${layoutPreset.collapsedSheetHeightClassName}, expandedSheet=${layoutPreset.expandedSheetHeightClassName}`,
+      );
+    }
   }, [layoutPreset, viewportHeight]);
 
   return (

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -157,7 +157,9 @@ function PanToFocus({ position }: { position: LatLng | null }) {
       logger.debug('position is null, skipping');
       return;
     }
-    logger.debug(`panning to lat=${position.lat}, lng=${position.lng}`);
+    if (logger.isEnabled('debug')) {
+      logger.debug(`panning to lat=${position.lat}, lng=${position.lng}`);
+    }
     smoothMoveTo(map, [position.lat, position.lng], map.getZoom());
   }, [map, position]);
 

--- a/src/components/marker/stop-markers-canvas.tsx
+++ b/src/components/marker/stop-markers-canvas.tsx
@@ -200,8 +200,10 @@ export function StopMarkersCanvas({
         }
       }
 
-      const elapsed = Math.round(performance.now() - t0);
-      logger.debug(`incremental: ${stops.length} stops in ${elapsed}ms`);
+      if (logger.isEnabled('debug')) {
+        const elapsed = Math.round(performance.now() - t0);
+        logger.debug(`incremental: ${stops.length} stops in ${elapsed}ms`);
+      }
     } else {
       // Full rebuild: clear all and recreate
       group.clearLayers();
@@ -213,8 +215,10 @@ export function StopMarkersCanvas({
         markersRef.current.set(stop.stop_id, marker);
       }
 
-      const elapsed = Math.round(performance.now() - t0);
-      logger.debug(`rebuild: ${stops.length} stops in ${elapsed}ms`);
+      if (logger.isEnabled('debug')) {
+        const elapsed = Math.round(performance.now() - t0);
+        logger.debug(`rebuild: ${stops.length} stops in ${elapsed}ms`);
+      }
     }
 
     // Show permanent tooltip for selected stop when tooltip display is enabled.

--- a/src/components/stop-history.tsx
+++ b/src/components/stop-history.tsx
@@ -60,9 +60,11 @@ export function StopHistory({
     const entry = stopMap.get(stopId);
     if (entry) {
       const isCurrent = stopId === selectedStopId;
-      logger.debug(
-        `select: stopId=${stopId}, name=${entry.stopWithMeta.stop.stop_name}, isCurrent=${isCurrent}`,
-      );
+      if (logger.isEnabled('debug')) {
+        logger.debug(
+          `select: stopId=${stopId}, name=${entry.stopWithMeta.stop.stop_name}, isCurrent=${isCurrent}`,
+        );
+      }
       onSelect(entry.stopWithMeta.stop, entry.routeTypes);
     }
   };

--- a/src/domain/transit/timetable-stats.ts
+++ b/src/domain/transit/timetable-stats.ts
@@ -172,8 +172,10 @@ export function computeTimetableEntryStats(
     trips.add(`${tl.patternId}|${tl.serviceId}|${tl.tripIndex}`);
   }
 
-  logger.debug('tripsHeadsigns', [...tripsHeadsigns]);
-  logger.debug('stopHeadsigns', [...stopHeadsigns]);
+  if (logger.isEnabled('debug')) {
+    logger.debug('tripsHeadsigns', [...tripsHeadsigns]);
+    logger.debug('stopHeadsigns', [...stopHeadsigns]);
+  }
 
   return {
     totalCount: entries.length,

--- a/src/hooks/use-map-locate-watch.ts
+++ b/src/hooks/use-map-locate-watch.ts
@@ -77,9 +77,11 @@ export function useMapLocateWatch({ enabled, onLocated, onError }: UseMapLocateW
         return;
       }
       const loc = toUserLocation(pos);
-      logger.debug(
-        `auto-tracking: initial position (elapsed=${Date.now() - enableTime}ms, ${formatLoc(loc)})`,
-      );
+      if (logger.isEnabled('debug')) {
+        logger.debug(
+          `auto-tracking: initial position (elapsed=${Date.now() - enableTime}ms, ${formatLoc(loc)})`,
+        );
+      }
       onLocated(loc);
     };
     const handleWatchSuccess: PositionCallback = (pos) => {
@@ -88,9 +90,11 @@ export function useMapLocateWatch({ enabled, onLocated, onError }: UseMapLocateW
       }
       watchUpdates += 1;
       const loc = toUserLocation(pos);
-      logger.debug(
-        `auto-tracking: watch update #${String(watchUpdates)} (since-enable=${Date.now() - enableTime}ms, ${formatLoc(loc)})`,
-      );
+      if (logger.isEnabled('debug')) {
+        logger.debug(
+          `auto-tracking: watch update #${String(watchUpdates)} (since-enable=${Date.now() - enableTime}ms, ${formatLoc(loc)})`,
+        );
+      }
       onLocated(loc);
     };
     const handleErr =
@@ -99,9 +103,11 @@ export function useMapLocateWatch({ enabled, onLocated, onError }: UseMapLocateW
         if (cancelled) {
           return;
         }
-        logger.debug(
-          `auto-tracking: ${kind} failed (since-enable=${Date.now() - enableTime}ms, code=${String(error.code)}, message=${error.message})`,
-        );
+        if (logger.isEnabled('debug')) {
+          logger.debug(
+            `auto-tracking: ${kind} failed (since-enable=${Date.now() - enableTime}ms, code=${String(error.code)}, message=${error.message})`,
+          );
+        }
         if (reportedCodes.has(error.code)) {
           // Same error code already surfaced this session (e.g. the
           // sibling request also failed with the same code).
@@ -124,9 +130,11 @@ export function useMapLocateWatch({ enabled, onLocated, onError }: UseMapLocateW
 
     return () => {
       cancelled = true;
-      logger.debug(
-        `auto-tracking: disabled (duration=${Date.now() - enableTime}ms, watch updates=${String(watchUpdates)})`,
-      );
+      if (logger.isEnabled('debug')) {
+        logger.debug(
+          `auto-tracking: disabled (duration=${Date.now() - enableTime}ms, watch updates=${String(watchUpdates)})`,
+        );
+      }
       navigator.geolocation.clearWatch(watchId);
     };
   }, [enabled, onLocated, onError]);

--- a/src/hooks/use-map-locate.ts
+++ b/src/hooks/use-map-locate.ts
@@ -67,9 +67,11 @@ export function useMapLocate(
     navigator.geolocation.getCurrentPosition(
       (pos) => {
         const loc = toUserLocation(pos);
-        logger.debug(
-          `manual locate: acquired (elapsed=${Date.now() - startTime}ms, lat=${loc.lat.toFixed(5)}, lng=${loc.lng.toFixed(5)}, accuracy=${loc.accuracy.toFixed(0)}m)`,
-        );
+        if (logger.isEnabled('debug')) {
+          logger.debug(
+            `manual locate: acquired (elapsed=${Date.now() - startTime}ms, lat=${loc.lat.toFixed(5)}, lng=${loc.lng.toFixed(5)}, accuracy=${loc.accuracy.toFixed(0)}m)`,
+          );
+        }
         const action = resolveLocateAction(map, loc);
         if (action.kind === 'move') {
           applyLocateAction(map, loc, action);
@@ -80,9 +82,11 @@ export function useMapLocate(
         setLocating(false);
       },
       (error) => {
-        logger.debug(
-          `manual locate: failed (elapsed=${Date.now() - startTime}ms, code=${String(error.code)}, message=${error.message})`,
-        );
+        if (logger.isEnabled('debug')) {
+          logger.debug(
+            `manual locate: failed (elapsed=${Date.now() - startTime}ms, code=${String(error.code)}, message=${error.message})`,
+          );
+        }
         setLocating(false);
         onError?.(error);
       },

--- a/src/hooks/use-route-stops.ts
+++ b/src/hooks/use-route-stops.ts
@@ -34,7 +34,9 @@ export function useRouteStops(
     }
     const stopIds = repo.getStopsForRoutes(routeIds);
     const stops = repo.getStopMetaByIds(stopIds);
-    logger.debug(`${routeIds.size} routes → ${stops.length} route stop markers`);
+    if (logger.isEnabled('debug')) {
+      logger.debug(`${routeIds.size} routes → ${stops.length} route stop markers`);
+    }
     return stops;
   }, [routeIds, repo]);
 }

--- a/src/hooks/use-selection.ts
+++ b/src/hooks/use-selection.ts
@@ -179,9 +179,11 @@ export function useSelection(params: UseSelectionParams): UseSelectionReturn {
   const focusStop = useCallback(
     (stop: Stop) => {
       const routeIds = extractRouteIdsForStop(stopTimes, stop.stop_id);
-      logger.debug(
-        `focusStop: stopId=${stop.stop_id}, name=${stop.stop_name}, routeIds=${routeIds.size}`,
-      );
+      if (logger.isEnabled('debug')) {
+        logger.debug(
+          `focusStop: stopId=${stop.stop_id}, name=${stop.stop_name}, routeIds=${routeIds.size}`,
+        );
+      }
       setDirectFocusPosition({ lat: stop.stop_lat, lng: stop.stop_lon });
       setSelectedStopId(stop.stop_id);
       setSelectionInfo({

--- a/src/lib/double-tap-zoom.ts
+++ b/src/lib/double-tap-zoom.ts
@@ -95,7 +95,9 @@ export function enableDoubleTapZoom(map: L.Map, options: DoubleTapZoomOptions = 
     map.options.zoomSnap = 1;
     map.setZoom(Math.round(map.getZoom()), { animate: true });
     map.dragging.enable();
-    logger.verbose('slide-zoom ended at zoom:', map.getZoom());
+    if (logger.isEnabled('verbose')) {
+      logger.verbose('slide-zoom ended at zoom:', map.getZoom());
+    }
   }
 
   function zoomInAt(latlng: L.LatLng) {
@@ -104,7 +106,9 @@ export function enableDoubleTapZoom(map: L.Map, options: DoubleTapZoomOptions = 
       return;
     }
     map.setZoomAround(latlng, currentZoom + 1, { animate: true });
-    logger.verbose('zoom in to:', currentZoom + 1, 'at', latlng);
+    if (logger.isEnabled('verbose')) {
+      logger.verbose('zoom in to:', currentZoom + 1, 'at', latlng);
+    }
   }
 
   // -- Touch slide handlers --------------------------------------------

--- a/src/lib/edge-marker.ts
+++ b/src/lib/edge-marker.ts
@@ -93,10 +93,12 @@ export function buildEdgeMarkers(
     return [{ stop, routeTypes, x, y, angle, hAlign, distance }];
   });
 
-  logger.verbose(
-    `total=${edgeStops.length} inView=${inViewCount.value} edge=${result.length}`,
-    result.map((m) => `${m.stop.stop_name}(${m.hAlign},${Math.round(m.x)},${Math.round(m.y)})`),
-  );
+  if (logger.isEnabled('verbose')) {
+    logger.verbose(
+      `total=${edgeStops.length} inView=${inViewCount.value} edge=${result.length}`,
+      result.map((m) => `${m.stop.stop_name}(${m.hAlign},${Math.round(m.x)},${Math.round(m.y)})`),
+    );
+  }
 
   // Sort by distance descending so that closer markers are rendered last
   // (appearing on top in both DOM z-order and Canvas paint order).

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -13,6 +13,17 @@ export type LogLevel = 'verbose' | 'debug' | 'info' | 'warn' | 'error';
 
 /** Logger instance bound to a specific tag. */
 export interface Logger {
+  /**
+   * Check whether a given level would currently emit for this tag.
+   *
+   * Use this to gate `debug` / `verbose` call sites whose arguments
+   * involve non-trivial work (function calls, array iteration,
+   * multi-variable template interpolation). Arguments are always
+   * evaluated before `debug` / `verbose` runs, so the gate avoids
+   * paying that cost when the level is filtered out.
+   *
+   * See `DEVELOPMENT.md` § Logger / Performance for the full pattern.
+   */
   isEnabled: (level: LogLevel) => boolean;
   verbose: (...args: unknown[]) => void;
   debug: (...args: unknown[]) => void;

--- a/src/lib/map-locate.ts
+++ b/src/lib/map-locate.ts
@@ -68,8 +68,10 @@ export function resolveLocateAction(map: L.Map, loc: UserLocation): LocateAction
  * @param action - The move action returned by {@link resolveLocateAction}.
  */
 export function applyLocateAction(map: L.Map, loc: UserLocation, action: MoveLocateAction): void {
-  logger.debug(
-    `applyLocateAction: center far from current location (${action.distanceToLocation.toFixed(1)}m > ${LOCATE_NEAR_THRESHOLD_METERS}m), moving to zoom ${CURRENT_LOCATION_TARGET_ZOOM}`,
-  );
+  if (logger.isEnabled('debug')) {
+    logger.debug(
+      `applyLocateAction: center far from current location (${action.distanceToLocation.toFixed(1)}m > ${LOCATE_NEAR_THRESHOLD_METERS}m), moving to zoom ${CURRENT_LOCATION_TARGET_ZOOM}`,
+    );
+  }
   smoothMoveTo(map, [loc.lat, loc.lng], CURRENT_LOCATION_TARGET_ZOOM);
 }

--- a/src/repositories/athenai-repository/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository/athenai-repository-v2.ts
@@ -160,7 +160,9 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     const { sources, loadResult } = await fetchSourcesV2(prefixes, dataSource);
     const tFetch = performance.now();
     const fetchMs = Math.round(tFetch - t0);
-    logger.debug(`fetchSources: ${fetchMs}ms (${sources.length} sources)`);
+    if (logger.isEnabled('debug')) {
+      logger.debug(`fetchSources: ${fetchMs}ms (${sources.length} sources)`);
+    }
 
     for (const source of sources) {
       logger.info(
@@ -171,9 +173,11 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     const merged = mergeSourcesV2(sources);
     const tMerge = performance.now();
     const mergeMs = Math.round(tMerge - tFetch);
-    logger.debug(
-      `mergeSources: ${mergeMs}ms (stops=${merged.stops.length} routes=${merged.routeMap.size} stopsMetaMap=${merged.stopsMetaMap.size})`,
-    );
+    if (logger.isEnabled('debug')) {
+      logger.debug(
+        `mergeSources: ${mergeMs}ms (stops=${merged.stops.length} routes=${merged.routeMap.size} stopsMetaMap=${merged.stopsMetaMap.size})`,
+      );
+    }
 
     for (const meta of merged.sourceMetas) {
       logger.info(
@@ -339,10 +343,12 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     const truncated = matching.length > effectiveLimit;
     const data = matching.slice(0, effectiveLimit).map((m) => m.meta);
 
-    const elapsed = Math.round(performance.now() - t0);
-    logger.debug(
-      `getStopsInBounds: ${data.length}/${matching.length} stops in ${elapsed}ms (${truncated ? 'truncated' : 'all'}) center=(${centerLat.toFixed(4)}, ${centerLng.toFixed(4)})`,
-    );
+    if (logger.isEnabled('debug')) {
+      const elapsed = Math.round(performance.now() - t0);
+      logger.debug(
+        `getStopsInBounds: ${data.length}/${matching.length} stops in ${elapsed}ms (${truncated ? 'truncated' : 'all'}) center=(${centerLat.toFixed(4)}, ${centerLng.toFixed(4)})`,
+      );
+    }
     return Promise.resolve({ success: true, data, truncated });
   }
 
@@ -377,10 +383,12 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       distance: distKm * 1000,
     }));
 
-    const elapsed = Math.round(performance.now() - t0);
-    logger.debug(
-      `getStopsNearby: ${data.length}/${sorted.length} stops within ${radiusM}m in ${elapsed}ms (${truncated ? 'truncated' : 'all'}) center=(${center.lat.toFixed(4)}, ${center.lng.toFixed(4)})`,
-    );
+    if (logger.isEnabled('debug')) {
+      const elapsed = Math.round(performance.now() - t0);
+      logger.debug(
+        `getStopsNearby: ${data.length}/${sorted.length} stops within ${radiusM}m in ${elapsed}ms (${truncated ? 'truncated' : 'all'}) center=(${center.lat.toFixed(4)}, ${center.lng.toFixed(4)})`,
+      );
+    }
     return Promise.resolve({ success: true, data, truncated });
   }
 
@@ -524,10 +532,12 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       truncated = true;
     }
 
-    const elapsed = Math.round(performance.now() - t0);
-    logger.verbose(
-      `getUpcomingTimetableEntries: ${stopId} → ${result.length}/${totalAvailable} entries in ${elapsed}ms (${truncated ? 'truncated' : 'all'}) serviceDay=${formatDateKey(serviceDay)} prev=${formatDateKey(prevServiceDay)}`,
-    );
+    if (logger.isEnabled('verbose')) {
+      const elapsed = Math.round(performance.now() - t0);
+      logger.verbose(
+        `getUpcomingTimetableEntries: ${stopId} → ${result.length}/${totalAvailable} entries in ${elapsed}ms (${truncated ? 'truncated' : 'all'}) serviceDay=${formatDateKey(serviceDay)} prev=${formatDateKey(prevServiceDay)}`,
+      );
+    }
     const meta: TimetableQueryMeta = {
       isBoardableOnServiceDay: hasBoardable,
       totalEntries: fullDayCount,
@@ -597,10 +607,12 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     }
 
     sortTimetableEntriesByDepartureTime(entries);
-    const elapsed = Math.round(performance.now() - t0);
-    logger.debug(
-      `getFullDayTimetableEntries: ${stopId} → ${entries.length} entries in ${elapsed}ms`,
-    );
+    if (logger.isEnabled('debug')) {
+      const elapsed = Math.round(performance.now() - t0);
+      logger.debug(
+        `getFullDayTimetableEntries: ${stopId} → ${entries.length} entries in ${elapsed}ms`,
+      );
+    }
     const meta: TimetableQueryMeta = {
       isBoardableOnServiceDay: getTimetableEntriesState(entries) === 'boardable',
       totalEntries: entries.length,
@@ -759,7 +771,9 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       logger.verbose(`getRouteTypesForStop: ${stopId} → not found`);
       return Promise.resolve({ success: false, error: `No route types for stop: ${stopId}` });
     }
-    logger.verbose(`getRouteTypesForStop: ${stopId} → [${routeTypes.join(', ')}]`);
+    if (logger.isEnabled('verbose')) {
+      logger.verbose(`getRouteTypesForStop: ${stopId} → [${routeTypes.join(', ')}]`);
+    }
     return Promise.resolve({ success: true, data: routeTypes });
   }
 
@@ -796,7 +810,9 @@ export class AthenaiRepositoryV2 implements TransitRepository {
         }
       }
     }
-    logger.debug(`getStopsForRoutes: ${routeIds.size} routes → ${stopIds.size} stops`);
+    if (logger.isEnabled('debug')) {
+      logger.debug(`getStopsForRoutes: ${routeIds.size} routes → ${stopIds.size} stops`);
+    }
     return stopIds;
   }
 
@@ -817,26 +833,34 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       }
     }
     this.routeStopsCache = map;
-    logger.debug(
-      `routeStopsCache built: ${map.size} routes in ${(performance.now() - t0).toFixed(2)}ms`,
-    );
+    if (logger.isEnabled('debug')) {
+      logger.debug(
+        `routeStopsCache built: ${map.size} routes in ${(performance.now() - t0).toFixed(2)}ms`,
+      );
+    }
     return map;
   }
 
   /** {@inheritDoc TransitRepository.getAllStops} */
   getAllStops(): Promise<CollectionResult<Stop>> {
-    logger.debug(`getAllStops: ${this.stops.length} stops`);
+    if (logger.isEnabled('debug')) {
+      logger.debug(`getAllStops: ${this.stops.length} stops`);
+    }
     return Promise.resolve({ success: true, data: this.stops, truncated: false });
   }
 
   /** {@inheritDoc TransitRepository.getRouteShapes} */
   async getRouteShapes(): Promise<CollectionResult<RouteShape>> {
     if (this.shapesCache) {
-      logger.debug(`getRouteShapes: ${this.shapesCache.length} shapes (cached)`);
+      if (logger.isEnabled('debug')) {
+        logger.debug(`getRouteShapes: ${this.shapesCache.length} shapes (cached)`);
+      }
       return { success: true, data: this.shapesCache, truncated: false };
     }
     this.shapesCache = await this.shapesPromise;
-    logger.debug(`getRouteShapes: ${this.shapesCache.length} shapes`);
+    if (logger.isEnabled('debug')) {
+      logger.debug(`getRouteShapes: ${this.shapesCache.length} shapes`);
+    }
     return { success: true, data: this.shapesCache, truncated: false };
   }
 


### PR DESCRIPTION
## Summary

- Sweep existing `logger.debug(...)` / `logger.verbose(...)` call sites and wrap them in `if (logger.isEnabled(...))` where the argument involves non-trivial work (function calls, array iteration, multi-variable template interpolation with `.length` / `.size` aggregates).
- Skip cold-path single-variable interpolations and literal-only calls per Issue #178 guidance.
- Follow the migration pattern established in `src/hooks/use-nearby-stop-times.ts`.

The behavior is unchanged — `debug` / `verbose` are already filtered out in production at the `emit()` level. The win is skipping the argument evaluation (template allocation, array iteration, `.toFixed()`, etc.) that was paid even when the log was filtered. Hot paths in `athenai-repository-v2` (~12 sites) and `stop-markers-canvas` benefit most.

### Files touched (14)

- `src/repositories/athenai-repository/athenai-repository-v2.ts` — 12 sites (fetchSources, mergeSources, getStopsInBounds, getStopsNearby, getUpcomingTimetableEntries, getFullDayTimetableEntries, getRouteTypesForStop, getStopsForRoutes, routeStopsCache, getAllStops, getRouteShapes ×2)
- `src/components/marker/stop-markers-canvas.tsx` — incremental / rebuild
- `src/lib/edge-marker.ts` — verbose with `result.map(...)`
- `src/hooks/use-map-locate.ts` / `use-map-locate-watch.ts` — `.toFixed()` / `formatLoc()` / `String()` heavy logs
- `src/lib/double-tap-zoom.ts` — `map.getZoom()` / arithmetic
- `src/lib/map-locate.ts` — `.toFixed(1)`
- `src/components/map/map-view.tsx` — pan log
- `src/app.tsx` — LangChain `.join()`, anchor add, tile cycle
- `src/hooks/use-selection.ts` / `use-route-stops.ts` — `.size` aggregates
- `src/components/stop-history.tsx`, `map-bottom-sheet-layout.tsx` — multi-prop interpolation
- `src/domain/transit/timetable-stats.ts` — spread `[...]`

### Out of scope

- `pipeline/` (WebApp scope only)
- `logger.info` / `logger.warn` / `logger.error` (always emitted)
- Cold-path simple interpolations (~32 calls intentionally left alone per Issue guidance)
- Existing already-guarded sites (10 sites untouched)

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format` — no diff
- [x] `npm run test` — 217 files / 3352 tests pass
- [x] `npm run build` — tsc + vite build successful
- [x] No UI behavior change — debug/verbose are off in production; browser-verify not required

Refs: #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)