### PR TITLE
fix(timetable): order hour groups by displayed minute (#63)

### DIFF
--- a/src/components/timetable/timetable-grid.tsx
+++ b/src/components/timetable/timetable-grid.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { resolveAgencyLang } from '@/config/transit-defaults';
 import { getEffectiveHeadsign } from '@/domain/transit/get-effective-headsign';
 import { getTimetableHeadsignPrefixLengths } from '@/domain/transit/get-timetable-headsign-prefix-lengths';
-import { getDisplayMinutes } from '@/domain/transit/timetable-utils';
+import { groupTimetableEntriesByHour } from '@/domain/transit/group-timetable-entries-by-hour';
+import { sortTimetableEntriesByDisplayTime } from '@/domain/transit/sort-timetable-for-ui';
 import { useInfoLevel } from '@/hooks/use-info-level';
 import type { TimetableOmitted } from '@/types/app/repository';
 import type { InfoLevel } from '@/types/app/settings';
@@ -64,19 +65,10 @@ export function TimetableGrid({
     [timetableEntries, showHeadsign, dataLangs, agencies],
   );
 
-  const hourGroups = useMemo(() => {
-    const groups = new Map<number, TimetableEntry[]>();
-    for (const entry of timetableEntries) {
-      const hour = Math.floor(getDisplayMinutes(entry) / 60);
-      const list = groups.get(hour);
-      if (list) {
-        list.push(entry);
-      } else {
-        groups.set(hour, [entry]);
-      }
-    }
-    return groups;
-  }, [timetableEntries]);
+  const hourGroups = useMemo(
+    () => groupTimetableEntriesByHour(sortTimetableEntriesByDisplayTime([...timetableEntries])),
+    [timetableEntries],
+  );
 
   if (hourGroups.size === 0) {
     return (

--- a/src/domain/transit/__tests__/group-timetable-entries-by-hour.test.ts
+++ b/src/domain/transit/__tests__/group-timetable-entries-by-hour.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import type { Route } from '../../../types/app/transit';
+import type { TimetableEntry } from '../../../types/app/transit-composed';
+import { groupTimetableEntriesByHour } from '../group-timetable-entries-by-hour';
+
+function makeRoute(routeId: string): Route {
+  return {
+    route_id: routeId,
+    route_short_name: routeId,
+    route_short_names: {},
+    route_long_name: routeId,
+    route_long_names: {},
+    route_type: 3,
+    route_color: '000000',
+    route_text_color: 'FFFFFF',
+    agency_id: 'test:agency',
+  };
+}
+
+function makeEntry(overrides: {
+  departureMinutes: number;
+  arrivalMinutes?: number;
+  isTerminal?: boolean;
+}): TimetableEntry {
+  const route = makeRoute('test:R1');
+  return {
+    schedule: {
+      departureMinutes: overrides.departureMinutes,
+      arrivalMinutes: overrides.arrivalMinutes ?? overrides.departureMinutes,
+    },
+    routeDirection: {
+      route,
+      tripHeadsign: { name: 'Test', names: {} },
+    },
+    boarding: { pickupType: 0, dropOffType: 0 },
+    patternPosition: {
+      stopIndex: 0,
+      totalStops: 10,
+      isTerminal: overrides.isTerminal ?? false,
+      isOrigin: false,
+    },
+    tripLocator: { patternId: `${route.route_id}__test`, serviceId: 'test', tripIndex: 0 },
+  };
+}
+
+describe('groupTimetableEntriesByHour', () => {
+  it('keys buckets by hour of displayed minute', () => {
+    const entries = [
+      makeEntry({ departureMinutes: 9 * 60 + 10 }),
+      makeEntry({ departureMinutes: 10 * 60 + 5 }),
+      makeEntry({ departureMinutes: 10 * 60 + 50 }),
+    ];
+    const groups = groupTimetableEntriesByHour(entries);
+    expect([...groups.keys()]).toEqual([9, 10]);
+    expect(groups.get(10)?.length).toBe(2);
+  });
+
+  it('uses arrivalMinutes as the bucket key for terminal entries', () => {
+    // A terminal entry with arrival 10:57 / departure 11:00 must bucket into
+    // hour 10 (arrival), not hour 11 (departure).
+    const terminalCrossingHour = makeEntry({
+      departureMinutes: 11 * 60,
+      arrivalMinutes: 10 * 60 + 57,
+      isTerminal: true,
+    });
+    const groups = groupTimetableEntriesByHour([terminalCrossingHour]);
+    expect([...groups.keys()]).toEqual([10]);
+    expect(groups.get(10)?.[0]).toBe(terminalCrossingHour);
+  });
+
+  it('preserves input order within each bucket', () => {
+    // The helper does not sort; callers that want a display-ordered grid
+    // pre-sort with sortTimetableEntriesByDisplayTime.
+    const first = makeEntry({ departureMinutes: 9 * 60 + 30 });
+    const second = makeEntry({ departureMinutes: 9 * 60 + 10 });
+    const groups = groupTimetableEntriesByHour([first, second]);
+    const bucket = groups.get(9);
+    expect(bucket?.[0]).toBe(first);
+    expect(bucket?.[1]).toBe(second);
+  });
+
+  it('returns an empty map for an empty input', () => {
+    const groups = groupTimetableEntriesByHour([]);
+    expect(groups.size).toBe(0);
+  });
+
+  it('preserves first-encounter order of hour keys', () => {
+    // Map iteration order mirrors the upstream input — required by the grid,
+    // which renders hour groups via Array.from(groups.entries()). Callers
+    // that need ascending hour-key order should pre-sort entries by
+    // displayed time.
+    const entries = [
+      makeEntry({ departureMinutes: 14 * 60 + 0 }),
+      makeEntry({ departureMinutes: 8 * 60 + 30 }),
+      makeEntry({ departureMinutes: 14 * 60 + 30 }),
+      makeEntry({ departureMinutes: 11 * 60 + 0 }),
+    ];
+    const groups = groupTimetableEntriesByHour(entries);
+    expect([...groups.keys()]).toEqual([14, 8, 11]);
+  });
+});

--- a/src/domain/transit/__tests__/sort-timetable-for-ui.test.ts
+++ b/src/domain/transit/__tests__/sort-timetable-for-ui.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+import type { Route } from '../../../types/app/transit';
+import type { TimetableEntry } from '../../../types/app/transit-composed';
+import { sortTimetableEntriesByDisplayTime } from '../sort-timetable-for-ui';
+
+function makeRoute(routeId: string): Route {
+  return {
+    route_id: routeId,
+    route_short_name: routeId,
+    route_short_names: {},
+    route_long_name: routeId,
+    route_long_names: {},
+    route_type: 3,
+    route_color: '000000',
+    route_text_color: 'FFFFFF',
+    agency_id: 'test:agency',
+  };
+}
+
+function makeEntry(overrides: {
+  departureMinutes: number;
+  arrivalMinutes?: number;
+  isTerminal?: boolean;
+  isOrigin?: boolean;
+  stopIndex?: number;
+  routeId?: string;
+}): TimetableEntry {
+  const route = makeRoute(overrides.routeId ?? 'test:R1');
+  return {
+    schedule: {
+      departureMinutes: overrides.departureMinutes,
+      arrivalMinutes: overrides.arrivalMinutes ?? overrides.departureMinutes,
+    },
+    routeDirection: {
+      route,
+      tripHeadsign: { name: 'Test', names: {} },
+    },
+    boarding: { pickupType: 0, dropOffType: 0 },
+    patternPosition: {
+      stopIndex: overrides.stopIndex ?? 0,
+      totalStops: 10,
+      isTerminal: overrides.isTerminal ?? false,
+      isOrigin: overrides.isOrigin ?? false,
+    },
+    tripLocator: { patternId: `${route.route_id}__test`, serviceId: 'test', tripIndex: 0 },
+  };
+}
+
+describe('sortTimetableEntriesByDisplayTime', () => {
+  describe('1. primary key: getDisplayMinutes', () => {
+    it('sorts non-terminal entries ascending by departure (= display) minute', () => {
+      const entries = [
+        makeEntry({ departureMinutes: 600 }),
+        makeEntry({ departureMinutes: 400 }),
+        makeEntry({ departureMinutes: 500 }),
+      ];
+      sortTimetableEntriesByDisplayTime(entries);
+      expect(entries.map((e) => e.schedule.departureMinutes)).toEqual([400, 500, 600]);
+    });
+
+    it('sorts terminal entries by arrival (= display), not by departure', () => {
+      // Terminal with dwell: display = arrival, not departure.
+      const earlierDisplay = makeEntry({
+        departureMinutes: 10 * 60 + 19,
+        arrivalMinutes: 10 * 60 + 16,
+        isTerminal: true,
+      });
+      const laterDisplay = makeEntry({
+        departureMinutes: 10 * 60 + 17,
+        arrivalMinutes: 10 * 60 + 17,
+        isTerminal: true,
+      });
+      // Input order: laterDisplay first (departure-time order would keep it
+      // first because 10:17 < 10:19), but display order should put
+      // earlierDisplay (arrival 10:16) first.
+      const entries = [laterDisplay, earlierDisplay];
+      sortTimetableEntriesByDisplayTime(entries);
+      expect(entries[0]).toBe(earlierDisplay);
+      expect(entries[1]).toBe(laterDisplay);
+    });
+
+    it('reproduces Issue #63 bus_park case: terminal with dwell vs same-route non-terminal', () => {
+      // bus_yukkuri01 at bus_park (mock repo):
+      //   - terminal entry (もり公園前 行): arr 09:05 / dep 09:08, display 09:05
+      //   - non-terminal entry (あおば中央駅 行): dep 09:06, display 09:06
+      // Upstream `sortTimetableEntriesByDepartureTime` would put non-terminal
+      // first (06 < 08). After display sort, terminal (05) comes first.
+      const nonTerminal = makeEntry({
+        departureMinutes: 9 * 60 + 6,
+      });
+      const terminal = makeEntry({
+        departureMinutes: 9 * 60 + 8,
+        arrivalMinutes: 9 * 60 + 5,
+        isTerminal: true,
+      });
+      const entries = [nonTerminal, terminal];
+      sortTimetableEntriesByDisplayTime(entries);
+      expect(entries[0]).toBe(terminal);
+      expect(entries[1]).toBe(nonTerminal);
+    });
+  });
+
+  describe('2. tie-break: schedule.arrivalMinutes', () => {
+    it('orders entries with equal display by arrivalMinutes ascending', () => {
+      // Two non-terminals with same display (= departure) but different arrival.
+      // arr 10:28 / dep 10:30 vs arr 10:25 / dep 10:30: earlier arrival first.
+      const laterArrival = makeEntry({
+        departureMinutes: 10 * 60 + 30,
+        arrivalMinutes: 10 * 60 + 28,
+      });
+      const earlierArrival = makeEntry({
+        departureMinutes: 10 * 60 + 30,
+        arrivalMinutes: 10 * 60 + 25,
+      });
+      const entries = [laterArrival, earlierArrival];
+      sortTimetableEntriesByDisplayTime(entries);
+      expect(entries[0]).toBe(earlierArrival);
+      expect(entries[1]).toBe(laterArrival);
+    });
+  });
+
+  describe('3. tie-break: schedule.departureMinutes', () => {
+    it('orders entries with equal display + arrival by departureMinutes ascending', () => {
+      // Two terminals sharing arrival (= display) but different departure dwell:
+      //   A: arr 10:30 / dep 10:30 (no dwell)
+      //   B: arr 10:30 / dep 10:33 (3-min dwell)
+      // Display and arrival both tie at 10:30, so departure breaks: A leaves first.
+      const noDwell = makeEntry({
+        departureMinutes: 10 * 60 + 30,
+        arrivalMinutes: 10 * 60 + 30,
+        isTerminal: true,
+      });
+      const withDwell = makeEntry({
+        departureMinutes: 10 * 60 + 33,
+        arrivalMinutes: 10 * 60 + 30,
+        isTerminal: true,
+      });
+      const entries = [withDwell, noDwell];
+      sortTimetableEntriesByDisplayTime(entries);
+      expect(entries[0]).toBe(noDwell);
+      expect(entries[1]).toBe(withDwell);
+    });
+  });
+
+  describe('4. tie-break: patternPosition.isOrigin (true first)', () => {
+    it('places origin entries before non-origin when all time keys tie', () => {
+      const nonOrigin = makeEntry({ departureMinutes: 600 });
+      const origin = makeEntry({ departureMinutes: 600, isOrigin: true });
+      const entries = [nonOrigin, origin];
+      sortTimetableEntriesByDisplayTime(entries);
+      expect(entries[0]).toBe(origin);
+      expect(entries[1]).toBe(nonOrigin);
+    });
+  });
+
+  describe('5. tie-break: patternPosition.isTerminal (true first)', () => {
+    it('places terminal entries before non-terminal when origin status also ties', () => {
+      // Both non-origin. Same arr/dep. One is terminal (dwell=0 case).
+      const middle = makeEntry({
+        departureMinutes: 600,
+        arrivalMinutes: 600,
+      });
+      const terminal = makeEntry({
+        departureMinutes: 600,
+        arrivalMinutes: 600,
+        isTerminal: true,
+      });
+      const entries = [middle, terminal];
+      sortTimetableEntriesByDisplayTime(entries);
+      expect(entries[0]).toBe(terminal);
+      expect(entries[1]).toBe(middle);
+    });
+  });
+
+  describe('priority order (display → arrival → isOrigin)', () => {
+    it('applies higher-priority keys before lower-priority ones', () => {
+      // Note: isTerminal flips display from departure to arrival, so an
+      // entry with isTerminal=true and arr=490 has display=490 — that
+      // is why e5 below sorts between e1 (display 400) and e2 (display 500).
+      const e1 = makeEntry({ departureMinutes: 400 });
+      // → display 400 (non-terminal)
+      const e2 = makeEntry({
+        departureMinutes: 500,
+        arrivalMinutes: 480,
+      });
+      // → display 500, arrival 480
+      const e3 = makeEntry({
+        departureMinutes: 500,
+        arrivalMinutes: 490,
+      });
+      // → display 500, arrival 490, isOrigin false
+      const e4 = makeEntry({
+        departureMinutes: 500,
+        arrivalMinutes: 490,
+        isOrigin: true,
+      });
+      // → display 500, arrival 490, isOrigin true (beats e3)
+      const e5 = makeEntry({
+        departureMinutes: 500,
+        arrivalMinutes: 490,
+        isTerminal: true,
+      });
+      // → display = arrival = 490 (terminal shifts display)
+      const entries = [e5, e3, e1, e4, e2];
+      sortTimetableEntriesByDisplayTime(entries);
+      expect(entries).toEqual([e1, e5, e2, e4, e3]);
+    });
+  });
+
+  describe('mutation contract', () => {
+    it('mutates the input array in place', () => {
+      const entries = [makeEntry({ departureMinutes: 600 }), makeEntry({ departureMinutes: 400 })];
+      const before = entries;
+      sortTimetableEntriesByDisplayTime(entries);
+      expect(entries).toBe(before);
+      expect(entries.map((e) => e.schedule.departureMinutes)).toEqual([400, 600]);
+    });
+
+    it('returns the input array (for chaining)', () => {
+      const entries = [makeEntry({ departureMinutes: 600 })];
+      const returned = sortTimetableEntriesByDisplayTime(entries);
+      expect(returned).toBe(entries);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles an empty input', () => {
+      const entries: TimetableEntry[] = [];
+      sortTimetableEntriesByDisplayTime(entries);
+      expect(entries).toEqual([]);
+    });
+
+    it('returns equally-keyed entries together (order between them unspecified)', () => {
+      const a = makeEntry({ departureMinutes: 600, routeId: 'test:RA' });
+      const b = makeEntry({ departureMinutes: 600, routeId: 'test:RB' });
+      const entries = [a, b];
+      sortTimetableEntriesByDisplayTime(entries);
+      // Both keys (display/arrival/departure/isOrigin/isTerminal) tie.
+      // Don't assert a specific order — just that both survive.
+      expect(new Set(entries)).toEqual(new Set([a, b]));
+      expect(entries.length).toBe(2);
+    });
+  });
+});

--- a/src/domain/transit/group-timetable-entries-by-hour.ts
+++ b/src/domain/transit/group-timetable-entries-by-hour.ts
@@ -1,0 +1,28 @@
+import type { TimetableEntry } from '../../types/app/transit-composed';
+import { getDisplayMinutes } from './timetable-utils';
+
+/**
+ * Group entries into hour buckets keyed by displayed time.
+ *
+ * Both the bucket key and the within-bucket order are taken straight from
+ * the input — entries land in the bucket of `floor(getDisplayMinutes / 60)`
+ * in first-encounter order. Callers that need a chronological display
+ * (Issue #63) should pre-sort with `sortTimetableEntriesByDisplayTime`;
+ * both the hour-key iteration order and the within-bucket order then read
+ * correctly because Map preserves insertion order.
+ */
+export function groupTimetableEntriesByHour<T extends TimetableEntry>(
+  entries: readonly T[],
+): Map<number, T[]> {
+  const groups = new Map<number, T[]>();
+  for (const entry of entries) {
+    const hour = Math.floor(getDisplayMinutes(entry) / 60);
+    const list = groups.get(hour);
+    if (list) {
+      list.push(entry);
+    } else {
+      groups.set(hour, [entry]);
+    }
+  }
+  return groups;
+}

--- a/src/domain/transit/sort-timetable-for-ui.ts
+++ b/src/domain/transit/sort-timetable-for-ui.ts
@@ -1,0 +1,56 @@
+/**
+ * @module sort-timetable-for-ui
+ *
+ * UI-facing sort helpers for timetable entries.
+ *
+ * Unlike {@link ./sort-timetable-entries} which provides canonical
+ * data-layer orderings keyed on `schedule.departureMinutes`, the helpers
+ * here key on the time value that the UI actually renders for each entry
+ * (`getDisplayMinutes` — `arrivalMinutes` for terminal stops, otherwise
+ * `departureMinutes`). Use them at the UI consumer just before render so
+ * the visible `:MM` labels read chronologically (Issue #63).
+ */
+
+import type { TimetableEntry } from '../../types/app/transit-composed';
+import { getDisplayMinutes } from './timetable-utils';
+
+/**
+ * Sort entries so their visible `:MM` labels read chronologically.
+ *
+ * Keys are UI-meaningful only — time values plus origin / terminal flags.
+ * Pattern and route identity (route_id, stopIndex, etc.) is intentionally
+ * excluded as it has no meaning for the visible ordering. See Issue #63
+ * for the underlying display-vs-departure mismatch this corrects.
+ *
+ * Mutates the input array in place AND returns it (for chaining).
+ */
+export function sortTimetableEntriesByDisplayTime<T extends TimetableEntry>(entries: T[]): T[] {
+  entries.sort((a, b) => {
+    // 1. display minute ascending (arrival for terminals, else departure)
+    const displayDiff = getDisplayMinutes(a) - getDisplayMinutes(b);
+    if (displayDiff !== 0) {
+      return displayDiff;
+    }
+    // 2. arrival minute ascending — earlier arrival first
+    const arrivalDiff = a.schedule.arrivalMinutes - b.schedule.arrivalMinutes;
+    if (arrivalDiff !== 0) {
+      return arrivalDiff;
+    }
+    // 3. departure minute ascending — earlier departure first
+    const departureDiff = a.schedule.departureMinutes - b.schedule.departureMinutes;
+    if (departureDiff !== 0) {
+      return departureDiff;
+    }
+    // 4. isOrigin first — true (origin) sorts before false
+    if (a.patternPosition.isOrigin !== b.patternPosition.isOrigin) {
+      return a.patternPosition.isOrigin ? -1 : 1;
+    }
+    // 5. isTerminal first — true (terminal) sorts before false
+    if (a.patternPosition.isTerminal !== b.patternPosition.isTerminal) {
+      return a.patternPosition.isTerminal ? -1 : 1;
+    }
+    // When all five keys tie, the order is unspecified.
+    return 0;
+  });
+  return entries;
+}


### PR DESCRIPTION
## Summary

- Within-hour timetable entries now appear in displayed-minute order so terminal entries with dwell time stop trailing their visible neighbours (Issue #63).
- Introduces `sortTimetableEntriesByDisplayTime` (UI-facing display-order sort) alongside the canonical departure-order sort, and splits `groupTimetableEntriesByHour` into a pure grouping helper. `TimetableGrid` composes `sort -> group` before rendering.
- The same root cause exists in the bottom sheet and the trip-inspection pager; both are outside this PR's scope and will be tracked in follow-up issues.

## Test plan

- [x] `npx vitest run` (3369 tests, 219 files)
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on touched files
- [x] `npm run build`
- [x] Manual: `?repo=mock&stop=bus_park&time=2026-05-11T09:00:00+09:00` → 9 o'clock row reads `01着 / 01 / 05着 / 06 / 09 / 25 / 25 / 29着 / 33着 / 35 / 41 / 49 / 57着 / 57` — terminal `05着` (yukkuri arr=09:05 / dep=09:08) correctly precedes non-terminal `06`.
- [x] Manual: `?repo=mock&stop=bus_central_dropoff&time=2026-05-11T10:00:00+09:00` → 10 o'clock row reads `03着 / 16着 / 17着 / 28着 / 41着 / 45着 / 53着` — yukkuri `16着` (arr=10:16 / dep=10:19) correctly precedes aoba01 `17着` (arr=dep=10:17).

Refs: #63