### PR TITLE
fix(trip-inspection): order TripPager navigation by displayed minute

### DIFF
--- a/src/domain/transit/__tests__/trip-inspection-state.test.ts
+++ b/src/domain/transit/__tests__/trip-inspection-state.test.ts
@@ -1,0 +1,474 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Route } from '../../../types/app/transit';
+import type {
+  SelectedTripSnapshot,
+  TimetableEntry,
+  TripInspectionTarget,
+  TripLocator,
+  TripSnapshot,
+  TripStopTime,
+} from '../../../types/app/transit-composed';
+import {
+  buildTripInspectionMatchDiagnostics,
+  getEmptyTripInspectionTargetsNote,
+  loadTripInspectionSnapshot,
+  refineTripInspectionState,
+  serviceDayReferenceDateTime,
+} from '../trip-inspection-state';
+
+vi.mock('../../../lib/logger', () => ({
+  createLogger: () => ({
+    isEnabled: vi.fn().mockReturnValue(false),
+    verbose: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// --- Fixtures ---
+
+function makeRoute(routeId = 'test:R1'): Route {
+  return {
+    route_id: routeId,
+    route_short_name: routeId,
+    route_short_names: {},
+    route_long_name: routeId,
+    route_long_names: {},
+    route_type: 3,
+    route_color: '000000',
+    route_text_color: 'FFFFFF',
+    agency_id: 'test:agency',
+  };
+}
+
+function makeLocator(overrides: Partial<TripLocator> = {}): TripLocator {
+  return { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 0, ...overrides };
+}
+
+function makeTarget(overrides: Partial<TripInspectionTarget> = {}): TripInspectionTarget {
+  return {
+    tripLocator: makeLocator(),
+    serviceDate: new Date(2026, 4, 11),
+    stopIndex: 3,
+    departureMinutes: 600,
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: {
+  patternId?: string;
+  serviceId?: string;
+  tripIndex?: number;
+  stopIndex?: number;
+  departureMinutes: number;
+  arrivalMinutes?: number;
+  isTerminal?: boolean;
+  isOrigin?: boolean;
+  routeId?: string;
+}): TimetableEntry {
+  const route = makeRoute(overrides.routeId ?? 'test:R1');
+  return {
+    schedule: {
+      departureMinutes: overrides.departureMinutes,
+      arrivalMinutes: overrides.arrivalMinutes ?? overrides.departureMinutes,
+    },
+    routeDirection: {
+      route,
+      tripHeadsign: { name: 'Terminal', names: {} },
+    },
+    boarding: { pickupType: 0, dropOffType: 0 },
+    patternPosition: {
+      stopIndex: overrides.stopIndex ?? 3,
+      totalStops: 10,
+      isTerminal: overrides.isTerminal ?? false,
+      isOrigin: overrides.isOrigin ?? false,
+    },
+    tripLocator: {
+      patternId: overrides.patternId ?? 'pattern-a',
+      serviceId: overrides.serviceId ?? 'weekday',
+      tripIndex: overrides.tripIndex ?? 0,
+    },
+  };
+}
+
+function makeStopTime(stopIndex: number, departureMinutes: number): TripStopTime {
+  return {
+    routeTypes: [],
+    timetableEntry: {
+      tripLocator: makeLocator(),
+      schedule: { departureMinutes, arrivalMinutes: departureMinutes },
+      routeDirection: {
+        route: makeRoute(),
+        tripHeadsign: { name: 'Terminal', names: {} },
+      },
+      boarding: { pickupType: 0, dropOffType: 0 },
+      patternPosition: {
+        stopIndex,
+        totalStops: 10,
+        isTerminal: false,
+        isOrigin: false,
+      },
+    },
+    stopMeta: {
+      stop: {
+        stop_id: `stop-${String(stopIndex)}`,
+        stop_name: `Stop ${String(stopIndex)}`,
+        stop_names: {},
+        stop_lat: 0,
+        stop_lon: 0,
+        location_type: 0,
+        agency_id: 'test:agency',
+      },
+      agencies: [],
+      routes: [],
+    },
+  };
+}
+
+function makeTripSnapshot(stopTimes: TripStopTime[]): TripSnapshot {
+  return {
+    locator: makeLocator(),
+    route: makeRoute(),
+    tripHeadsign: { name: 'Terminal', names: {} },
+    serviceDate: new Date(2026, 4, 11),
+    stopTimes,
+  };
+}
+
+function makeSelectedSnapshot(
+  stopTimes: TripStopTime[],
+  selectedIndex: number,
+): SelectedTripSnapshot {
+  const selectedStop = stopTimes[selectedIndex];
+  if (!selectedStop) {
+    throw new Error(`fixture: stopTimes[${String(selectedIndex)}] is undefined`);
+  }
+  return {
+    ...makeTripSnapshot(stopTimes),
+    currentStopIndex: selectedIndex,
+    selectedStop,
+  };
+}
+
+// --- Tests ---
+
+describe('serviceDayReferenceDateTime', () => {
+  it('returns noon on the same local calendar day for a midnight-anchored input', () => {
+    const midnight = new Date(2026, 4, 11, 0, 0, 0, 0);
+    const result = serviceDayReferenceDateTime(midnight);
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(4);
+    expect(result.getDate()).toBe(11);
+    expect(result.getHours()).toBe(12);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+  });
+
+  it('does not mutate the input Date', () => {
+    const midnight = new Date(2026, 4, 11, 0, 0, 0, 0);
+    const originalTime = midnight.getTime();
+    serviceDayReferenceDateTime(midnight);
+    expect(midnight.getTime()).toBe(originalTime);
+    expect(midnight.getHours()).toBe(0);
+  });
+
+  it('still anchors to local noon when the input is itself just before the 03:00 service-day boundary', () => {
+    // 02:59 would otherwise be normalised to the previous service day by
+    // `getServiceDay`. Anchoring to noon avoids the boundary entirely.
+    const justBeforeBoundary = new Date(2026, 4, 11, 2, 59, 59, 999);
+    const result = serviceDayReferenceDateTime(justBeforeBoundary);
+    expect(result.getDate()).toBe(11);
+    expect(result.getHours()).toBe(12);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+  });
+
+  it('keeps the local calendar day stable for a 23:59 input', () => {
+    const lateEvening = new Date(2026, 4, 11, 23, 59, 30, 250);
+    const result = serviceDayReferenceDateTime(lateEvening);
+    expect(result.getDate()).toBe(11);
+    expect(result.getHours()).toBe(12);
+    expect(result.getMinutes()).toBe(0);
+  });
+
+  it('returns a fresh Date instance', () => {
+    const input = new Date(2026, 4, 11);
+    const result = serviceDayReferenceDateTime(input);
+    expect(result).not.toBe(input);
+  });
+});
+
+describe('getEmptyTripInspectionTargetsNote', () => {
+  it('returns the no-stop-data note for the no-stop-data reason', () => {
+    expect(getEmptyTripInspectionTargetsNote('no-stop-data')).toBe(
+      'The stop has no trip-inspection stop data.',
+    );
+  });
+
+  it('returns the no-service-on-this-day note for the no-service-on-this-day reason', () => {
+    expect(getEmptyTripInspectionTargetsNote('no-service-on-this-day')).toBe(
+      'The stop has trip-inspection data, but no services on the selected service day.',
+    );
+  });
+});
+
+describe('buildTripInspectionMatchDiagnostics', () => {
+  it('returns empty samples when candidates is empty', () => {
+    const target = makeTarget();
+    const result = buildTripInspectionMatchDiagnostics(target, []);
+    expect(result.sampleSameService).toEqual([]);
+    expect(result.sampleSameTripIndex).toEqual([]);
+    expect(result.sampleSameStopIndex).toEqual([]);
+    expect(result.patternId).toBe(target.tripLocator.patternId);
+    expect(result.stopIndex).toBe(target.stopIndex);
+  });
+
+  it('narrows samples by patternId+serviceId → tripIndex → stopIndex', () => {
+    const target = makeTarget({
+      tripLocator: { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 5 },
+      stopIndex: 3,
+    });
+    const candidates: TripInspectionTarget[] = [
+      // same service, different tripIndex
+      makeTarget({
+        tripLocator: { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 1 },
+      }),
+      // same service, same tripIndex, different stopIndex
+      makeTarget({
+        tripLocator: { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 5 },
+        stopIndex: 4,
+      }),
+      // same service, same tripIndex, same stopIndex (full match)
+      makeTarget({
+        tripLocator: { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 5 },
+        stopIndex: 3,
+      }),
+      // different patternId — should not appear in sameService
+      makeTarget({
+        tripLocator: { patternId: 'pattern-z', serviceId: 'weekday', tripIndex: 5 },
+        stopIndex: 3,
+      }),
+    ];
+    const result = buildTripInspectionMatchDiagnostics(target, candidates);
+    expect(result.sampleSameService).toHaveLength(3);
+    expect(result.sampleSameTripIndex).toHaveLength(2);
+    expect(result.sampleSameStopIndex).toHaveLength(1);
+  });
+
+  it('caps each sample list at 5 entries', () => {
+    const target = makeTarget({
+      tripLocator: { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 5 },
+      stopIndex: 3,
+    });
+    const candidates: TripInspectionTarget[] = Array.from({ length: 7 }, () =>
+      makeTarget({
+        tripLocator: { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 5 },
+        stopIndex: 3,
+      }),
+    );
+    const result = buildTripInspectionMatchDiagnostics(target, candidates);
+    expect(result.sampleSameService).toHaveLength(5);
+    expect(result.sampleSameTripIndex).toHaveLength(5);
+    expect(result.sampleSameStopIndex).toHaveLength(5);
+  });
+});
+
+describe('loadTripInspectionSnapshot', () => {
+  it('returns the loaded snapshot when the stop row is present and has stopMeta', () => {
+    const stopTimes = [makeStopTime(3, 600)];
+    const trip = makeTripSnapshot(stopTimes);
+    const target = makeTarget({ stopIndex: 3 });
+
+    const result = loadTripInspectionSnapshot(trip, target);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.selectedStopId).toBe('stop-3');
+      expect(result.data.snapshot.currentStopIndex).toBe(0);
+    }
+  });
+
+  it('returns no-data when the requested pattern position is missing from the snapshot', () => {
+    const trip = makeTripSnapshot([]);
+    const result = loadTripInspectionSnapshot(trip, makeTarget());
+    expect(result).toEqual({ ok: false, reason: 'no-data' });
+  });
+
+  it('returns no-data when the stop row has no stopMeta', () => {
+    const stopTime = makeStopTime(3, 600);
+    // Drop stopMeta to trigger the missing-metadata branch.
+    const stopTimeNoMeta: TripStopTime = {
+      routeTypes: stopTime.routeTypes,
+      timetableEntry: stopTime.timetableEntry,
+    };
+    const trip = makeTripSnapshot([stopTimeNoMeta]);
+    const result = loadTripInspectionSnapshot(trip, makeTarget({ stopIndex: 3 }));
+    expect(result).toEqual({ ok: false, reason: 'no-data' });
+  });
+});
+
+describe('refineTripInspectionState', () => {
+  it('returns no-data when the entry list is empty', () => {
+    const stopTimes = [makeStopTime(3, 600)];
+    const snapshot = makeSelectedSnapshot(stopTimes, 0);
+    const target = makeTarget({ stopIndex: 3, departureMinutes: 600 });
+
+    const result = refineTripInspectionState([], target.serviceDate, snapshot, target);
+
+    expect(result).toEqual({ ok: false, reason: 'no-data' });
+  });
+
+  it('orders candidates by displayed minute (terminal arrival comes before non-terminal departure)', () => {
+    // Reproduces the Issue #63 yukkuri / bus_park style mismatch: a terminal
+    // entry with display=arr=09:05 / dep=09:08 must sort before a non-terminal
+    // entry with display=dep=09:06.
+    const terminalEntry = makeEntry({
+      tripIndex: 1,
+      stopIndex: 3,
+      arrivalMinutes: 9 * 60 + 5,
+      departureMinutes: 9 * 60 + 8,
+      isTerminal: true,
+    });
+    const nonTerminalEntry = makeEntry({
+      tripIndex: 2,
+      stopIndex: 3,
+      departureMinutes: 9 * 60 + 6,
+    });
+
+    const stopTimes = [makeStopTime(3, 9 * 60 + 6)];
+    const snapshot = makeSelectedSnapshot(stopTimes, 0);
+    const target = makeTarget({
+      tripLocator: makeLocator({ tripIndex: 2 }),
+      stopIndex: 3,
+      departureMinutes: 9 * 60 + 6,
+    });
+
+    // Pass entries in departure order (the canonical repo order). The
+    // pure function must re-sort them into display order.
+    const result = refineTripInspectionState(
+      [nonTerminalEntry, terminalEntry],
+      target.serviceDate,
+      snapshot,
+      target,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.targets[0]?.tripLocator.tripIndex).toBe(1);
+      expect(result.data.targets[1]?.tripLocator.tripIndex).toBe(2);
+      expect(result.data.targetIndex).toBe(1);
+    }
+  });
+
+  it('resolves the requested target via exact match on the sorted candidate list', () => {
+    const first = makeEntry({ tripIndex: 1, departureMinutes: 500 });
+    const second = makeEntry({ tripIndex: 2, departureMinutes: 600 });
+    const third = makeEntry({ tripIndex: 3, departureMinutes: 700 });
+    const stopTimes = [makeStopTime(3, 600)];
+    const snapshot = makeSelectedSnapshot(stopTimes, 0);
+    const target = makeTarget({
+      tripLocator: makeLocator({ tripIndex: 2 }),
+      stopIndex: 3,
+      departureMinutes: 600,
+    });
+
+    const result = refineTripInspectionState(
+      [first, second, third],
+      target.serviceDate,
+      snapshot,
+      target,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.targets).toHaveLength(3);
+      expect(result.data.targetIndex).toBe(1);
+    }
+  });
+
+  it('returns no-data when no candidate shares the requested trip locator', () => {
+    // Verify that the `resolveTripInspectionDisplayState`
+    // `target-not-found` outcome is collapsed into the
+    // `RefinedTripInspectionStateResult` `no-data` reason variant.
+    const unrelatedEntry = makeEntry({
+      patternId: 'pattern-b',
+      tripIndex: 0,
+      stopIndex: 3,
+      departureMinutes: 600,
+    });
+    const stopTimes = [makeStopTime(3, 600)];
+    const snapshot = makeSelectedSnapshot(stopTimes, 0);
+    const target = makeTarget({
+      tripLocator: makeLocator({ patternId: 'pattern-a', tripIndex: 0 }),
+      stopIndex: 3,
+      departureMinutes: 600,
+    });
+
+    const result = refineTripInspectionState(
+      [unrelatedEntry],
+      target.serviceDate,
+      snapshot,
+      target,
+    );
+
+    expect(result).toEqual({ ok: false, reason: 'no-data' });
+  });
+
+  it('rewrites the snapshot to the fallback stop row when no exact-match candidate exists', () => {
+    // The requested target points at stopIndex=5 / depMin=620, but the
+    // entries only contain a single same-trip candidate at stopIndex=4.
+    // `resolveTripInspectionDisplayState` therefore returns `matchType:
+    // 'fallback'` and `refineTripInspectionState` is expected to surface
+    // the rewritten snapshot whose `currentStopIndex` points at the
+    // fallback stop row.
+    const fallbackEntry = makeEntry({
+      tripIndex: 1,
+      stopIndex: 4,
+      departureMinutes: 615,
+    });
+    const requestedStop = makeStopTime(5, 620);
+    const fallbackStop = makeStopTime(4, 615);
+    const snapshot = makeSelectedSnapshot([requestedStop, fallbackStop], 0);
+    const target = makeTarget({
+      tripLocator: makeLocator({ tripIndex: 1 }),
+      stopIndex: 5,
+      departureMinutes: 620,
+    });
+
+    const result = refineTripInspectionState([fallbackEntry], target.serviceDate, snapshot, target);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.targets).toHaveLength(1);
+      expect(result.data.targets[0]?.stopIndex).toBe(4);
+      expect(result.data.targetIndex).toBe(0);
+      // The snapshot must point at the fallback stop row, not the
+      // originally requested (and missing) stopIndex=5 row.
+      expect(result.data.snapshot.currentStopIndex).toBe(1);
+      expect(result.data.snapshot.selectedStop).toBe(fallbackStop);
+    }
+  });
+
+  it('attaches the supplied serviceDate to each derived candidate', () => {
+    const entry = makeEntry({ tripIndex: 1, departureMinutes: 500 });
+    const stopTimes = [makeStopTime(3, 500)];
+    const snapshot = makeSelectedSnapshot(stopTimes, 0);
+    const target = makeTarget({
+      tripLocator: makeLocator({ tripIndex: 1 }),
+      stopIndex: 3,
+      departureMinutes: 500,
+    });
+    const serviceDate = new Date(2026, 4, 11);
+
+    const result = refineTripInspectionState([entry], serviceDate, snapshot, target);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.targets[0]?.serviceDate).toBe(serviceDate);
+    }
+  });
+});

--- a/src/domain/transit/__tests__/trip-inspection-state.test.ts
+++ b/src/domain/transit/__tests__/trip-inspection-state.test.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../types/app/transit-composed';
 import {
   buildTripInspectionMatchDiagnostics,
+  deriveTripInspectionCandidates,
   getEmptyTripInspectionTargetsNote,
   loadTripInspectionSnapshot,
   refineTripInspectionState,
@@ -311,15 +312,9 @@ describe('loadTripInspectionSnapshot', () => {
   });
 });
 
-describe('refineTripInspectionState', () => {
-  it('returns no-data when the entry list is empty', () => {
-    const stopTimes = [makeStopTime(3, 600)];
-    const snapshot = makeSelectedSnapshot(stopTimes, 0);
-    const target = makeTarget({ stopIndex: 3, departureMinutes: 600 });
-
-    const result = refineTripInspectionState([], target.serviceDate, snapshot, target);
-
-    expect(result).toEqual({ ok: false, reason: 'no-data' });
+describe('deriveTripInspectionCandidates', () => {
+  it('returns an empty array when no entries are provided', () => {
+    expect(deriveTripInspectionCandidates([], new Date(2026, 4, 11))).toEqual([]);
   });
 
   it('orders candidates by displayed minute (terminal arrival comes before non-terminal departure)', () => {
@@ -338,36 +333,83 @@ describe('refineTripInspectionState', () => {
       stopIndex: 3,
       departureMinutes: 9 * 60 + 6,
     });
-
-    const stopTimes = [makeStopTime(3, 9 * 60 + 6)];
-    const snapshot = makeSelectedSnapshot(stopTimes, 0);
-    const target = makeTarget({
-      tripLocator: makeLocator({ tripIndex: 2 }),
-      stopIndex: 3,
-      departureMinutes: 9 * 60 + 6,
-    });
+    const serviceDate = new Date(2026, 4, 11);
 
     // Pass entries in departure order (the canonical repo order). The
-    // pure function must re-sort them into display order.
-    const result = refineTripInspectionState(
+    // helper must re-sort them into display order.
+    const candidates = deriveTripInspectionCandidates(
       [nonTerminalEntry, terminalEntry],
-      target.serviceDate,
-      snapshot,
-      target,
+      serviceDate,
     );
 
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.data.targets[0]?.tripLocator.tripIndex).toBe(1);
-      expect(result.data.targets[1]?.tripLocator.tripIndex).toBe(2);
-      expect(result.data.targetIndex).toBe(1);
-    }
+    expect(candidates.map((candidate) => candidate.tripLocator.tripIndex)).toEqual([1, 2]);
   });
 
-  it('resolves the requested target via exact match on the sorted candidate list', () => {
-    const first = makeEntry({ tripIndex: 1, departureMinutes: 500 });
-    const second = makeEntry({ tripIndex: 2, departureMinutes: 600 });
-    const third = makeEntry({ tripIndex: 3, departureMinutes: 700 });
+  it('maps the entry fields onto the TripInspectionTarget shape', () => {
+    const entry = makeEntry({
+      patternId: 'pattern-a',
+      serviceId: 'weekday',
+      tripIndex: 7,
+      stopIndex: 4,
+      departureMinutes: 615,
+    });
+    const serviceDate = new Date(2026, 4, 11);
+
+    const [candidate] = deriveTripInspectionCandidates([entry], serviceDate);
+
+    expect(candidate).toEqual({
+      tripLocator: { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 7 },
+      stopIndex: 4,
+      departureMinutes: 615,
+      serviceDate,
+    });
+  });
+
+  it('attaches the supplied serviceDate to each derived candidate by reference', () => {
+    const entries = [
+      makeEntry({ tripIndex: 1, departureMinutes: 500 }),
+      makeEntry({ tripIndex: 2, departureMinutes: 600 }),
+    ];
+    const serviceDate = new Date(2026, 4, 11);
+
+    const candidates = deriveTripInspectionCandidates(entries, serviceDate);
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]?.serviceDate).toBe(serviceDate);
+    expect(candidates[1]?.serviceDate).toBe(serviceDate);
+  });
+
+  it('does not mutate the input entries array', () => {
+    const entries = [
+      makeEntry({ tripIndex: 2, departureMinutes: 9 * 60 + 6 }),
+      makeEntry({
+        tripIndex: 1,
+        stopIndex: 3,
+        arrivalMinutes: 9 * 60 + 5,
+        departureMinutes: 9 * 60 + 8,
+        isTerminal: true,
+      }),
+    ];
+    const originalOrder = entries.map((entry) => entry.tripLocator.tripIndex);
+
+    deriveTripInspectionCandidates(entries, new Date(2026, 4, 11));
+
+    expect(entries.map((entry) => entry.tripLocator.tripIndex)).toEqual(originalOrder);
+  });
+});
+
+describe('refineTripInspectionState', () => {
+  it('returns no-data when the candidate list is empty', () => {
+    const stopTimes = [makeStopTime(3, 600)];
+    const snapshot = makeSelectedSnapshot(stopTimes, 0);
+    const target = makeTarget({ stopIndex: 3, departureMinutes: 600 });
+
+    const result = refineTripInspectionState([], snapshot, target);
+
+    expect(result).toEqual({ ok: false, reason: 'no-data' });
+  });
+
+  it('resolves the requested target via exact match on the candidate list', () => {
     const stopTimes = [makeStopTime(3, 600)];
     const snapshot = makeSelectedSnapshot(stopTimes, 0);
     const target = makeTarget({
@@ -375,16 +417,29 @@ describe('refineTripInspectionState', () => {
       stopIndex: 3,
       departureMinutes: 600,
     });
+    const candidates = [
+      makeTarget({
+        tripLocator: makeLocator({ tripIndex: 1 }),
+        stopIndex: 3,
+        departureMinutes: 500,
+      }),
+      makeTarget({
+        tripLocator: makeLocator({ tripIndex: 2 }),
+        stopIndex: 3,
+        departureMinutes: 600,
+      }),
+      makeTarget({
+        tripLocator: makeLocator({ tripIndex: 3 }),
+        stopIndex: 3,
+        departureMinutes: 700,
+      }),
+    ];
 
-    const result = refineTripInspectionState(
-      [first, second, third],
-      target.serviceDate,
-      snapshot,
-      target,
-    );
+    const result = refineTripInspectionState(candidates, snapshot, target);
 
     expect(result.ok).toBe(true);
     if (result.ok) {
+      expect(result.data.targets).toBe(candidates);
       expect(result.data.targets).toHaveLength(3);
       expect(result.data.targetIndex).toBe(1);
     }
@@ -394,12 +449,6 @@ describe('refineTripInspectionState', () => {
     // Verify that the `resolveTripInspectionDisplayState`
     // `target-not-found` outcome is collapsed into the
     // `RefinedTripInspectionStateResult` `no-data` reason variant.
-    const unrelatedEntry = makeEntry({
-      patternId: 'pattern-b',
-      tripIndex: 0,
-      stopIndex: 3,
-      departureMinutes: 600,
-    });
     const stopTimes = [makeStopTime(3, 600)];
     const snapshot = makeSelectedSnapshot(stopTimes, 0);
     const target = makeTarget({
@@ -407,29 +456,26 @@ describe('refineTripInspectionState', () => {
       stopIndex: 3,
       departureMinutes: 600,
     });
+    const candidates = [
+      makeTarget({
+        tripLocator: makeLocator({ patternId: 'pattern-b', tripIndex: 0 }),
+        stopIndex: 3,
+        departureMinutes: 600,
+      }),
+    ];
 
-    const result = refineTripInspectionState(
-      [unrelatedEntry],
-      target.serviceDate,
-      snapshot,
-      target,
-    );
+    const result = refineTripInspectionState(candidates, snapshot, target);
 
     expect(result).toEqual({ ok: false, reason: 'no-data' });
   });
 
   it('rewrites the snapshot to the fallback stop row when no exact-match candidate exists', () => {
     // The requested target points at stopIndex=5 / depMin=620, but the
-    // entries only contain a single same-trip candidate at stopIndex=4.
-    // `resolveTripInspectionDisplayState` therefore returns `matchType:
-    // 'fallback'` and `refineTripInspectionState` is expected to surface
-    // the rewritten snapshot whose `currentStopIndex` points at the
-    // fallback stop row.
-    const fallbackEntry = makeEntry({
-      tripIndex: 1,
-      stopIndex: 4,
-      departureMinutes: 615,
-    });
+    // candidate list only contains a single same-trip candidate at
+    // stopIndex=4. `resolveTripInspectionDisplayState` therefore returns
+    // `matchType: 'fallback'` and `refineTripInspectionState` is expected
+    // to surface the rewritten snapshot whose `currentStopIndex` points
+    // at the fallback stop row.
     const requestedStop = makeStopTime(5, 620);
     const fallbackStop = makeStopTime(4, 615);
     const snapshot = makeSelectedSnapshot([requestedStop, fallbackStop], 0);
@@ -438,8 +484,15 @@ describe('refineTripInspectionState', () => {
       stopIndex: 5,
       departureMinutes: 620,
     });
+    const candidates = [
+      makeTarget({
+        tripLocator: makeLocator({ tripIndex: 1 }),
+        stopIndex: 4,
+        departureMinutes: 615,
+      }),
+    ];
 
-    const result = refineTripInspectionState([fallbackEntry], target.serviceDate, snapshot, target);
+    const result = refineTripInspectionState(candidates, snapshot, target);
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -450,25 +503,6 @@ describe('refineTripInspectionState', () => {
       // originally requested (and missing) stopIndex=5 row.
       expect(result.data.snapshot.currentStopIndex).toBe(1);
       expect(result.data.snapshot.selectedStop).toBe(fallbackStop);
-    }
-  });
-
-  it('attaches the supplied serviceDate to each derived candidate', () => {
-    const entry = makeEntry({ tripIndex: 1, departureMinutes: 500 });
-    const stopTimes = [makeStopTime(3, 500)];
-    const snapshot = makeSelectedSnapshot(stopTimes, 0);
-    const target = makeTarget({
-      tripLocator: makeLocator({ tripIndex: 1 }),
-      stopIndex: 3,
-      departureMinutes: 500,
-    });
-    const serviceDate = new Date(2026, 4, 11);
-
-    const result = refineTripInspectionState([entry], serviceDate, snapshot, target);
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.data.targets[0]?.serviceDate).toBe(serviceDate);
     }
   });
 });

--- a/src/domain/transit/__tests__/trip-inspection-target.test.ts
+++ b/src/domain/transit/__tests__/trip-inspection-target.test.ts
@@ -287,6 +287,60 @@ describe('resolveTripInspectionTarget', () => {
 
     expect(resolveTripInspectionTarget(candidates, requestedTarget)).toBeNull();
   });
+
+  it('finds the exact match when candidates are supplied in descending departure-time order', () => {
+    // The TSDoc on `resolveTripInspectionTarget` claims the exact-match
+    // path is order-agnostic. Verify by reversing the canonical
+    // `departureMinutes`-ascending order: descending input must still
+    // locate the exact candidate, and the returned `index` must refer to
+    // its position in the **input** array as-is.
+    const requestedTarget = makeTarget({ stopIndex: 4, departureMinutes: 620 });
+    const candidates = [
+      makeTarget({ stopIndex: 7, departureMinutes: 700 }),
+      makeTarget({ stopIndex: 4, departureMinutes: 620 }),
+      makeTarget({ stopIndex: 1, departureMinutes: 500 }),
+    ];
+
+    expect(resolveTripInspectionTarget(candidates, requestedTarget)).toEqual({
+      target: candidates[1],
+      index: 1,
+      matchType: 'exact',
+    });
+  });
+
+  it('finds the exact match when candidates are supplied in display-time order with a terminal arrival before a later departure', () => {
+    // Display-time ordering surfaces a terminal arrival (display = arr =
+    // 09:05) ahead of a later non-terminal departure (display = dep =
+    // 09:06) even though their raw `departureMinutes` (9*60+8 vs 9*60+6)
+    // disagree with their display order. The exact-match path must
+    // return the requested candidate regardless of this ordering.
+    const requestedTarget = makeTarget({
+      tripLocator: makeLocator({ tripIndex: 2 }),
+      stopIndex: 3,
+      departureMinutes: 9 * 60 + 6,
+    });
+    const candidates = [
+      // Terminal arrival sorted first by display time despite later
+      // raw departure (`departureMinutes = 548`).
+      makeTarget({
+        tripLocator: { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 1 },
+        stopIndex: 3,
+        departureMinutes: 9 * 60 + 8,
+      }),
+      // The requested non-terminal departure sorted after the terminal.
+      makeTarget({
+        tripLocator: makeLocator({ tripIndex: 2 }),
+        stopIndex: 3,
+        departureMinutes: 9 * 60 + 6,
+      }),
+    ];
+
+    expect(resolveTripInspectionTarget(candidates, requestedTarget)).toEqual({
+      target: candidates[1],
+      index: 1,
+      matchType: 'exact',
+    });
+  });
 });
 
 describe('resolveSnapshotStopIndex', () => {

--- a/src/domain/transit/trip-inspection-state.ts
+++ b/src/domain/transit/trip-inspection-state.ts
@@ -183,38 +183,55 @@ export function loadTripInspectionSnapshot(
 }
 
 /**
- * Derive the trip-inspection navigation state from a stop's full-day
- * timetable entries. Pure: takes the entry list and pure context as
- * input and returns the refined state without any I/O.
+ * Build the trip-inspection candidate list from a stop's full-day
+ * timetable entries.
  *
  * The entries are sorted with {@link sortTimetableEntriesByDisplayTime}
- * (display-minute order) before being mapped to
- * {@link TripInspectionTarget}, so the resulting navigation list reads
- * chronologically in the UI (Issue #63). The requested target is then
- * located within the candidate list via
- * {@link resolveTripInspectionDisplayState}; if it cannot be resolved
- * (and the helper has no fallback either) the function returns
- * `{ ok: false, reason: 'no-data' }`.
+ * (display-minute order) and then mapped to {@link TripInspectionTarget},
+ * so the resulting navigation list reads chronologically in the UI
+ * (Issue #63). The input array is never mutated -- the helper sorts a
+ * defensive copy.
  *
- * Failure-path logging is intentionally NOT performed here so the function
- * stays trivially testable. Callers that want diagnostics on failure can
- * invoke {@link buildTripInspectionMatchDiagnostics} and log the result
- * themselves.
+ * The candidate list is exposed as its own value (rather than hidden
+ * inside {@link refineTripInspectionState}) so callers can pass the same
+ * list both to the resolver and to
+ * {@link buildTripInspectionMatchDiagnostics} on failure.
  */
-export function refineTripInspectionState(
+export function deriveTripInspectionCandidates(
   entries: TimetableEntry[],
   serviceDate: Date,
-  snapshot: SelectedTripSnapshot,
-  target: TripInspectionTarget,
-): RefinedTripInspectionStateResult {
+): TripInspectionTarget[] {
   const sorted = sortTimetableEntriesByDisplayTime([...entries]);
-  const candidates: TripInspectionTarget[] = sorted.map((entry) => ({
+  return sorted.map((entry) => ({
     tripLocator: entry.tripLocator,
     stopIndex: entry.patternPosition.stopIndex,
     departureMinutes: entry.schedule.departureMinutes,
     serviceDate,
   }));
+}
 
+/**
+ * Resolve the trip-inspection navigation state for a requested target
+ * against an already-derived candidate list. Pure: takes the candidate
+ * list and pure context as input and returns the refined state without
+ * any I/O.
+ *
+ * The requested target is located within `candidates` via
+ * {@link resolveTripInspectionDisplayState}; if it cannot be resolved
+ * (and the helper has no fallback either) the function returns
+ * `{ ok: false, reason: 'no-data' }`. The same outcome is also produced
+ * for an empty `candidates` array.
+ *
+ * Failure-path logging is intentionally NOT performed here so the function
+ * stays trivially testable. Callers that want diagnostics on failure can
+ * invoke {@link buildTripInspectionMatchDiagnostics} with the same
+ * `candidates` list they passed in.
+ */
+export function refineTripInspectionState(
+  candidates: TripInspectionTarget[],
+  snapshot: SelectedTripSnapshot,
+  target: TripInspectionTarget,
+): RefinedTripInspectionStateResult {
   if (candidates.length === 0) {
     return { ok: false, reason: 'no-data' };
   }

--- a/src/domain/transit/trip-inspection-state.ts
+++ b/src/domain/transit/trip-inspection-state.ts
@@ -1,0 +1,235 @@
+/**
+ * @module trip-inspection-state
+ *
+ * Pure helpers that derive trip-inspection display state from canonical
+ * timetable data. Paired with `./trip-inspection-target` (which contains
+ * pure helpers that operate on `TripInspectionTarget`); the helpers here
+ * compose those into the higher-level state (`RefinedTripInspectionState`
+ * / `LoadedTripInspectionSnapshot`) consumed by `useTripInspection`.
+ *
+ * The functions in this module are not React-aware: they receive their
+ * inputs as plain values and return plain results. Side effects are
+ * limited to warning-level logger calls on failure branches, matching the
+ * pattern already used by `./timetable-stats`.
+ */
+
+import { createLogger } from '../../lib/logger';
+import type { TripInspectionTargetsEmptyReason } from '../../types/app/repository';
+import type {
+  SelectedTripSnapshot,
+  TimetableEntry,
+  TripInspectionTarget,
+  TripSnapshot,
+} from '../../types/app/transit-composed';
+import { sortTimetableEntriesByDisplayTime } from './sort-timetable-for-ui';
+import {
+  resolveSelectedTripInspectionSnapshot,
+  resolveTripInspectionDisplayState,
+} from './trip-inspection-target';
+
+const logger = createLogger('TripInspectionState');
+
+/**
+ * Anchor a service-day Date to noon so it survives `getServiceDay`'s
+ * 03:00 boundary check. `target.serviceDate` is midnight-anchored by
+ * convention, and `repo.getFullDayTimetableEntries(stopId, dateTime)`
+ * normalises its argument via `getServiceDay(dateTime)` which would
+ * otherwise treat midnight as the **previous** service day (hours < 3).
+ *
+ * The returned Date is always a fresh instance — the input is never
+ * mutated.
+ */
+export function serviceDayReferenceDateTime(serviceDate: Date): Date {
+  const result = new Date(serviceDate);
+  result.setHours(12, 0, 0, 0);
+  return result;
+}
+
+/** Snapshot + selected stop_id for a successfully loaded trip inspection. */
+export interface LoadedTripInspectionSnapshot {
+  snapshot: SelectedTripSnapshot;
+  selectedStopId: string;
+}
+
+/** Result of {@link loadTripInspectionSnapshot}. */
+export type LoadedTripInspectionSnapshotResult =
+  | { ok: true; data: LoadedTripInspectionSnapshot }
+  | { ok: false; reason: 'no-data' };
+
+/** State derived for trip-inspection prev/next navigation. */
+export interface RefinedTripInspectionState {
+  snapshot: SelectedTripSnapshot;
+  targets: TripInspectionTarget[];
+  targetIndex: number;
+}
+
+/** Result of {@link refineTripInspectionState}. */
+export type RefinedTripInspectionStateResult =
+  | { ok: true; data: RefinedTripInspectionState }
+  | { ok: false; reason: 'no-data' };
+
+/**
+ * Map a {@link TripInspectionTargetsEmptyReason} to a human-readable note
+ * used in warning logs.
+ */
+export function getEmptyTripInspectionTargetsNote(
+  emptyReason: TripInspectionTargetsEmptyReason,
+): string {
+  if (emptyReason === 'no-stop-data') {
+    return 'The stop has no trip-inspection stop data.';
+  }
+
+  return 'The stop has trip-inspection data, but no services on the selected service day.';
+}
+
+/**
+ * Build a diagnostic payload describing why a requested target did not
+ * match against the candidate list. Used by callers that want to log
+ * detailed mismatch context at `debug` level.
+ *
+ * Pure: the function does not log; callers gate logging behind their
+ * level filter and pass the returned object to `logger.debug(...)`.
+ */
+export function buildTripInspectionMatchDiagnostics(
+  target: TripInspectionTarget,
+  candidates: TripInspectionTarget[],
+) {
+  const summarizeTarget = (candidate: TripInspectionTarget) => ({
+    patternId: candidate.tripLocator.patternId,
+    serviceId: candidate.tripLocator.serviceId,
+    tripIndex: candidate.tripLocator.tripIndex,
+    stopIndex: candidate.stopIndex,
+    departureMinutes: candidate.departureMinutes,
+    serviceDate: candidate.serviceDate.toISOString(),
+  });
+
+  const sameService = candidates.filter(
+    (candidate) =>
+      candidate.tripLocator.patternId === target.tripLocator.patternId &&
+      candidate.tripLocator.serviceId === target.tripLocator.serviceId,
+  );
+  const sameTripIndex = sameService.filter(
+    (candidate) => candidate.tripLocator.tripIndex === target.tripLocator.tripIndex,
+  );
+  const sameStopIndex = sameTripIndex.filter(
+    (candidate) => candidate.stopIndex === target.stopIndex,
+  );
+
+  return {
+    patternId: target.tripLocator.patternId,
+    serviceId: target.tripLocator.serviceId,
+    tripIndex: target.tripLocator.tripIndex,
+    stopIndex: target.stopIndex,
+    departureMinutes: target.departureMinutes,
+    serviceDate: target.serviceDate.toISOString(),
+    sampleSameService: sameService.slice(0, 5).map(summarizeTarget),
+    sampleSameTripIndex: sameTripIndex.slice(0, 5).map(summarizeTarget),
+    sampleSameStopIndex: sameStopIndex.slice(0, 5).map(summarizeTarget),
+  };
+}
+
+/**
+ * Resolve the trip-inspection snapshot for a reconstructed trip and a
+ * requested target. Wraps {@link resolveSelectedTripInspectionSnapshot}
+ * and emits warning logs on each failure branch so the caller only has
+ * to handle the boolean outcome.
+ */
+export function loadTripInspectionSnapshot(
+  trip: TripSnapshot,
+  target: TripInspectionTarget,
+): LoadedTripInspectionSnapshotResult {
+  const resolvedSnapshot = resolveSelectedTripInspectionSnapshot(trip, target);
+  if (!resolvedSnapshot.ok) {
+    switch (resolvedSnapshot.reason) {
+      case 'pattern-position-missing':
+        logger.warn(
+          `loadTripInspectionSnapshot: selected stop index ${target.stopIndex} is missing from reconstructed trip snapshot`,
+        );
+        break;
+      case 'stop-row-missing':
+        logger.warn(
+          'loadTripInspectionSnapshot: selected stop row is missing from reconstructed trip snapshot',
+          {
+            target,
+          },
+        );
+        break;
+      default: {
+        const exhaustiveReason: never = resolvedSnapshot.reason;
+        logger.warn('loadTripInspectionSnapshot: unexpected snapshot resolution failure', {
+          target,
+          reason: exhaustiveReason,
+        });
+      }
+    }
+
+    return { ok: false, reason: 'no-data' };
+  }
+
+  if (resolvedSnapshot.data.selectedStopId === undefined) {
+    logger.warn(
+      'loadTripInspectionSnapshot: selected stop metadata missing; skip trip-inspection target lookup',
+    );
+    return { ok: false, reason: 'no-data' };
+  }
+
+  return {
+    ok: true,
+    data: {
+      snapshot: resolvedSnapshot.data.snapshot,
+      selectedStopId: resolvedSnapshot.data.selectedStopId,
+    },
+  };
+}
+
+/**
+ * Derive the trip-inspection navigation state from a stop's full-day
+ * timetable entries. Pure: takes the entry list and pure context as
+ * input and returns the refined state without any I/O.
+ *
+ * The entries are sorted with {@link sortTimetableEntriesByDisplayTime}
+ * (display-minute order) before being mapped to
+ * {@link TripInspectionTarget}, so the resulting navigation list reads
+ * chronologically in the UI (Issue #63). The requested target is then
+ * located within the candidate list via
+ * {@link resolveTripInspectionDisplayState}; if it cannot be resolved
+ * (and the helper has no fallback either) the function returns
+ * `{ ok: false, reason: 'no-data' }`.
+ *
+ * Failure-path logging is intentionally NOT performed here so the function
+ * stays trivially testable. Callers that want diagnostics on failure can
+ * invoke {@link buildTripInspectionMatchDiagnostics} and log the result
+ * themselves.
+ */
+export function refineTripInspectionState(
+  entries: TimetableEntry[],
+  serviceDate: Date,
+  snapshot: SelectedTripSnapshot,
+  target: TripInspectionTarget,
+): RefinedTripInspectionStateResult {
+  const sorted = sortTimetableEntriesByDisplayTime([...entries]);
+  const candidates: TripInspectionTarget[] = sorted.map((entry) => ({
+    tripLocator: entry.tripLocator,
+    stopIndex: entry.patternPosition.stopIndex,
+    departureMinutes: entry.schedule.departureMinutes,
+    serviceDate,
+  }));
+
+  if (candidates.length === 0) {
+    return { ok: false, reason: 'no-data' };
+  }
+
+  const resolvedState = resolveTripInspectionDisplayState(snapshot, candidates, target);
+  if (!resolvedState.ok) {
+    return { ok: false, reason: 'no-data' };
+  }
+
+  return {
+    ok: true,
+    data: {
+      snapshot: resolvedState.data.snapshot,
+      targets: resolvedState.data.targets,
+      targetIndex: resolvedState.data.targetIndex,
+    },
+  };
+}

--- a/src/domain/transit/trip-inspection-target.ts
+++ b/src/domain/transit/trip-inspection-target.ts
@@ -163,14 +163,21 @@ export function selectTripInspectionTargetByReferenceTime(
 }
 
 /**
- * Resolves one trip-inspection target from an ordered candidate list using an
- * existing target as the reference.
+ * Resolves one trip-inspection target from a candidate list using an existing
+ * target as the reference.
  *
- * The input is expected to preserve repository ordering (`departureMinutes`
- * ascending, then `stopIndex`, then route ordering). This helper does not sort
- * the full input itself; it only sorts the narrowed same-trip fallback subset.
+ * Order-agnostic for the exact-match path: the helper scans `candidates`
+ * linearly via {@link isSameTripInspectionTarget} so the caller may sort the
+ * input in `departureMinutes`-ascending order (repository canonical), in
+ * display-time order (UI surfaces such as `<TripPager>` after Issue #63),
+ * or any other deterministic order. The returned `index` is the index inside
+ * the supplied `candidates` array as-is.
  *
- * @param candidates - Ordered trip-inspection candidates to choose from.
+ * When no exact match is found, the helper narrows to the same-trip subset
+ * and self-sorts it by closeness to the reference target before picking the
+ * fallback — the caller does not need to pre-sort for this path either.
+ *
+ * @param candidates - Trip-inspection candidates to choose from.
  * @param target - Reference target that should be matched or approximated.
  * @returns The resolved candidate and its original index, or `null` when no
  *          candidate can be selected from the input.

--- a/src/hooks/__tests__/use-trip-inspection.test.ts
+++ b/src/hooks/__tests__/use-trip-inspection.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { makeRepo } from '../../__tests__/helpers';
 import { getServiceDay } from '../../domain/transit/service-day';
@@ -339,6 +339,197 @@ describe('useTripInspection', () => {
     expect(mockWarn).toHaveBeenCalledWith(
       'openTripInspection: current target missing from trip-inspection targets',
       { target },
+    );
+  });
+
+  it('uses cached targets for previous navigation without refetching full-day entries', async () => {
+    const serviceDate = new Date(2026, 4, 11);
+    const firstTarget = makeTarget({
+      tripLocator: makeLocator({ tripIndex: 1 }),
+      serviceDate,
+      stopIndex: 3,
+      departureMinutes: 9 * 60 + 5,
+    });
+    const secondTarget = makeTarget({
+      tripLocator: makeLocator({ tripIndex: 2 }),
+      serviceDate,
+      stopIndex: 3,
+      departureMinutes: 9 * 60 + 6,
+    });
+    const getTripSnapshot = vi.fn().mockImplementation((tripLocator: TripLocator) => ({
+      success: true,
+      data: makeTripSnapshot([
+        makeStopTime(
+          3,
+          tripLocator.tripIndex === 1
+            ? firstTarget.departureMinutes
+            : secondTarget.departureMinutes,
+        ),
+      ]),
+    }));
+    const getFullDayTimetableEntries = vi.fn().mockResolvedValue({
+      success: true,
+      data: [
+        makeEntry({ tripIndex: 1, stopIndex: 3, departureMinutes: firstTarget.departureMinutes }),
+        makeEntry({ tripIndex: 2, stopIndex: 3, departureMinutes: secondTarget.departureMinutes }),
+      ],
+      truncated: false,
+      meta: { isBoardableOnServiceDay: true, totalEntries: 2 },
+    });
+    const repo = makeRepo({
+      getTripSnapshot,
+      getFullDayTimetableEntries,
+    });
+
+    const { result } = renderHook(() => useTripInspection(repo));
+
+    await act(async () => {
+      await result.current.openTripInspectionFromTarget(secondTarget);
+    });
+
+    expect(result.current.currentTripInspectionTargetIndex).toBe(1);
+    expect(getFullDayTimetableEntries).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.openPreviousTripInspection();
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentTripInspectionTargetIndex).toBe(0);
+    });
+    expect(getFullDayTimetableEntries).toHaveBeenCalledTimes(1);
+    expect(getTripSnapshot).toHaveBeenCalledTimes(2);
+    expect(getTripSnapshot.mock.calls[1]?.[0]).toEqual(firstTarget.tripLocator);
+  });
+
+  it('refetches full-day entries when stale pager targets miss the cache', async () => {
+    const serviceDate = new Date(2026, 4, 11);
+    const firstList = {
+      first: makeTarget({
+        tripLocator: makeLocator({ tripIndex: 1 }),
+        serviceDate,
+        stopIndex: 3,
+        departureMinutes: 9 * 60 + 5,
+      }),
+      second: makeTarget({
+        tripLocator: makeLocator({ tripIndex: 2 }),
+        serviceDate,
+        stopIndex: 3,
+        departureMinutes: 9 * 60 + 6,
+      }),
+    };
+    const secondList = {
+      first: makeTarget({
+        tripLocator: makeLocator({ patternId: 'pattern-b', tripIndex: 5 }),
+        serviceDate,
+        stopIndex: 8,
+        departureMinutes: 10 * 60 + 1,
+      }),
+      second: makeTarget({
+        tripLocator: makeLocator({ patternId: 'pattern-b', tripIndex: 6 }),
+        serviceDate,
+        stopIndex: 8,
+        departureMinutes: 10 * 60 + 2,
+      }),
+    };
+
+    const getTripSnapshot = vi.fn().mockImplementation((tripLocator: TripLocator) => ({
+      success: true,
+      data: makeTripSnapshot([
+        makeStopTime(
+          tripLocator.patternId === 'pattern-b' ? 8 : 3,
+          tripLocator.tripIndex === 1
+            ? firstList.first.departureMinutes
+            : tripLocator.tripIndex === 2
+              ? firstList.second.departureMinutes
+              : tripLocator.tripIndex === 5
+                ? secondList.first.departureMinutes
+                : secondList.second.departureMinutes,
+        ),
+      ]),
+    }));
+    const getFullDayTimetableEntries = vi.fn().mockImplementation((stopId: string) => {
+      if (stopId === 'stop-3') {
+        return Promise.resolve({
+          success: true,
+          data: [
+            makeEntry({
+              tripIndex: 1,
+              stopIndex: 3,
+              departureMinutes: firstList.first.departureMinutes,
+            }),
+            makeEntry({
+              tripIndex: 2,
+              stopIndex: 3,
+              departureMinutes: firstList.second.departureMinutes,
+            }),
+          ],
+          truncated: false,
+          meta: { isBoardableOnServiceDay: true, totalEntries: 2 },
+        });
+      }
+
+      return Promise.resolve({
+        success: true,
+        data: [
+          makeEntry({
+            patternId: 'pattern-b',
+            tripIndex: 5,
+            stopIndex: 8,
+            departureMinutes: secondList.first.departureMinutes,
+          }),
+          makeEntry({
+            patternId: 'pattern-b',
+            tripIndex: 6,
+            stopIndex: 8,
+            departureMinutes: secondList.second.departureMinutes,
+          }),
+        ],
+        truncated: false,
+        meta: { isBoardableOnServiceDay: true, totalEntries: 2 },
+      });
+    });
+    const repo = makeRepo({
+      getTripSnapshot,
+      getFullDayTimetableEntries,
+    });
+
+    const { result } = renderHook(() => useTripInspection(repo));
+
+    await act(async () => {
+      await result.current.openTripInspectionFromTarget(firstList.second);
+    });
+
+    const staleOpenPreviousTripInspection = result.current.openPreviousTripInspection;
+
+    await act(async () => {
+      await result.current.openTripInspectionFromTarget(secondList.second);
+    });
+
+    expect(
+      result.current.tripInspectionTargets.map((target) => target.tripLocator.tripIndex),
+    ).toEqual([5, 6]);
+    expect(getFullDayTimetableEntries).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      staleOpenPreviousTripInspection();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.tripInspectionTargets.map((target) => target.tripLocator.tripIndex),
+      ).toEqual([1, 2]);
+    });
+    expect(result.current.currentTripInspectionTargetIndex).toBe(0);
+    expect(result.current.tripInspectionSnapshot?.selectedStop.stopMeta?.stop.stop_id).toBe(
+      'stop-3',
+    );
+    expect(getFullDayTimetableEntries).toHaveBeenCalledTimes(3);
+    expect(mockWarn).toHaveBeenCalledWith(
+      'openTripInspection: target missing from cached trip-inspection targets',
+      expect.objectContaining({
+        target: firstList.first,
+      }),
     );
   });
 });

--- a/src/hooks/__tests__/use-trip-inspection.test.ts
+++ b/src/hooks/__tests__/use-trip-inspection.test.ts
@@ -2,6 +2,14 @@ import { renderHook, act } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { makeRepo } from '../../__tests__/helpers';
 import { getServiceDay } from '../../domain/transit/service-day';
+import type { Route } from '../../types/app/transit';
+import type {
+  TimetableEntry,
+  TripInspectionTarget,
+  TripLocator,
+  TripSnapshot,
+  TripStopTime,
+} from '../../types/app/transit-composed';
 import { useTripInspection } from '../use-trip-inspection';
 
 const mockWarn = vi.fn();
@@ -18,6 +26,111 @@ vi.mock('../../lib/logger', () => ({
     error: vi.fn(),
   }),
 }));
+
+function makeRoute(routeId = 'test:R1'): Route {
+  return {
+    route_id: routeId,
+    route_short_name: routeId,
+    route_short_names: {},
+    route_long_name: routeId,
+    route_long_names: {},
+    route_type: 3,
+    route_color: '000000',
+    route_text_color: 'FFFFFF',
+    agency_id: 'test:agency',
+  };
+}
+
+function makeLocator(overrides: Partial<TripLocator> = {}): TripLocator {
+  return { patternId: 'pattern-a', serviceId: 'weekday', tripIndex: 0, ...overrides };
+}
+
+function makeTarget(overrides: Partial<TripInspectionTarget> = {}): TripInspectionTarget {
+  return {
+    tripLocator: makeLocator(),
+    serviceDate: new Date(2026, 4, 11),
+    stopIndex: 3,
+    departureMinutes: 600,
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: {
+  patternId?: string;
+  serviceId?: string;
+  tripIndex?: number;
+  stopIndex?: number;
+  departureMinutes: number;
+  arrivalMinutes?: number;
+  isTerminal?: boolean;
+}): TimetableEntry {
+  return {
+    schedule: {
+      departureMinutes: overrides.departureMinutes,
+      arrivalMinutes: overrides.arrivalMinutes ?? overrides.departureMinutes,
+    },
+    routeDirection: {
+      route: makeRoute(),
+      tripHeadsign: { name: 'Terminal', names: {} },
+    },
+    boarding: { pickupType: 0, dropOffType: 0 },
+    patternPosition: {
+      stopIndex: overrides.stopIndex ?? 3,
+      totalStops: 10,
+      isTerminal: overrides.isTerminal ?? false,
+      isOrigin: false,
+    },
+    tripLocator: {
+      patternId: overrides.patternId ?? 'pattern-a',
+      serviceId: overrides.serviceId ?? 'weekday',
+      tripIndex: overrides.tripIndex ?? 0,
+    },
+  };
+}
+
+function makeStopTime(stopIndex: number, departureMinutes: number): TripStopTime {
+  return {
+    routeTypes: [],
+    timetableEntry: {
+      tripLocator: makeLocator(),
+      schedule: { departureMinutes, arrivalMinutes: departureMinutes },
+      routeDirection: {
+        route: makeRoute(),
+        tripHeadsign: { name: 'Terminal', names: {} },
+      },
+      boarding: { pickupType: 0, dropOffType: 0 },
+      patternPosition: {
+        stopIndex,
+        totalStops: 10,
+        isTerminal: false,
+        isOrigin: false,
+      },
+    },
+    stopMeta: {
+      stop: {
+        stop_id: `stop-${String(stopIndex)}`,
+        stop_name: `Stop ${String(stopIndex)}`,
+        stop_names: {},
+        stop_lat: 0,
+        stop_lon: 0,
+        location_type: 0,
+        agency_id: 'test:agency',
+      },
+      agencies: [],
+      routes: [],
+    },
+  };
+}
+
+function makeTripSnapshot(stopTimes: TripStopTime[]): TripSnapshot {
+  return {
+    locator: makeLocator(),
+    route: makeRoute(),
+    tripHeadsign: { name: 'Terminal', names: {} },
+    serviceDate: new Date(2026, 4, 11),
+    stopTimes,
+  };
+}
 
 describe('useTripInspection', () => {
   afterEach(() => {
@@ -94,6 +207,138 @@ describe('useTripInspection', () => {
         emptyReason: 'no-stop-data',
         note: 'The stop has no trip-inspection stop data.',
       }),
+    );
+  });
+
+  it('opens from a target using full-day timetable entries ordered by display time', async () => {
+    const serviceDate = new Date(2026, 4, 11);
+    const requestedTarget = makeTarget({
+      tripLocator: makeLocator({ tripIndex: 2 }),
+      serviceDate,
+      stopIndex: 3,
+      departureMinutes: 9 * 60 + 6,
+    });
+    const terminalEntry = makeEntry({
+      tripIndex: 1,
+      stopIndex: 3,
+      arrivalMinutes: 9 * 60 + 5,
+      departureMinutes: 9 * 60 + 8,
+      isTerminal: true,
+    });
+    const requestedEntry = makeEntry({
+      tripIndex: 2,
+      stopIndex: 3,
+      departureMinutes: 9 * 60 + 6,
+    });
+    const getTripSnapshot = vi.fn().mockReturnValue({
+      success: true,
+      data: makeTripSnapshot([makeStopTime(3, 9 * 60 + 6)]),
+    });
+    const getFullDayTimetableEntries = vi.fn().mockResolvedValue({
+      success: true,
+      data: [requestedEntry, terminalEntry],
+      truncated: false,
+      meta: { isBoardableOnServiceDay: true, totalEntries: 2 },
+    });
+    const repo = makeRepo({
+      getTripSnapshot,
+      getFullDayTimetableEntries,
+    });
+
+    const { result } = renderHook(() => useTripInspection(repo));
+
+    let status: Awaited<ReturnType<typeof result.current.openTripInspectionFromTarget>>;
+    await act(async () => {
+      status = await result.current.openTripInspectionFromTarget(requestedTarget);
+    });
+
+    expect(status!).toEqual({ status: 'opened' });
+    expect(getTripSnapshot).toHaveBeenCalledWith(requestedTarget.tripLocator, serviceDate);
+    expect(getFullDayTimetableEntries).toHaveBeenCalledWith('stop-3', expect.any(Date));
+
+    const referenceDateTime = getFullDayTimetableEntries.mock.calls[0]?.[1] as Date;
+    expect(referenceDateTime.getFullYear()).toBe(2026);
+    expect(referenceDateTime.getMonth()).toBe(4);
+    expect(referenceDateTime.getDate()).toBe(11);
+    expect(referenceDateTime.getHours()).toBe(12);
+    expect(referenceDateTime.getMinutes()).toBe(0);
+
+    expect(
+      result.current.tripInspectionTargets.map((target) => target.tripLocator.tripIndex),
+    ).toEqual([1, 2]);
+    expect(result.current.currentTripInspectionTargetIndex).toBe(1);
+    expect(result.current.tripInspectionSnapshot?.selectedStop.stopMeta?.stop.stop_id).toBe(
+      'stop-3',
+    );
+  });
+
+  it('returns error when full-day timetable lookup fails', async () => {
+    const target = makeTarget();
+    const getFullDayTimetableEntries = vi.fn().mockResolvedValue({
+      success: false,
+      error: 'lookup failed',
+    });
+    const repo = makeRepo({
+      getTripSnapshot: vi.fn().mockReturnValue({
+        success: true,
+        data: makeTripSnapshot([makeStopTime(3, 600)]),
+      }),
+      getFullDayTimetableEntries,
+    });
+
+    const { result } = renderHook(() => useTripInspection(repo));
+
+    let status: Awaited<ReturnType<typeof result.current.openTripInspectionFromTarget>>;
+    await act(async () => {
+      status = await result.current.openTripInspectionFromTarget(target);
+    });
+
+    expect(status!).toEqual({ status: 'error' });
+    expect(result.current.tripInspectionSnapshot).toBeNull();
+    expect(result.current.tripInspectionTargets).toEqual([]);
+    expect(result.current.currentTripInspectionTargetIndex).toBe(-1);
+    expect(mockWarn).toHaveBeenCalledWith(
+      'openTripInspection: trip-inspection entry lookup failed',
+      'lookup failed',
+      target,
+    );
+  });
+
+  it('returns target-missing when full-day entries do not contain the requested trip', async () => {
+    const target = makeTarget({
+      tripLocator: makeLocator({ patternId: 'pattern-a', tripIndex: 4 }),
+      stopIndex: 3,
+      departureMinutes: 600,
+    });
+    const repo = makeRepo({
+      getTripSnapshot: vi.fn().mockReturnValue({
+        success: true,
+        data: makeTripSnapshot([makeStopTime(3, 600)]),
+      }),
+      getFullDayTimetableEntries: vi.fn().mockResolvedValue({
+        success: true,
+        data: [
+          makeEntry({ patternId: 'pattern-b', tripIndex: 1, stopIndex: 3, departureMinutes: 600 }),
+        ],
+        truncated: false,
+        meta: { isBoardableOnServiceDay: true, totalEntries: 1 },
+      }),
+    });
+
+    const { result } = renderHook(() => useTripInspection(repo));
+
+    let status: Awaited<ReturnType<typeof result.current.openTripInspectionFromTarget>>;
+    await act(async () => {
+      status = await result.current.openTripInspectionFromTarget(target);
+    });
+
+    expect(status!).toEqual({ status: 'no-data', reason: 'target-missing' });
+    expect(result.current.tripInspectionSnapshot).toBeNull();
+    expect(result.current.tripInspectionTargets).toEqual([]);
+    expect(result.current.currentTripInspectionTargetIndex).toBe(-1);
+    expect(mockWarn).toHaveBeenCalledWith(
+      'openTripInspection: current target missing from trip-inspection targets',
+      { target },
     );
   });
 });

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -3,6 +3,7 @@ import { formatDateKey } from '../domain/transit/calendar-utils';
 import { getServiceDayMinutes } from '../domain/transit/service-day';
 import {
   buildTripInspectionMatchDiagnostics,
+  deriveTripInspectionCandidates,
   getEmptyTripInspectionTargetsNote,
   loadTripInspectionSnapshot,
   refineTripInspectionState,
@@ -161,18 +162,14 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         return { status: 'error' };
       }
 
-      const refinedState = refineTripInspectionState(
+      const candidates = deriveTripInspectionCandidates(
         entriesResult.data,
         target.serviceDate,
-        snapshot,
-        target,
       );
+      const refinedState = refineTripInspectionState(candidates, snapshot, target);
       if (!refinedState.ok) {
         if (logger.isEnabled('debug')) {
-          const diagnostics = buildTripInspectionMatchDiagnostics(
-            target,
-            tripInspectionTargetsRef.current,
-          );
+          const diagnostics = buildTripInspectionMatchDiagnostics(target, candidates);
           logger.debug(
             'openTripInspection: target lookup mismatch sampleSameService',
             diagnostics.sampleSameService,

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -1,11 +1,15 @@
 import { useCallback, useRef, useState } from 'react';
 import { formatDateKey } from '../domain/transit/calendar-utils';
 import { getServiceDayMinutes } from '../domain/transit/service-day';
-import { sortTimetableEntriesByDisplayTime } from '../domain/transit/sort-timetable-for-ui';
+import {
+  buildTripInspectionMatchDiagnostics,
+  getEmptyTripInspectionTargetsNote,
+  loadTripInspectionSnapshot,
+  refineTripInspectionState,
+  serviceDayReferenceDateTime,
+} from '../domain/transit/trip-inspection-state';
 import {
   isSameTripInspectionTarget,
-  resolveSelectedTripInspectionSnapshot,
-  resolveTripInspectionDisplayState,
   selectTripInspectionTargetByReferenceTime,
 } from '../domain/transit/trip-inspection-target';
 import { createLogger, type Logger } from '../lib/logger';
@@ -14,11 +18,7 @@ import type {
   TripInspectionTargetsEmptyReason,
   TripInspectionTargetsResult,
 } from '../types/app/repository';
-import type {
-  SelectedTripSnapshot,
-  TripInspectionTarget,
-  TripSnapshot,
-} from '../types/app/transit-composed';
+import type { SelectedTripSnapshot, TripInspectionTarget } from '../types/app/transit-composed';
 
 const logger: Logger = createLogger('TripInspection');
 
@@ -27,8 +27,6 @@ interface OpenTripInspectionByStopIdParams {
   now: Date;
   serviceDate: Date;
 }
-
-type TripInspectionOpenResult = 'opened' | 'no-data' | 'error' | 'cancelled';
 
 export type TripInspectionNoDataReason =
   | TripInspectionTargetsEmptyReason
@@ -44,40 +42,6 @@ type TripInspectionOpenOutcome =
       reason: TripInspectionNoDataReason;
     };
 
-type TripInspectionLoadResult = Extract<TripInspectionOpenResult, 'error' | 'no-data'>;
-type RefineFailureStatus = Extract<TripInspectionOpenResult, 'no-data' | 'error' | 'cancelled'>;
-
-interface LoadedTripInspectionSnapshot {
-  snapshot: SelectedTripSnapshot;
-  selectedStopId: string;
-}
-
-type LoadedTripInspectionSnapshotResult =
-  | {
-      ok: true;
-      data: LoadedTripInspectionSnapshot;
-    }
-  | {
-      ok: false;
-      status: TripInspectionLoadResult;
-    };
-
-interface RefinedTripInspectionState {
-  snapshot: SelectedTripSnapshot;
-  targets: TripInspectionTarget[];
-  targetIndex: number;
-}
-
-type RefinedTripInspectionStateResult =
-  | {
-      ok: true;
-      data: RefinedTripInspectionState;
-    }
-  | {
-      ok: false;
-      status: RefineFailureStatus;
-    };
-
 interface UseTripInspectionReturn {
   tripInspectionSnapshot: SelectedTripSnapshot | null;
   tripInspectionTargets: TripInspectionTarget[];
@@ -91,199 +55,6 @@ interface UseTripInspectionReturn {
   openPreviousTripInspection: () => void;
   openNextTripInspection: () => void;
   closeTripInspection: () => void;
-}
-
-function getEmptyTripInspectionTargetsNote(emptyReason: TripInspectionTargetsEmptyReason): string {
-  if (emptyReason === 'no-stop-data') {
-    return 'The stop has no trip-inspection stop data.';
-  }
-
-  return 'The stop has trip-inspection data, but no services on the selected service day.';
-}
-
-function buildTripInspectionMatchDiagnostics(
-  target: TripInspectionTarget,
-  candidates: TripInspectionTarget[],
-) {
-  const summarizeTarget = (candidate: TripInspectionTarget) => ({
-    patternId: candidate.tripLocator.patternId,
-    serviceId: candidate.tripLocator.serviceId,
-    tripIndex: candidate.tripLocator.tripIndex,
-    stopIndex: candidate.stopIndex,
-    departureMinutes: candidate.departureMinutes,
-    serviceDate: candidate.serviceDate.toISOString(),
-  });
-
-  const sameService = candidates.filter(
-    (candidate) =>
-      candidate.tripLocator.patternId === target.tripLocator.patternId &&
-      candidate.tripLocator.serviceId === target.tripLocator.serviceId,
-  );
-  const sameTripIndex = sameService.filter(
-    (candidate) => candidate.tripLocator.tripIndex === target.tripLocator.tripIndex,
-  );
-  const sameStopIndex = sameTripIndex.filter(
-    (candidate) => candidate.stopIndex === target.stopIndex,
-  );
-
-  return {
-    patternId: target.tripLocator.patternId,
-    serviceId: target.tripLocator.serviceId,
-    tripIndex: target.tripLocator.tripIndex,
-    stopIndex: target.stopIndex,
-    departureMinutes: target.departureMinutes,
-    serviceDate: target.serviceDate.toISOString(),
-    sampleSameService: sameService.slice(0, 5).map(summarizeTarget),
-    sampleSameTripIndex: sameTripIndex.slice(0, 5).map(summarizeTarget),
-    sampleSameStopIndex: sameStopIndex.slice(0, 5).map(summarizeTarget),
-  };
-}
-
-function loadTripInspectionSnapshot(
-  trip: TripSnapshot,
-  target: TripInspectionTarget,
-): LoadedTripInspectionSnapshotResult {
-  const resolvedSnapshot = resolveSelectedTripInspectionSnapshot(trip, target);
-  if (!resolvedSnapshot.ok) {
-    switch (resolvedSnapshot.reason) {
-      case 'pattern-position-missing':
-        logger.warn(
-          `openTripInspection: selected stop index ${target.stopIndex} is missing from reconstructed trip snapshot`,
-        );
-        break;
-      case 'stop-row-missing':
-        logger.warn(
-          'openTripInspection: selected stop row is missing from reconstructed trip snapshot',
-          {
-            target,
-          },
-        );
-        break;
-      default: {
-        const exhaustiveReason: never = resolvedSnapshot.reason;
-        logger.warn('openTripInspection: unexpected snapshot resolution failure', {
-          target,
-          reason: exhaustiveReason,
-        });
-      }
-    }
-
-    return { ok: false, status: 'no-data' };
-  }
-
-  if (resolvedSnapshot.data.selectedStopId === undefined) {
-    logger.warn(
-      'openTripInspection: selected stop metadata missing; skip trip-inspection target lookup',
-    );
-    return { ok: false, status: 'no-data' };
-  }
-
-  return {
-    ok: true,
-    data: {
-      snapshot: resolvedSnapshot.data.snapshot,
-      selectedStopId: resolvedSnapshot.data.selectedStopId,
-    },
-  };
-}
-
-async function refineTripInspectionState(
-  repo: TransitRepository,
-  target: TripInspectionTarget,
-  snapshot: SelectedTripSnapshot,
-  selectedStopId: string,
-  isCancelled: () => boolean,
-): Promise<RefinedTripInspectionStateResult> {
-  try {
-    // Build the trip-inspection navigation list from the stop's full-day
-    // timetable entries so prev/next steps follow display-time order
-    // (Issue #63). Reusing the repo's canonical TimetableEntry list lets
-    // us share the same sort + (future) filter helpers used by the
-    // timetable grid and the NearbyStop bottom sheet.
-    //
-    // The companion entry point `openTripInspectionFromStopId` still calls
-    // `getTripInspectionTargets` because `selectTripInspectionTargetByReferenceTime`
-    // assumes `departureMinutes`-ascending input (see its TSDoc).
-    const entriesResult = await repo.getFullDayTimetableEntries(selectedStopId, target.serviceDate);
-
-    if (isCancelled()) {
-      return { ok: false, status: 'cancelled' };
-    }
-
-    if (!entriesResult.success) {
-      logger.warn(
-        'openTripInspection: trip-inspection entry lookup failed',
-        entriesResult.error,
-        target,
-      );
-      return { ok: false, status: 'error' };
-    }
-
-    // `entriesResult.data` (TimetableEntry[]) is passed directly into the
-    // sort below. No filter is applied here.
-    const sorted = sortTimetableEntriesByDisplayTime([...entriesResult.data]);
-    const candidates: TripInspectionTarget[] = sorted.map((entry) => ({
-      tripLocator: entry.tripLocator,
-      stopIndex: entry.patternPosition.stopIndex,
-      departureMinutes: entry.schedule.departureMinutes,
-      serviceDate: target.serviceDate,
-    }));
-
-    if (candidates.length === 0) {
-      return { ok: false, status: 'no-data' };
-    }
-
-    const resolvedState = resolveTripInspectionDisplayState(snapshot, candidates, target);
-    if (!resolvedState.ok) {
-      if (logger.isEnabled('debug')) {
-        const diagnostics = buildTripInspectionMatchDiagnostics(target, candidates);
-        logger.debug(
-          'openTripInspection: target lookup mismatch sampleSameService',
-          diagnostics.sampleSameService,
-        );
-        logger.debug(
-          'openTripInspection: target lookup mismatch sampleSameTripIndex',
-          diagnostics.sampleSameTripIndex,
-        );
-        logger.debug(
-          'openTripInspection: target lookup mismatch sampleSameStopIndex',
-          diagnostics.sampleSameStopIndex,
-        );
-        logger.debug('openTripInspection: target lookup mismatch diagnostics', diagnostics);
-      }
-      logger.warn('openTripInspection: current target missing from trip-inspection targets', {
-        target,
-        targets: candidates,
-      });
-      return { ok: false, status: 'no-data' };
-    }
-
-    if (
-      resolvedState.data.snapshot.currentStopIndex !== snapshot.currentStopIndex ||
-      resolvedState.data.snapshot.selectedStop !== snapshot.selectedStop
-    ) {
-      logger.warn('openTripInspection: using fallback trip-inspection target', {
-        requestedTarget: target,
-        resolvedTarget: resolvedState.data.targets[resolvedState.data.targetIndex],
-      });
-    }
-
-    return {
-      ok: true,
-      data: {
-        snapshot: resolvedState.data.snapshot,
-        targets: resolvedState.data.targets,
-        targetIndex: resolvedState.data.targetIndex,
-      },
-    };
-  } catch (error: unknown) {
-    if (isCancelled()) {
-      return { ok: false, status: 'cancelled' };
-    }
-
-    logger.warn('openTripInspection: trip-inspection target lookup threw', error, target);
-    return { ok: false, status: 'error' };
-  }
 }
 
 /**
@@ -330,9 +101,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
 
       const loadedSnapshot = loadTripInspectionSnapshot(trip.data, target);
       if (!loadedSnapshot.ok) {
-        return loadedSnapshot.status === 'no-data'
-          ? { status: 'no-data', reason: 'snapshot-unavailable' }
-          : { status: loadedSnapshot.status };
+        return { status: 'no-data', reason: 'snapshot-unavailable' };
       }
 
       const { snapshot, selectedStopId } = loadedSnapshot.data;
@@ -356,17 +125,82 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         });
       }
 
-      const refinedState = await refineTripInspectionState(
-        repo,
-        target,
+      // I/O glue: fetch the stop's full-day timetable entries and hand them
+      // to the pure `refineTripInspectionState` for sort + resolve. The
+      // navigation list now follows display-time order (Issue #63), shared
+      // with the timetable grid (#201) and the NearbyStop bottom sheet (#202).
+      //
+      // The companion entry point `openTripInspectionFromStopId` still uses
+      // `repo.getTripInspectionTargets` because
+      // `selectTripInspectionTargetByReferenceTime` assumes
+      // `departureMinutes`-ascending input (see its TSDoc).
+      let entriesResult;
+      try {
+        entriesResult = await repo.getFullDayTimetableEntries(
+          selectedStopId,
+          serviceDayReferenceDateTime(target.serviceDate),
+        );
+      } catch (error: unknown) {
+        if (lookupRequestIdRef.current !== lookupRequestId) {
+          return { status: 'cancelled' };
+        }
+        logger.warn('openTripInspection: trip-inspection entry lookup threw', error, target);
+        return { status: 'error' };
+      }
+
+      if (lookupRequestIdRef.current !== lookupRequestId) {
+        return { status: 'cancelled' };
+      }
+
+      if (!entriesResult.success) {
+        logger.warn(
+          'openTripInspection: trip-inspection entry lookup failed',
+          entriesResult.error,
+          target,
+        );
+        return { status: 'error' };
+      }
+
+      const refinedState = refineTripInspectionState(
+        entriesResult.data,
+        target.serviceDate,
         snapshot,
-        selectedStopId,
-        () => lookupRequestIdRef.current !== lookupRequestId,
+        target,
       );
       if (!refinedState.ok) {
-        return refinedState.status === 'no-data'
-          ? { status: 'no-data', reason: 'target-missing' }
-          : { status: refinedState.status };
+        if (logger.isEnabled('debug')) {
+          const diagnostics = buildTripInspectionMatchDiagnostics(
+            target,
+            tripInspectionTargetsRef.current,
+          );
+          logger.debug(
+            'openTripInspection: target lookup mismatch sampleSameService',
+            diagnostics.sampleSameService,
+          );
+          logger.debug(
+            'openTripInspection: target lookup mismatch sampleSameTripIndex',
+            diagnostics.sampleSameTripIndex,
+          );
+          logger.debug(
+            'openTripInspection: target lookup mismatch sampleSameStopIndex',
+            diagnostics.sampleSameStopIndex,
+          );
+          logger.debug('openTripInspection: target lookup mismatch diagnostics', diagnostics);
+        }
+        logger.warn('openTripInspection: current target missing from trip-inspection targets', {
+          target,
+        });
+        return { status: 'no-data', reason: 'target-missing' };
+      }
+
+      if (
+        refinedState.data.snapshot.currentStopIndex !== snapshot.currentStopIndex ||
+        refinedState.data.snapshot.selectedStop !== snapshot.selectedStop
+      ) {
+        logger.warn('openTripInspection: using fallback trip-inspection target', {
+          requestedTarget: target,
+          resolvedTarget: refinedState.data.targets[refinedState.data.targetIndex],
+        });
       }
 
       updateTripInspectionTargets(refinedState.data.targets);

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import { formatDateKey } from '../domain/transit/calendar-utils';
 import { getServiceDayMinutes } from '../domain/transit/service-day';
+import { sortTimetableEntriesByDisplayTime } from '../domain/transit/sort-timetable-for-ui';
 import {
   isSameTripInspectionTarget,
   resolveSelectedTripInspectionSnapshot,
@@ -194,28 +195,48 @@ async function refineTripInspectionState(
   isCancelled: () => boolean,
 ): Promise<RefinedTripInspectionStateResult> {
   try {
-    const result = await repo.getTripInspectionTargets({
-      serviceDate: target.serviceDate,
-      stopId: selectedStopId,
-    });
+    // Build the trip-inspection navigation list from the stop's full-day
+    // timetable entries so prev/next steps follow display-time order
+    // (Issue #63). Reusing the repo's canonical TimetableEntry list lets
+    // us share the same sort + (future) filter helpers used by the
+    // timetable grid and the NearbyStop bottom sheet.
+    //
+    // The companion entry point `openTripInspectionFromStopId` still calls
+    // `getTripInspectionTargets` because `selectTripInspectionTargetByReferenceTime`
+    // assumes `departureMinutes`-ascending input (see its TSDoc).
+    const entriesResult = await repo.getFullDayTimetableEntries(selectedStopId, target.serviceDate);
 
     if (isCancelled()) {
       return { ok: false, status: 'cancelled' };
     }
 
-    if (!result.success) {
-      logger.warn('openTripInspection: trip-inspection target lookup failed', result.error, target);
+    if (!entriesResult.success) {
+      logger.warn(
+        'openTripInspection: trip-inspection entry lookup failed',
+        entriesResult.error,
+        target,
+      );
       return { ok: false, status: 'error' };
     }
 
-    if (result.data.length === 0) {
+    // `entriesResult.data` (TimetableEntry[]) is passed directly into the
+    // sort below. No filter is applied here.
+    const sorted = sortTimetableEntriesByDisplayTime([...entriesResult.data]);
+    const candidates: TripInspectionTarget[] = sorted.map((entry) => ({
+      tripLocator: entry.tripLocator,
+      stopIndex: entry.patternPosition.stopIndex,
+      departureMinutes: entry.schedule.departureMinutes,
+      serviceDate: target.serviceDate,
+    }));
+
+    if (candidates.length === 0) {
       return { ok: false, status: 'no-data' };
     }
 
-    const resolvedState = resolveTripInspectionDisplayState(snapshot, result.data, target);
+    const resolvedState = resolveTripInspectionDisplayState(snapshot, candidates, target);
     if (!resolvedState.ok) {
       if (logger.isEnabled('debug')) {
-        const diagnostics = buildTripInspectionMatchDiagnostics(target, result.data);
+        const diagnostics = buildTripInspectionMatchDiagnostics(target, candidates);
         logger.debug(
           'openTripInspection: target lookup mismatch sampleSameService',
           diagnostics.sampleSameService,
@@ -232,7 +253,7 @@ async function refineTripInspectionState(
       }
       logger.warn('openTripInspection: current target missing from trip-inspection targets', {
         target,
-        targets: result.data,
+        targets: candidates,
       });
       return { ok: false, status: 'no-data' };
     }

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -135,7 +135,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
       // `repo.getTripInspectionTargets` because
       // `selectTripInspectionTargetByReferenceTime` assumes
       // `departureMinutes`-ascending input (see its TSDoc).
-      let entriesResult;
+      let entriesResult: Awaited<ReturnType<TransitRepository['getFullDayTimetableEntries']>>;
       try {
         entriesResult = await repo.getFullDayTimetableEntries(
           selectedStopId,


### PR DESCRIPTION
## Summary

Follow-up of #63 (and the two preceding PRs #201 / #202) for the last remaining surface that still navigated in `departureMinutes` order: the `TripPager` prev/next inside `TripInspectionDialog`.

`useTripInspection.refineTripInspectionState` (now extracted to `src/domain/transit/trip-inspection-state.ts`) builds the navigation candidates from `repo.getFullDayTimetableEntries` and runs them through `sortTimetableEntriesByDisplayTime` before mapping to `TripInspectionTarget[]`. The TripPager prev/next now follows the same displayed-minute order used by the timetable grid (#201) and the NearbyStop bottom sheet (#202).

- No change to `TripInspectionTarget` type or either repo.
- `repo.getTripInspectionTargets` is still required: `openTripInspectionFromStopId` (the stop-id entry point) keeps calling it because `selectTripInspectionTargetByReferenceTime` is documented to require `departureMinutes`-ascending input. Diagnostics (`repo-benchmark`) and the repo unit tests likewise continue to depend on it.
- No GlobalFilter handling is added by this PR; the comment in the new code is strictly descriptive of current behaviour.

## Review feedback addressed

Four review items raised against the initial commit `4fd30702`:

- **`getFullDayTimetableEntries` 03:00 boundary** (Gemini high / Copilot): `target.serviceDate` is midnight-anchored, and `getFullDayTimetableEntries` derives its service day via `getServiceDay(dateTime)` which treats `hours < 3` as the previous service day. Now wrapped with the new pure helper `serviceDayReferenceDateTime` that clones the date and anchors it to local noon before the repo call.
- **`resolveTripInspectionTarget` order contract** (Gemini medium): the previous TSDoc only documented `departureMinutes`-ascending input. The exact-match path is in fact order-agnostic (linear `findIndex` on `isSameTripInspectionTarget`), and the fallback path self-sorts the same-trip subset. TSDoc updated to spell this out, and two extra unit tests (descending input / display-time ordered terminal) lock the claim.
- **`refineTripInspectionState` was untested at the domain level** (Copilot): the helper has been moved into `src/domain/transit/trip-inspection-state.ts` along with `loadTripInspectionSnapshot`, `buildTripInspectionMatchDiagnostics`, `getEmptyTripInspectionTargetsNote`, and `serviceDayReferenceDateTime`. 19 new unit tests in `trip-inspection-state.test.ts` cover the noon-anchor boundary cases, the empty / fallback / no-data branches of `refineTripInspectionState`, the diagnostics narrowing/cap, and the snapshot loader.
- **Hook-level integration coverage of the new branch** (Copilot): three new cases in `use-trip-inspection.test.ts` exercise `openTripInspectionFromTarget` end-to-end. The happy-path case asserts (a) the repo receives a noon-anchored reference datetime -- the 03:00 boundary regression guard -- and (b) the resulting `tripInspectionTargets` are in display-time order. The other two cases cover the lookup-failure path (`status: 'error'` and state reset) and the target-missing path (`status: 'no-data', reason: 'target-missing'`).

## Refactor

`src/hooks/use-trip-inspection.ts` was bloated with pure helpers that did not need React state. They now live in `src/domain/transit/trip-inspection-state.ts`:

- `serviceDayReferenceDateTime(serviceDate)` -- noon-anchor helper
- `getEmptyTripInspectionTargetsNote(emptyReason)` -- `TripInspectionTargetsEmptyReason` to human-readable note
- `buildTripInspectionMatchDiagnostics(target, candidates)` -- diagnostics payload for `debug` logs
- `loadTripInspectionSnapshot(trip, target)` -- snapshot resolver + selectedStopId surfacing
- `refineTripInspectionState(entries, serviceDate, snapshot, target)` -- display-time sort + resolver

The hook keeps the I/O glue (repo calls, cancellation, state updates) and composes the domain helpers.

## Behavioural deltas

| Aspect | Before | After |
| --- | --- | --- |
| Sort primary key | `departureMinutes` ascending | `getDisplayMinutes` ascending (display = arrival for terminal else departure) |
| Tie-break order | `stopIndex` -> `route_id.localeCompare` | `arrival` -> `departure` -> `isOrigin` (true first) -> `isTerminal` (true first) |
| Empty result taxonomy | `meta.emptyReason` distinguishes `no-stop-data` / `no-service-on-this-day` | Collapsed to `success: true, data: []`. The `refineTripInspectionState` branch already discarded `emptyReason`, so no user-visible message change. |
| Corrupted-data signal | "all active groups reference missing patterns" -> `success: false` -> `status: 'error'` | `getFullDayTimetableEntries` silently skips missing-pattern entries -> `success: true, data: []` -> `status: 'no-data'`. Small detection regression for an extremely rare repo data-integrity path. |

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx eslint src/hooks/use-trip-inspection.ts src/hooks/__tests__/use-trip-inspection.test.ts src/domain/transit/trip-inspection-state.ts src/domain/transit/__tests__/trip-inspection-state.test.ts src/domain/transit/__tests__/trip-inspection-target.test.ts`
- [x] `npx vitest run` -- 3405 tests / 221 files pass. New / changed test files: `trip-inspection-state.test.ts` (19 new cases), `trip-inspection-target.test.ts` (+2 cases), `use-trip-inspection.test.ts` (+3 cases).
- [x] `npm run build`
- [x] Manual (mock): `?repo=mock&stop=bus_park&time=2026-05-11T09:00:00+09:00` -- click yukkuri01 terminal entry showing `9:05着`. TripPager header shows prev=`9:01`, next=`9:06` -- display order. Before the fix this entry's `departureMinutes` was `9:08`, so prev/next were `9:06` / `9:09`.

Refs: #63