### PR TITLE
feat: improve trip inspection stop navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - Trip inspection: stop list から stop を選択状態に切り替えられるようにした。選択に合わせて map も移動し、ダイアログは開いたまま維持される。
 - Trip inspection: 異なる stop の trip inspection に切り替えられるようにした。各 stop の時刻タップから、対応する のりば と時刻の trip inspection を直接開ける。
+- Stop navigation: `app.tsx` 内に散っていた stop 選択・map 移動・history 追加の処理を `useStopNavigation` に集約し、viewport/fallback 解決の純関数を `src/domain/transit/stop-navigation.ts` へ分離。`useSelection.selectStopById` は fallback stop を受け取れるようにし、関連 hook/domain test を追加した。
 
 ## [2026.05.10]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ### Changed
 
+- Trip inspection: dialog 内で別の trip や stop に切り替えたとき、更新 notice と文言を見直し、内容だけが切り替わって気づきにくい UX を改善した。
 - Trip inspection: stop list から stop を選択状態に切り替えられるようにした。選択に合わせて map も移動し、ダイアログは開いたまま維持される。
 - Trip inspection: 異なる stop の trip inspection に切り替えられるようにした。各 stop の時刻タップから、対応する のりば と時刻の trip inspection を直接開ける。
 - Stop navigation: `app.tsx` 内に散っていた stop 選択・map 移動・history 追加の処理を `useStopNavigation` に集約し、viewport/fallback 解決の純関数を `src/domain/transit/stop-navigation.ts` へ分離。`useSelection.selectStopById` は fallback stop を受け取れるようにし、関連 hook/domain test を追加した。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Trip inspection: stop list から stop を選択状態に切り替えられるようにした。選択に合わせて map も移動し、ダイアログは開いたまま維持される。
+- Trip inspection: 異なる stop の trip inspection に切り替えられるようにした。各 stop の時刻タップから、対応する のりば と時刻の trip inspection を直接開ける。
+
 ## [2026.05.10]
 
 ### Changed

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -18,7 +18,6 @@ import { formatDateKey } from './domain/transit/calendar-utils';
 import { computeStopsCounts } from './domain/transit/compute-stops-counts';
 import { getStopDisplayNames } from './domain/transit/name-resolver/get-stop-display-names';
 import { resolveLangChain, type LangChain } from './domain/transit/i18n/resolve-lang-chain';
-import { resolveStopRouteTypes } from './domain/transit/resolve-stop-route-types';
 import { getServiceDay, getServiceDayMinutes } from './domain/transit/service-day';
 import {
   applyStopEventAttributeTogglesToStops,
@@ -31,6 +30,7 @@ import { useKeyboardShortcuts } from './hooks/use-keyboard-shortcuts';
 import { useNearbyStopTimes } from './hooks/use-nearby-stop-times';
 import { useRouteStops } from './hooks/use-route-stops';
 import { useSelection } from './hooks/use-selection';
+import { useStopNavigation } from './hooks/use-stop-navigation';
 import { useStopHistory } from './hooks/use-stop-history';
 import { useTimetable } from './hooks/use-timetable';
 import { useTransitRepository } from './hooks/use-transit-repository';
@@ -232,7 +232,6 @@ export default function App({ loadResult }: AppProps) {
     selectedStopId,
     selectionInfo,
     focusPosition,
-    selectStop,
     selectStopById,
     deselectStop,
     selectRouteShape,
@@ -293,42 +292,6 @@ export default function App({ loadResult }: AppProps) {
     }
   }, [anchors, repo, batchUpdateAnchors]);
 
-  // Viewport-limited StopWithMeta lookup.
-  //
-  // ⚠️ This callback only searches `radiusStops` (~1 km from the user)
-  // and `inBoundStops` (current map viewport). It is intentionally
-  // narrow because it sits on the hot path of map interaction and is
-  // re-created whenever those collections change.
-  //
-  // Use this ONLY for stops that are by definition near the user at
-  // the moment of the call:
-  //   - the just-clicked map marker (radiusStops by construction)
-  //   - the currently selected stop being re-resolved during pan
-  //   - any other case where the caller already has the stop on screen
-  //
-  // Do NOT use this for persistent / long-lived / arbitrary stop IDs
-  // such as anchors (bookmarks), history entries, stops belonging to
-  // a selected route, or a `stop_id` from the URL `?stop=` parameter
-  // — `?stop=` is resolved via `repo.getStopMetaById(stopId)` in the
-  // effect below precisely because it can target a stop anywhere in
-  // the dataset, not just inside the viewport. Those IDs may point
-  // to stops far outside the viewport, so this lookup will silently
-  // return null and the caller will fall back to a stale snapshot.
-  // For those cases call `repo.getStopMetaByIds(...)` (full-dataset
-  // indexed lookup) instead — the anchor display lookup below
-  // (`anchorStopMetaMap`) is the canonical example.
-  //
-  // See `DEVELOPMENT.md > Stop ID lookup の選び方` for the rule and
-  // historical context (route stops and anchor i18n both regressed
-  // by reaching for this helper instead of `getStopMetaByIds`).
-  const findStopWithMeta = useCallback(
-    (stopId: string) =>
-      radiusStops.find((s) => s.stop.stop_id === stopId) ??
-      inBoundStops.find((s) => s.stop.stop_id === stopId) ??
-      null,
-    [radiusStops, inBoundStops],
-  );
-
   // Pre-resolved StopWithMeta map for every anchored stop_id.
   // Built from the repository's full dataset (not just the visible
   // viewport) so that `Portals` can look up the latest translated
@@ -351,6 +314,18 @@ export default function App({ loadResult }: AppProps) {
     [anchorStopMetaMap],
   );
 
+  const { selectStopWithFallback, navigateAndFocusStop, navigateAndFocusStopById } =
+    useStopNavigation({
+      repo,
+      routeTypeMap,
+      radiusStops,
+      inBoundStops,
+      disableAutoLocate,
+      selectStopById,
+      focusStop,
+      pushStop,
+    });
+
   // Wrap selectStop to also record in history.
   //
   // Disables auto-tracking because selecting a stop pans the map to
@@ -359,46 +334,18 @@ export default function App({ loadResult }: AppProps) {
   // `moveend` events ineligible for nearby/in-bounds refetch.
   const handleSelectStop = useCallback(
     (stop: Stop) => {
-      logger.debug(`handleSelectStop [Marker]: stopId=${stop.stop_id}, name=${stop.stop_name}`);
-      disableAutoLocate('select-marker');
-      selectStop(stop);
-      const meta = findStopWithMeta(stop.stop_id);
-      if (meta) {
-        pushStop(
-          meta,
-          resolveStopRouteTypes({
-            stopId: stop.stop_id,
-            routeTypeMap,
-            routes: meta.routes,
-            unknownPolicy: 'include-unknown',
-          }),
-        );
-      }
+      selectStopWithFallback(stop.stop_id, 'select-marker', stop);
     },
-    [selectStop, pushStop, findStopWithMeta, routeTypeMap, disableAutoLocate],
+    [selectStopWithFallback],
   );
 
   // Wrap selectStopById to also record in history.
   // See `handleSelectStop` for the rationale of disabling auto-tracking.
   const handleSelectStopById = useCallback(
     (stopId: string) => {
-      logger.debug(`handleSelectStopById [BottomSheet]: stopId=${stopId}`);
-      disableAutoLocate('select-bottom-sheet');
-      selectStopById(stopId);
-      const meta = findStopWithMeta(stopId);
-      if (meta) {
-        pushStop(
-          meta,
-          resolveStopRouteTypes({
-            stopId,
-            routeTypeMap,
-            routes: meta.routes,
-            unknownPolicy: 'include-unknown',
-          }),
-        );
-      }
+      selectStopWithFallback(stopId, 'select-bottom-sheet');
     },
-    [selectStopById, pushStop, findStopWithMeta, routeTypeMap, disableAutoLocate],
+    [selectStopWithFallback],
   );
 
   // Apply ?stop= query param: select and pan to the stop after data loads.
@@ -416,30 +363,19 @@ export default function App({ loadResult }: AppProps) {
       stopParamApplied.current = true;
       return;
     }
-    void repo.getStopMetaById(stopId).then((result) => {
+    void navigateAndFocusStopById(stopId, 'apply-stop-param').then((result) => {
       if (stopParamApplied.current) {
         return;
       }
       if (result.success) {
-        const stop = result.data;
-        logger.info(`Applying ?stop=${stopId}: ${stop.stop.stop_name}`);
-        focusStop(stop.stop);
-        pushStop(
-          stop,
-          resolveStopRouteTypes({
-            stopId,
-            routeTypeMap,
-            routes: stop.routes,
-            unknownPolicy: 'include-unknown',
-          }),
-        );
+        logger.info(`Applying ?stop=${stopId}: ${result.data.stop.stop_name}`);
         stopParamApplied.current = true;
       } else {
         logger.warn(`?stop=${stopId}: not found`);
         stopParamApplied.current = true;
       }
     });
-  }, [repo, focusStop, pushStop, routeTypeMap]);
+  }, [navigateAndFocusStopById]);
 
   // Load route shapes once on mount
   useEffect(() => {
@@ -648,26 +584,13 @@ export default function App({ loadResult }: AppProps) {
 
   const handleSelectStopFromTripInspection = useCallback(
     (stopId: string) => {
-      disableAutoLocate('select-trip-inspection');
-      void repo.getStopMetaById(stopId).then((result) => {
+      void navigateAndFocusStopById(stopId, 'select-trip-inspection').then((result) => {
         if (!result.success) {
           toast.error(t('tripInspection.messages.openFailed'));
-          return;
         }
-
-        focusStop(result.data.stop);
-        pushStop(
-          result.data,
-          resolveStopRouteTypes({
-            stopId,
-            routeTypeMap,
-            routes: result.data.routes,
-            unknownPolicy: 'include-unknown',
-          }),
-        );
       });
     },
-    [disableAutoLocate, focusStop, pushStop, repo, routeTypeMap, t],
+    [navigateAndFocusStopById, t],
   );
 
   const handleTripInspectionOpenChange = useCallback(
@@ -689,12 +612,9 @@ export default function App({ loadResult }: AppProps) {
   const handleHistorySelect = useCallback(
     (stop: Stop, routeTypes: AppRouteTypeValue[]) => {
       logger.debug(`handleHistorySelect [History]: stopId=${stop.stop_id}, name=${stop.stop_name}`);
-      disableAutoLocate('select-history');
-      focusStop(stop);
-      const meta = findStopWithMeta(stop.stop_id) ?? { stop, agencies: [], routes: [] };
-      pushStop(meta, routeTypes);
+      navigateAndFocusStop(stop, 'select-history', routeTypes);
     },
-    [focusStop, pushStop, findStopWithMeta, disableAutoLocate],
+    [navigateAndFocusStop],
   );
 
   // Anchor stop_id set for efficient lookup in BottomSheet
@@ -709,7 +629,7 @@ export default function App({ loadResult }: AppProps) {
         // the user's current language even though the stored entry
         // only has a snapshot stopName. We use `lookupAnchorStopMeta`
         // (full-dataset scan over the anchor set) rather than
-        // `findStopWithMeta` (viewport-only) here because the stop_id
+        // the stop-navigation viewport lookup here because the stop_id
         // is a persistent anchor reference and may, in some future UI
         // path, be triggered for an anchor that is not currently in
         // radiusStops / inBoundStops. See `DEVELOPMENT.md > Stop ID
@@ -782,7 +702,6 @@ export default function App({ loadResult }: AppProps) {
   const handlePortalSelect = useCallback(
     (entry: AnchorEntry) => {
       logger.debug(`handlePortalSelect [Portal]: stopId=${entry.stopId}, name=${entry.stopName}`);
-      disableAutoLocate('select-portal');
       // Build a minimal Stop from AnchorEntry for map pan
       const stop: Stop = {
         stop_id: entry.stopId,
@@ -793,12 +712,9 @@ export default function App({ loadResult }: AppProps) {
         location_type: 0,
         agency_id: '',
       };
-      focusStop(stop);
-      // Also record in history
-      const meta = findStopWithMeta(entry.stopId) ?? { stop, agencies: [], routes: [] };
-      pushStop(meta, entry.routeTypes);
+      navigateAndFocusStop(stop, 'select-portal', entry.routeTypes);
     },
-    [focusStop, findStopWithMeta, pushStop, disableAutoLocate],
+    [navigateAndFocusStop],
   );
 
   // Select + pan to a stop chosen from the search dialog.
@@ -807,15 +723,12 @@ export default function App({ loadResult }: AppProps) {
   const handleSearchSelect = useCallback(
     (stop: Stop, routeTypes: AppRouteTypeValue[]) => {
       logger.debug(`handleSearchSelect [Search]: stopId=${stop.stop_id}, name=${stop.stop_name}`);
-      disableAutoLocate('select-search');
-      focusStop(stop);
+      navigateAndFocusStop(stop, 'select-search', routeTypes);
       setSearchModalOpen(false);
       // SearchDialog already resolved routeTypes from its own routeTypeMap,
       // so we can use them directly without re-resolving.
-      const meta = findStopWithMeta(stop.stop_id) ?? { stop, agencies: [], routes: [] };
-      pushStop(meta, routeTypes);
     },
-    [focusStop, pushStop, findStopWithMeta, disableAutoLocate],
+    [navigateAndFocusStop],
   );
 
   // --- App-wide filter state (shared across surfaces) ---

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1109,6 +1109,7 @@ export default function App({ loadResult }: AppProps) {
         dataLangs={langChain}
         onOpenPreviousTrip={openPreviousTripInspection}
         onOpenNextTrip={openNextTripInspection}
+        onInspectTrip={handleInspectTrip}
         onOpenChange={handleTripInspectionOpenChange}
       />
       <TimetableModal

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -646,6 +646,30 @@ export default function App({ loadResult }: AppProps) {
     [openTripInspectionFromTarget, t],
   );
 
+  const handleSelectStopFromTripInspection = useCallback(
+    (stopId: string) => {
+      disableAutoLocate('select-trip-inspection');
+      void repo.getStopMetaById(stopId).then((result) => {
+        if (!result.success) {
+          toast.error(t('tripInspection.messages.openFailed'));
+          return;
+        }
+
+        focusStop(result.data.stop);
+        pushStop(
+          result.data,
+          resolveStopRouteTypes({
+            stopId,
+            routeTypeMap,
+            routes: result.data.routes,
+            unknownPolicy: 'include-unknown',
+          }),
+        );
+      });
+    },
+    [disableAutoLocate, focusStop, pushStop, repo, routeTypeMap, t],
+  );
+
   const handleTripInspectionOpenChange = useCallback(
     (open: boolean) => {
       if (!open) {
@@ -1134,6 +1158,7 @@ export default function App({ loadResult }: AppProps) {
         onOpenPreviousTrip={openPreviousTripInspection}
         onOpenNextTrip={openNextTripInspection}
         onInspectTrip={handleInspectTripFromDialog}
+        onSelectStopById={handleSelectStopFromTripInspection}
         onOpenChange={handleTripInspectionOpenChange}
       />
       <TimetableModal

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -165,6 +165,7 @@ export default function App({ loadResult }: AppProps) {
     tripInspectionSnapshot,
     tripInspectionTargets,
     currentTripInspectionTargetIndex,
+    showNoticeNonce,
     openTripInspectionFromTarget,
     openTripInspectionFromStopId,
     openPreviousTripInspection,
@@ -603,7 +604,29 @@ export default function App({ loadResult }: AppProps) {
 
   const handleInspectTrip = useCallback(
     (target: TripInspectionTarget) => {
-      void openTripInspectionFromTarget(target).then((status) => {
+      void openTripInspectionFromTarget(target, 'direct-open').then((status) => {
+        if (status.status === 'no-data') {
+          const messageKey =
+            status.reason === 'no-stop-data'
+              ? 'tripInspection.messages.noStopData'
+              : status.reason === 'no-service-on-this-day'
+                ? 'tripInspection.messages.noServiceOnThisDay'
+                : 'tripInspection.messages.noData';
+          toast.warning(t(messageKey));
+          return;
+        }
+
+        if (status.status === 'error') {
+          toast.error(t('tripInspection.messages.openFailed'));
+        }
+      });
+    },
+    [openTripInspectionFromTarget, t],
+  );
+
+  const handleInspectTripFromDialog = useCallback(
+    (target: TripInspectionTarget) => {
+      void openTripInspectionFromTarget(target, 'trip-stops-time-select').then((status) => {
         if (status.status === 'no-data') {
           const messageKey =
             status.reason === 'no-stop-data'
@@ -1104,12 +1127,13 @@ export default function App({ loadResult }: AppProps) {
         snapshot={tripInspectionSnapshot}
         tripInspectionTargets={tripInspectionTargets}
         currentTripInspectionTargetIndex={currentTripInspectionTargetIndex}
+        showNoticeNonce={showNoticeNonce}
         now={dateTime}
         infoLevel={settings.infoLevel}
         dataLangs={langChain}
         onOpenPreviousTrip={openPreviousTripInspection}
         onOpenNextTrip={openNextTripInspection}
-        onInspectTrip={handleInspectTrip}
+        onInspectTrip={handleInspectTripFromDialog}
         onOpenChange={handleTripInspectionOpenChange}
       />
       <TimetableModal

--- a/src/components/dialog/dialog-memoization.test.tsx
+++ b/src/components/dialog/dialog-memoization.test.tsx
@@ -415,6 +415,7 @@ describe('dialog memoization regressions', () => {
       snapshot,
       tripInspectionTargets,
       currentTripInspectionTargetIndex: 0,
+      showNoticeNonce: 0,
       now: new Date(2026, 3, 1, 8, 0),
       infoLevel: 'normal' as const,
       dataLangs: ['ja'] as const,

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -60,6 +60,7 @@ interface TripInspectionDialogProps {
   dataLangs: readonly string[];
   onOpenPreviousTrip: () => void;
   onOpenNextTrip: () => void;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
 interface TripInspectionSummaryProps {
@@ -446,6 +447,7 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
   now,
   onOpenPreviousTrip,
   onOpenNextTrip,
+  onInspectTrip,
 }: TripInspectionDialogProps) {
   const infoLevelFlag = useInfoLevel(infoLevel);
   const { t } = useTranslation();
@@ -828,6 +830,7 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
               infoLevel={infoLevel}
               dataLangs={dataLangs}
               now={now}
+              onInspectTrip={onInspectTrip}
             />
           </div>
           {contentScroll.showBottom && <ScrollFadeEdge position="bottom" />}

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -5,6 +5,7 @@ import { JourneyTimeBar } from '@/components/journey-time-bar';
 import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
 import { StopInfo } from '@/components/stop-info';
 import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
   Dialog,
   DialogContent,
@@ -39,6 +40,7 @@ import type {
   TripStopTime,
 } from '@/types/app/transit-composed';
 import { getContrastAwareAlphaSuffixes } from '@/utils/color/contrast-alpha-suffixes';
+import { ArrowRightLeftIcon } from 'lucide-react';
 import { IdBadge } from '../badge/id-badge';
 import { TripPositionIndicator } from '../label/trip-position-indicator';
 import { TripBasicInfo } from '../trip/trip-basic-info';
@@ -55,6 +57,7 @@ interface TripInspectionDialogProps {
   snapshot: SelectedTripSnapshot | null;
   tripInspectionTargets: TripInspectionTarget[];
   currentTripInspectionTargetIndex: number;
+  showNoticeNonce: number;
   now: Date;
   infoLevel: InfoLevel;
   dataLangs: readonly string[];
@@ -121,6 +124,13 @@ interface TripEndpointsSummaryProps {
    */
   onSelectLast?: () => void;
 }
+
+interface TripInspectionUpdateNoticeProps {
+  kind: TripInspectionUpdateNoticeKind;
+  visible: boolean;
+}
+
+type TripInspectionUpdateNoticeKind = 'stop-changed';
 
 function resolveTripStopDisplay(
   stop: TripStopTime | undefined,
@@ -274,6 +284,42 @@ function RichStopSummary({ stop, infoLevel, dataLangs, onSelect }: RichStopSumma
         />
       </div>
     </Button>
+  );
+}
+
+function TripInspectionUpdateNotice({ kind, visible }: TripInspectionUpdateNoticeProps) {
+  const { t } = useTranslation();
+
+  if (!visible) {
+    return null;
+  }
+
+  const messageByKind: Record<
+    TripInspectionUpdateNoticeKind,
+    { titleKey: string; descriptionKey?: string }
+  > = {
+    'stop-changed': {
+      titleKey: 'tripInspection.messages.stopChangedTitle',
+      descriptionKey: undefined,
+    },
+  };
+  const message = messageByKind[kind];
+
+  return (
+    <Alert
+      aria-live="polite"
+      className="motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-top-1 border-emerald-300 bg-emerald-50 px-3 py-2 text-left shadow-sm dark:border-emerald-800 dark:bg-emerald-950/40"
+    >
+      <ArrowRightLeftIcon className="mt-0.5 text-emerald-700 dark:text-emerald-300" />
+      <AlertTitle className="text-xs font-semibold text-emerald-900 dark:text-emerald-200">
+        {t(message.titleKey)}
+      </AlertTitle>
+      {message.descriptionKey && (
+        <AlertDescription className="text-[11px] text-emerald-800 dark:text-emerald-300">
+          {t(message.descriptionKey)}
+        </AlertDescription>
+      )}
+    </Alert>
   );
 }
 
@@ -442,6 +488,7 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
   snapshot,
   tripInspectionTargets,
   currentTripInspectionTargetIndex,
+  showNoticeNonce,
   infoLevel,
   dataLangs,
   now,
@@ -452,7 +499,9 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
   const infoLevelFlag = useInfoLevel(infoLevel);
   const { t } = useTranslation();
   const contentContainerRef = useRef<HTMLDivElement>(null);
+  const [inactiveShowNoticeNonce, setInactiveShowNoticeNonce] = useState(showNoticeNonce);
   const [contentContainerEl, setContentContainerEl] = useState<HTMLDivElement | null>(null);
+  const [dismissedShowNoticeNonce, setDismissedShowNoticeNonce] = useState(showNoticeNonce);
   const setContentContainerNode = useCallback((node: HTMLDivElement | null) => {
     contentContainerRef.current = node;
     setContentContainerEl(node);
@@ -506,6 +555,10 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
   // smooth scroll has had time to settle.
   const programmaticScrollSettleRef = useRef<number>(0);
 
+  if ((!open || !snapshot) && inactiveShowNoticeNonce !== showNoticeNonce) {
+    setInactiveShowNoticeNonce(showNoticeNonce);
+  }
+
   useEffect(() => {
     if (!open || !snapshot) {
       return;
@@ -519,6 +572,26 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
       window.cancelAnimationFrame(frameId);
     };
   }, [open, snapshot]);
+
+  const isTripSwitchNoticeVisible =
+    open &&
+    !!snapshot &&
+    showNoticeNonce !== inactiveShowNoticeNonce &&
+    showNoticeNonce !== dismissedShowNoticeNonce;
+
+  useEffect(() => {
+    if (!isTripSwitchNoticeVisible) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setDismissedShowNoticeNonce(showNoticeNonce);
+    }, 2_000);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [isTripSwitchNoticeVisible, showNoticeNonce]);
 
   const scrollToStopRow = useCallback((stopIndex: number, behavior: ScrollBehavior): boolean => {
     const container = contentContainerRef.current;
@@ -712,6 +785,12 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
               />
             </div>
           </DialogTitle>
+
+          <div className="px-0 py-1">
+            <div className="flex items-center justify-center">
+              <TripInspectionUpdateNotice kind="stop-changed" visible={isTripSwitchNoticeVisible} />
+            </div>
+          </div>
 
           <div className="px-2">
             {/*

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -64,6 +64,7 @@ interface TripInspectionDialogProps {
   onOpenPreviousTrip: () => void;
   onOpenNextTrip: () => void;
   onInspectTrip?: (target: TripInspectionTarget) => void;
+  onSelectStopById?: (stopId: string) => void;
 }
 
 interface TripInspectionSummaryProps {
@@ -495,6 +496,7 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
   onOpenPreviousTrip,
   onOpenNextTrip,
   onInspectTrip,
+  onSelectStopById,
 }: TripInspectionDialogProps) {
   const infoLevelFlag = useInfoLevel(infoLevel);
   const { t } = useTranslation();
@@ -910,6 +912,7 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
               dataLangs={dataLangs}
               now={now}
               onInspectTrip={onInspectTrip}
+              onSelectStopById={onSelectStopById}
             />
           </div>
           {contentScroll.showBottom && <ScrollFadeEdge position="bottom" />}

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -311,7 +311,11 @@ function TripInspectionUpdateNotice({ kind, visible }: TripInspectionUpdateNotic
       aria-live="polite"
       className="motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-top-1 border-emerald-300 bg-emerald-50 px-3 py-2 text-left shadow-sm dark:border-emerald-800 dark:bg-emerald-950/40"
     >
-      <ArrowRightLeftIcon className="mt-0.5 text-emerald-700 dark:text-emerald-300" />
+      <ArrowRightLeftIcon
+        aria-hidden="true"
+        focusable="false"
+        className="mt-0.5 text-emerald-700 dark:text-emerald-300"
+      />
       <AlertTitle className="text-xs font-semibold text-emerald-900 dark:text-emerald-200">
         {t(message.titleKey)}
       </AlertTitle>

--- a/src/components/stop-time-time-info.tsx
+++ b/src/components/stop-time-time-info.tsx
@@ -66,6 +66,10 @@ export interface StopTimeTimeInfoProps extends WithServiceDate {
   forceShowRelativeTime: boolean;
   /** Optional payload describing which trip inspection target should open. */
   inspectTarget?: TripInspectionTarget;
+  /** Optional stop ID selected together with the trip change. */
+  stopId?: string;
+  /** Optional stop selection callback used by TripStops time taps. */
+  onSelectStopById?: (stopId: string) => void;
   /** Optional callback that opens trip inspection for the provided target. */
   onInspectTrip?: (target: TripInspectionTarget) => void;
 }
@@ -83,6 +87,8 @@ export function StopTimeTimeInfo({
   collapseToleranceMinutes,
   forceShowRelativeTime,
   inspectTarget,
+  stopId,
+  onSelectStopById,
   onInspectTrip,
 }: StopTimeTimeInfoProps) {
   const primaryMinutes = showDepartureTime ? departureMinutes : arrivalMinutes;
@@ -180,6 +186,9 @@ export function StopTimeTimeInfo({
       )}
       onClick={(e) => {
         e.stopPropagation();
+        if (stopId !== undefined) {
+          onSelectStopById?.(stopId);
+        }
         onInspectTrip(inspectTarget);
       }}
     >

--- a/src/components/trip/__tests__/trip-stops.test.tsx
+++ b/src/components/trip/__tests__/trip-stops.test.tsx
@@ -1,0 +1,188 @@
+import type { ComponentProps } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AppRouteTypeValue } from '@/types/app/transit';
+import { TripStops } from '../trip-stops';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/hooks/use-info-level', () => ({
+  useInfoLevel: () => ({
+    isSimpleEnabled: true,
+    isNormalEnabled: true,
+    isDetailedEnabled: false,
+    isVerboseEnabled: false,
+  }),
+}));
+
+vi.mock('../../stop-info', () => ({
+  StopInfo: () => <div>StopInfo</div>,
+}));
+
+vi.mock('../../stop-time-time-info', () => ({
+  StopTimeTimeInfo: () => <div>StopTimeTimeInfo</div>,
+}));
+
+vi.mock('../../trip-info', () => ({
+  TripInfo: () => null,
+}));
+
+vi.mock('../../verbose/verbose-trip-stop-time', () => ({
+  VerboseTripStopTime: () => null,
+}));
+
+vi.mock('../../badge/label-count-badge', () => ({
+  LabelCountBadge: ({ label }: { label: string }) => <div>{label}</div>,
+}));
+
+function makeTripStopsProps(): ComponentProps<typeof TripStops> {
+  const serviceDate = new Date(2026, 4, 11);
+  const routeTypes: AppRouteTypeValue[] = [3];
+
+  return {
+    tripSnapshot: {
+      locator: { patternId: 'pattern-1', serviceId: 'weekday', tripIndex: 0 },
+      route: {
+        route_id: 'route-1',
+        route_short_name: 'R1',
+        route_short_names: {},
+        route_long_name: 'Route 1',
+        route_long_names: {},
+        route_type: 3,
+        agency_id: 'agency-1',
+        route_color: '112233',
+        route_text_color: 'ffffff',
+      },
+      tripHeadsign: { name: 'Headsign', names: {} },
+      direction: 0,
+      stopTimes: [
+        {
+          stopMeta: {
+            stop: {
+              stop_id: 'stop-1',
+              stop_name: 'Stop 1',
+              stop_names: {},
+              stop_lat: 0,
+              stop_lon: 0,
+              location_type: 0,
+              agency_id: 'agency-1',
+            },
+            distance: 0,
+            agencies: [],
+            routes: [],
+          },
+          routeTypes,
+          timetableEntry: {
+            tripLocator: { patternId: 'pattern-1', serviceId: 'weekday', tripIndex: 0 },
+            schedule: { arrivalMinutes: 480, departureMinutes: 480 },
+            routeDirection: {
+              route: {
+                route_id: 'route-1',
+                route_short_name: 'R1',
+                route_short_names: {},
+                route_long_name: 'Route 1',
+                route_long_names: {},
+                route_type: 3,
+                agency_id: 'agency-1',
+                route_color: '112233',
+                route_text_color: 'ffffff',
+              },
+              tripHeadsign: { name: 'Headsign', names: {} },
+            },
+            boarding: { pickupType: 0, dropOffType: 0 },
+            patternPosition: {
+              stopIndex: 0,
+              totalStops: 1,
+              isOrigin: true,
+              isTerminal: true,
+            },
+          },
+        },
+      ],
+      currentStopIndex: 0,
+      selectedStop: {
+        stopMeta: {
+          stop: {
+            stop_id: 'stop-1',
+            stop_name: 'Stop 1',
+            stop_names: {},
+            stop_lat: 0,
+            stop_lon: 0,
+            location_type: 0,
+            agency_id: 'agency-1',
+          },
+          distance: 0,
+          agencies: [],
+          routes: [],
+        },
+        routeTypes,
+        timetableEntry: {
+          tripLocator: { patternId: 'pattern-1', serviceId: 'weekday', tripIndex: 0 },
+          schedule: { arrivalMinutes: 480, departureMinutes: 480 },
+          routeDirection: {
+            route: {
+              route_id: 'route-1',
+              route_short_name: 'R1',
+              route_short_names: {},
+              route_long_name: 'Route 1',
+              route_long_names: {},
+              route_type: 3,
+              agency_id: 'agency-1',
+              route_color: '112233',
+              route_text_color: 'ffffff',
+            },
+            tripHeadsign: { name: 'Headsign', names: {} },
+          },
+          boarding: { pickupType: 0, dropOffType: 0 },
+          patternPosition: {
+            stopIndex: 0,
+            totalStops: 1,
+            isOrigin: true,
+            isTerminal: true,
+          },
+        },
+      },
+      serviceDate,
+    },
+    renderedSnapshot: null,
+    selectedPatternStopIndex: 0,
+    routeColors: { color: '#112233', textColor: '#ffffff' },
+    infoLevel: 'normal' as const,
+    dataLangs: ['ja'] as const,
+    now: new Date(2026, 4, 11, 8, 0),
+  };
+}
+
+describe('TripStops', () => {
+  it('does not mark rows interactive when onSelectStopById is absent', () => {
+    const props = makeTripStopsProps();
+    const { container } = render(<TripStops {...props} />);
+
+    const row = container.querySelector('[data-trip-stop-index="0"]');
+
+    expect(row).not.toBeNull();
+    expect(row).not.toHaveAttribute('role');
+    expect(row).not.toHaveAttribute('tabindex');
+  });
+
+  it('marks rows interactive and selects the stop when onSelectStopById exists', () => {
+    const onSelectStopById = vi.fn();
+    const props = makeTripStopsProps();
+    const { container } = render(<TripStops {...props} onSelectStopById={onSelectStopById} />);
+
+    const row = container.querySelector('[data-trip-stop-index="0"]');
+
+    expect(row).not.toBeNull();
+    expect(row).toHaveAttribute('role', 'button');
+    expect(row).toHaveAttribute('tabindex', '0');
+
+    fireEvent.click(row!);
+
+    expect(onSelectStopById).toHaveBeenCalledWith('stop-1');
+  });
+});

--- a/src/components/trip/trip-stops.tsx
+++ b/src/components/trip/trip-stops.tsx
@@ -207,7 +207,7 @@ function TripStopRow({
     stopIndex,
     departureMinutes: tripStopTime.timetableEntry.schedule.departureMinutes,
   };
-  const handleSelectStop = stopId ? () => onSelectStopById?.(stopId) : undefined;
+  const handleSelectStop = stopId && onSelectStopById ? () => onSelectStopById(stopId) : undefined;
   const handleRowKeyDown =
     handleSelectStop === undefined
       ? undefined

--- a/src/components/trip/trip-stops.tsx
+++ b/src/components/trip/trip-stops.tsx
@@ -10,7 +10,11 @@ import { buildStopByPatternIndex, getPatternTotalStops } from '@/domain/transit/
 import { useInfoLevel } from '@/hooks/use-info-level';
 import { cn } from '@/lib/utils';
 import type { InfoLevel } from '@/types/app/settings';
-import type { SelectedTripSnapshot, TripStopTime } from '@/types/app/transit-composed';
+import type {
+  SelectedTripSnapshot,
+  TripInspectionTarget,
+  TripStopTime,
+} from '@/types/app/transit-composed';
 import { LabelCountBadge } from '../badge/label-count-badge';
 import { StopInfo } from '../stop-info';
 import { StopTimeTimeInfo } from '../stop-time-time-info';
@@ -26,10 +30,12 @@ interface TripStopsProps {
   infoLevel: InfoLevel;
   dataLangs: readonly string[];
   now: Date;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
 interface TripStopRowProps {
   tripStopTime: TripStopTime;
+  tripLocator: SelectedTripSnapshot['locator'];
   totalStops: number;
   currentPatternStopIndex: number;
   routeColors: AdjustedRouteColors<string>;
@@ -37,6 +43,7 @@ interface TripStopRowProps {
   serviceDate: Date;
   dataLangs: readonly string[];
   now: Date;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
 interface TripStopPlaceholderRowProps {
@@ -62,6 +69,8 @@ interface TripStopMetaInfoProps {
   labelFg?: string;
   frameColor?: string;
   className?: string;
+  inspectTarget?: TripInspectionTarget;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
 type RenderedTripStopRow =
@@ -105,6 +114,8 @@ function TripStopMetaInfo({
   labelFg,
   frameColor,
   className,
+  inspectTarget,
+  onInspectTrip,
 }: TripStopMetaInfoProps) {
   const shouldRenderStopTimeTimeInfo =
     arrivalMinutes !== undefined &&
@@ -138,6 +149,8 @@ function TripStopMetaInfo({
           collapseToleranceMinutes={collapseToleranceMinutes}
           forceShowRelativeTime={true}
           textAppearance={{ color: timeTextColor }}
+          inspectTarget={inspectTarget}
+          onInspectTrip={onInspectTrip}
         />
       )}
     </div>
@@ -146,6 +159,7 @@ function TripStopMetaInfo({
 
 function TripStopRow({
   tripStopTime,
+  tripLocator,
   totalStops,
   currentPatternStopIndex,
   routeColors,
@@ -153,6 +167,7 @@ function TripStopRow({
   dataLangs,
   serviceDate,
   now,
+  onInspectTrip,
 }: TripStopRowProps) {
   const { t } = useTranslation();
   const infoLevelFlag = useInfoLevel(infoLevel);
@@ -177,6 +192,12 @@ function TripStopRow({
     isTerminal: isTerminalStop,
     infoLevel,
   });
+  const inspectTarget: TripInspectionTarget = {
+    serviceDate,
+    tripLocator,
+    stopIndex,
+    departureMinutes: tripStopTime.timetableEntry.schedule.departureMinutes,
+  };
 
   return (
     <div
@@ -201,6 +222,8 @@ function TripStopRow({
           labelFg={routeColors.textColor}
           frameColor={routeColors.color}
           className="flex min-h-8 flex-col items-end gap-1"
+          inspectTarget={inspectTarget}
+          onInspectTrip={onInspectTrip}
         />
         <div className="min-w-0">
           {stopMeta ? (
@@ -317,6 +340,7 @@ export const TripStops = memo(function TripStops({
   infoLevel,
   dataLangs,
   now,
+  onInspectTrip,
 }: TripStopsProps) {
   const renderedTripStopRows = buildRenderedTripStopRows(tripSnapshot.stopTimes);
   const initialRenderStart = Math.max(
@@ -354,6 +378,7 @@ export const TripStops = memo(function TripStops({
             <TripStopRow
               key={rowKey}
               tripStopTime={row.stop}
+              tripLocator={tripSnapshot.locator}
               totalStops={row.totalStops}
               currentPatternStopIndex={selectedPatternStopIndex}
               routeColors={routeColors}
@@ -361,6 +386,7 @@ export const TripStops = memo(function TripStops({
               dataLangs={dataLangs}
               serviceDate={tripSnapshot.serviceDate}
               now={now}
+              onInspectTrip={onInspectTrip}
             />
           );
         })}

--- a/src/components/trip/trip-stops.tsx
+++ b/src/components/trip/trip-stops.tsx
@@ -31,6 +31,7 @@ interface TripStopsProps {
   dataLangs: readonly string[];
   now: Date;
   onInspectTrip?: (target: TripInspectionTarget) => void;
+  onSelectStopById?: (stopId: string) => void;
 }
 
 interface TripStopRowProps {
@@ -44,6 +45,7 @@ interface TripStopRowProps {
   dataLangs: readonly string[];
   now: Date;
   onInspectTrip?: (target: TripInspectionTarget) => void;
+  onSelectStopById?: (stopId: string) => void;
 }
 
 interface TripStopPlaceholderRowProps {
@@ -69,7 +71,9 @@ interface TripStopMetaInfoProps {
   labelFg?: string;
   frameColor?: string;
   className?: string;
+  stopId?: string;
   inspectTarget?: TripInspectionTarget;
+  onSelectStopById?: (stopId: string) => void;
   onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
@@ -114,7 +118,9 @@ function TripStopMetaInfo({
   labelFg,
   frameColor,
   className,
+  stopId,
   inspectTarget,
+  onSelectStopById,
   onInspectTrip,
 }: TripStopMetaInfoProps) {
   const shouldRenderStopTimeTimeInfo =
@@ -149,7 +155,9 @@ function TripStopMetaInfo({
           collapseToleranceMinutes={collapseToleranceMinutes}
           forceShowRelativeTime={true}
           textAppearance={{ color: timeTextColor }}
+          stopId={stopId}
           inspectTarget={inspectTarget}
+          onSelectStopById={onSelectStopById}
           onInspectTrip={onInspectTrip}
         />
       )}
@@ -168,6 +176,7 @@ function TripStopRow({
   serviceDate,
   now,
   onInspectTrip,
+  onSelectStopById,
 }: TripStopRowProps) {
   const { t } = useTranslation();
   const infoLevelFlag = useInfoLevel(infoLevel);
@@ -198,11 +207,65 @@ function TripStopRow({
     stopIndex,
     departureMinutes: tripStopTime.timetableEntry.schedule.departureMinutes,
   };
+  const handleSelectStop = stopId ? () => onSelectStopById?.(stopId) : undefined;
+  const handleRowKeyDown =
+    handleSelectStop === undefined
+      ? undefined
+      : (e: React.KeyboardEvent<HTMLDivElement>) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleSelectStop();
+          }
+        };
+  const stopContent = stopMeta ? (
+    <StopInfo
+      stop={stopMeta.stop}
+      agencies={stopMeta.agencies}
+      showAgencies={true}
+      routeTypes={tripStopTime.routeTypes}
+      showRouteTypes={true}
+      routes={stopMeta.routes}
+      showRoutes={true}
+      stats={stopMeta.stats}
+      geo={stopMeta.geo}
+      mapCenter={null}
+      infoLevel={infoLevel}
+      dataLangs={dataLangs}
+      agencyBadgeSize="xs"
+      routeBadgeSize="xs"
+    />
+  ) : (
+    <>
+      <div className="flex min-w-0 flex-col gap-1">
+        {stopNames && stopNames.subNames.length > 0 && (
+          <div className="text-muted-foreground truncate text-xs">
+            {stopNames.subNames.join(' / ')}
+          </div>
+        )}
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground text-xs">#{stopIndex}</span>
+          <span className="truncate font-medium">
+            {stopNames?.name || stopId || t('tripInspection.unknownStop')}
+          </span>
+        </div>
+        {stopId !== undefined && (
+          <div className="text-muted-foreground truncate text-xs">{stopId}</div>
+        )}
+      </div>
+    </>
+  );
 
   return (
     <div
       {...tripStopRowDataAttrs(stopIndex)}
-      className={cn('bg-background rounded-md border-2 px-3 py-2')}
+      {...(handleSelectStop ? { role: 'button' as const, tabIndex: 0 } : {})}
+      onClick={handleSelectStop}
+      onKeyDown={handleRowKeyDown}
+      className={cn(
+        'bg-background rounded-md border-2 px-3 py-2',
+        handleSelectStop &&
+          'cursor-pointer focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+      )}
       style={isCurrent ? { borderColor: routeColors.color } : undefined}
     >
       {/* StopTime / StopInfo / Index  */}
@@ -222,48 +285,12 @@ function TripStopRow({
           labelFg={routeColors.textColor}
           frameColor={routeColors.color}
           className="flex min-h-8 flex-col items-end gap-1"
+          stopId={stopId}
           inspectTarget={inspectTarget}
+          onSelectStopById={onSelectStopById}
           onInspectTrip={onInspectTrip}
         />
-        <div className="min-w-0">
-          {stopMeta ? (
-            <StopInfo
-              stop={stopMeta.stop}
-              agencies={stopMeta.agencies}
-              showAgencies={true}
-              routeTypes={tripStopTime.routeTypes}
-              showRouteTypes={true}
-              routes={stopMeta.routes}
-              showRoutes={true}
-              stats={stopMeta.stats}
-              geo={stopMeta.geo}
-              mapCenter={null}
-              infoLevel={infoLevel}
-              dataLangs={dataLangs}
-              agencyBadgeSize="xs"
-              routeBadgeSize="xs"
-            />
-          ) : (
-            <>
-              <div className="flex min-w-0 flex-col gap-1">
-                {stopNames && stopNames.subNames.length > 0 && (
-                  <div className="text-muted-foreground truncate text-xs">
-                    {stopNames.subNames.join(' / ')}
-                  </div>
-                )}
-                <div className="flex items-center gap-2">
-                  <span className="text-muted-foreground text-xs">#{stopIndex}</span>
-                  <span className="truncate font-medium">
-                    {stopNames?.name || stopId || t('tripInspection.unknownStop')}
-                  </span>
-                </div>
-                {stopId !== undefined && (
-                  <div className="text-muted-foreground truncate text-xs">{stopId}</div>
-                )}
-              </div>
-            </>
-          )}
-        </div>
+        <div className="min-w-0">{stopContent}</div>
       </div>
       {infoLevelFlag.isDetailedEnabled && (
         <TripInfo
@@ -341,6 +368,7 @@ export const TripStops = memo(function TripStops({
   dataLangs,
   now,
   onInspectTrip,
+  onSelectStopById,
 }: TripStopsProps) {
   const renderedTripStopRows = buildRenderedTripStopRows(tripSnapshot.stopTimes);
   const initialRenderStart = Math.max(
@@ -387,6 +415,7 @@ export const TripStops = memo(function TripStops({
               serviceDate={tripSnapshot.serviceDate}
               now={now}
               onInspectTrip={onInspectTrip}
+              onSelectStopById={onSelectStopById}
             />
           );
         })}

--- a/src/domain/transit/__tests__/stop-navigation.test.ts
+++ b/src/domain/transit/__tests__/stop-navigation.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { makeStop, makeStopMeta } from '../../../__tests__/helpers';
+import { findNavigableStopMeta, resolveNavigableStopMeta } from '../stop-navigation';
+
+describe('findNavigableStopMeta', () => {
+  it('prefers radius stops before in-bound stops', () => {
+    const radiusMeta = makeStopMeta('A');
+    const inBoundMeta = makeStopMeta('A');
+
+    const result = findNavigableStopMeta('A', [radiusMeta], [inBoundMeta]);
+
+    expect(result).toBe(radiusMeta);
+  });
+
+  it('returns an in-bound stop when radius stops do not contain the id', () => {
+    const inBoundMeta = makeStopMeta('B');
+
+    const result = findNavigableStopMeta('B', [], [inBoundMeta]);
+
+    expect(result).toBe(inBoundMeta);
+  });
+
+  it('returns null when the stop is not present', () => {
+    expect(findNavigableStopMeta('missing', [], [])).toBeNull();
+  });
+
+  it('returns the first matching radius stop when the same stop id appears multiple times', () => {
+    const firstRadiusMeta = makeStopMeta('A');
+    const secondRadiusMeta = makeStopMeta('A');
+
+    const result = findNavigableStopMeta('A', [firstRadiusMeta, secondRadiusMeta], []);
+
+    expect(result).toBe(firstRadiusMeta);
+  });
+
+  it('does not mutate the input stop lists', () => {
+    const radiusMeta = makeStopMeta('A');
+    const inBoundMeta = makeStopMeta('B');
+    const radiusStops = [radiusMeta];
+    const inBoundStops = [inBoundMeta];
+
+    findNavigableStopMeta('A', radiusStops, inBoundStops);
+
+    expect(radiusStops).toEqual([radiusMeta]);
+    expect(inBoundStops).toEqual([inBoundMeta]);
+  });
+});
+
+describe('resolveNavigableStopMeta', () => {
+  it('returns existing stop meta when present', () => {
+    const stopMeta = makeStopMeta('A');
+
+    const result = resolveNavigableStopMeta('A', [stopMeta], []);
+
+    expect(result).toBe(stopMeta);
+  });
+
+  it('builds fallback stop meta when lists do not contain the stop', () => {
+    const fallbackStop = makeStop('A');
+
+    const result = resolveNavigableStopMeta('A', [], [], fallbackStop);
+
+    expect(result).toEqual({ stop: fallbackStop, agencies: [], routes: [] });
+  });
+
+  it('ignores fallback stop when visible stop meta already exists', () => {
+    const stopMeta = makeStopMeta('A');
+    const fallbackStop = makeStop('A');
+
+    const result = resolveNavigableStopMeta('A', [stopMeta], [], fallbackStop);
+
+    expect(result).toBe(stopMeta);
+  });
+
+  it('returns null when neither lists nor fallback can resolve the stop', () => {
+    expect(resolveNavigableStopMeta('missing', [], [])).toBeNull();
+  });
+
+  it('does not mutate the fallback stop object when building fallback meta', () => {
+    const fallbackStop = makeStop('A');
+    const originalStop = { ...fallbackStop };
+
+    const result = resolveNavigableStopMeta('A', [], [], fallbackStop);
+
+    expect(fallbackStop).toEqual(originalStop);
+    expect(result?.stop).toBe(fallbackStop);
+  });
+});

--- a/src/domain/transit/stop-navigation.ts
+++ b/src/domain/transit/stop-navigation.ts
@@ -1,0 +1,26 @@
+import type { Stop } from '../../types/app/transit';
+import type { StopWithMeta } from '../../types/app/transit-composed';
+
+export function findNavigableStopMeta(
+  stopId: string,
+  radiusStops: readonly StopWithMeta[],
+  inBoundStops: readonly StopWithMeta[],
+): StopWithMeta | null {
+  return (
+    radiusStops.find((stopMeta) => stopMeta.stop.stop_id === stopId) ??
+    inBoundStops.find((stopMeta) => stopMeta.stop.stop_id === stopId) ??
+    null
+  );
+}
+
+export function resolveNavigableStopMeta(
+  stopId: string,
+  radiusStops: readonly StopWithMeta[],
+  inBoundStops: readonly StopWithMeta[],
+  fallbackStop?: Stop,
+): StopWithMeta | null {
+  return (
+    findNavigableStopMeta(stopId, radiusStops, inBoundStops) ??
+    (fallbackStop ? { stop: fallbackStop, agencies: [], routes: [] } : null)
+  );
+}

--- a/src/hooks/__tests__/use-selection.test.ts
+++ b/src/hooks/__tests__/use-selection.test.ts
@@ -324,6 +324,23 @@ describe('useSelection', () => {
       expect(result.current.selectionInfo).toBeNull();
     });
 
+    it('uses fallback stop when stop is not in stop times', () => {
+      const stop = makeStop('A');
+      const routeTypeMap = new Map<string, AppRouteTypeValue[]>([['A', [3]]]);
+      const { result } = renderHook(() => useSelection(makeParams({ routeTypeMap })));
+
+      act(() => {
+        result.current.selectStopById('A', stop);
+      });
+
+      expect(result.current.selectedStopId).toBe('A');
+      expect(result.current.selectionInfo?.type).toBe('stop');
+      if (result.current.selectionInfo?.type === 'stop') {
+        expect(result.current.selectionInfo.stop).toEqual(stop);
+        expect(result.current.selectionInfo.routeTypes).toEqual([3]);
+      }
+    });
+
     it('uses routeTypes from stop time context', () => {
       const stop = makeStop('A');
       const ctx = makeStopWithContext(stop, ['R1'], [1]);

--- a/src/hooks/__tests__/use-stop-navigation.test.ts
+++ b/src/hooks/__tests__/use-stop-navigation.test.ts
@@ -1,0 +1,160 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { makeRepo, makeStop, makeStopMeta } from '../../__tests__/helpers';
+import type { AppRouteTypeValue } from '../../types/app/transit';
+import { useStopNavigation, type UseStopNavigationParams } from '../use-stop-navigation';
+
+function makeParams(overrides: Partial<UseStopNavigationParams> = {}): UseStopNavigationParams {
+  return {
+    repo: makeRepo(),
+    routeTypeMap: new Map<string, AppRouteTypeValue[]>(),
+    radiusStops: [],
+    inBoundStops: [],
+    disableAutoLocate: vi.fn(),
+    selectStopById: vi.fn(),
+    focusStop: vi.fn(),
+    pushStop: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('useStopNavigation', () => {
+  it('selectStopWithFallback disables auto-locate, selects the stop, and pushes resolved meta', () => {
+    const stop = makeStop('A');
+    const stopMeta = makeStopMeta(stop);
+    const disableAutoLocate = vi.fn();
+    const selectStopById = vi.fn();
+    const pushStop = vi.fn();
+    const routeTypeMap = new Map<string, AppRouteTypeValue[]>([['A', [3]]]);
+    const { result } = renderHook(() =>
+      useStopNavigation(
+        makeParams({
+          routeTypeMap,
+          radiusStops: [stopMeta],
+          disableAutoLocate,
+          selectStopById,
+          pushStop,
+        }),
+      ),
+    );
+
+    act(() => {
+      result.current.selectStopWithFallback('A', 'select-bottom-sheet');
+    });
+
+    expect(disableAutoLocate).toHaveBeenCalledWith('select-bottom-sheet');
+    expect(selectStopById).toHaveBeenCalledWith('A', undefined);
+    expect(pushStop).toHaveBeenCalledWith(stopMeta, [3]);
+  });
+
+  it('selectStopWithFallback uses fallback stop when visible meta is missing', () => {
+    const stop = makeStop('A');
+    const disableAutoLocate = vi.fn();
+    const selectStopById = vi.fn();
+    const pushStop = vi.fn();
+    const routeTypeMap = new Map<string, AppRouteTypeValue[]>([['A', [1]]]);
+    const { result } = renderHook(() =>
+      useStopNavigation(
+        makeParams({
+          routeTypeMap,
+          disableAutoLocate,
+          selectStopById,
+          pushStop,
+        }),
+      ),
+    );
+
+    act(() => {
+      result.current.selectStopWithFallback('A', 'select-marker', stop);
+    });
+
+    expect(selectStopById).toHaveBeenCalledWith('A', stop);
+    expect(pushStop).toHaveBeenCalledWith({ stop, agencies: [], routes: [] }, [1]);
+  });
+
+  it('navigateAndFocusStop disables auto-locate, focuses the stop, and pushes history', () => {
+    const stop = makeStop('A');
+    const stopMeta = makeStopMeta(stop);
+    const disableAutoLocate = vi.fn();
+    const focusStop = vi.fn();
+    const pushStop = vi.fn();
+    const routeTypes: AppRouteTypeValue[] = [11];
+    const { result } = renderHook(() =>
+      useStopNavigation(
+        makeParams({
+          radiusStops: [stopMeta],
+          disableAutoLocate,
+          focusStop,
+          pushStop,
+        }),
+      ),
+    );
+
+    act(() => {
+      result.current.navigateAndFocusStop(stop, 'select-history', routeTypes);
+    });
+
+    expect(disableAutoLocate).toHaveBeenCalledWith('select-history');
+    expect(focusStop).toHaveBeenCalledWith(stop);
+    expect(pushStop).toHaveBeenCalledWith(stopMeta, routeTypes);
+  });
+
+  it('navigateAndFocusStopById resolves stop meta and navigates on success', async () => {
+    const stopMeta = makeStopMeta('A');
+    const getStopMetaById = vi.fn().mockResolvedValue({ success: true, data: stopMeta });
+    const repo = makeRepo({
+      getStopMetaById,
+    });
+    const disableAutoLocate = vi.fn();
+    const focusStop = vi.fn();
+    const pushStop = vi.fn();
+    const { result } = renderHook(() =>
+      useStopNavigation(
+        makeParams({
+          repo,
+          disableAutoLocate,
+          focusStop,
+          pushStop,
+        }),
+      ),
+    );
+
+    const resolved = await result.current.navigateAndFocusStopById('A', 'apply-stop-param');
+
+    expect(getStopMetaById).toHaveBeenCalledWith('A');
+    expect(resolved).toEqual({ success: true, data: stopMeta });
+    expect(disableAutoLocate).toHaveBeenCalledWith('apply-stop-param');
+    expect(focusStop).toHaveBeenCalledWith(stopMeta.stop);
+    expect(pushStop).toHaveBeenCalledWith(stopMeta, [-1]);
+  });
+
+  it('navigateAndFocusStopById returns failure without navigating when lookup fails', async () => {
+    const getStopMetaById = vi.fn().mockResolvedValue({ success: false, error: 'Not found' });
+    const repo = makeRepo({
+      getStopMetaById,
+    });
+    const disableAutoLocate = vi.fn();
+    const focusStop = vi.fn();
+    const pushStop = vi.fn();
+    const { result } = renderHook(() =>
+      useStopNavigation(
+        makeParams({
+          repo,
+          disableAutoLocate,
+          focusStop,
+          pushStop,
+        }),
+      ),
+    );
+
+    const resolved = await result.current.navigateAndFocusStopById(
+      'missing',
+      'select-trip-inspection',
+    );
+
+    expect(resolved).toEqual({ success: false, error: 'Not found' });
+    expect(disableAutoLocate).not.toHaveBeenCalled();
+    expect(focusStop).not.toHaveBeenCalled();
+    expect(pushStop).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-selection.ts
+++ b/src/hooks/use-selection.ts
@@ -40,8 +40,8 @@ export interface UseSelectionReturn {
   focusPosition: LatLng | null;
   /** Select a stop by its object. */
   selectStop: (stop: Stop) => void;
-  /** Select a stop by its ID. */
-  selectStopById: (stopId: string) => void;
+  /** Select a stop by its ID, optionally falling back to a provided stop object. */
+  selectStopById: (stopId: string, fallbackStop?: Stop) => void;
   /** Clear the current selection. */
   deselectStop: () => void;
   /** Select a route shape by route ID. */
@@ -112,43 +112,57 @@ export function useSelection(params: UseSelectionParams): UseSelectionReturn {
   // jitter from radiusStops / inBoundStops re-renders.
   const focusPosition = directFocusPosition ? rawFocusPosition : stableFocusPosition;
 
-  const selectStop = useCallback(
-    (stop: Stop) => {
+  const applyStopSelection = useCallback(
+    (stop: Stop, routeTypes: AppRouteTypeValue[]) => {
       setSelectedStopId(stop.stop_id);
       setSelectionInfo({
         type: 'stop',
         stop,
-        routeTypes: resolveStopRouteTypes({
+        routeTypes,
+        routeIds: extractRouteIdsForStop(stopTimes, stop.stop_id),
+      });
+      setDirectFocusPosition(null);
+    },
+    [stopTimes],
+  );
+
+  const selectStop = useCallback(
+    (stop: Stop) => {
+      applyStopSelection(
+        stop,
+        resolveStopRouteTypes({
           stopId: stop.stop_id,
           routeTypeMap,
           routes: null,
           unknownPolicy: 'include-unknown',
         }),
-        routeIds: extractRouteIdsForStop(stopTimes, stop.stop_id),
-      });
-      setDirectFocusPosition(null);
+      );
     },
-    [routeTypeMap, stopTimes],
+    [applyStopSelection, routeTypeMap],
   );
 
   const selectStopById = useCallback(
-    (stopId: string) => {
+    (stopId: string, fallbackStop?: Stop) => {
       const ctx = stopTimes.find((d) => d.stop.stop_id === stopId);
       if (ctx) {
-        setSelectedStopId(stopId);
-        setSelectionInfo({
-          type: 'stop',
-          stop: ctx.stop,
-          routeTypes: ctx.routeTypes,
-          routeIds: extractRouteIdsForStop(stopTimes, stopId),
-        });
+        applyStopSelection(ctx.stop, ctx.routeTypes);
+      } else if (fallbackStop) {
+        applyStopSelection(
+          fallbackStop,
+          resolveStopRouteTypes({
+            stopId,
+            routeTypeMap,
+            routes: null,
+            unknownPolicy: 'include-unknown',
+          }),
+        );
       } else {
         setSelectedStopId(null);
         setSelectionInfo(null);
+        setDirectFocusPosition(null);
       }
-      setDirectFocusPosition(null);
     },
-    [stopTimes],
+    [applyStopSelection, routeTypeMap, stopTimes],
   );
 
   const deselectStop = useCallback(() => {

--- a/src/hooks/use-stop-navigation.ts
+++ b/src/hooks/use-stop-navigation.ts
@@ -67,6 +67,11 @@ export function useStopNavigation(params: UseStopNavigationParams): UseStopNavig
     [pushStop, routeTypeMap],
   );
 
+  // Viewport-limited lookup: this only searches `radiusStops` and `inBoundStops`.
+  // Use it for already-visible / user-picked stops (marker, bottom sheet, search,
+  // history, portal fallback) where a stale-free fallback Stop is available.
+  // Do not use it for arbitrary persistent stop IDs such as URL params or other
+  // long-lived references; those must go through `repo.getStopMetaById`.
   const selectStopWithFallback = useCallback(
     (stopId: string, reason: AutoLocateOffReason, fallbackStop?: Stop) => {
       if (logger.isEnabled('debug')) {

--- a/src/hooks/use-stop-navigation.ts
+++ b/src/hooks/use-stop-navigation.ts
@@ -1,0 +1,117 @@
+import { useCallback } from 'react';
+import { resolveNavigableStopMeta } from '../domain/transit/stop-navigation';
+import { resolveStopRouteTypes } from '../domain/transit/resolve-stop-route-types';
+import { createLogger } from '../lib/logger';
+import type { TransitRepository } from '../repositories/transit-repository';
+import type { AutoLocateOffReason } from '../types/app/auto-locate';
+import type { Result } from '../types/app/repository';
+import type { AppRouteTypeValue, Stop } from '../types/app/transit';
+import type { StopWithMeta } from '../types/app/transit-composed';
+
+const logger = createLogger('StopNavigation');
+
+export interface UseStopNavigationParams {
+  repo: TransitRepository;
+  routeTypeMap: ReadonlyMap<string, AppRouteTypeValue[]>;
+  radiusStops: readonly StopWithMeta[];
+  inBoundStops: readonly StopWithMeta[];
+  disableAutoLocate: (reason: AutoLocateOffReason) => void;
+  selectStopById: (stopId: string, fallbackStop?: Stop) => void;
+  focusStop: (stop: Stop) => void;
+  pushStop: (stopWithMeta: StopWithMeta, routeTypes: AppRouteTypeValue[]) => void;
+}
+
+export interface UseStopNavigationReturn {
+  selectStopWithFallback: (
+    stopId: string,
+    reason: AutoLocateOffReason,
+    fallbackStop?: Stop,
+  ) => void;
+  navigateAndFocusStop: (
+    stop: Stop,
+    reason: AutoLocateOffReason,
+    routeTypes?: AppRouteTypeValue[],
+  ) => void;
+  navigateAndFocusStopById: (
+    stopId: string,
+    reason: AutoLocateOffReason,
+    routeTypes?: AppRouteTypeValue[],
+  ) => Promise<Result<StopWithMeta>>;
+}
+
+export function useStopNavigation(params: UseStopNavigationParams): UseStopNavigationReturn {
+  const {
+    repo,
+    routeTypeMap,
+    radiusStops,
+    inBoundStops,
+    disableAutoLocate,
+    selectStopById,
+    focusStop,
+    pushStop,
+  } = params;
+
+  const pushStopHistoryEntry = useCallback(
+    (meta: StopWithMeta, routeTypes?: AppRouteTypeValue[]) => {
+      pushStop(
+        meta,
+        routeTypes ??
+          resolveStopRouteTypes({
+            stopId: meta.stop.stop_id,
+            routeTypeMap,
+            routes: meta.routes,
+            unknownPolicy: 'include-unknown',
+          }),
+      );
+    },
+    [pushStop, routeTypeMap],
+  );
+
+  const selectStopWithFallback = useCallback(
+    (stopId: string, reason: AutoLocateOffReason, fallbackStop?: Stop) => {
+      if (logger.isEnabled('debug')) {
+        logger.debug(
+          `selectStopWithFallback: reason=${reason}, stopId=${stopId}, name=${fallbackStop?.stop_name ?? 'unknown'}`,
+        );
+      }
+      disableAutoLocate(reason);
+      selectStopById(stopId, fallbackStop);
+      const meta = resolveNavigableStopMeta(stopId, radiusStops, inBoundStops, fallbackStop);
+      if (meta) {
+        pushStopHistoryEntry(meta);
+      }
+    },
+    [disableAutoLocate, selectStopById, radiusStops, inBoundStops, pushStopHistoryEntry],
+  );
+
+  const navigateAndFocusStop = useCallback(
+    (stop: Stop, reason: AutoLocateOffReason, routeTypes?: AppRouteTypeValue[]) => {
+      disableAutoLocate(reason);
+      focusStop(stop);
+      const meta = resolveNavigableStopMeta(stop.stop_id, radiusStops, inBoundStops, stop);
+      if (meta) {
+        pushStopHistoryEntry(meta, routeTypes);
+      }
+    },
+    [disableAutoLocate, focusStop, radiusStops, inBoundStops, pushStopHistoryEntry],
+  );
+
+  const navigateAndFocusStopById = useCallback(
+    async (stopId: string, reason: AutoLocateOffReason, routeTypes?: AppRouteTypeValue[]) => {
+      const result = await repo.getStopMetaById(stopId);
+      if (result.success) {
+        disableAutoLocate(reason);
+        focusStop(result.data.stop);
+        pushStopHistoryEntry(result.data, routeTypes);
+      }
+      return result;
+    },
+    [repo, disableAutoLocate, focusStop, pushStopHistoryEntry],
+  );
+
+  return {
+    selectStopWithFallback,
+    navigateAndFocusStop,
+    navigateAndFocusStopById,
+  };
+}

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -43,12 +43,19 @@ type TripInspectionOpenOutcome =
       reason: TripInspectionNoDataReason;
     };
 
+export type TripInspectionTransitionSource =
+  | 'direct-open'
+  | 'trip-stops-time-select'
+  | 'pager-step';
+
 interface UseTripInspectionReturn {
   tripInspectionSnapshot: SelectedTripSnapshot | null;
   tripInspectionTargets: TripInspectionTarget[];
   currentTripInspectionTargetIndex: number;
+  showNoticeNonce: number;
   openTripInspectionFromTarget: (
     target: TripInspectionTarget,
+    source?: TripInspectionTransitionSource,
   ) => Promise<TripInspectionOpenOutcome>;
   openTripInspectionFromStopId: (
     params: OpenTripInspectionByStopIdParams,
@@ -71,6 +78,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
   );
   const [tripInspectionTargets, setTripInspectionTargets] = useState<TripInspectionTarget[]>([]);
   const [currentTripInspectionTargetIndex, setCurrentTripInspectionTargetIndex] = useState(-1);
+  const [showNoticeNonce, setShowNoticeNonce] = useState(0);
   const tripInspectionTargetsRef = useRef<TripInspectionTarget[]>([]);
   const lookupRequestIdRef = useRef(0);
 
@@ -78,6 +86,36 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
     tripInspectionTargetsRef.current = targets;
     setTripInspectionTargets(targets);
   }, []);
+
+  const beginLookup = useCallback(() => {
+    const lookupRequestId = lookupRequestIdRef.current + 1;
+    lookupRequestIdRef.current = lookupRequestId;
+    return lookupRequestId;
+  }, []);
+
+  const isLookupCancelled = useCallback((lookupRequestId: number) => {
+    return lookupRequestIdRef.current !== lookupRequestId;
+  }, []);
+
+  const openResolvedTripInspection = useCallback(
+    (
+      snapshot: SelectedTripSnapshot,
+      targetIndex: number,
+      source: TripInspectionTransitionSource,
+      targets?: TripInspectionTarget[],
+    ): TripInspectionOpenOutcome => {
+      if (targets !== undefined) {
+        updateTripInspectionTargets(targets);
+      }
+      setCurrentTripInspectionTargetIndex(targetIndex);
+      if (source === 'trip-stops-time-select') {
+        setShowNoticeNonce((prev) => prev + 1);
+      }
+      setTripInspectionSnapshot(snapshot);
+      return { status: 'opened' };
+    },
+    [updateTripInspectionTargets],
+  );
 
   const closeTripInspection = useCallback(() => {
     lookupRequestIdRef.current += 1;
@@ -90,9 +128,18 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
     async (
       target: TripInspectionTarget,
       preferCachedTargets: boolean,
+      source: TripInspectionTransitionSource,
     ): Promise<TripInspectionOpenOutcome> => {
-      const lookupRequestId = lookupRequestIdRef.current + 1;
-      lookupRequestIdRef.current = lookupRequestId;
+      const lookupRequestId = beginLookup();
+
+      if (logger.isEnabled('debug')) {
+        logger.debug('openTripInspection: start', {
+          source,
+          preferCachedTargets,
+          lookupRequestId,
+          target,
+        });
+      }
 
       const trip = repo.getTripSnapshot(target.tripLocator, target.serviceDate);
       if (!trip.success) {
@@ -115,9 +162,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
           isSameTripInspectionTarget(candidate, target),
         );
         if (currentIndex >= 0) {
-          setTripInspectionSnapshot(snapshot);
-          setCurrentTripInspectionTargetIndex(currentIndex);
-          return { status: 'opened' };
+          return openResolvedTripInspection(snapshot, currentIndex, source);
         }
 
         logger.warn('openTripInspection: target missing from cached trip-inspection targets', {
@@ -142,14 +187,14 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
           serviceDayReferenceDateTime(target.serviceDate),
         );
       } catch (error: unknown) {
-        if (lookupRequestIdRef.current !== lookupRequestId) {
+        if (isLookupCancelled(lookupRequestId)) {
           return { status: 'cancelled' };
         }
         logger.warn('openTripInspection: trip-inspection entry lookup threw', error, target);
         return { status: 'error' };
       }
 
-      if (lookupRequestIdRef.current !== lookupRequestId) {
+      if (isLookupCancelled(lookupRequestId)) {
         return { status: 'cancelled' };
       }
 
@@ -197,25 +242,26 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         });
       }
 
-      updateTripInspectionTargets(refinedState.data.targets);
-      setCurrentTripInspectionTargetIndex(refinedState.data.targetIndex);
-      setTripInspectionSnapshot(refinedState.data.snapshot);
-      return { status: 'opened' };
+      return openResolvedTripInspection(
+        refinedState.data.snapshot,
+        refinedState.data.targetIndex,
+        source,
+        refinedState.data.targets,
+      );
     },
-    [repo, updateTripInspectionTargets],
+    [beginLookup, isLookupCancelled, openResolvedTripInspection, repo],
   );
 
   const openTripInspectionFromTarget = useCallback(
-    (target: TripInspectionTarget) => {
-      return openTripInspectionInternal(target, false);
+    (target: TripInspectionTarget, source: TripInspectionTransitionSource = 'direct-open') => {
+      return openTripInspectionInternal(target, false, source);
     },
     [openTripInspectionInternal],
   );
 
   const openTripInspectionFromStopId = useCallback(
     async ({ stopId, now, serviceDate }: OpenTripInspectionByStopIdParams) => {
-      const lookupRequestId = lookupRequestIdRef.current + 1;
-      lookupRequestIdRef.current = lookupRequestId;
+      const lookupRequestId = beginLookup();
       const currentServiceDayMinutes = getServiceDayMinutes(now);
 
       try {
@@ -224,7 +270,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
           serviceDate,
         });
 
-        if (lookupRequestIdRef.current !== lookupRequestId) {
+        if (isLookupCancelled(lookupRequestId)) {
           return { status: 'cancelled' } satisfies TripInspectionOpenOutcome;
         }
 
@@ -282,9 +328,9 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
           return { status: 'error' } satisfies TripInspectionOpenOutcome;
         }
 
-        return openTripInspectionInternal(selectedTarget.target, false);
+        return openTripInspectionInternal(selectedTarget.target, false, 'direct-open');
       } catch (error: unknown) {
-        if (lookupRequestIdRef.current !== lookupRequestId) {
+        if (isLookupCancelled(lookupRequestId)) {
           return { status: 'cancelled' } satisfies TripInspectionOpenOutcome;
         }
 
@@ -296,7 +342,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         return { status: 'error' } satisfies TripInspectionOpenOutcome;
       }
     },
-    [openTripInspectionInternal, repo],
+    [beginLookup, isLookupCancelled, openTripInspectionInternal, repo],
   );
 
   const openPreviousTripInspection = useCallback(() => {
@@ -306,7 +352,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
 
     const previousTarget = tripInspectionTargets[currentTripInspectionTargetIndex - 1];
     if (previousTarget) {
-      void openTripInspectionInternal(previousTarget, true).then((status) => {
+      void openTripInspectionInternal(previousTarget, true, 'pager-step').then((status) => {
         if (
           (status.status === 'no-data' || status.status === 'error') &&
           logger.isEnabled('debug')
@@ -327,7 +373,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
 
     const nextTarget = tripInspectionTargets[currentTripInspectionTargetIndex + 1];
     if (nextTarget) {
-      void openTripInspectionInternal(nextTarget, true).then((status) => {
+      void openTripInspectionInternal(nextTarget, true, 'pager-step').then((status) => {
         if (
           (status.status === 'no-data' || status.status === 'error') &&
           logger.isEnabled('debug')
@@ -345,6 +391,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
     tripInspectionSnapshot,
     tripInspectionTargets,
     currentTripInspectionTargetIndex,
+    showNoticeNonce,
     openTripInspectionFromTarget,
     openTripInspectionFromStopId,
     openPreviousTripInspection,

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -162,10 +162,7 @@ export function useTripInspection(repo: TransitRepository): UseTripInspectionRet
         return { status: 'error' };
       }
 
-      const candidates = deriveTripInspectionCandidates(
-        entriesResult.data,
-        target.serviceDate,
-      );
+      const candidates = deriveTripInspectionCandidates(entriesResult.data, target.serviceDate);
       const refinedState = refineTripInspectionState(candidates, snapshot, target);
       if (!refinedState.ok) {
         if (logger.isEnabled('debug')) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -209,8 +209,7 @@
       "noServiceOnThisDay": "No services run on the selected day",
       "openFailed": "Could not load trip information",
       "noUpcomingTrips": "No departures are available after the current time",
-      "stopChangedTitle": "Updated the displayed stop",
-      "stopChangedDescription": "Showing the stop details for the selected time"
+      "stopChangedTitle": "Updated the displayed stop"
     },
     "sections": {
       "summary": "Summary",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -208,7 +208,9 @@
       "noStopData": "No trip information is available for this stop",
       "noServiceOnThisDay": "No services run on the selected day",
       "openFailed": "Could not load trip information",
-      "noUpcomingTrips": "No departures are available after the current time"
+      "noUpcomingTrips": "No departures are available after the current time",
+      "stopChangedTitle": "Updated the displayed stop",
+      "stopChangedDescription": "Showing the stop details for the selected time"
     },
     "sections": {
       "summary": "Summary",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -209,8 +209,7 @@
       "noServiceOnThisDay": "この運行日には便がありません",
       "openFailed": "便情報を取得できませんでした",
       "noUpcomingTrips": "現在時刻以降の便がありません",
-      "stopChangedTitle": "表示中の乗り場を切り替えました",
-      "stopChangedDescription": "選択した時刻に対応する乗り場の内容を表示しています"
+      "stopChangedTitle": "表示中の乗り場を切り替えました"
     },
     "sections": {
       "summary": "概要",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -205,10 +205,12 @@
     "description": "選択した便の停車順と時刻を表示します",
     "messages": {
       "noData": "便情報がありません",
-      "noStopData": "この停留所の便情報データがありません",
+      "noStopData": "この乗り場の便情報データがありません",
       "noServiceOnThisDay": "この運行日には便がありません",
       "openFailed": "便情報を取得できませんでした",
-      "noUpcomingTrips": "現在時刻以降の便がありません"
+      "noUpcomingTrips": "現在時刻以降の便がありません",
+      "stopChangedTitle": "表示中の乗り場を切り替えました",
+      "stopChangedDescription": "選択した時刻に対応する乗り場の内容を表示しています"
     },
     "sections": {
       "summary": "概要",

--- a/src/types/app/auto-locate.ts
+++ b/src/types/app/auto-locate.ts
@@ -13,6 +13,8 @@ export type AutoLocateOffReason =
   | 'select-marker'
   /** BottomSheet stop list click. */
   | 'select-bottom-sheet'
+  /** TripInspection stop list click. */
+  | 'select-trip-inspection'
   /** Search dialog selection. */
   | 'select-search'
   /** History dropdown selection. */

--- a/src/types/app/auto-locate.ts
+++ b/src/types/app/auto-locate.ts
@@ -9,6 +9,8 @@ export type AutoLocateOffReason =
   | 'user-toggle'
   /** GeolocationPositionError code 1 (PERMISSION_DENIED). */
   | 'permission-denied'
+  /** Initial ?stop= query parameter application. */
+  | 'apply-stop-param'
   /** Map stop marker click. */
   | 'select-marker'
   /** BottomSheet stop list click. */


### PR DESCRIPTION
## Summary
- add trip inspection support for switching to another stop and opening a different trip directly from stop times
- clarify in-dialog trip inspection update behavior and keep the dialog open while map and selection state change
- extract stop navigation logic from app.tsx into useStopNavigation and add focused hook and domain tests
- update the changelog for the new trip inspection and stop navigation behavior

## Testing
- npm run format
- npm run lint
- npm run build