### PR TITLE
refactor(trip): split trip stops variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Trip inspection: trip 内の stop list を timeline 形式の design に切り替え (`TripStops2` を既定)。 1 行ごとに gutter を独立させて stop 時刻 label を中央寄せ、 stop 間はコネクター線で接続する layout に。 facade `TripStops` 経由で旧 design (`TripStops1`) と比較できる暫定 query parameter `?tripStops=v1` / `?tripStops=v2` を追加し、 row 構築の共通 helper を `src/components/trip/trip-stop-rows.ts` に切り出した (design レビュー用、 一本化後に撤去予定)。
+
+### Changed
+
+- Stop summary: sizing API を `textSize` (本体テキスト) と `labelSize` (badge 類) に分割し、 `StopInfo` 経由の呼び出し箇所と stories を新 API に追従。 route badge 描画を制御していた detailed mode gate を撤廃し、 `showRoutes` のみで可否を決める形に整理。
+- Marker: marker 専用の `StopSummary` component / stories / 参照箇所を `StopMarkerSummary` に rename。 右ペイン等で使う汎用 `StopSummary` と区別。
+- Trip inspection: stop summary のテキスト wrap と `TripBasicInfo` の左寄せを許可し、 1 行に収まらない長い stop 名・ trip 情報の表示崩れを解消。
+- Trip inspection: detailed mode の trip stop row 内 `TripInfo` 表示サイズを `md` → `sm` に縮小し、 stop 情報主・ route 情報従の主従関係を整理。
+
 ## [2026.05.11]
 
 ### Changed

--- a/src/components/dialog/dialog-memoization.test.tsx
+++ b/src/components/dialog/dialog-memoization.test.tsx
@@ -126,6 +126,10 @@ vi.mock('@/domain/transit/time', () => ({
 }));
 
 vi.mock('@/domain/transit/trip-stop-times', () => ({
+  buildStopByPatternIndex: (stopTimes: TripStopTime[]) =>
+    new Map(stopTimes.map((stop) => [stop.timetableEntry.patternPosition.stopIndex, stop])),
+  getPatternTotalStops: (stopTimes: TripStopTime[]) =>
+    stopTimes[0]?.timetableEntry.patternPosition.totalStops ?? 0,
   getOriginStop: (stopTimes: TripStopTime[]) => stopTimes[0],
   getTerminalStop: (stopTimes: TripStopTime[]) => stopTimes[stopTimes.length - 1],
 }));
@@ -151,6 +155,7 @@ vi.mock('../trip/trip-basic-info', () => ({
 
 vi.mock('../trip/trip-stop-row-dom', () => ({
   findTripStopRow: () => null,
+  tripStopRowDataAttrs: (stopIndex: number) => ({ 'data-trip-stop-index': String(stopIndex) }),
 }));
 
 vi.mock('../trip/trip-stop-scroll', () => ({

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { JourneyTimeBar } from '@/components/journey-time-bar';
 import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
 import { StopInfo } from '@/components/stop-info';
-import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -14,6 +14,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { DEFAULT_AGENCY_LANG, resolveAgencyLang } from '@/config/transit-defaults';
+import { minutesToDate } from '@/domain/transit/calendar-utils';
 import {
   LOW_CONTRAST_BADGE_MIN_RATIO,
   LOW_CONTRAST_TEXT_MIN_RATIO,
@@ -23,10 +24,9 @@ import {
   getContrastAdjustedRouteColors,
   resolveRouteColors,
 } from '@/domain/transit/color-resolver/route-colors';
-import { minutesToDate } from '@/domain/transit/calendar-utils';
+import { deriveJourneyTimeFromTrip } from '@/domain/transit/journey-time';
 import { getHeadsignDisplayNames } from '@/domain/transit/name-resolver/get-headsign-display-names';
 import { getStopDisplayNames } from '@/domain/transit/name-resolver/get-stop-display-names';
-import { deriveJourneyTimeFromTrip } from '@/domain/transit/journey-time';
 import { formatAbsoluteTime } from '@/domain/transit/time';
 import { getOriginStop, getTerminalStop } from '@/domain/transit/trip-stop-times';
 import { useInfoLevel } from '@/hooks/use-info-level';
@@ -44,10 +44,10 @@ import { ArrowRightLeftIcon } from 'lucide-react';
 import { IdBadge } from '../badge/id-badge';
 import { TripPositionIndicator } from '../label/trip-position-indicator';
 import { TripBasicInfo } from '../trip/trip-basic-info';
+import { TripPager } from '../trip/trip-pager';
 import { findTripStopRow } from '../trip/trip-stop-row-dom';
 import { computeScrolledStopIndex, getSelectedRowScrollTop } from '../trip/trip-stop-scroll';
 import { TripStops } from '../trip/trip-stops';
-import { TripPager } from '../trip/trip-pager';
 import { VerboseTripLocator } from '../verbose/verbose-trip-locator';
 import { VerboseTripStopTime } from '../verbose/verbose-trip-stop-time';
 
@@ -927,20 +927,6 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
               onSelectStopById={onSelectStopById}
             />
           </div>
-          {/* WIP  */}
-          {/* <div className="flex flex-col gap-4 pt-2 pb-2">
-            <TripStops2
-              tripSnapshot={snapshot}
-              renderedSnapshot={renderedSnapshot}
-              selectedPatternStopIndex={selectedPatternStopIndex}
-              routeColors={adjustedRouteColors}
-              infoLevel={infoLevel}
-              dataLangs={dataLangs}
-              now={now}
-              onInspectTrip={onInspectTrip}
-              onSelectStopById={onSelectStopById}
-            />
-          </div> */}
           {contentScroll.showBottom && <ScrollFadeEdge position="bottom" />}
         </div>
       </DialogContent>

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -252,9 +252,13 @@ function TripEndpointsSummary({
 }
 
 function RichStopSummary({ stop, infoLevel, dataLangs, onSelect }: RichStopSummaryProps) {
-  if (stop?.stopMeta === undefined) {
+  const stopMeta = stop?.stopMeta;
+  const routeTypes = stop?.routeTypes;
+
+  if (stopMeta === undefined || routeTypes === undefined) {
     return null;
   }
+
   // Override Button's inherent fixed height / horizontal padding so the
   // wrapped content controls sizing, while keeping the design system's
   // focus ring, hover accent, and disabled handling. `min-w-0` lets the
@@ -268,20 +272,24 @@ function RichStopSummary({ stop, infoLevel, dataLangs, onSelect }: RichStopSumma
     >
       <div className="min-w-0 px-2">
         <StopInfo
-          stop={stop.stopMeta.stop}
-          agencies={stop.stopMeta.agencies}
+          stop={stopMeta.stop}
+          agencies={stopMeta.agencies}
           showAgencies={true}
-          routeTypes={stop.routeTypes}
+          routeTypes={routeTypes}
           showRouteTypes={true}
-          routes={stop.stopMeta.routes}
+          routes={stopMeta.routes}
           showRoutes={true}
-          stats={stop.stopMeta.stats}
-          geo={stop.stopMeta.geo}
+          distance={undefined}
           mapCenter={null}
           infoLevel={infoLevel}
           dataLangs={dataLangs}
+          stopServiceState={undefined}
+          textSize="md"
+          labelSize="md"
           agencyBadgeSize="sm"
           routeBadgeSize="xs"
+          stats={stopMeta.stats}
+          geo={stopMeta.geo}
         />
       </div>
     </Button>

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -927,6 +927,20 @@ export const TripInspectionDialog = memo(function TripInspectionDialog({
               onSelectStopById={onSelectStopById}
             />
           </div>
+          {/* WIP  */}
+          {/* <div className="flex flex-col gap-4 pt-2 pb-2">
+            <TripStops2
+              tripSnapshot={snapshot}
+              renderedSnapshot={renderedSnapshot}
+              selectedPatternStopIndex={selectedPatternStopIndex}
+              routeColors={adjustedRouteColors}
+              infoLevel={infoLevel}
+              dataLangs={dataLangs}
+              now={now}
+              onInspectTrip={onInspectTrip}
+              onSelectStopById={onSelectStopById}
+            />
+          </div> */}
           {contentScroll.showBottom && <ScrollFadeEdge position="bottom" />}
         </div>
       </DialogContent>

--- a/src/components/dialog/trip-inspection-dialog.tsx
+++ b/src/components/dialog/trip-inspection-dialog.tsx
@@ -264,9 +264,9 @@ function RichStopSummary({ stop, infoLevel, dataLangs, onSelect }: RichStopSumma
       variant="ghost"
       onClick={onSelect}
       disabled={!onSelect}
-      className="block h-auto w-full min-w-0 cursor-pointer rounded-md p-0"
+      className="block h-auto w-full min-w-0 cursor-pointer rounded-md p-0 wrap-break-word whitespace-normal"
     >
-      <div className="min-w-0 rounded-md px-2">
+      <div className="min-w-0 px-2">
         <StopInfo
           stop={stop.stopMeta.stop}
           agencies={stop.stopMeta.agencies}

--- a/src/components/marker/edge-markers-canvas.tsx
+++ b/src/components/marker/edge-markers-canvas.tsx
@@ -8,7 +8,7 @@ import { getRouteTypeColor } from '../../lib/leaflet-helpers';
 import { formatDistance } from '../../domain/transit/distance';
 import { distanceStyle } from '../../utils/distance-style';
 import { MARKER_STYLES } from '../../config/marker-styles';
-import { StopSummary } from './stop-summary';
+import { StopMarkerSummary } from './stop-marker-summary';
 import { createLogger } from '../../lib/logger';
 
 const logger = createLogger('EdgeMarkersCanvas');
@@ -272,7 +272,7 @@ export function EdgeMarkersCanvas({
           <div
             className={`pointer-events-none absolute z-10 rounded-md bg-white px-2 py-1.5 shadow-[0_2px_8px_rgba(0,0,0,0.25)] dark:bg-gray-800 ${MARKER_STYLES.tooltip.className} ${tooltipVClass} ${tooltipHClass}`}
           >
-            <StopSummary
+            <StopMarkerSummary
               stop={hoveredMarker.stop}
               routeTypes={hoveredMarker.routeTypes}
               agencies={agenciesMap?.get(hoveredMarker.stop.stop_id) ?? []}

--- a/src/components/marker/edge-markers-dom.tsx
+++ b/src/components/marker/edge-markers-dom.tsx
@@ -12,7 +12,7 @@ import { routeTypeColor } from '../../utils/route-type-color';
 import { createInfoLevel } from '../../utils/create-info-level';
 import { createLogger } from '../../lib/logger';
 import { MARKER_STYLES } from '../../config/marker-styles';
-import { StopSummary } from './stop-summary';
+import { StopMarkerSummary } from './stop-marker-summary';
 
 const logger = createLogger('EdgeMarkersDom');
 
@@ -179,7 +179,7 @@ function EdgeMarkerItem({
         <div
           className={`pointer-events-none absolute z-10 rounded-md bg-white px-2 py-1.5 shadow-[0_2px_8px_rgba(0,0,0,0.25)] dark:bg-gray-800 ${MARKER_STYLES.tooltip.className} ${tooltipVClass} ${tooltipHClass}`}
         >
-          <StopSummary
+          <StopMarkerSummary
             stop={marker.stop}
             routeTypes={marker.routeTypes}
             agencies={stopTimes?.agencies ?? agencies}

--- a/src/components/marker/stop-marker-summary.stories.tsx
+++ b/src/components/marker/stop-marker-summary.stories.tsx
@@ -12,7 +12,7 @@ import {
   tramRoute,
 } from '../../stories/fixtures';
 import { LANG_COMPARISON_CASES } from '../../stories/lang-comparison';
-import { StopSummary } from './stop-summary';
+import { StopMarkerSummary } from './stop-marker-summary';
 
 const defaultEntries = [
   createEntry({ departureMinutes: 870, route: busRoute, headsign: '大塚駅前' }),
@@ -46,8 +46,8 @@ const kitchenSinkEntries = [
 ];
 
 const meta = {
-  title: 'Map/MarkerStopSummary',
-  component: StopSummary,
+  title: 'Map/StopMarkerSummary',
+  component: StopMarkerSummary,
   args: {
     stop: baseStop,
     routeTypes: [3] as AppRouteTypeValue[],
@@ -67,7 +67,7 @@ const meta = {
       </div>
     ),
   ],
-} satisfies Meta<typeof StopSummary>;
+} satisfies Meta<typeof StopMarkerSummary>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -112,7 +112,7 @@ export const LangComparison: Story = {
       {LANG_COMPARISON_CASES.map(({ dataLang, label }) => (
         <div key={label} className="space-y-1">
           <span className="block text-[10px] text-gray-400">{label}</span>
-          <StopSummary {...args} dataLang={dataLang} />
+          <StopMarkerSummary {...args} dataLang={dataLang} />
         </div>
       ))}
     </div>

--- a/src/components/marker/stop-marker-summary.tsx
+++ b/src/components/marker/stop-marker-summary.tsx
@@ -13,7 +13,7 @@ import { IdBadge } from '../badge/id-badge';
 import { RelativeTime } from '../relative-time';
 import { TripInfo } from '../trip-info';
 
-interface StopSummaryProps {
+interface StopMarkerSummaryProps {
   stop: Stop;
   routeTypes: AppRouteTypeValue[];
   agencies: Agency[];
@@ -32,7 +32,7 @@ interface StopSummaryProps {
  *
  * Shared by both standard-mode Tooltip and lightweight-mode Popup.
  */
-export function StopSummary({
+export function StopMarkerSummary({
   stop,
   routeTypes,
   agencies,
@@ -40,7 +40,7 @@ export function StopSummary({
   now,
   infoLevel,
   dataLang,
-}: StopSummaryProps) {
+}: StopMarkerSummaryProps) {
   const info = createInfoLevel(infoLevel);
   const stopNames = getStopDisplayNames(
     stop,

--- a/src/components/marker/stop-markers-canvas.tsx
+++ b/src/components/marker/stop-markers-canvas.tsx
@@ -12,7 +12,7 @@ import { createLogger } from '../../lib/logger';
 
 const logger = createLogger('StopMarkersCanvas');
 import { MARKER_STYLES } from '../../config/marker-styles';
-import { StopSummary } from './stop-summary';
+import { StopMarkerSummary } from './stop-marker-summary';
 
 /**
  * Track markers with lazy tooltip binding to prevent duplicate listeners during incremental updates.
@@ -52,7 +52,7 @@ interface StopMarkersCanvasProps {
 /**
  * Build HTML content for a stop summary (used by both tooltip and popup).
  *
- * Uses {@link StopSummary} via `renderToStaticMarkup` so the
+ * Uses {@link StopMarkerSummary} via `renderToStaticMarkup` so the
  * display logic is shared with standard-mode tooltips.
  *
  * @param stop - The stop to display.
@@ -70,7 +70,7 @@ function buildSummaryHtml(
   dataLang: readonly string[],
 ): string {
   return renderToStaticMarkup(
-    <StopSummary
+    <StopMarkerSummary
       stop={stop}
       routeTypes={routeTypes}
       agencies={agencies}
@@ -222,7 +222,7 @@ export function StopMarkersCanvas({
     }
 
     // Show permanent tooltip for selected stop when tooltip display is enabled.
-    // Unlike hover tooltips, this does not require `now` — StopSummary renders
+    // Unlike hover tooltips, this does not require `now` — StopMarkerSummary renders
     // stop name and agencies even without time data (matching DOM mode behavior).
     if (showTooltip && selectedStopId) {
       const selectedStop = stops.find((s) => s.stop_id === selectedStopId);

--- a/src/components/marker/stop-markers-dom.tsx
+++ b/src/components/marker/stop-markers-dom.tsx
@@ -96,8 +96,8 @@ function StopMarkerDomItem({
         >
           <StopSummary
             stop={stop}
-            routeTypes={routeTypes}
             agencies={hoverAgencies ?? agencies}
+            routeTypes={routeTypes}
             entries={hasEntries ? entries : undefined}
             now={now}
             infoLevel={infoLevel}

--- a/src/components/marker/stop-markers-dom.tsx
+++ b/src/components/marker/stop-markers-dom.tsx
@@ -7,7 +7,7 @@ import { primaryRouteType } from '../../domain/transit/route-type-priority';
 import { createStopIcon } from '../../lib/leaflet-helpers';
 import { createLogger } from '../../lib/logger';
 import { MARKER_STYLES } from '../../config/marker-styles';
-import { StopSummary } from './stop-summary';
+import { StopMarkerSummary } from './stop-marker-summary';
 
 const logger = createLogger('StopMarkerDom');
 
@@ -94,7 +94,7 @@ function StopMarkerDomItem({
           permanent={isSelected}
           className={MARKER_STYLES.tooltip.className}
         >
-          <StopSummary
+          <StopMarkerSummary
             stop={stop}
             agencies={hoverAgencies ?? agencies}
             routeTypes={routeTypes}

--- a/src/components/nearby-stop.tsx
+++ b/src/components/nearby-stop.tsx
@@ -119,21 +119,23 @@ export function NearbyStop({
       <div className="m-0 mb-1.5 flex items-stretch gap-1">
         <StopInfo
           stop={stop}
-          showAgencies={true}
-          showRouteTypes={true}
-          routeTypes={routeTypes}
           agencies={agencies}
+          showAgencies={true}
+          routeTypes={routeTypes}
+          showRouteTypes={true}
+          routes={routes}
+          showRoutes={info.isDetailedEnabled}
           distance={distance}
           mapCenter={mapCenter}
           infoLevel={infoLevel}
           dataLangs={dataLangs}
           stopServiceState={stopServiceState}
-          routes={routes}
-          showRoutes={true}
-          stats={stats}
-          geo={geo}
+          textSize="md"
+          labelSize="sm"
           agencyBadgeSize={'sm'}
           routeBadgeSize={'xs'}
+          stats={stats}
+          geo={geo}
         />
         <StopActionButtons
           stopId={stop.stop_id}

--- a/src/components/stop-info.stories.tsx
+++ b/src/components/stop-info.stories.tsx
@@ -31,6 +31,8 @@ const meta = {
     distance: 235,
     mapCenter: storyMapCenter,
     infoLevel: 'normal',
+    textSize: 'md',
+    labelSize: 'sm',
     dataLangs: ['ja'],
     stopServiceState: 'boardable',
     routes: [busRoute],
@@ -40,6 +42,8 @@ const meta = {
   },
   argTypes: {
     infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
+    textSize: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    labelSize: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
     stopServiceState: { control: 'radio', options: ['boardable', 'drop-off-only', 'no-service'] },
     agencyBadgeSize: { control: 'inline-radio', options: ['xs', 'sm', 'md'] },
     routeBadgeSize: { control: 'inline-radio', options: ['xs', 'sm', 'md'] },
@@ -100,11 +104,68 @@ export const MultiTypeDropOff: Story = {
   },
 };
 
+// --- Summary sizes ---
+
+export const Compact: Story = {
+  args: { textSize: 'sm' },
+};
+
+export const Large: Story = {
+  args: { textSize: 'lg' },
+};
+
+export const SizeComparison: Story = {
+  args: {
+    stop: longNameStop,
+    routeTypes: [0, 3] as AppRouteTypeValue[],
+    agencies: [agencyGx, agencyOretetsu],
+    stopServiceState: 'drop-off-only',
+    textSize: 'md',
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-3">
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=sm labelSize=md</span>
+        <StopInfo {...args} textSize="sm" labelSize="md" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=md</span>
+        <StopInfo {...args} textSize="md" labelSize="md" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=lg labelSize=md</span>
+        <StopInfo {...args} textSize="lg" labelSize="md" />
+      </div>
+      <div className="border-t border-dashed border-gray-300 pt-4 dark:border-gray-700" />
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=xs</span>
+        <StopInfo {...args} textSize="md" labelSize="xs" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=sm</span>
+        <StopInfo {...args} textSize="md" labelSize="sm" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=md</span>
+        <StopInfo {...args} textSize="md" labelSize="md" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=lg</span>
+        <StopInfo {...args} textSize="md" labelSize="lg" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=xl</span>
+        <StopInfo {...args} textSize="md" labelSize="xl" />
+      </div>
+    </div>
+  ),
+};
+
 // --- Badge sizes ---
 
 export const CompactBadges: Story = {
   args: {
-    infoLevel: 'detailed',
+    infoLevel: 'simple',
     agencies: [agencyGx, agencyOretetsu],
     routes: [busRoute, tramRoute],
     routeTypes: [0, 3] as AppRouteTypeValue[],
@@ -115,7 +176,7 @@ export const CompactBadges: Story = {
 
 export const LargeBadges: Story = {
   args: {
-    infoLevel: 'detailed',
+    infoLevel: 'simple',
     agencies: [agencyGx, agencyOretetsu],
     routes: [busRoute, tramRoute],
     routeTypes: [0, 3] as AppRouteTypeValue[],
@@ -126,7 +187,7 @@ export const LargeBadges: Story = {
 
 export const BadgeSizeComparison: Story = {
   args: {
-    infoLevel: 'detailed',
+    infoLevel: 'simple',
     agencies: [agencyGx, agencyOretetsu],
     routes: [busRoute, tramRoute],
     routeTypes: [0, 3] as AppRouteTypeValue[],

--- a/src/components/stop-info.tsx
+++ b/src/components/stop-info.tsx
@@ -35,6 +35,8 @@ export function StopInfo({
   infoLevel,
   dataLangs,
   stopServiceState,
+  textSize,
+  labelSize,
   agencyBadgeSize,
   routeBadgeSize,
   stats,
@@ -57,6 +59,8 @@ export function StopInfo({
           infoLevel={infoLevel}
           dataLangs={dataLangs}
           stopServiceState={stopServiceState}
+          textSize={textSize}
+          labelSize={labelSize}
           agencyBadgeSize={agencyBadgeSize}
           routeBadgeSize={routeBadgeSize}
           distanceBadge={

--- a/src/components/stop-summary.stories.tsx
+++ b/src/components/stop-summary.stories.tsx
@@ -31,11 +31,15 @@ const meta = {
     stopServiceState: 'boardable',
     routes: [busRoute],
     showRoutes: true,
+    textSize: 'md',
+    labelSize: 'sm',
     agencyBadgeSize: 'sm',
     routeBadgeSize: 'sm',
   },
   argTypes: {
     infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
+    textSize: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    labelSize: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
     stopServiceState: { control: 'radio', options: ['boardable', 'drop-off-only', 'no-service'] },
     agencyBadgeSize: { control: 'inline-radio', options: ['xs', 'sm', 'md'] },
     routeBadgeSize: { control: 'inline-radio', options: ['xs', 'sm', 'md'] },
@@ -74,11 +78,68 @@ export const MultiType: Story = {
   args: { routeTypes: [0, 3] as AppRouteTypeValue[], agencies: [agencyGx, agencyOretetsu] },
 };
 
+// --- Summary sizes ---
+
+export const Compact: Story = {
+  args: { textSize: 'sm' },
+};
+
+export const Large: Story = {
+  args: { textSize: 'lg' },
+};
+
+export const SizeComparison: Story = {
+  args: {
+    stop: longNameStop,
+    routeTypes: [0, 3] as AppRouteTypeValue[],
+    agencies: [agencyGx, agencyOretetsu],
+    stopServiceState: 'drop-off-only',
+    textSize: 'md',
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-3">
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=sm labelSize=md</span>
+        <StopSummary {...args} textSize="sm" labelSize="md" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=md</span>
+        <StopSummary {...args} textSize="md" labelSize="md" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=lg labelSize=md</span>
+        <StopSummary {...args} textSize="lg" labelSize="md" />
+      </div>
+      <div className="border-t border-dashed border-gray-300 pt-4 dark:border-gray-700" />
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=xs</span>
+        <StopSummary {...args} textSize="md" labelSize="xs" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=sm</span>
+        <StopSummary {...args} textSize="md" labelSize="sm" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=md</span>
+        <StopSummary {...args} textSize="md" labelSize="md" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=lg</span>
+        <StopSummary {...args} textSize="md" labelSize="lg" />
+      </div>
+      <div className="space-y-1">
+        <span className="block text-[10px] text-gray-400">textSize=md labelSize=xl</span>
+        <StopSummary {...args} textSize="md" labelSize="xl" />
+      </div>
+    </div>
+  ),
+};
+
 // --- Badge sizes ---
 
 export const CompactBadges: Story = {
   args: {
-    infoLevel: 'detailed',
+    infoLevel: 'simple',
     agencies: [agencyGx, agencyOretetsu],
     routes: [busRoute, tramRoute],
     routeTypes: [0, 3] as AppRouteTypeValue[],
@@ -89,7 +150,7 @@ export const CompactBadges: Story = {
 
 export const LargeBadges: Story = {
   args: {
-    infoLevel: 'detailed',
+    infoLevel: 'simple',
     agencies: [agencyGx, agencyOretetsu],
     routes: [busRoute, tramRoute],
     routeTypes: [0, 3] as AppRouteTypeValue[],
@@ -100,7 +161,7 @@ export const LargeBadges: Story = {
 
 export const BadgeSizeComparison: Story = {
   args: {
-    infoLevel: 'detailed',
+    infoLevel: 'simple',
     agencies: [agencyGx, agencyOretetsu],
     routes: [busRoute, tramRoute],
     routeTypes: [0, 3] as AppRouteTypeValue[],

--- a/src/components/stop-summary.tsx
+++ b/src/components/stop-summary.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { resolveAgencyLang } from '../config/transit-defaults';
 import { getStopDisplayNames } from '../domain/transit/name-resolver/get-stop-display-names';
 import { useInfoLevel } from '../hooks/use-info-level';
+import { cn } from '../lib/utils';
 import type { InfoLevel } from '../types/app/settings';
 import type {
   Agency,
@@ -15,14 +16,17 @@ import { AgencyBadge, type AgencyBadgeSize } from './badge/agency-badge';
 import { IdBadge } from './badge/id-badge';
 import { RouteBadge, type RouteBadgeSize } from './badge/route-badge';
 import { StopServiceStateLabel } from './label/stop-service-state-label';
+import type { BaseDisplaySize } from './shared/display-size';
 import { AccessibilityLabel } from './stop/accessibility-label';
 import { PlatformCodeLabel } from './stop/platform-code-label';
 import { VerboseAgencies } from './verbose/verbose-agencies';
 import { VerboseRoutes } from './verbose/verbose-routes';
 import { VerboseStop } from './verbose/verbose-stop';
 import { VerboseStopDisplayNames } from './verbose/verbose-stop-display-names';
+import type { BaseLabelSize } from './label/base-label';
 
-export type StopSummaryVariant = 'default' | 'compact';
+export type StopSummaryTextSize = BaseDisplaySize;
+export type StopSummaryLabelSize = BaseLabelSize;
 
 /**
  * Shared core props for stop summary presentation.
@@ -51,6 +55,10 @@ export interface StopSummaryCoreProps {
   dataLangs: readonly string[];
   /** Service state of the stop on the current service day. */
   stopServiceState?: StopServiceState;
+  /** Headline text size for stop name, route-type emoji, and related row typography. */
+  textSize?: StopSummaryTextSize;
+  /** Label size for sub names and inline auxiliary labels. */
+  labelSize?: StopSummaryLabelSize;
   /** Badge size for agency badges. */
   agencyBadgeSize: AgencyBadgeSize;
   /** Badge size for route badges. */
@@ -84,11 +92,13 @@ export function StopSummary({
   infoLevel,
   dataLangs,
   stopServiceState,
+  textSize = 'md',
+  labelSize = 'md',
   agencyBadgeSize,
   routeBadgeSize,
   distanceBadge,
 }: StopSummaryProps) {
-  const info = useInfoLevel(infoLevel);
+  const infoLevelFlag = useInfoLevel(infoLevel);
   const showVerbose = infoLevel === 'verbose';
   const stopNames = getStopDisplayNames(
     stop,
@@ -97,10 +107,24 @@ export function StopSummary({
   );
 
   const idRowClass = 'mb-1 flex gap-1';
-  const mainRowClass = 'm-0 flex flex-wrap items-center gap-1 text-xl font-semibold';
+  const mainRowBaseClass = 'm-0 flex flex-wrap items-center gap-1 font-semibold';
+  const mainRowTextClassBySize: Record<StopSummaryTextSize, string> = {
+    sm: 'text-base',
+    md: 'text-xl',
+    lg: 'text-2xl',
+  };
   const routeTypeClass = 'mr-1';
   const stopNameClass = 'text-info';
-  const stopSubNamesClass = 'm-0 mb-0.5 text-xs font-normal text-[#888] dark:text-gray-400';
+  const stopSubNamesBaseClass = 'm-0 mb-0.5 font-normal text-[#888] dark:text-gray-400';
+  const stopSubNamesTextClassBySize: Record<StopSummaryTextSize, string> = {
+    sm: 'text-[10px]',
+    md: 'text-xs',
+    lg: 'text-sm',
+  };
+  const metaLabelSize = labelSize;
+
+  const mainRowClass = cn(mainRowBaseClass, mainRowTextClassBySize[textSize]);
+  const stopSubNamesClass = cn(stopSubNamesBaseClass, stopSubNamesTextClassBySize[textSize]);
 
   return (
     <div className="min-w-0 flex-1">
@@ -112,7 +136,7 @@ export function StopSummary({
       )}
 
       {/* Stop sub names */}
-      {info.isNormalEnabled && stopNames.subNames.length > 0 && (
+      {infoLevelFlag.isNormalEnabled && stopNames.subNames.length > 0 && (
         <p className={stopSubNamesClass}>{stopNames.subNames.join(' / ')}</p>
       )}
 
@@ -123,13 +147,13 @@ export function StopSummary({
         <span className={stopNameClass}>{stopNames.name}</span>
         {/* <span>{stopNames.name}</span> */}
         {/* Platform code */}
-        {stop.platform_code && <PlatformCodeLabel code={stop.platform_code} size="sm" />}
+        {stop.platform_code && <PlatformCodeLabel code={stop.platform_code} size={metaLabelSize} />}
         {/* Distance badge */}
         {distanceBadge && <span className="ml-2">{distanceBadge}</span>}
         {/* Accessibility */}
-        <AccessibilityLabel wheelchairBoarding={stop.wheelchair_boarding} size="sm" />
+        <AccessibilityLabel wheelchairBoarding={stop.wheelchair_boarding} size={metaLabelSize} />
         {stopServiceState && (
-          <StopServiceStateLabel stopServiceState={stopServiceState} size="sm" />
+          <StopServiceStateLabel stopServiceState={stopServiceState} size={metaLabelSize} />
         )}
         {showAgencies &&
           agencies.length > 0 &&
@@ -145,7 +169,7 @@ export function StopSummary({
             />
           ))}
       </div>
-      {showRoutes && info.isDetailedEnabled && routes && routes.length > 0 && (
+      {showRoutes && routes && routes.length > 0 && (
         <div className="mt-0.5 flex flex-wrap items-center gap-1">
           {routes.map((route) => (
             <RouteBadge

--- a/src/components/stop-summary.tsx
+++ b/src/components/stop-summary.tsx
@@ -55,9 +55,15 @@ export interface StopSummaryCoreProps {
   dataLangs: readonly string[];
   /** Service state of the stop on the current service day. */
   stopServiceState?: StopServiceState;
-  /** Headline text size for stop name, route-type emoji, and related row typography. */
+  /**
+   * Text size for stop name, route-type emoji, sub names, and related summary
+   * typography.
+   */
   textSize?: StopSummaryTextSize;
-  /** Label size for sub names and inline auxiliary labels. */
+  /**
+   * Label size for inline auxiliary labels such as platform, accessibility, and
+   * service-state badges.
+   */
   labelSize?: StopSummaryLabelSize;
   /** Badge size for agency badges. */
   agencyBadgeSize: AgencyBadgeSize;

--- a/src/components/timetable/timetable-header.tsx
+++ b/src/components/timetable/timetable-header.tsx
@@ -47,8 +47,10 @@ export function TimetableHeader({
       dataLangs={dataLangs}
       stopServiceState={stopServiceState}
       routes={routes}
-      agencyBadgeSize="md"
-      routeBadgeSize="md"
+      textSize="sm"
+      labelSize="sm"
+      agencyBadgeSize="sm"
+      routeBadgeSize="sm"
     />
   );
 }

--- a/src/components/trip/__tests__/trip-stop-rows.test.ts
+++ b/src/components/trip/__tests__/trip-stop-rows.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SelectedTripSnapshot, TripStopTime } from '@/types/app/transit-composed';
+import { getRenderedTripStopRowKey, getVisibleTripStopRows } from '../trip-stop-rows';
+
+function makeTripStopTime({
+  stopIndex,
+  totalStops,
+  stopId,
+}: {
+  stopIndex: number;
+  totalStops: number;
+  stopId?: string;
+}): TripStopTime {
+  return {
+    stopMeta: stopId
+      ? {
+          stop: { stop_id: stopId },
+          agencies: [],
+          routes: [],
+        }
+      : undefined,
+    timetableEntry: {
+      patternPosition: {
+        stopIndex,
+        totalStops,
+        isOrigin: stopIndex === 0,
+        isTerminal: stopIndex === totalStops - 1,
+      },
+    },
+  } as TripStopTime;
+}
+
+function makeTripSnapshot(stopTimes: readonly TripStopTime[]): SelectedTripSnapshot {
+  return {
+    stopTimes,
+  } as SelectedTripSnapshot;
+}
+
+describe('trip-stop-rows', () => {
+  describe('getVisibleTripStopRows', () => {
+    it('returns all dense rows when the rendered snapshot matches the trip snapshot', () => {
+      const tripSnapshot = makeTripSnapshot([
+        makeTripStopTime({ stopIndex: 0, totalStops: 3, stopId: 'stop-0' }),
+        makeTripStopTime({ stopIndex: 2, totalStops: 3, stopId: 'stop-2' }),
+      ]);
+
+      const rows = getVisibleTripStopRows({
+        tripSnapshot,
+        renderedSnapshot: tripSnapshot,
+        selectedPatternStopIndex: 1,
+      });
+
+      expect(rows).toHaveLength(3);
+      expect(rows[0]).toMatchObject({ kind: 'stop', stopIndex: 0, totalStops: 3 });
+      expect(rows[1]).toEqual({ kind: 'placeholder', stopIndex: 1, totalStops: 3 });
+      expect(rows[2]).toMatchObject({ kind: 'stop', stopIndex: 2, totalStops: 3 });
+    });
+
+    it('returns only the initial window around the selected stop before the full list is restored', () => {
+      const stopTimes = Array.from({ length: 20 }, (_, stopIndex) =>
+        makeTripStopTime({
+          stopIndex,
+          totalStops: 20,
+          stopId: `stop-${stopIndex}`,
+        }),
+      );
+      const tripSnapshot = makeTripSnapshot(stopTimes);
+
+      const rows = getVisibleTripStopRows({
+        tripSnapshot,
+        renderedSnapshot: null,
+        selectedPatternStopIndex: 10,
+      });
+
+      expect(rows).toHaveLength(11);
+      expect(rows[0]).toMatchObject({ kind: 'stop', stopIndex: 5, totalStops: 20 });
+      expect(rows[10]).toMatchObject({ kind: 'stop', stopIndex: 15, totalStops: 20 });
+    });
+
+    it('clamps the initial window at the start of the pattern', () => {
+      const stopTimes = Array.from({ length: 20 }, (_, stopIndex) =>
+        makeTripStopTime({
+          stopIndex,
+          totalStops: 20,
+          stopId: `stop-${stopIndex}`,
+        }),
+      );
+      const tripSnapshot = makeTripSnapshot(stopTimes);
+
+      const rows = getVisibleTripStopRows({
+        tripSnapshot,
+        renderedSnapshot: null,
+        selectedPatternStopIndex: 0,
+      });
+
+      expect(rows).toHaveLength(6);
+      expect(rows[0]).toMatchObject({ kind: 'stop', stopIndex: 0, totalStops: 20 });
+      expect(rows[5]).toMatchObject({ kind: 'stop', stopIndex: 5, totalStops: 20 });
+    });
+
+    it('returns an empty array when there are no stop times', () => {
+      const tripSnapshot = makeTripSnapshot([]);
+
+      const rows = getVisibleTripStopRows({
+        tripSnapshot,
+        renderedSnapshot: null,
+        selectedPatternStopIndex: 0,
+      });
+
+      expect(rows).toEqual([]);
+    });
+  });
+
+  describe('getRenderedTripStopRowKey', () => {
+    it('uses a placeholder prefix for placeholder rows', () => {
+      expect(getRenderedTripStopRowKey({ kind: 'placeholder', stopIndex: 4, totalStops: 10 })).toBe(
+        'placeholder:4',
+      );
+    });
+
+    it('falls back to unknown-stop when a stop row has no stop id', () => {
+      const row = {
+        kind: 'stop' as const,
+        stop: makeTripStopTime({ stopIndex: 7, totalStops: 10 }),
+        stopIndex: 7,
+        totalStops: 10,
+      };
+
+      expect(getRenderedTripStopRowKey(row)).toBe('(unknown-stop):7');
+    });
+  });
+});

--- a/src/components/trip/__tests__/trip-stops-switching.test.tsx
+++ b/src/components/trip/__tests__/trip-stops-switching.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { TripStops } from '../trip-stops';
+
+vi.mock('../trip-stops-1', () => ({
+  TripStops1: () => <div>TripStops1 rendered</div>,
+}));
+
+vi.mock('../trip-stops-2', () => ({
+  TripStops2: () => <div>TripStops2 rendered</div>,
+}));
+
+function makeProps(): React.ComponentProps<typeof TripStops> {
+  return {
+    tripSnapshot: {
+      currentStopIndex: 0,
+      locator: { patternId: 'pattern-1', serviceId: 'weekday', tripIndex: 0 },
+      route: {
+        route_id: 'route-1',
+        route_short_name: 'R1',
+        route_short_names: {},
+        route_long_name: 'Route 1',
+        route_long_names: {},
+        route_type: 3,
+        agency_id: 'agency-1',
+        route_color: '112233',
+        route_text_color: 'ffffff',
+      },
+      tripHeadsign: { name: 'Headsign', names: {} },
+      serviceDate: new Date(2026, 4, 11),
+      stopTimes: [],
+      selectedStop: {
+        timetableEntry: {
+          patternPosition: {
+            stopIndex: 0,
+            totalStops: 0,
+          },
+        },
+      },
+    } as unknown as React.ComponentProps<typeof TripStops>['tripSnapshot'],
+    renderedSnapshot: null,
+    selectedPatternStopIndex: 0,
+    routeColors: { color: '#112233', textColor: '#ffffff' },
+    infoLevel: 'normal',
+    dataLangs: ['ja'],
+    now: new Date(2026, 4, 11, 8, 0),
+  };
+}
+
+afterEach(() => {
+  window.history.replaceState({}, '', '/');
+});
+
+describe('TripStops', () => {
+  it('renders the configured default variant when the query parameter is absent', () => {
+    window.history.replaceState({}, '', '/');
+
+    render(<TripStops {...makeProps()} />);
+
+    expect(screen.getByText('TripStops2 rendered')).toBeInTheDocument();
+  });
+
+  it('renders TripStops2 when ?tripStops=v2 is present', () => {
+    window.history.replaceState({}, '', '/?tripStops=v2');
+
+    render(<TripStops {...makeProps()} />);
+
+    expect(screen.getByText('TripStops2 rendered')).toBeInTheDocument();
+  });
+
+  it('falls back to the configured default variant when the query parameter is invalid', () => {
+    window.history.replaceState({}, '', '/?tripStops=unexpected');
+
+    render(<TripStops {...makeProps()} />);
+
+    expect(screen.getByText('TripStops2 rendered')).toBeInTheDocument();
+  });
+});

--- a/src/components/trip/__tests__/trip-stops.test.tsx
+++ b/src/components/trip/__tests__/trip-stops.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AppRouteTypeValue } from '@/types/app/transit';
-import { TripStops } from '../trip-stops';
+import { TripStops1 } from '../trip-stops-1';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -40,7 +40,7 @@ vi.mock('../../badge/label-count-badge', () => ({
   LabelCountBadge: ({ label }: { label: string }) => <div>{label}</div>,
 }));
 
-function makeTripStopsProps(): ComponentProps<typeof TripStops> {
+function makeTripStopsProps(): ComponentProps<typeof TripStops1> {
   const serviceDate = new Date(2026, 4, 11);
   const routeTypes: AppRouteTypeValue[] = [3];
 
@@ -158,10 +158,10 @@ function makeTripStopsProps(): ComponentProps<typeof TripStops> {
   };
 }
 
-describe('TripStops', () => {
+describe('TripStops1', () => {
   it('does not mark rows interactive when onSelectStopById is absent', () => {
     const props = makeTripStopsProps();
-    const { container } = render(<TripStops {...props} />);
+    const { container } = render(<TripStops1 {...props} />);
 
     const row = container.querySelector('[data-trip-stop-index="0"]');
 
@@ -173,7 +173,7 @@ describe('TripStops', () => {
   it('marks rows interactive and selects the stop when onSelectStopById exists', () => {
     const onSelectStopById = vi.fn();
     const props = makeTripStopsProps();
-    const { container } = render(<TripStops {...props} onSelectStopById={onSelectStopById} />);
+    const { container } = render(<TripStops1 {...props} onSelectStopById={onSelectStopById} />);
 
     const row = container.querySelector('[data-trip-stop-index="0"]');
 

--- a/src/components/trip/trip-basic-info.tsx
+++ b/src/components/trip/trip-basic-info.tsx
@@ -38,7 +38,7 @@ export function TripBasicInfo({
         countClassName="bg-background text-info"
         frameClassName="border-info"
       />
-      <div className="flex min-w-0 flex-1 flex-wrap items-center justify-center gap-2 text-center">
+      <div className="flex min-w-0 flex-1 flex-wrap items-center justify-start gap-2 text-left">
         {routeTypesEmoji([route.route_type])}
 
         {routeAgency && (

--- a/src/components/trip/trip-stop-rows.ts
+++ b/src/components/trip/trip-stop-rows.ts
@@ -1,0 +1,59 @@
+import { buildStopByPatternIndex, getPatternTotalStops } from '@/domain/transit/trip-stop-times';
+import type { SelectedTripSnapshot, TripStopTime } from '@/types/app/transit-composed';
+
+// Initial frame renders the selected stop and +/- 5 neighbors so
+// long trips paint quickly before the full list is restored.
+const INITIAL_TRIP_STOP_RENDER_PADDING = 5;
+
+export type RenderedTripStopRow =
+  | { kind: 'stop'; stop: TripStopTime; stopIndex: number; totalStops: number }
+  | { kind: 'placeholder'; stopIndex: number; totalStops: number };
+
+function buildRenderedTripStopRows(stopTimes: readonly TripStopTime[]): RenderedTripStopRow[] {
+  const totalStops = getPatternTotalStops(stopTimes);
+  if (totalStops === 0) {
+    return [];
+  }
+
+  const stopByIndex = buildStopByPatternIndex(stopTimes);
+
+  return Array.from({ length: totalStops }, (_, stopIndex) => {
+    const stop = stopByIndex.get(stopIndex);
+    if (stop) {
+      return { kind: 'stop', stop, stopIndex, totalStops } satisfies RenderedTripStopRow;
+    }
+
+    return { kind: 'placeholder', stopIndex, totalStops } satisfies RenderedTripStopRow;
+  });
+}
+
+export function getVisibleTripStopRows({
+  tripSnapshot,
+  renderedSnapshot,
+  selectedPatternStopIndex,
+}: {
+  tripSnapshot: SelectedTripSnapshot;
+  renderedSnapshot: SelectedTripSnapshot | null;
+  selectedPatternStopIndex: number;
+}): RenderedTripStopRow[] {
+  const renderedTripStopRows = buildRenderedTripStopRows(tripSnapshot.stopTimes);
+  const initialRenderStart = Math.max(
+    0,
+    selectedPatternStopIndex - INITIAL_TRIP_STOP_RENDER_PADDING,
+  );
+  const initialRenderEnd = Math.min(
+    renderedTripStopRows.length,
+    selectedPatternStopIndex + INITIAL_TRIP_STOP_RENDER_PADDING + 1,
+  );
+  const renderAllStops = renderedSnapshot === tripSnapshot;
+
+  return renderAllStops
+    ? renderedTripStopRows
+    : renderedTripStopRows.slice(initialRenderStart, initialRenderEnd);
+}
+
+export function getRenderedTripStopRowKey(row: RenderedTripStopRow): string {
+  return row.kind === 'placeholder'
+    ? `placeholder:${row.stopIndex}`
+    : `${row.stop.stopMeta?.stop.stop_id || '(unknown-stop)'}:${row.stopIndex}`;
+}

--- a/src/components/trip/trip-stops-1.tsx
+++ b/src/components/trip/trip-stops-1.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactNode } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DEFAULT_AGENCY_LANG, resolveAgencyLang } from '@/config/transit-defaults';
@@ -7,54 +7,18 @@ import { deriveStopTimeRoleDisplayProps } from '@/domain/transit/stop-time-displ
 import { getTimetableEntryAttributes } from '@/domain/transit/timetable-entry-attributes';
 import { useInfoLevel } from '@/hooks/use-info-level';
 import { cn } from '@/lib/utils';
-import type { InfoLevel } from '@/types/app/settings';
 import type { TripInspectionTarget } from '@/types/app/transit-composed';
 import { StopInfo } from '../stop-info';
 import { TripInfo } from '../trip-info';
 import { VerboseTripStopTime } from '../verbose/verbose-trip-stop-time';
 import { tripStopRowDataAttrs } from './trip-stop-row-dom';
 import { getRenderedTripStopRowKey, getVisibleTripStopRows } from './trip-stop-rows';
-
-interface TripStopTimelineGutterProps {
-  routeColor: string;
-  isLast: boolean;
-  children: ReactNode;
-  infoLevel: InfoLevel;
-}
-
 import {
   TripStopMetaInfo,
   type TripStopPlaceholderRowProps,
   type TripStopRowProps,
   type TripStopsProps,
 } from './trip-stops';
-const TRIP_STOP_TIMELINE_GUTTER_CLASS = 'grid grid-cols-[4rem_minmax(0,1fr)] items-start gap-2';
-
-function TripStopTimelineGutter({
-  routeColor,
-  isLast,
-  children,
-  infoLevel,
-}: TripStopTimelineGutterProps) {
-  const connectorClassByInfoLevel: Record<InfoLevel, string> = {
-    simple: 'w-1 rounded',
-    normal: 'w-1 rounded',
-    detailed: 'w-1 rounded',
-    verbose: 'w-1 rounded',
-  };
-
-  return (
-    <div className="flex h-full min-h-8 flex-col items-center self-stretch">
-      <div className="bg-background rounded-md px-1 py-1">{children}</div>
-      {!isLast && (
-        <div
-          className={cn('mt-0 h-full min-h-0 flex-80', connectorClassByInfoLevel[infoLevel])}
-          style={{ backgroundColor: routeColor }}
-        />
-      )}
-    </div>
-  );
-}
 
 function TripStopRow({
   tripStopTime,
@@ -84,7 +48,6 @@ function TripStopRow({
     ? getStopDisplayNames(tripStopTime.stopMeta.stop, dataLangs, stopAgencyLangs)
     : null;
   const stopIndex = tripStopTime.timetableEntry.patternPosition.stopIndex;
-  const isLastStop = stopIndex === totalStops - 1;
   const isCurrent = stopIndex === currentPatternStopIndex;
   const isTerminalStop = tripStopTime.timetableEntry.patternPosition.isTerminal;
   const isFirstStop = tripStopTime.timetableEntry.patternPosition.isOrigin;
@@ -158,18 +121,16 @@ function TripStopRow({
       onClick={handleSelectStop}
       onKeyDown={handleRowKeyDown}
       className={cn(
-        TRIP_STOP_TIMELINE_GUTTER_CLASS,
-        handleSelectStop && 'cursor-pointer',
-        !isLastStop && 'pb-2',
+        'bg-background rounded-md border-2 px-3 py-2',
+        handleSelectStop &&
+          'cursor-pointer focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
       )}
+      style={isCurrent ? { borderColor: routeColors.color } : undefined}
     >
-      <TripStopTimelineGutter
-        routeColor={routeColors.color}
-        isLast={isLastStop}
-        infoLevel={infoLevel}
-      >
+      {/* StopTime / StopInfo / Index  */}
+      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-3">
         <TripStopMetaInfo
-          align={'center'}
+          align="right"
           serviceDate={serviceDate}
           now={now}
           arrivalMinutes={tripStopTime.timetableEntry.schedule.arrivalMinutes}
@@ -183,47 +144,37 @@ function TripStopRow({
           labelBg={routeColors.color}
           labelFg={routeColors.textColor}
           frameColor={routeColors.color}
-          className="m-0 flex min-h-8 flex-col items-end gap-1 p-0"
+          className="flex min-h-8 flex-col items-end gap-1"
           stopId={stopId}
           inspectTarget={inspectTarget}
           onSelectStopById={onSelectStopById}
           onInspectTrip={onInspectTrip}
         />
-      </TripStopTimelineGutter>
-      <div
-        className={cn(
-          'bg-background self-stretch rounded-md border-2 px-3 py-2',
-          handleSelectStop &&
-            'focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-        )}
-        style={isCurrent ? { borderColor: routeColors.color } : undefined}
-      >
-        {/* StopTime / StopInfo / Index  */}
-        <div className="min-w-0">{stopContent}</div>
-        {infoLevelFlag.isDetailedEnabled && (
-          <div className="border-border/70 mt-1 border-t border-dashed pt-1">
-            <TripInfo
-              size="sm"
-              routeDirection={tripStopTime.timetableEntry.routeDirection}
-              infoLevel={infoLevel}
-              dataLangs={dataLangs}
-              showRouteTypeIcon={false}
-              agency={stopAgency}
-              showAgency={false}
-              attributes={stopAttributes}
-            />
-          </div>
-        )}
-        {infoLevelFlag.isVerboseEnabled && (
-          <div className="border-border/70 mt-2 border-t border-dashed pt-2">
-            <VerboseTripStopTime
-              tripStopTime={tripStopTime}
-              serviceDate={serviceDate}
-              dataLangs={dataLangs}
-            />
-          </div>
-        )}
+        <div className="min-w-0">
+          {stopContent}
+          {infoLevelFlag.isDetailedEnabled && (
+            <div className="border-border/70 mt-1 border-t border-dashed pt-1">
+              <TripInfo
+                size="sm"
+                routeDirection={tripStopTime.timetableEntry.routeDirection}
+                infoLevel={infoLevel}
+                dataLangs={dataLangs}
+                showRouteTypeIcon={false}
+                agency={stopAgency}
+                showAgency={false}
+                attributes={stopAttributes}
+              />
+            </div>
+          )}
+        </div>
       </div>
+      {infoLevelFlag.isVerboseEnabled && (
+        <VerboseTripStopTime
+          tripStopTime={tripStopTime}
+          serviceDate={serviceDate}
+          dataLangs={dataLangs}
+        />
+      )}
     </div>
   );
 }
@@ -233,24 +184,22 @@ function TripStopPlaceholderRow({
   totalStops,
   currentPatternStopIndex,
   routeColors,
-  infoLevel: infoLevel,
+  infoLevel: _infoLevel,
 }: TripStopPlaceholderRowProps) {
   const { t } = useTranslation();
-  const isLastStop = stopIndex === totalStops - 1;
   const isCurrent = stopIndex === currentPatternStopIndex;
 
   return (
     <div
       {...tripStopRowDataAttrs(stopIndex)}
-      className={cn(TRIP_STOP_TIMELINE_GUTTER_CLASS, !isLastStop && 'pb-2')}
+      className={['rounded-md border-2 border-dashed px-3 py-2', 'border-border bg-muted/20'].join(
+        ' ',
+      )}
+      style={isCurrent ? { borderColor: routeColors.color } : undefined}
     >
-      <TripStopTimelineGutter
-        routeColor={routeColors.color}
-        isLast={isLastStop}
-        infoLevel={infoLevel}
-      >
+      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-3">
         <TripStopMetaInfo
-          align="center"
+          align="right"
           // No schedule → `StopTimeTimeInfo` is not rendered inside
           // `TripStopMetaInfo`; the value is effectively dead. Use `null`
           // (= "collapse disabled") to make the inert intent explicit
@@ -263,14 +212,6 @@ function TripStopPlaceholderRow({
           frameColor={routeColors.color}
           className="flex min-h-8 flex-col items-end gap-1"
         />
-      </TripStopTimelineGutter>
-      <div
-        className={[
-          'self-stretch rounded-md border-2 border-dashed px-3 py-2',
-          'border-border bg-muted/20',
-        ].join(' ')}
-        style={isCurrent ? { borderColor: routeColors.color } : undefined}
-      >
         <div className="flex min-w-0 flex-col gap-1">
           <div className="flex items-center gap-2">
             <span className="text-muted-foreground truncate font-medium">
@@ -283,7 +224,7 @@ function TripStopPlaceholderRow({
   );
 }
 
-export const TripStops2 = memo(function TripStops2({
+export const TripStops1 = memo(function TripStops({
   tripSnapshot,
   renderedSnapshot,
   selectedPatternStopIndex,
@@ -302,7 +243,7 @@ export const TripStops2 = memo(function TripStops2({
 
   return (
     <section className="flex flex-col gap-2">
-      <div className="flex flex-col">
+      <div className="flex flex-col gap-2">
         {visibleTripStopRows.map((row) => {
           const rowKey = getRenderedTripStopRowKey(row);
 

--- a/src/components/trip/trip-stops-2.tsx
+++ b/src/components/trip/trip-stops-2.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DEFAULT_AGENCY_LANG, resolveAgencyLang } from '@/config/transit-defaults';
@@ -77,6 +77,13 @@ interface TripStopMetaInfoProps {
   onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
+interface TripStopTimelineGutterProps {
+  routeColor: string;
+  isLast: boolean;
+  children: ReactNode;
+  infoLevel: InfoLevel;
+}
+
 type RenderedTripStopRow =
   | { kind: 'stop'; stop: TripStopTime; stopIndex: number; totalStops: number }
   | { kind: 'placeholder'; stopIndex: number; totalStops: number };
@@ -146,6 +153,7 @@ function TripStopMetaInfo({
       </div>
       {shouldRenderStopTimeTimeInfo && (
         <StopTimeTimeInfo
+          align="center"
           arrivalMinutes={arrivalMinutes}
           departureMinutes={departureMinutes}
           serviceDate={serviceDate}
@@ -160,6 +168,32 @@ function TripStopMetaInfo({
           inspectTarget={inspectTarget}
           onSelectStopById={onSelectStopById}
           onInspectTrip={onInspectTrip}
+        />
+      )}
+    </div>
+  );
+}
+
+function TripStopTimelineGutter({
+  routeColor,
+  isLast,
+  children,
+  infoLevel,
+}: TripStopTimelineGutterProps) {
+  const connectorClassByInfoLevel: Record<InfoLevel, string> = {
+    simple: 'w-1 rounded',
+    normal: 'w-1 rounded',
+    detailed: 'w-1 rounded',
+    verbose: 'w-1 rounded',
+  };
+
+  return (
+    <div className="flex h-full min-h-8 flex-col items-center self-stretch">
+      <div className="bg-background rounded-md px-1 py-1">{children}</div>
+      {!isLast && (
+        <div
+          className={cn('mt-0 h-full min-h-0 flex-80', connectorClassByInfoLevel[infoLevel])}
+          style={{ backgroundColor: routeColor }}
         />
       )}
     </div>
@@ -194,6 +228,7 @@ function TripStopRow({
     ? getStopDisplayNames(tripStopTime.stopMeta.stop, dataLangs, stopAgencyLangs)
     : null;
   const stopIndex = tripStopTime.timetableEntry.patternPosition.stopIndex;
+  const isLastStop = stopIndex === totalStops - 1;
   const isCurrent = stopIndex === currentPatternStopIndex;
   const isTerminalStop = tripStopTime.timetableEntry.patternPosition.isTerminal;
   const isFirstStop = tripStopTime.timetableEntry.patternPosition.isOrigin;
@@ -266,35 +301,41 @@ function TripStopRow({
       {...(handleSelectStop ? { role: 'button' as const, tabIndex: 0 } : {})}
       onClick={handleSelectStop}
       onKeyDown={handleRowKeyDown}
-      className={cn(TRIP_STOP_TIMELINE_GUTTER_CLASS, handleSelectStop && 'cursor-pointer')}
+      className={cn(
+        TRIP_STOP_TIMELINE_GUTTER_CLASS,
+        handleSelectStop && 'cursor-pointer',
+        !isLastStop && 'pb-2',
+      )}
     >
-      <div className="relative flex justify-center">
-        <div className="bg-background relative z-10 rounded-md px-1 py-1">
-          <TripStopMetaInfo
-            serviceDate={serviceDate}
-            now={now}
-            arrivalMinutes={tripStopTime.timetableEntry.schedule.arrivalMinutes}
-            departureMinutes={tripStopTime.timetableEntry.schedule.departureMinutes}
-            collapseToleranceMinutes={display.collapseToleranceMinutes}
-            showArrivalTime={display.showArrivalTime}
-            showDepartureTime={display.showDepartureTime}
-            stopIndex={stopIndex}
-            totalStops={totalStops}
-            timeTextColor={routeColors.color}
-            labelBg={routeColors.color}
-            labelFg={routeColors.textColor}
-            frameColor={routeColors.color}
-            className="flex min-h-8 flex-col items-end gap-1"
-            stopId={stopId}
-            inspectTarget={inspectTarget}
-            onSelectStopById={onSelectStopById}
-            onInspectTrip={onInspectTrip}
-          />
-        </div>
-      </div>
+      <TripStopTimelineGutter
+        routeColor={routeColors.color}
+        isLast={isLastStop}
+        infoLevel={infoLevel}
+      >
+        <TripStopMetaInfo
+          serviceDate={serviceDate}
+          now={now}
+          arrivalMinutes={tripStopTime.timetableEntry.schedule.arrivalMinutes}
+          departureMinutes={tripStopTime.timetableEntry.schedule.departureMinutes}
+          collapseToleranceMinutes={display.collapseToleranceMinutes}
+          showArrivalTime={display.showArrivalTime}
+          showDepartureTime={display.showDepartureTime}
+          stopIndex={stopIndex}
+          totalStops={totalStops}
+          timeTextColor={routeColors.color}
+          labelBg={routeColors.color}
+          labelFg={routeColors.textColor}
+          frameColor={routeColors.color}
+          className="m-0 flex min-h-8 flex-col items-end gap-1 p-0"
+          stopId={stopId}
+          inspectTarget={inspectTarget}
+          onSelectStopById={onSelectStopById}
+          onInspectTrip={onInspectTrip}
+        />
+      </TripStopTimelineGutter>
       <div
         className={cn(
-          'bg-background rounded-md border-2 px-3 py-2',
+          'bg-background self-stretch rounded-md border-2 px-3 py-2',
           handleSelectStop &&
             'focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
         )}
@@ -335,33 +376,39 @@ function TripStopPlaceholderRow({
   totalStops,
   currentPatternStopIndex,
   routeColors,
-  infoLevel: _infoLevel,
+  infoLevel: infoLevel,
 }: TripStopPlaceholderRowProps) {
   const { t } = useTranslation();
+  const isLastStop = stopIndex === totalStops - 1;
   const isCurrent = stopIndex === currentPatternStopIndex;
 
   return (
-    <div {...tripStopRowDataAttrs(stopIndex)} className={TRIP_STOP_TIMELINE_GUTTER_CLASS}>
-      <div className="relative flex justify-center">
-        <div className="bg-background relative z-10 rounded-md px-1 py-1">
-          <TripStopMetaInfo
-            // No schedule → `StopTimeTimeInfo` is not rendered inside
-            // `TripStopMetaInfo`; the value is effectively dead. Use `null`
-            // (= "collapse disabled") to make the inert intent explicit
-            // rather than picking a tolerance that would imply a policy.
-            collapseToleranceMinutes={null}
-            stopIndex={stopIndex}
-            totalStops={totalStops}
-            labelBg={routeColors.color}
-            labelFg={routeColors.textColor}
-            frameColor={routeColors.color}
-            className="flex min-h-8 flex-col items-end gap-1"
-          />
-        </div>
-      </div>
+    <div
+      {...tripStopRowDataAttrs(stopIndex)}
+      className={cn(TRIP_STOP_TIMELINE_GUTTER_CLASS, !isLastStop && 'pb-2')}
+    >
+      <TripStopTimelineGutter
+        routeColor={routeColors.color}
+        isLast={isLastStop}
+        infoLevel={infoLevel}
+      >
+        <TripStopMetaInfo
+          // No schedule → `StopTimeTimeInfo` is not rendered inside
+          // `TripStopMetaInfo`; the value is effectively dead. Use `null`
+          // (= "collapse disabled") to make the inert intent explicit
+          // rather than picking a tolerance that would imply a policy.
+          collapseToleranceMinutes={null}
+          stopIndex={stopIndex}
+          totalStops={totalStops}
+          labelBg={routeColors.color}
+          labelFg={routeColors.textColor}
+          frameColor={routeColors.color}
+          className="flex min-h-8 flex-col items-end gap-1"
+        />
+      </TripStopTimelineGutter>
       <div
         className={[
-          'rounded-md border-2 border-dashed px-3 py-2',
+          'self-stretch rounded-md border-2 border-dashed px-3 py-2',
           'border-border bg-muted/20',
         ].join(' ')}
         style={isCurrent ? { borderColor: routeColors.color } : undefined}
@@ -405,12 +452,7 @@ export const TripStops2 = memo(function TripStops2({
 
   return (
     <section className="flex flex-col gap-2">
-      <div className="relative flex flex-col gap-2">
-        <div
-          aria-hidden="true"
-          className="absolute top-0 bottom-0 left-8 w-4"
-          style={{ backgroundColor: routeColors.color }}
-        />
+      <div className="flex flex-col">
         {visibleTripStopRows.map((row) => {
           const rowKey =
             row.kind === 'placeholder'

--- a/src/components/trip/trip-stops-2.tsx
+++ b/src/components/trip/trip-stops-2.tsx
@@ -84,6 +84,7 @@ type RenderedTripStopRow =
 // Initial frame renders the selected stop and +/- 5 neighbors so
 // long trips paint quickly before the full list is restored.
 const INITIAL_TRIP_STOP_RENDER_PADDING = 5;
+const TRIP_STOP_TIMELINE_GUTTER_CLASS = 'grid grid-cols-[4rem_minmax(0,1fr)] items-start gap-2';
 
 function buildRenderedTripStopRows(stopTimes: readonly TripStopTime[]): RenderedTripStopRow[] {
   const totalStops = getPatternTotalStops(stopTimes);
@@ -133,7 +134,7 @@ function TripStopMetaInfo({
 
   return (
     <div className={className ?? 'flex flex-col items-end gap-1'}>
-      <div className="self-start">
+      <div className="self-center">
         <LabelCountBadge
           label={`${stopIndex + 1}`}
           count={totalStops}
@@ -265,60 +266,66 @@ function TripStopRow({
       {...(handleSelectStop ? { role: 'button' as const, tabIndex: 0 } : {})}
       onClick={handleSelectStop}
       onKeyDown={handleRowKeyDown}
-      className={cn(
-        'bg-background rounded-md border-2 px-3 py-2',
-        handleSelectStop &&
-          'cursor-pointer focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-      )}
-      style={isCurrent ? { borderColor: routeColors.color } : undefined}
+      className={cn(TRIP_STOP_TIMELINE_GUTTER_CLASS, handleSelectStop && 'cursor-pointer')}
     >
-      {/* StopTime / StopInfo / Index  */}
-      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-3">
-        <TripStopMetaInfo
-          serviceDate={serviceDate}
-          now={now}
-          arrivalMinutes={tripStopTime.timetableEntry.schedule.arrivalMinutes}
-          departureMinutes={tripStopTime.timetableEntry.schedule.departureMinutes}
-          collapseToleranceMinutes={display.collapseToleranceMinutes}
-          showArrivalTime={display.showArrivalTime}
-          showDepartureTime={display.showDepartureTime}
-          stopIndex={stopIndex}
-          totalStops={totalStops}
-          timeTextColor={routeColors.color}
-          labelBg={routeColors.color}
-          labelFg={routeColors.textColor}
-          frameColor={routeColors.color}
-          className="flex min-h-8 flex-col items-end gap-1"
-          stopId={stopId}
-          inspectTarget={inspectTarget}
-          onSelectStopById={onSelectStopById}
-          onInspectTrip={onInspectTrip}
-        />
-        <div className="min-w-0">
-          {stopContent}
-          {infoLevelFlag.isDetailedEnabled && (
-            <div className="border-border/70 mt-1 border-t border-dashed pt-1">
-              <TripInfo
-                size="sm"
-                routeDirection={tripStopTime.timetableEntry.routeDirection}
-                infoLevel={infoLevel}
-                dataLangs={dataLangs}
-                showRouteTypeIcon={false}
-                agency={stopAgency}
-                showAgency={false}
-                attributes={stopAttributes}
-              />
-            </div>
-          )}
+      <div className="relative flex justify-center">
+        <div className="bg-background relative z-10 rounded-md px-1 py-1">
+          <TripStopMetaInfo
+            serviceDate={serviceDate}
+            now={now}
+            arrivalMinutes={tripStopTime.timetableEntry.schedule.arrivalMinutes}
+            departureMinutes={tripStopTime.timetableEntry.schedule.departureMinutes}
+            collapseToleranceMinutes={display.collapseToleranceMinutes}
+            showArrivalTime={display.showArrivalTime}
+            showDepartureTime={display.showDepartureTime}
+            stopIndex={stopIndex}
+            totalStops={totalStops}
+            timeTextColor={routeColors.color}
+            labelBg={routeColors.color}
+            labelFg={routeColors.textColor}
+            frameColor={routeColors.color}
+            className="flex min-h-8 flex-col items-end gap-1"
+            stopId={stopId}
+            inspectTarget={inspectTarget}
+            onSelectStopById={onSelectStopById}
+            onInspectTrip={onInspectTrip}
+          />
         </div>
       </div>
-      {infoLevelFlag.isVerboseEnabled && (
-        <VerboseTripStopTime
-          tripStopTime={tripStopTime}
-          serviceDate={serviceDate}
-          dataLangs={dataLangs}
-        />
-      )}
+      <div
+        className={cn(
+          'bg-background rounded-md border-2 px-3 py-2',
+          handleSelectStop &&
+            'focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+        )}
+        style={isCurrent ? { borderColor: routeColors.color } : undefined}
+      >
+        {/* StopTime / StopInfo / Index  */}
+        <div className="min-w-0">{stopContent}</div>
+        {infoLevelFlag.isDetailedEnabled && (
+          <div className="border-border/70 mt-1 border-t border-dashed pt-1">
+            <TripInfo
+              size="sm"
+              routeDirection={tripStopTime.timetableEntry.routeDirection}
+              infoLevel={infoLevel}
+              dataLangs={dataLangs}
+              showRouteTypeIcon={false}
+              agency={stopAgency}
+              showAgency={false}
+              attributes={stopAttributes}
+            />
+          </div>
+        )}
+        {infoLevelFlag.isVerboseEnabled && (
+          <div className="border-border/70 mt-2 border-t border-dashed pt-2">
+            <VerboseTripStopTime
+              tripStopTime={tripStopTime}
+              serviceDate={serviceDate}
+              dataLangs={dataLangs}
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -334,27 +341,31 @@ function TripStopPlaceholderRow({
   const isCurrent = stopIndex === currentPatternStopIndex;
 
   return (
-    <div
-      {...tripStopRowDataAttrs(stopIndex)}
-      className={['rounded-md border-2 border-dashed px-3 py-2', 'border-border bg-muted/20'].join(
-        ' ',
-      )}
-      style={isCurrent ? { borderColor: routeColors.color } : undefined}
-    >
-      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-3">
-        <TripStopMetaInfo
-          // No schedule → `StopTimeTimeInfo` is not rendered inside
-          // `TripStopMetaInfo`; the value is effectively dead. Use `null`
-          // (= "collapse disabled") to make the inert intent explicit
-          // rather than picking a tolerance that would imply a policy.
-          collapseToleranceMinutes={null}
-          stopIndex={stopIndex}
-          totalStops={totalStops}
-          labelBg={routeColors.color}
-          labelFg={routeColors.textColor}
-          frameColor={routeColors.color}
-          className="flex min-h-8 flex-col items-end gap-1"
-        />
+    <div {...tripStopRowDataAttrs(stopIndex)} className={TRIP_STOP_TIMELINE_GUTTER_CLASS}>
+      <div className="relative flex justify-center">
+        <div className="bg-background relative z-10 rounded-md px-1 py-1">
+          <TripStopMetaInfo
+            // No schedule → `StopTimeTimeInfo` is not rendered inside
+            // `TripStopMetaInfo`; the value is effectively dead. Use `null`
+            // (= "collapse disabled") to make the inert intent explicit
+            // rather than picking a tolerance that would imply a policy.
+            collapseToleranceMinutes={null}
+            stopIndex={stopIndex}
+            totalStops={totalStops}
+            labelBg={routeColors.color}
+            labelFg={routeColors.textColor}
+            frameColor={routeColors.color}
+            className="flex min-h-8 flex-col items-end gap-1"
+          />
+        </div>
+      </div>
+      <div
+        className={[
+          'rounded-md border-2 border-dashed px-3 py-2',
+          'border-border bg-muted/20',
+        ].join(' ')}
+        style={isCurrent ? { borderColor: routeColors.color } : undefined}
+      >
         <div className="flex min-w-0 flex-col gap-1">
           <div className="flex items-center gap-2">
             <span className="text-muted-foreground truncate font-medium">
@@ -367,7 +378,7 @@ function TripStopPlaceholderRow({
   );
 }
 
-export const TripStops = memo(function TripStops({
+export const TripStops2 = memo(function TripStops2({
   tripSnapshot,
   renderedSnapshot,
   selectedPatternStopIndex,
@@ -394,7 +405,12 @@ export const TripStops = memo(function TripStops({
 
   return (
     <section className="flex flex-col gap-2">
-      <div className="flex flex-col gap-2">
+      <div className="relative flex flex-col gap-2">
+        <div
+          aria-hidden="true"
+          className="absolute top-0 bottom-0 left-8 w-4"
+          style={{ backgroundColor: routeColors.color }}
+        />
         {visibleTripStopRows.map((row) => {
           const rowKey =
             row.kind === 'placeholder'

--- a/src/components/trip/trip-stops-2.tsx
+++ b/src/components/trip/trip-stops-2.tsx
@@ -14,6 +14,12 @@ import { TripInfo } from '../trip-info';
 import { VerboseTripStopTime } from '../verbose/verbose-trip-stop-time';
 import { tripStopRowDataAttrs } from './trip-stop-row-dom';
 import { getRenderedTripStopRowKey, getVisibleTripStopRows } from './trip-stop-rows';
+import {
+  TripStopMetaInfo,
+  type TripStopPlaceholderRowProps,
+  type TripStopRowProps,
+  type TripStopsProps,
+} from './trip-stops';
 
 interface TripStopTimelineGutterProps {
   routeColor: string;
@@ -22,12 +28,6 @@ interface TripStopTimelineGutterProps {
   infoLevel: InfoLevel;
 }
 
-import {
-  TripStopMetaInfo,
-  type TripStopPlaceholderRowProps,
-  type TripStopRowProps,
-  type TripStopsProps,
-} from './trip-stops';
 const TRIP_STOP_TIMELINE_GUTTER_CLASS = 'grid grid-cols-[4rem_minmax(0,1fr)] items-start gap-2';
 
 function TripStopTimelineGutter({

--- a/src/components/trip/trip-stops.tsx
+++ b/src/components/trip/trip-stops.tsx
@@ -298,7 +298,7 @@ function TripStopRow({
       </div>
       {infoLevelFlag.isDetailedEnabled && (
         <TripInfo
-          size="md"
+          size="sm"
           routeDirection={tripStopTime.timetableEntry.routeDirection}
           infoLevel={infoLevel}
           dataLangs={dataLangs}

--- a/src/components/trip/trip-stops.tsx
+++ b/src/components/trip/trip-stops.tsx
@@ -191,7 +191,7 @@ function getTripStopsVariantFromQuery(): TripStopsVariant {
     return TRIP_STOPS_VARIANT_DEFAULT_VALUE;
   }
 
-  return requestedVariant in TRIP_STOPS_COMPONENT_BY_VARIANT
+  return Object.hasOwn(TRIP_STOPS_COMPONENT_BY_VARIANT, requestedVariant)
     ? (requestedVariant as TripStopsVariant)
     : TRIP_STOPS_VARIANT_DEFAULT_VALUE;
 }

--- a/src/components/trip/trip-stops.tsx
+++ b/src/components/trip/trip-stops.tsx
@@ -1,14 +1,6 @@
 import { memo } from 'react';
-import { useTranslation } from 'react-i18next';
 
-import { DEFAULT_AGENCY_LANG, resolveAgencyLang } from '@/config/transit-defaults';
 import { type AdjustedRouteColors } from '@/domain/transit/color-resolver/route-colors';
-import { getStopDisplayNames } from '@/domain/transit/name-resolver/get-stop-display-names';
-import { deriveStopTimeRoleDisplayProps } from '@/domain/transit/stop-time-display';
-import { getTimetableEntryAttributes } from '@/domain/transit/timetable-entry-attributes';
-import { buildStopByPatternIndex, getPatternTotalStops } from '@/domain/transit/trip-stop-times';
-import { useInfoLevel } from '@/hooks/use-info-level';
-import { cn } from '@/lib/utils';
 import type { InfoLevel } from '@/types/app/settings';
 import type {
   SelectedTripSnapshot,
@@ -16,13 +8,12 @@ import type {
   TripStopTime,
 } from '@/types/app/transit-composed';
 import { LabelCountBadge } from '../badge/label-count-badge';
-import { StopInfo } from '../stop-info';
-import { StopTimeTimeInfo } from '../stop-time-time-info';
-import { TripInfo } from '../trip-info';
-import { VerboseTripStopTime } from '../verbose/verbose-trip-stop-time';
-import { tripStopRowDataAttrs } from './trip-stop-row-dom';
+import { StopTimeTimeInfo, type StopTimeTimeInfoAlign } from '../stop-time-time-info';
+import { TripStops1 } from './trip-stops-1';
+import { TripStops2 } from './trip-stops-2';
 
-interface TripStopsProps {
+/** Shared props forwarded to the active TripStops implementation. */
+export interface TripStopsProps {
   tripSnapshot: SelectedTripSnapshot;
   renderedSnapshot: SelectedTripSnapshot | null;
   selectedPatternStopIndex: number;
@@ -34,7 +25,8 @@ interface TripStopsProps {
   onSelectStopById?: (stopId: string) => void;
 }
 
-interface TripStopRowProps {
+/** Shared props for a concrete reconstructed stop row in the trip stops list. */
+export interface TripStopRowProps {
   tripStopTime: TripStopTime;
   tripLocator: SelectedTripSnapshot['locator'];
   totalStops: number;
@@ -48,7 +40,8 @@ interface TripStopRowProps {
   onSelectStopById?: (stopId: string) => void;
 }
 
-interface TripStopPlaceholderRowProps {
+/** Shared props for placeholder rows rendered for missing pattern positions. */
+export interface TripStopPlaceholderRowProps {
   stopIndex: number;
   totalStops: number;
   currentPatternStopIndex: number;
@@ -70,6 +63,7 @@ interface TripStopMetaInfoProps {
   labelBg?: string;
   labelFg?: string;
   frameColor?: string;
+  align: StopTimeTimeInfoAlign;
   className?: string;
   stopId?: string;
   inspectTarget?: TripInspectionTarget;
@@ -77,33 +71,16 @@ interface TripStopMetaInfoProps {
   onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
-type RenderedTripStopRow =
-  | { kind: 'stop'; stop: TripStopTime; stopIndex: number; totalStops: number }
-  | { kind: 'placeholder'; stopIndex: number; totalStops: number };
-
-// Initial frame renders the selected stop and +/- 5 neighbors so
-// long trips paint quickly before the full list is restored.
-const INITIAL_TRIP_STOP_RENDER_PADDING = 5;
-
-function buildRenderedTripStopRows(stopTimes: readonly TripStopTime[]): RenderedTripStopRow[] {
-  const totalStops = getPatternTotalStops(stopTimes);
-  if (totalStops === 0) {
-    return [];
-  }
-
-  const stopByIndex = buildStopByPatternIndex(stopTimes);
-
-  return Array.from({ length: totalStops }, (_, stopIndex) => {
-    const stop = stopByIndex.get(stopIndex);
-    if (stop) {
-      return { kind: 'stop', stop, stopIndex, totalStops } satisfies RenderedTripStopRow;
-    }
-
-    return { kind: 'placeholder', stopIndex, totalStops } satisfies RenderedTripStopRow;
-  });
-}
-
-function TripStopMetaInfo({
+/**
+ * Compact meta block rendered beside each trip stop row.
+ *
+ * Displays the stop index badge and, when schedule inputs are complete, the
+ * corresponding arrival / departure time summary.
+ *
+ * @param props - Display and interaction data for the stop meta block.
+ * @returns The stop badge and optional time summary for a trip stop row.
+ */
+export function TripStopMetaInfo({
   serviceDate,
   now,
   arrivalMinutes,
@@ -117,6 +94,7 @@ function TripStopMetaInfo({
   labelBg,
   labelFg,
   frameColor,
+  align,
   className,
   stopId,
   inspectTarget,
@@ -150,6 +128,7 @@ function TripStopMetaInfo({
           serviceDate={serviceDate}
           now={now}
           size="md"
+          align={align}
           showArrivalTime={showArrivalTime}
           showDepartureTime={showDepartureTime}
           collapseToleranceMinutes={collapseToleranceMinutes}
@@ -165,269 +144,76 @@ function TripStopMetaInfo({
   );
 }
 
-function TripStopRow({
-  tripStopTime,
-  tripLocator,
-  totalStops,
-  currentPatternStopIndex,
-  routeColors,
-  infoLevel,
-  dataLangs,
-  serviceDate,
-  now,
-  onInspectTrip,
-  onSelectStopById,
-}: TripStopRowProps) {
-  const { t } = useTranslation();
-  const infoLevelFlag = useInfoLevel(infoLevel);
-  const stopMeta = tripStopTime.stopMeta;
-  const stopId = tripStopTime.stopMeta?.stop.stop_id;
-  const stopAttributes = getTimetableEntryAttributes(tripStopTime.timetableEntry);
-  const stopAgency = stopMeta?.agencies.find(
-    (agency) => agency.agency_id === tripStopTime.timetableEntry.routeDirection.route.agency_id,
-  );
-  const stopAgencyLangs = tripStopTime.stopMeta
-    ? resolveAgencyLang(tripStopTime.stopMeta.agencies, tripStopTime.stopMeta.stop.agency_id)
-    : DEFAULT_AGENCY_LANG;
-  const stopNames = tripStopTime.stopMeta
-    ? getStopDisplayNames(tripStopTime.stopMeta.stop, dataLangs, stopAgencyLangs)
-    : null;
-  const stopIndex = tripStopTime.timetableEntry.patternPosition.stopIndex;
-  const isCurrent = stopIndex === currentPatternStopIndex;
-  const isTerminalStop = tripStopTime.timetableEntry.patternPosition.isTerminal;
-  const isFirstStop = tripStopTime.timetableEntry.patternPosition.isOrigin;
-  const display = deriveStopTimeRoleDisplayProps({
-    isOrigin: isFirstStop,
-    isTerminal: isTerminalStop,
-    infoLevel,
-  });
-  const inspectTarget: TripInspectionTarget = {
-    serviceDate,
-    tripLocator,
-    stopIndex,
-    departureMinutes: tripStopTime.timetableEntry.schedule.departureMinutes,
-  };
-  const handleSelectStop = stopId && onSelectStopById ? () => onSelectStopById(stopId) : undefined;
-  const handleRowKeyDown =
-    handleSelectStop === undefined
-      ? undefined
-      : (e: React.KeyboardEvent<HTMLDivElement>) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleSelectStop();
-          }
-        };
-  const stopContent = stopMeta ? (
-    <StopInfo
-      stop={stopMeta.stop}
-      agencies={stopMeta.agencies}
-      showAgencies={true}
-      routeTypes={tripStopTime.routeTypes}
-      showRouteTypes={true}
-      routes={stopMeta.routes}
-      showRoutes={true}
-      distance={undefined}
-      mapCenter={null}
-      infoLevel={infoLevel}
-      dataLangs={dataLangs}
-      stopServiceState={undefined}
-      textSize="sm"
-      labelSize="sm"
-      agencyBadgeSize="xs"
-      routeBadgeSize="xs"
-      stats={stopMeta.stats}
-      geo={stopMeta.geo}
-    />
-  ) : (
-    <>
-      <div className="flex min-w-0 flex-col gap-1">
-        {stopNames && stopNames.subNames.length > 0 && (
-          <div className="text-muted-foreground truncate text-xs">
-            {stopNames.subNames.join(' / ')}
-          </div>
-        )}
-        <div className="flex items-center gap-2">
-          <span className="text-muted-foreground text-xs">#{stopIndex}</span>
-          <span className="truncate font-medium">
-            {stopNames?.name || stopId || t('tripInspection.unknownStop')}
-          </span>
-        </div>
-        {stopId !== undefined && (
-          <div className="text-muted-foreground truncate text-xs">{stopId}</div>
-        )}
-      </div>
-    </>
+/** Supported temporary variants for the TripStops design comparison. */
+type TripStopsVariant = 'v1' | 'v2';
+
+/** Query parameter name for the temporary TripStops design comparison switch. */
+const TRIP_STOPS_VARIANT_QUERY_PARAM = 'tripStops';
+
+/**
+ * Default temporary variant used when the query parameter is absent or invalid.
+ *
+ * Keep this value explicit so the preferred design under review is obvious in
+ * both the implementation and the tests.
+ */
+const TRIP_STOPS_VARIANT_DEFAULT_VALUE: TripStopsVariant = 'v2';
+
+/** Component implementation used for each temporary TripStops variant. */
+const TRIP_STOPS_COMPONENT_BY_VARIANT: Record<TripStopsVariant, typeof TripStops1> = {
+  v1: TripStops1,
+  v2: TripStops2,
+};
+
+/** Default TripStops implementation used when no temporary variant is selected. */
+const DEFAULT_TRIP_STOPS_COMPONENT =
+  TRIP_STOPS_COMPONENT_BY_VARIANT[TRIP_STOPS_VARIANT_DEFAULT_VALUE];
+
+/**
+ * Resolve the temporary TripStops design variant from the query string.
+ *
+ * The comparison switch is intentionally local to the TripStops facade so the
+ * rest of the UI does not need to know about the temporary `TripStops1` /
+ * `TripStops2` split during design review.
+ *
+ * @returns The requested temporary variant, or the configured default when the
+ * query parameter is absent or invalid.
+ */
+function getTripStopsVariantFromQuery(): TripStopsVariant {
+  if (typeof window === 'undefined') {
+    return TRIP_STOPS_VARIANT_DEFAULT_VALUE;
+  }
+
+  const requestedVariant = new URLSearchParams(window.location.search).get(
+    TRIP_STOPS_VARIANT_QUERY_PARAM,
   );
 
-  return (
-    <div
-      {...tripStopRowDataAttrs(stopIndex)}
-      {...(handleSelectStop ? { role: 'button' as const, tabIndex: 0 } : {})}
-      onClick={handleSelectStop}
-      onKeyDown={handleRowKeyDown}
-      className={cn(
-        'bg-background rounded-md border-2 px-3 py-2',
-        handleSelectStop &&
-          'cursor-pointer focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-      )}
-      style={isCurrent ? { borderColor: routeColors.color } : undefined}
-    >
-      {/* StopTime / StopInfo / Index  */}
-      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-3">
-        <TripStopMetaInfo
-          serviceDate={serviceDate}
-          now={now}
-          arrivalMinutes={tripStopTime.timetableEntry.schedule.arrivalMinutes}
-          departureMinutes={tripStopTime.timetableEntry.schedule.departureMinutes}
-          collapseToleranceMinutes={display.collapseToleranceMinutes}
-          showArrivalTime={display.showArrivalTime}
-          showDepartureTime={display.showDepartureTime}
-          stopIndex={stopIndex}
-          totalStops={totalStops}
-          timeTextColor={routeColors.color}
-          labelBg={routeColors.color}
-          labelFg={routeColors.textColor}
-          frameColor={routeColors.color}
-          className="flex min-h-8 flex-col items-end gap-1"
-          stopId={stopId}
-          inspectTarget={inspectTarget}
-          onSelectStopById={onSelectStopById}
-          onInspectTrip={onInspectTrip}
-        />
-        <div className="min-w-0">
-          {stopContent}
-          {infoLevelFlag.isDetailedEnabled && (
-            <div className="border-border/70 mt-1 border-t border-dashed pt-1">
-              <TripInfo
-                size="sm"
-                routeDirection={tripStopTime.timetableEntry.routeDirection}
-                infoLevel={infoLevel}
-                dataLangs={dataLangs}
-                showRouteTypeIcon={false}
-                agency={stopAgency}
-                showAgency={false}
-                attributes={stopAttributes}
-              />
-            </div>
-          )}
-        </div>
-      </div>
-      {infoLevelFlag.isVerboseEnabled && (
-        <VerboseTripStopTime
-          tripStopTime={tripStopTime}
-          serviceDate={serviceDate}
-          dataLangs={dataLangs}
-        />
-      )}
-    </div>
-  );
+  if (requestedVariant == null) {
+    return TRIP_STOPS_VARIANT_DEFAULT_VALUE;
+  }
+
+  return requestedVariant in TRIP_STOPS_COMPONENT_BY_VARIANT
+    ? (requestedVariant as TripStopsVariant)
+    : TRIP_STOPS_VARIANT_DEFAULT_VALUE;
 }
 
-function TripStopPlaceholderRow({
-  stopIndex,
-  totalStops,
-  currentPatternStopIndex,
-  routeColors,
-  infoLevel: _infoLevel,
-}: TripStopPlaceholderRowProps) {
-  const { t } = useTranslation();
-  const isCurrent = stopIndex === currentPatternStopIndex;
+/**
+ * Public TripStops facade used by dialogs and other callers.
+ *
+ * TEMPORARY DESIGN COMPARISON SWITCH:
+ * This query-param based branch exists only to switch between the TripStops1
+ * and TripStops2 UI designs during review. Keep the branching logic isolated
+ * here, and remove it once the design comparison ends and a single
+ * implementation is chosen.
+ *
+ * @param props - Shared props forwarded unchanged to the active TripStops variant.
+ * @returns The active TripStops implementation for the current temporary variant.
+ */
+export const TripStops = memo(function TripStops(props: TripStopsProps) {
+  const activeVariant = getTripStopsVariantFromQuery();
+  const ActiveTripStops =
+    activeVariant === TRIP_STOPS_VARIANT_DEFAULT_VALUE
+      ? DEFAULT_TRIP_STOPS_COMPONENT
+      : TRIP_STOPS_COMPONENT_BY_VARIANT[activeVariant];
 
-  return (
-    <div
-      {...tripStopRowDataAttrs(stopIndex)}
-      className={['rounded-md border-2 border-dashed px-3 py-2', 'border-border bg-muted/20'].join(
-        ' ',
-      )}
-      style={isCurrent ? { borderColor: routeColors.color } : undefined}
-    >
-      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-3">
-        <TripStopMetaInfo
-          // No schedule → `StopTimeTimeInfo` is not rendered inside
-          // `TripStopMetaInfo`; the value is effectively dead. Use `null`
-          // (= "collapse disabled") to make the inert intent explicit
-          // rather than picking a tolerance that would imply a policy.
-          collapseToleranceMinutes={null}
-          stopIndex={stopIndex}
-          totalStops={totalStops}
-          labelBg={routeColors.color}
-          labelFg={routeColors.textColor}
-          frameColor={routeColors.color}
-          className="flex min-h-8 flex-col items-end gap-1"
-        />
-        <div className="flex min-w-0 flex-col gap-1">
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground truncate font-medium">
-              {t('tripInspection.unknownStop')} ({stopIndex + 1}/{totalStops})
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-export const TripStops = memo(function TripStops({
-  tripSnapshot,
-  renderedSnapshot,
-  selectedPatternStopIndex,
-  routeColors,
-  infoLevel,
-  dataLangs,
-  now,
-  onInspectTrip,
-  onSelectStopById,
-}: TripStopsProps) {
-  const renderedTripStopRows = buildRenderedTripStopRows(tripSnapshot.stopTimes);
-  const initialRenderStart = Math.max(
-    0,
-    selectedPatternStopIndex - INITIAL_TRIP_STOP_RENDER_PADDING,
-  );
-  const initialRenderEnd = Math.min(
-    renderedTripStopRows.length,
-    selectedPatternStopIndex + INITIAL_TRIP_STOP_RENDER_PADDING + 1,
-  );
-  const renderAllStops = renderedSnapshot === tripSnapshot;
-  const visibleTripStopRows = renderAllStops
-    ? renderedTripStopRows
-    : renderedTripStopRows.slice(initialRenderStart, initialRenderEnd);
-
-  return (
-    <section className="flex flex-col gap-2">
-      <div className="flex flex-col gap-2">
-        {visibleTripStopRows.map((row) => {
-          const rowKey =
-            row.kind === 'placeholder'
-              ? `placeholder:${row.stopIndex}`
-              : `${row.stop.stopMeta?.stop.stop_id || '(unknown-stop)'}:${row.stopIndex}`;
-
-          return row.kind === 'placeholder' ? (
-            <TripStopPlaceholderRow
-              key={rowKey}
-              stopIndex={row.stopIndex}
-              totalStops={row.totalStops}
-              currentPatternStopIndex={selectedPatternStopIndex}
-              routeColors={routeColors}
-              infoLevel={infoLevel}
-            />
-          ) : (
-            <TripStopRow
-              key={rowKey}
-              tripStopTime={row.stop}
-              tripLocator={tripSnapshot.locator}
-              totalStops={row.totalStops}
-              currentPatternStopIndex={selectedPatternStopIndex}
-              routeColors={routeColors}
-              infoLevel={infoLevel}
-              dataLangs={dataLangs}
-              serviceDate={tripSnapshot.serviceDate}
-              now={now}
-              onInspectTrip={onInspectTrip}
-              onSelectStopById={onSelectStopById}
-            />
-          );
-        })}
-      </div>
-    </section>
-  );
+  return <ActiveTripStops {...props} />;
 });

--- a/src/components/trip/trip-stops.tsx
+++ b/src/components/trip/trip-stops.tsx
@@ -226,13 +226,17 @@ function TripStopRow({
       showRouteTypes={true}
       routes={stopMeta.routes}
       showRoutes={true}
-      stats={stopMeta.stats}
-      geo={stopMeta.geo}
+      distance={undefined}
       mapCenter={null}
       infoLevel={infoLevel}
       dataLangs={dataLangs}
+      stopServiceState={undefined}
+      textSize="sm"
+      labelSize="sm"
       agencyBadgeSize="xs"
       routeBadgeSize="xs"
+      stats={stopMeta.stats}
+      geo={stopMeta.geo}
     />
   ) : (
     <>


### PR DESCRIPTION
## Summary
- extract shared trip stop row helpers into a dedicated module
- restore the `TripStops` facade and route it to `TripStops1` or `TripStops2`
- keep the temporary query-param based design switch isolated in `TripStops`
- add focused tests for row helper behavior and temporary variant switching

## Validation
- `npm run build`
- targeted Vitest coverage for trip stop rows and variant switching