### PR TITLE
feat(data-source-settings): Phase 1 user-settings (persistence + interactive dialog)

### DIFF
--- a/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
+++ b/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * Tests for data-source-settings-dialog.tsx.
+ *
+ * Mocks the four hooks the dialog consumes so the test focuses on the
+ * dialog's own logic (Switch checked / disabled / visibility filter,
+ * Alert variant selection, Reset button enable / disable).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DataSourceSettingsDialog } from '../data-source-settings-dialog';
+import settings from '../../../config/data-source-settings';
+import { getDefaultEnabledIds } from '../../../domain/datasource/data-source-selection';
+import type { SourceLoadState } from '../../../domain/datasource/source-load-state';
+import type { SourceGroup } from '../../../types/app/source-group';
+
+const mockComputeDialogDisplay = vi.hoisted(() => vi.fn());
+
+// Mock react-i18next: identity translation so the test asserts against
+// raw i18n keys, decoupling it from locale file content. If options are
+// provided, append the first stringy value so interpolated aria-labels
+// stay distinguishable across instances.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts) {
+        const firstStringOpt = Object.values(opts).find((v): v is string => typeof v === 'string');
+        if (firstStringOpt !== undefined) {
+          return `${key} [${firstStringOpt}]`;
+        }
+      }
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+const mockUseSourceLoadStatus = vi.fn<() => SourceLoadState>();
+vi.mock('../../../hooks/use-source-load-status', () => ({
+  useSourceLoadStatus: () => mockUseSourceLoadStatus(),
+}));
+
+const mockUseIsForcedSourcesMode = vi.fn<() => boolean>();
+vi.mock('../../../hooks/use-is-forced-sources-mode', () => ({
+  useIsForcedSourcesMode: () => mockUseIsForcedSourcesMode(),
+}));
+
+const mockSetGroupEnabled = vi.fn<(id: string, enabled: boolean) => void>();
+const mockSetGroupsEnabled = vi.fn<(ids: readonly string[], enabled: boolean) => void>();
+const mockResetToDefaults = vi.fn<() => void>();
+const mockUseUserDataSourceSettings = vi.fn<
+  () => {
+    enabledGroupIds: ReadonlySet<string>;
+    setGroupEnabled: (id: string, enabled: boolean) => void;
+    setGroupsEnabled: (ids: readonly string[], enabled: boolean) => void;
+    resetToDefaults: () => void;
+  }
+>();
+vi.mock('../../../hooks/use-user-data-source-settings', () => ({
+  useUserDataSourceSettings: () => mockUseUserDataSourceSettings(),
+}));
+
+vi.mock('../../../domain/datasource/dialog-display', async () => {
+  const actual = await vi.importActual<typeof import('../../../domain/datasource/dialog-display')>(
+    '../../../domain/datasource/dialog-display',
+  );
+  return {
+    ...actual,
+    computeDialogDisplay: (
+      ...args: Parameters<typeof actual.computeDialogDisplay>
+    ): ReturnType<typeof actual.computeDialogDisplay> => {
+      const impl = mockComputeDialogDisplay.getMockImplementation();
+      if (impl) {
+        return impl(...args) as ReturnType<typeof actual.computeDialogDisplay>;
+      }
+      return actual.computeDialogDisplay(...args);
+    },
+  };
+});
+
+const noopOnOpenChange = (): void => {
+  // intentionally empty for tests that don't care about close
+};
+
+const emptyLoadStatus: SourceLoadState = new Map();
+
+const defaultEnabledIds = getDefaultEnabledIds(settings);
+
+beforeEach(() => {
+  mockComputeDialogDisplay.mockReset();
+  // Default: normal mode, no load status, user has defaults.
+  mockUseSourceLoadStatus.mockReturnValue(emptyLoadStatus);
+  mockUseIsForcedSourcesMode.mockReturnValue(false);
+  mockUseUserDataSourceSettings.mockReturnValue({
+    enabledGroupIds: defaultEnabledIds,
+    setGroupEnabled: mockSetGroupEnabled,
+    setGroupsEnabled: mockSetGroupsEnabled,
+    resetToDefaults: mockResetToDefaults,
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+/**
+ * Returns the FIRST `<li>` row containing a Switch with the given
+ * group-name aria label. A group with multiple `routeTypes` (e.g.
+ * `toko` with `[0,1,2,3]`) appears once per section — Switch state is
+ * identical across them (it's a `groupId` lookup against the same
+ * `enabledGroupIds` Set), so asserting on the first occurrence is
+ * sufficient. Callers that need the "every occurrence" assertion use
+ * {@link getAllSwitchesFor}.
+ */
+function findGroupRow(groupName: string): HTMLElement {
+  const switchEl = screen.getAllByRole('switch', {
+    name: `dataSourceSettings.toggle.aria [${groupName}]`,
+  })[0];
+  if (!switchEl) {
+    throw new Error(`row container not found for ${groupName}`);
+  }
+  // Walk up to the <li> container so the test can scope queries.
+  let el: HTMLElement | null = switchEl;
+  while (el && el.tagName !== 'LI') {
+    el = el.parentElement;
+  }
+  if (!el) {
+    throw new Error(`<li> not found for ${groupName}`);
+  }
+  return el;
+}
+
+function getAllSwitchesFor(groupName: string): HTMLElement[] {
+  return screen.getAllByRole('switch', {
+    name: `dataSourceSettings.toggle.aria [${groupName}]`,
+  });
+}
+
+describe('DataSourceSettingsDialog — normal mode', () => {
+  it('shows the development notice Alert, not the forced-mode Alert', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    expect(screen.getByText('dataSourceSettings.developmentNotice.title')).toBeInTheDocument();
+    expect(screen.queryByText('dataSourceSettings.forcedMode.title')).not.toBeInTheDocument();
+  });
+
+  it('renders an other section for groups whose routeTypes are outside ROUTE_TYPE_PRIORITY', () => {
+    const customGroup: SourceGroup = {
+      id: 'other-test',
+      prefixes: ['other-test-prefix'],
+      routeTypes: [999 as never],
+      systemEnabledByDefault: true,
+      userEnabledByDefault: true,
+      name: { name: 'Other Test', names: { en: 'Other Test' } },
+      countries: ['JP'],
+    };
+    mockComputeDialogDisplay.mockReturnValue({
+      visibleGroups: [customGroup],
+      effectiveEnabledIds: new Set(['other-test']),
+    });
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    expect(screen.getByText('dataSourceSettings.section.other')).toBeInTheDocument();
+  });
+
+  it('enables the Reset to defaults button', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    const resetButton = screen.getByRole('button', {
+      name: 'dataSourceSettings.resetToDefaults',
+    });
+    expect(resetButton).not.toBeDisabled();
+  });
+
+  it('renders a Switch checked = enabledGroupIds.has(groupId)', () => {
+    // Pick a default-enabled group (Toei Bus) and one that's NOT in the
+    // user's selection (Odakyu Bus is systemEnabledByDefault: false so
+    // it would not be in defaults — keep enabledGroupIds as defaults and
+    // assert based on that).
+    mockUseUserDataSourceSettings.mockReturnValue({
+      enabledGroupIds: new Set(['toei-bus']),
+      setGroupEnabled: mockSetGroupEnabled,
+      setGroupsEnabled: mockSetGroupsEnabled,
+      resetToDefaults: mockResetToDefaults,
+    });
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    const toeiBusRow = findGroupRow('Toei Bus');
+    const toeiBusSwitch = within(toeiBusRow).getByRole('switch');
+    expect(toeiBusSwitch).toHaveAttribute('aria-checked', 'true');
+    // toei-train is NOT in the user-enabled set, so its Switch is OFF.
+    const toeiTrainRow = findGroupRow('Toei Train');
+    const toeiTrainSwitch = within(toeiTrainRow).getByRole('switch');
+    expect(toeiTrainSwitch).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('clicking a Switch calls setGroupEnabled with the matching group id', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    const toeiBusRow = findGroupRow('Toei Bus');
+    const toeiBusSwitch = within(toeiBusRow).getByRole('switch');
+    // Initial state is `checked` (toei-bus is in defaults), so clicking
+    // it toggles to false.
+    fireEvent.click(toeiBusSwitch);
+    expect(mockSetGroupEnabled).toHaveBeenCalledWith('toei-bus', false);
+  });
+
+  it('clicking Reset to defaults calls resetToDefaults', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    const resetButton = screen.getByRole('button', {
+      name: 'dataSourceSettings.resetToDefaults',
+    });
+    fireEvent.click(resetButton);
+    expect(mockResetToDefaults).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking the "All on" bulk button calls setGroupsEnabled with the section group ids and true', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    // There is one "All on" button per section; pick any one of the Bus
+    // section's by aria-label.
+    const enableAllBus = screen.getByRole('button', {
+      name: 'dataSourceSettings.bulkAction.enableAll.aria [dataSourceSettings.section.3]',
+    });
+    fireEvent.click(enableAllBus);
+    expect(mockSetGroupsEnabled).toHaveBeenCalledTimes(1);
+    const [ids, enabled] = mockSetGroupsEnabled.mock.calls[0];
+    expect(enabled).toBe(true);
+    // Every bus row's groupId must be in the passed array (Toei Bus,
+    // Kanto Bus, etc. — at least toei-bus and toko-bus-coverage).
+    expect(ids).toContain('toei-bus');
+    expect(ids).toContain('kanto-bus');
+  });
+
+  it('clicking the "All off" bulk button calls setGroupsEnabled with the section group ids and false', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    const disableAllBus = screen.getByRole('button', {
+      name: 'dataSourceSettings.bulkAction.disableAll.aria [dataSourceSettings.section.3]',
+    });
+    fireEvent.click(disableAllBus);
+    expect(mockSetGroupsEnabled).toHaveBeenCalledTimes(1);
+    const [ids, enabled] = mockSetGroupsEnabled.mock.calls[0];
+    expect(enabled).toBe(false);
+    expect(ids).toContain('toei-bus');
+  });
+
+  it('honours group-vs-prefix semantics (overlap does NOT carry through to Switch state)', () => {
+    // toei-bus and toko both contain `minkuru`. If the user has enabled
+    // toei-bus but not toko, toko's Switch must be OFF — Switch state is
+    // a group-id lookup, not a prefix lookup.
+    mockUseUserDataSourceSettings.mockReturnValue({
+      enabledGroupIds: new Set(['toei-bus']),
+      setGroupEnabled: mockSetGroupEnabled,
+      setGroupsEnabled: mockSetGroupsEnabled,
+      resetToDefaults: mockResetToDefaults,
+    });
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    const tokoRow = findGroupRow('Toei Transport');
+    const tokoSwitch = within(tokoRow).getByRole('switch');
+    expect(tokoSwitch).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('renders the partial loaded/total fraction for partially loaded groups', () => {
+    mockUseSourceLoadStatus.mockReturnValue(
+      new Map([
+        ['minkuru', { status: 'loaded' }],
+        ['toaran', { status: 'failed', error: new Error('network down') }],
+      ]),
+    );
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    expect(screen.getAllByText('dataSourceSettings.partial.fraction').length).toBeGreaterThan(0);
+  });
+
+  it('renders failed prefix messages for failed or partial groups', () => {
+    mockUseSourceLoadStatus.mockReturnValue(
+      new Map([['toaran', { status: 'failed', error: new Error('network down') }]]),
+    );
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    expect(screen.getAllByText(/toaran/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/network down/).length).toBeGreaterThan(0);
+  });
+});
+
+describe('DataSourceSettingsDialog — forced-sources mode', () => {
+  beforeEach(() => {
+    mockUseIsForcedSourcesMode.mockReturnValue(true);
+    // Simulate `?sources=minkuru` having loaded the `minkuru` prefix.
+    // Forced mode visibility filter shows only groups with any attempted
+    // prefix — that means toei-bus AND toko (both share minkuru) become
+    // visible; toei-train (toaran) does NOT.
+    mockUseSourceLoadStatus.mockReturnValue(
+      new Map<string, { status: 'loaded' }>([['minkuru', { status: 'loaded' }]]),
+    );
+  });
+
+  it('shows the forced-mode Alert, not the development notice', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    expect(screen.getByText('dataSourceSettings.forcedMode.title')).toBeInTheDocument();
+    expect(
+      screen.queryByText('dataSourceSettings.developmentNotice.title'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('narrows visibility to groups with attempted prefixes', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    // toei-bus (1 section) and toko (4 sections — `routeTypes: [0,1,2,3]`)
+    // share minkuru → both visible
+    expect(getAllSwitchesFor('Toei Bus').length).toBeGreaterThan(0);
+    expect(getAllSwitchesFor('Toei Transport').length).toBeGreaterThan(0);
+    // toei-train (toaran only) → not loaded → not visible in forced mode
+    expect(
+      screen.queryAllByRole('switch', {
+        name: 'dataSourceSettings.toggle.aria [Toei Train]',
+      }),
+    ).toHaveLength(0);
+  });
+
+  it('forces every visible Switch to checked=true regardless of user setting', () => {
+    // Set user to NOT include either toei-bus or toko — forced override
+    // wins.
+    mockUseUserDataSourceSettings.mockReturnValue({
+      enabledGroupIds: new Set(),
+      setGroupEnabled: mockSetGroupEnabled,
+      setGroupsEnabled: mockSetGroupsEnabled,
+      resetToDefaults: mockResetToDefaults,
+    });
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    for (const sw of getAllSwitchesFor('Toei Bus')) {
+      expect(sw).toHaveAttribute('aria-checked', 'true');
+    }
+    for (const sw of getAllSwitchesFor('Toei Transport')) {
+      expect(sw).toHaveAttribute('aria-checked', 'true');
+    }
+  });
+
+  it('disables every visible Switch', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    for (const sw of getAllSwitchesFor('Toei Bus')) {
+      expect(sw).toBeDisabled();
+    }
+    for (const sw of getAllSwitchesFor('Toei Transport')) {
+      expect(sw).toBeDisabled();
+    }
+  });
+
+  it('disables the Reset to defaults button', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    const resetButton = screen.getByRole('button', {
+      name: 'dataSourceSettings.resetToDefaults',
+    });
+    expect(resetButton).toBeDisabled();
+  });
+
+  it('disables every bulk-action button', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    // Bus section is the one that gets shown in forced mode for this
+    // setup (minkuru loaded). Both bulk buttons in that section must be
+    // disabled.
+    const enableAllBus = screen.getByRole('button', {
+      name: 'dataSourceSettings.bulkAction.enableAll.aria [dataSourceSettings.section.3]',
+    });
+    const disableAllBus = screen.getByRole('button', {
+      name: 'dataSourceSettings.bulkAction.disableAll.aria [dataSourceSettings.section.3]',
+    });
+    expect(enableAllBus).toBeDisabled();
+    expect(disableAllBus).toBeDisabled();
+  });
+});

--- a/src/components/dialog/data-source-settings-dialog.tsx
+++ b/src/components/dialog/data-source-settings-dialog.tsx
@@ -1,10 +1,12 @@
 import { useTranslation } from 'react-i18next';
-import { InfoIcon } from 'lucide-react';
+import { InfoIcon, WrenchIcon } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -14,10 +16,12 @@ import {
   aggregateGroupLoadStatus,
   type GroupLoadStatus,
 } from '../../domain/datasource/aggregate-group-status';
+import { computeDialogDisplay } from '../../domain/datasource/dialog-display';
 import { getSourceGroupDisplayName } from '../../domain/datasource/get-source-group-display-name';
 import { sortSourceGroupsForDisplay } from '../../domain/datasource/sort-source-groups';
 import { useIsForcedSourcesMode } from '../../hooks/use-is-forced-sources-mode';
 import { useSourceLoadStatus } from '../../hooks/use-source-load-status';
+import { useUserDataSourceSettings } from '../../hooks/use-user-data-source-settings';
 import type { SourceGroup } from '../../types/app/source-group';
 import { countriesFlagEmoji } from '../../utils/country-flag';
 import { routeTypeEmoji, routeTypesEmoji } from '../../utils/route-type-emoji';
@@ -27,6 +31,8 @@ import {
   type RouteTypeSectionKey,
 } from '../../domain/datasource/route-type-priority';
 
+type NoticeVariant = 'forced' | 'development';
+
 interface DataSourceSettingsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -35,6 +41,8 @@ interface DataSourceSettingsDialogProps {
 interface GroupRow {
   /** Stable key for React reconciliation within a section. */
   key: string;
+  /** Group id, used to look up the Switch state in `enabledGroupIds`. */
+  groupId: string;
   /** Display name for the group, resolved against the current UI language. */
   groupName: string;
   /** Concatenated route_type emoji for the *group's whole* coverage. */
@@ -43,15 +51,6 @@ interface GroupRow {
   countryEmoji: string;
   /** Aggregated load status (4-state). */
   loadStatus: GroupLoadStatus;
-  /**
-   * Default value of the user preference for this group.
-   *
-   * Read directly from {@link SourceGroup.userEnabledByDefault}; in a
-   * later phase this will be overridable by a persisted user-settings
-   * layer. Phase 0 surfaces the value via a disabled toggle so the
-   * dialog already reflects the field without yet being interactive.
-   */
-  userEnabledByDefault: boolean;
 }
 
 interface Section {
@@ -72,11 +71,11 @@ function buildGroupRow(
 ): GroupRow {
   return {
     key: group.id,
+    groupId: group.id,
     groupName: getSourceGroupDisplayName(group, lang),
     routeTypeEmoji: routeTypesEmoji(group.routeTypes),
     countryEmoji: countriesFlagEmoji(group.countries),
     loadStatus: aggregateGroupLoadStatus(group.prefixes, loadStatusByPrefix),
-    userEnabledByDefault: group.userEnabledByDefault,
   };
 }
 
@@ -223,26 +222,70 @@ function FailureList({ row }: { row: GroupRow }) {
   );
 }
 
+function DialogNotice({ variant }: { variant: NoticeVariant }) {
+  const { t } = useTranslation();
+
+  if (variant === 'forced') {
+    return (
+      <Alert
+        role="status"
+        className="mt-3 border-sky-300 bg-sky-50 px-3 py-2 text-left shadow-sm dark:border-sky-800 dark:bg-sky-950/40"
+      >
+        <InfoIcon
+          aria-hidden="true"
+          focusable="false"
+          className="mt-0.5 text-sky-700 dark:text-sky-300"
+        />
+        <AlertTitle className="text-xs font-semibold text-sky-900 dark:text-sky-200">
+          {t('dataSourceSettings.forcedMode.title')}
+        </AlertTitle>
+        <AlertDescription className="text-[11px] text-sky-800 dark:text-sky-300">
+          {t('dataSourceSettings.forcedMode.description')}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert
+      role="status"
+      className="mt-3 border-amber-300 bg-amber-50 px-3 py-2 text-left shadow-sm dark:border-amber-800 dark:bg-amber-950/40"
+    >
+      <WrenchIcon
+        aria-hidden="true"
+        focusable="false"
+        className="mt-0.5 text-amber-700 dark:text-amber-300"
+      />
+      <AlertTitle className="text-xs font-semibold text-amber-900 dark:text-amber-200">
+        {t('dataSourceSettings.developmentNotice.title')}
+      </AlertTitle>
+      <AlertDescription className="text-[11px] text-amber-800 dark:text-amber-300">
+        {t('dataSourceSettings.developmentNotice.description')}
+      </AlertDescription>
+    </Alert>
+  );
+}
+
 function GroupRowView({
   row,
-  isForcedSourcesMode,
+  checked,
+  disabled,
+  onCheckedChange,
 }: {
   row: GroupRow;
-  isForcedSourcesMode: boolean;
+  /** Switch checked state (caller resolves forced-mode override). */
+  checked: boolean;
+  /** Whether the Switch is non-interactive. */
+  disabled: boolean;
+  onCheckedChange: (next: boolean) => void;
 }) {
   const { t } = useTranslation();
-  // In forced-sources mode, the visible row is only here because at least one
-  // of its prefixes was attempted by the URL override, so reflecting
-  // `userEnabledByDefault` would mislead (e.g. system-disabled groups
-  // surfaced via `?sources=<list>` would show OFF despite being loaded).
-  // Forcing `checked` to `true` keeps the Switch consistent with the load
-  // status icon adjacent to it.
-  const switchChecked = isForcedSourcesMode ? true : row.userEnabledByDefault;
   return (
     <li className="border-border/40 flex items-start gap-2 border-b px-2 py-2 last:border-b-0">
       <Switch
-        checked={switchChecked}
-        disabled
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={onCheckedChange}
         aria-label={t('dataSourceSettings.toggle.aria', {
           group: row.groupName,
         })}
@@ -307,22 +350,19 @@ export function DataSourceSettingsDialog({ open, onOpenChange }: DataSourceSetti
   const { t, i18n } = useTranslation();
   const loadStatusByPrefix = useSourceLoadStatus();
   const isForcedSourcesMode = useIsForcedSourcesMode();
+  const { enabledGroupIds, setGroupEnabled, setGroupsEnabled, resetToDefaults } =
+    useUserDataSourceSettings();
 
-  // Visibility:
-  //  - Normal mode: app-enabled groups are always shown. App-disabled groups
-  //    (`systemEnabledByDefault: false`) are hidden, but reappear when their
-  //    data has actually been loaded (currently only via `?sources=all`).
-  //  - Forced-sources mode (`?sources=<list>` or `?sources=all` set): user
-  //    settings are bypassed entirely, so showing app-enabled-by-default
-  //    groups that the URL didn't request would be misleading. Restrict the
-  //    list to groups whose prefixes are actually in the load-status map.
-  const visibleGroups = settings.filter((g) => {
-    const anyAttempted = g.prefixes.some((prefix) => loadStatusByPrefix.has(prefix));
-    if (isForcedSourcesMode) {
-      return anyAttempted;
-    }
-    return g.systemEnabledByDefault || anyAttempted;
-  });
+  // Normalize the two operating modes (forced / normal) into one shape
+  // so the body below never branches on `isForcedSourcesMode`. The
+  // pure-function call returns the visible groups + the Set used for
+  // both per-row Switch state and per-section enabled counts.
+  const { visibleGroups, effectiveEnabledIds } = computeDialogDisplay(
+    settings,
+    loadStatusByPrefix,
+    isForcedSourcesMode,
+    enabledGroupIds,
+  );
 
   const sections = buildSections(visibleGroups, loadStatusByPrefix, i18n.language, t);
   const counts = countDistinctGroupStatuses(visibleGroups, loadStatusByPrefix);
@@ -347,45 +387,96 @@ export function DataSourceSettingsDialog({ open, onOpenChange }: DataSourceSetti
               notAttempted: counts.notAttempted,
             })}
           </div>
+          {/*
+            Per-section enabled count, driven from the same
+            `effectiveEnabledIds` Set as each row's Switch. A
+            multi-routeType group is counted once per section it
+            appears in, so the sum across sections can exceed the
+            distinct-group total in the summary line above.
+          */}
+          <div className="text-muted-foreground text-center text-xs">
+            {sections.map((section) => {
+              const enabledCount = section.rows.filter((row) =>
+                effectiveEnabledIds.has(row.groupId),
+              ).length;
+              return (
+                <span key={String(section.key)}>
+                  <span aria-hidden className="mx-1">
+                    {section.emoji}: {enabledCount}
+                  </span>
+                </span>
+              );
+            })}
+          </div>
         </DialogHeader>
-        {isForcedSourcesMode && (
-          <Alert
-            role="status"
-            className="mt-3 border-sky-300 bg-sky-50 px-3 py-2 text-left shadow-sm dark:border-sky-800 dark:bg-sky-950/40"
-          >
-            <InfoIcon
-              aria-hidden="true"
-              focusable="false"
-              className="mt-0.5 text-sky-700 dark:text-sky-300"
-            />
-            <AlertTitle className="text-xs font-semibold text-sky-900 dark:text-sky-200">
-              {t('dataSourceSettings.forcedMode.title')}
-            </AlertTitle>
-            <AlertDescription className="text-[11px] text-sky-800 dark:text-sky-300">
-              {t('dataSourceSettings.forcedMode.description')}
-            </AlertDescription>
-          </Alert>
-        )}
+        <DialogNotice variant={isForcedSourcesMode ? 'forced' : 'development'} />
         <div className="overflow-y-auto pt-3 text-sm">
-          {sections.map((section) => (
-            <section key={String(section.key)} className="mb-4 last:mb-0">
-              <h3 className="text-muted-foreground bg-muted/40 sticky top-0 z-10 flex items-baseline gap-2 px-2 py-1 text-xs font-semibold">
-                <span aria-hidden>{section.emoji}</span>
-                <span>{section.label}</span>
-                <span className="opacity-60">({section.rows.length})</span>
-              </h3>
-              <ul>
-                {section.rows.map((row) => (
-                  <GroupRowView
-                    key={`${String(section.key)}::${row.key}`}
-                    row={row}
-                    isForcedSourcesMode={isForcedSourcesMode}
-                  />
-                ))}
-              </ul>
-            </section>
-          ))}
+          {sections.map((section) => {
+            const sectionGroupIds = section.rows.map((row) => row.groupId);
+            return (
+              <section key={String(section.key)} className="mb-4 last:mb-0">
+                <h3 className="text-muted-foreground bg-muted/40 sticky top-0 z-10 flex items-center gap-2 px-2 py-1 text-xs font-semibold">
+                  <span aria-hidden>{section.emoji}</span>
+                  <span>{section.label}</span>
+                  <span className="opacity-60">({section.rows.length})</span>
+                  <div className="ml-auto flex gap-1">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => {
+                        setGroupsEnabled(sectionGroupIds, true);
+                      }}
+                      disabled={isForcedSourcesMode}
+                      aria-label={t('dataSourceSettings.bulkAction.enableAll.aria', {
+                        section: section.label,
+                      })}
+                      className="h-6 px-2 text-[11px]"
+                    >
+                      {t('dataSourceSettings.bulkAction.enableAll.label')}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => {
+                        setGroupsEnabled(sectionGroupIds, false);
+                      }}
+                      disabled={isForcedSourcesMode}
+                      aria-label={t('dataSourceSettings.bulkAction.disableAll.aria', {
+                        section: section.label,
+                      })}
+                      className="h-6 px-2 text-[11px]"
+                    >
+                      {t('dataSourceSettings.bulkAction.disableAll.label')}
+                    </Button>
+                  </div>
+                </h3>
+                <ul>
+                  {section.rows.map((row) => (
+                    <GroupRowView
+                      key={`${String(section.key)}::${row.key}`}
+                      row={row}
+                      checked={effectiveEnabledIds.has(row.groupId)}
+                      disabled={isForcedSourcesMode}
+                      onCheckedChange={(next) => {
+                        setGroupEnabled(row.groupId, next);
+                      }}
+                    />
+                  ))}
+                </ul>
+              </section>
+            );
+          })}
         </div>
+        <DialogFooter className="shrink-0 border-t pt-3 sm:justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={resetToDefaults}
+            disabled={isForcedSourcesMode}
+          >
+            {t('dataSourceSettings.resetToDefaults')}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/src/config/__tests__/data-source-manager.test.ts
+++ b/src/config/__tests__/data-source-manager.test.ts
@@ -7,8 +7,6 @@ import type { SourceGroup } from '../../types/app/source-group';
 import settings from '../data-source-settings';
 import { resetParamsCache } from '../../lib/query-params';
 
-const STORAGE_KEY = 'enabled-sources';
-
 /**
  * Replace the current URL (path + query) and reset the cached
  * URLSearchParams instance so the next call to `getSourcesParam()`
@@ -113,6 +111,9 @@ function createDuplicateIdSettings(): SourceGroup[] {
 }
 
 beforeEach(() => {
+  // DSM no longer touches localStorage directly (since Phase 1) but tests
+  // run in jsdom and may inherit state from earlier suites — clear to be
+  // safe.
   localStorage.clear();
   setSearch('');
 });
@@ -124,9 +125,9 @@ afterEach(() => {
 
 describe('DataSourceManager', () => {
   describe('Constructor', () => {
-    it('uses only default-enabled groups when neither URL param nor localStorage is present', async () => {
+    it('uses only default-enabled groups when neither URL param nor stored selection is present', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createCustomSettings());
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
 
       expect(manager.isEnabled('default-on')).toBe(true);
       expect(manager.isEnabled('default-off')).toBe(false);
@@ -136,7 +137,7 @@ describe('DataSourceManager', () => {
     it('enables every group including config-default-disabled ones when URL param is `?sources=all`', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createCustomSettings());
       setSearch('sources=all');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
 
       expect(manager.isEnabled('default-on')).toBe(true);
       expect(manager.isEnabled('default-off')).toBe(true);
@@ -146,7 +147,7 @@ describe('DataSourceManager', () => {
     it('enables only groups containing the requested prefix when URL param lists prefixes', () => {
       // `minkuru` belongs to the `toei-bus` group only.
       setSearch('sources=minkuru');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
       expect(manager.isEnabled('toei-bus')).toBe(true);
       expect(manager.isEnabled('toei-train')).toBe(false);
       expect(manager.isEnabled('yurikamome')).toBe(false);
@@ -156,7 +157,7 @@ describe('DataSourceManager', () => {
     it('enables a config-default-disabled group when query params explicitly target it', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
       setSearch('sources=beta-main');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
 
       expect(manager.isEnabled('alpha')).toBe(false);
       expect(manager.isEnabled('beta')).toBe(true);
@@ -164,18 +165,16 @@ describe('DataSourceManager', () => {
       expect(manager.getEnabledPrefixes()).toEqual(['beta-main']);
     });
 
-    it('hydrates the enabled set from localStorage when no URL param is present', () => {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus', 'yurikamome']));
-      const manager = new DataSourceManager();
+    it('hydrates the enabled set from the stored selection when no URL param is present', () => {
+      const manager = new DataSourceManager(new Set(['toei-bus', 'yurikamome']));
       expect(manager.isEnabled('toei-bus')).toBe(true);
       expect(manager.isEnabled('yurikamome')).toBe(true);
       expect(manager.isEnabled('keio-bus')).toBe(false);
     });
 
-    it('enables a config-default-disabled group when localStorage explicitly includes it', async () => {
+    it('enables a config-default-disabled group when the stored selection explicitly includes it', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(['beta']));
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(new Set(['beta']));
 
       expect(manager.isEnabled('alpha')).toBe(false);
       expect(manager.isEnabled('beta')).toBe(true);
@@ -183,32 +182,10 @@ describe('DataSourceManager', () => {
       expect(manager.getEnabledPrefixes()).toEqual(['beta-main']);
     });
 
-    it('falls back to default-enabled groups when localStorage contains invalid JSON', async () => {
-      localStorage.setItem(STORAGE_KEY, 'not-valid-json{{');
-      const DataSourceManager = await importFreshDataSourceManager(createCustomSettings());
-      const manager = new DataSourceManager();
-
-      expect(manager.isEnabled('default-on')).toBe(true);
-      expect(manager.isEnabled('default-off')).toBe(false);
-      expect(manager.getEnabledPrefixes()).toEqual(['on']);
-    });
-
-    it('treats a JSON string in localStorage as a malformed persisted selection and enables no known groups', async () => {
+    it('replaces the stored selection instead of unioning with it when URL params are present', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
-      localStorage.setItem(STORAGE_KEY, JSON.stringify('beta'));
-      const manager = new DataSourceManager();
-
-      expect(manager.isEnabled('alpha')).toBe(false);
-      expect(manager.isEnabled('beta')).toBe(false);
-      expect(manager.isEnabled('gamma')).toBe(false);
-      expect(manager.getEnabledPrefixes()).toEqual([]);
-    });
-
-    it('replaces localStorage entries instead of unioning with them when URL params are present', async () => {
-      const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(['alpha']));
       setSearch('sources=beta-main');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(new Set(['alpha']));
 
       expect(manager.isEnabled('alpha')).toBe(false);
       expect(manager.isEnabled('beta')).toBe(true);
@@ -216,10 +193,9 @@ describe('DataSourceManager', () => {
       expect(manager.getEnabledPrefixes()).toEqual(['beta-main']);
     });
 
-    it('treats a no-match URL param as an explicit empty override even when localStorage has enabled groups', () => {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus', 'yurikamome']));
+    it('treats a no-match URL param as an explicit empty override even when the stored selection has enabled groups', () => {
       setSearch('sources=nonexistent-prefix');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(new Set(['toei-bus', 'yurikamome']));
 
       for (const group of settings) {
         expect(manager.isEnabled(group.id)).toBe(false);
@@ -227,10 +203,9 @@ describe('DataSourceManager', () => {
       expect(manager.getEnabledPrefixes()).toEqual([]);
     });
 
-    it('falls through to localStorage when `?sources=` has an empty value', () => {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus']));
+    it('falls through to the stored selection when `?sources=` has an empty value', () => {
       setSearch('sources=');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(new Set(['toei-bus']));
 
       expect(manager.isEnabled('toei-bus')).toBe(true);
       expect(manager.isEnabled('yurikamome')).toBe(false);
@@ -239,7 +214,7 @@ describe('DataSourceManager', () => {
     it('does not treat an empty `?sources=` value as `all`', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createCustomSettings());
       setSearch('sources=');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
 
       expect(manager.isEnabled('default-on')).toBe(true);
       expect(manager.isEnabled('default-off')).toBe(false);
@@ -249,7 +224,7 @@ describe('DataSourceManager', () => {
     it('enables every group whose prefixes match a comma-separated list', () => {
       // `minkuru` → toei-bus, `toaran` → toei-train
       setSearch('sources=minkuru,toaran');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
       expect(manager.isEnabled('toei-bus')).toBe(true);
       expect(manager.isEnabled('toei-train')).toBe(true);
       expect(manager.isEnabled('yurikamome')).toBe(false);
@@ -257,7 +232,7 @@ describe('DataSourceManager', () => {
 
     it('trims whitespace around comma-separated prefixes', () => {
       setSearch('sources=minkuru%2C%20toaran'); // "minkuru, toaran"
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
       expect(manager.isEnabled('toei-bus')).toBe(true);
       expect(manager.isEnabled('toei-train')).toBe(true);
       expect(manager.isEnabled('yurikamome')).toBe(false);
@@ -265,7 +240,7 @@ describe('DataSourceManager', () => {
 
     it('enables nothing when the requested prefix matches no group', () => {
       setSearch('sources=nonexistent-prefix');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
       for (const group of settings) {
         expect(manager.isEnabled(group.id)).toBe(false);
       }
@@ -276,46 +251,35 @@ describe('DataSourceManager', () => {
       // Anything else is split on commas and looked up as prefixes, where
       // `all` itself never matches a real GTFS prefix.
       setSearch('sources=all,minkuru');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
       expect(manager.isEnabled('toei-bus')).toBe(true);
       expect(manager.isEnabled('toei-train')).toBe(false);
       expect(manager.isEnabled('yurikamome')).toBe(false);
     });
 
-    it('treats an empty array in localStorage as "everything disabled"', () => {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
-      const manager = new DataSourceManager();
+    it('treats an empty stored Set as "everything disabled" (user-explicit empty, β semantic)', () => {
+      const manager = new DataSourceManager(new Set());
       for (const group of settings) {
         expect(manager.isEnabled(group.id)).toBe(false);
       }
-    });
-
-    it('enables no known groups when localStorage contains only unknown ids', () => {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(['unknown-id']));
-      const manager = new DataSourceManager();
-      for (const group of settings) {
-        expect(manager.isEnabled(group.id)).toBe(false);
-      }
-      expect(manager.getEnabledPrefixes()).toEqual([]);
     });
 
     it('treats all groups with the same id as enabled when defaults include that id', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createDuplicateIdSettings());
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
 
       expect(manager.isEnabled('shared')).toBe(true);
       expect(manager.getEnabledPrefixes()).toEqual(['c', 'a', 'b']);
     });
 
-    it('treats all groups with the same id as enabled when localStorage includes that id', async () => {
+    it('treats all groups with the same id as enabled when the stored selection includes that id', async () => {
       const groups = createDuplicateIdSettings().map((group) => ({
         ...group,
         systemEnabledByDefault: false,
         userEnabledByDefault: false,
       }));
       const DataSourceManager = await importFreshDataSourceManager(groups);
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(['shared']));
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(new Set(['shared']));
 
       expect(manager.isEnabled('shared')).toBe(true);
       expect(manager.getEnabledPrefixes()).toEqual(['c', 'a', 'b']);
@@ -324,7 +288,7 @@ describe('DataSourceManager', () => {
     it('treats all groups with the same id as enabled when query param matches one of them', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createDuplicateIdSettings());
       setSearch('sources=b');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
 
       expect(manager.isEnabled('shared')).toBe(true);
       // DSM is the *group-driven* view, so the prefix list here is the
@@ -366,7 +330,7 @@ describe('DataSourceManager', () => {
 
     it('emits a warn log listing the unknown prefix from `?sources=`', () => {
       setSearch('sources=minkuru,definitely-not-a-real-prefix');
-      new DataSourceManager();
+      new DataSourceManager(null);
 
       const warnMessage = findUnknownPrefixWarn();
       expect(warnMessage).toBeDefined();
@@ -377,7 +341,7 @@ describe('DataSourceManager', () => {
 
     it('lists every unknown prefix when multiple are present', () => {
       setSearch('sources=foo,bar,minkuru');
-      new DataSourceManager();
+      new DataSourceManager(null);
 
       const warnMessage = findUnknownPrefixWarn();
       expect(warnMessage).toBeDefined();
@@ -387,21 +351,21 @@ describe('DataSourceManager', () => {
 
     it('does not emit the unknown-prefix warning when `?sources=all`', () => {
       setSearch('sources=all');
-      new DataSourceManager();
+      new DataSourceManager(null);
 
       expect(findUnknownPrefixWarn()).toBeUndefined();
     });
 
     it('does not emit the unknown-prefix warning when every requested prefix matches a group', () => {
       setSearch('sources=minkuru,toaran');
-      new DataSourceManager();
+      new DataSourceManager(null);
 
       expect(findUnknownPrefixWarn()).toBeUndefined();
     });
 
     it('does not emit the unknown-prefix warning when `?sources=` is absent', () => {
       // No ?sources= param → DSM does not even reach the warning path.
-      new DataSourceManager();
+      new DataSourceManager(null);
 
       expect(findUnknownPrefixWarn()).toBeUndefined();
     });
@@ -411,7 +375,7 @@ describe('DataSourceManager', () => {
     it('returns every configured source group in definition order', async () => {
       const groups = createMultiPrefixSettings();
       const DataSourceManager = await importFreshDataSourceManager(groups);
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
 
       expect(manager.getGroups()).toEqual(groups);
     });
@@ -419,8 +383,7 @@ describe('DataSourceManager', () => {
     it('returns groups regardless of their enabled state', async () => {
       const groups = createMultiPrefixSettings();
       const DataSourceManager = await importFreshDataSourceManager(groups);
-      localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(new Set());
 
       expect(manager.getGroups()).toEqual(groups);
       for (const group of manager.getGroups()) {
@@ -431,119 +394,35 @@ describe('DataSourceManager', () => {
 
   describe('isEnabled', () => {
     it('returns true for a default-enabled group', () => {
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
       expect(manager.isEnabled('toei-bus')).toBe(true);
-    });
-
-    it('returns false for a group that has been disabled via setEnabled', () => {
-      const manager = new DataSourceManager();
-      manager.setEnabled('toei-bus', false);
-      expect(manager.isEnabled('toei-bus')).toBe(false);
     });
 
     it('returns false for an unknown group id', () => {
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
       expect(manager.isEnabled('this-group-does-not-exist')).toBe(false);
     });
 
-    it('reflects re-enabling a previously disabled group', () => {
-      const manager = new DataSourceManager();
-      manager.setEnabled('toei-bus', false);
+    it('reflects the stored selection passed to the constructor', () => {
+      const manager = new DataSourceManager(new Set(['toei-train']));
+      expect(manager.isEnabled('toei-train')).toBe(true);
       expect(manager.isEnabled('toei-bus')).toBe(false);
-      manager.setEnabled('toei-bus', true);
-      expect(manager.isEnabled('toei-bus')).toBe(true);
-    });
-  });
-
-  describe('setEnabled', () => {
-    it('disables a previously enabled group', () => {
-      const manager = new DataSourceManager();
-      expect(manager.isEnabled('toei-bus')).toBe(true);
-      manager.setEnabled('toei-bus', false);
-      expect(manager.isEnabled('toei-bus')).toBe(false);
-    });
-
-    it('enables a previously disabled group', () => {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
-      const manager = new DataSourceManager();
-      expect(manager.isEnabled('toei-bus')).toBe(false);
-      manager.setEnabled('toei-bus', true);
-      expect(manager.isEnabled('toei-bus')).toBe(true);
-    });
-
-    it('is idempotent: enabling an already-enabled group is a no-op', () => {
-      const manager = new DataSourceManager();
-      manager.setEnabled('toei-bus', true);
-      manager.setEnabled('toei-bus', true);
-      expect(manager.isEnabled('toei-bus')).toBe(true);
-      // The persisted set must not contain duplicate entries.
-      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]') as string[];
-      const occurrences = stored.filter((id) => id === 'toei-bus').length;
-      expect(occurrences).toBe(1);
-    });
-
-    it('disabling an unknown id does not throw', () => {
-      const manager = new DataSourceManager();
-      expect(() => manager.setEnabled('unknown-id', false)).not.toThrow();
-    });
-
-    it('persists the resulting enabled set to localStorage', async () => {
-      const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
-      const manager = new DataSourceManager();
-      manager.setEnabled('gamma', false);
-
-      const stored = localStorage.getItem(STORAGE_KEY);
-      expect(stored).not.toBeNull();
-      const parsed = JSON.parse(stored ?? '[]') as string[];
-      expect(parsed).toEqual(['alpha']);
-    });
-
-    it('changes are visible to a freshly constructed manager (round-trip via localStorage)', async () => {
-      const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
-      const manager1 = new DataSourceManager();
-      manager1.setEnabled('alpha', false);
-      manager1.setEnabled('beta', true);
-
-      const manager2 = new DataSourceManager();
-      expect(manager2.isEnabled('alpha')).toBe(false);
-      expect(manager2.isEnabled('beta')).toBe(true);
-      expect(manager2.isEnabled('gamma')).toBe(true);
-    });
-
-    it('disables all groups that share the same id', async () => {
-      const DataSourceManager = await importFreshDataSourceManager(createDuplicateIdSettings());
-      const manager = new DataSourceManager();
-
-      manager.setEnabled('shared', false);
-
-      expect(manager.isEnabled('shared')).toBe(false);
-      expect(manager.getEnabledPrefixes()).toEqual([]);
-      expect(localStorage.getItem(STORAGE_KEY)).toBe('[]');
     });
   });
 
   describe('getEnabledPrefixes', () => {
     it('returns prefixes from default-enabled groups in group order', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
 
       expect(manager.getEnabledPrefixes()).toEqual(['alpha-local', 'alpha-express', 'gamma-main']);
     });
 
     it('returns an empty array when nothing is enabled', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
-      localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(new Set());
 
       expect(manager.getEnabledPrefixes()).toEqual([]);
-    });
-
-    it('excludes prefixes from groups that were disabled after construction', async () => {
-      const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
-      const manager = new DataSourceManager();
-      manager.setEnabled('alpha', false);
-
-      expect(manager.getEnabledPrefixes()).toEqual(['gamma-main']);
     });
 
     it('returns prefixes only from explicitly enabled groups when URL param is used', async () => {
@@ -553,15 +432,14 @@ describe('DataSourceManager', () => {
       // `resolveFetchDataSources`, not by DSM directly — see its tests.
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
       setSearch('sources=alpha-express,beta-main');
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
 
       expect(manager.getEnabledPrefixes()).toEqual(['alpha-local', 'alpha-express', 'beta-main']);
     });
 
-    it('preserves group definition order instead of localStorage insertion order', async () => {
+    it('preserves group definition order instead of stored-selection insertion order', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(['gamma', 'alpha']));
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(new Set(['gamma', 'alpha']));
 
       expect(manager.getEnabledPrefixes()).toEqual(['alpha-local', 'alpha-express', 'gamma-main']);
     });
@@ -588,7 +466,7 @@ describe('DataSourceManager', () => {
         },
       ];
       const DataSourceManager = await importFreshDataSourceManager(groups);
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
 
       expect(manager.getEnabledPrefixes()).toEqual(['on', 'off']);
     });
@@ -615,7 +493,7 @@ describe('DataSourceManager', () => {
         },
       ];
       const DataSourceManager = await importFreshDataSourceManager(groups);
-      const manager = new DataSourceManager();
+      const manager = new DataSourceManager(null);
 
       expect(manager.getEnabledPrefixes()).toEqual(['c', 'a', 'b']);
     });

--- a/src/config/__tests__/data-source-manager.test.ts
+++ b/src/config/__tests__/data-source-manager.test.ts
@@ -155,6 +155,11 @@ describe('DataSourceManager', () => {
     });
 
     it('enables a config-default-disabled group when query params explicitly target it', async () => {
+      // URL `?sources=` is the operator/debug escape hatch — it
+      // bypasses the system gate that the stored-selection path above
+      // enforces. Force-loading a `systemEnabledByDefault: false`
+      // group via URL is intended behavior (test fixtures, debugging
+      // a retired source).
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
       setSearch('sources=beta-main');
       const manager = new DataSourceManager(null);
@@ -172,14 +177,33 @@ describe('DataSourceManager', () => {
       expect(manager.isEnabled('keio-bus')).toBe(false);
     });
 
-    it('enables a config-default-disabled group when the stored selection explicitly includes it', async () => {
+    it('drops stored IDs that point to system-disabled groups on boot (system gate)', async () => {
+      // A group flipped off in config (`systemEnabledByDefault: false`)
+      // must NOT load just because the user's localStorage still has its
+      // ID — otherwise retiring a source becomes a no-op for returning
+      // users with stale storage. The URL `?sources=` override (see the
+      // dedicated test below) is the intentional debug/operator escape
+      // hatch and is exempt from this gate.
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
       const manager = new DataSourceManager(new Set(['beta']));
 
       expect(manager.isEnabled('alpha')).toBe(false);
-      expect(manager.isEnabled('beta')).toBe(true);
+      expect(manager.isEnabled('beta')).toBe(false);
       expect(manager.isEnabled('gamma')).toBe(false);
-      expect(manager.getEnabledPrefixes()).toEqual(['beta-main']);
+      expect(manager.getEnabledPrefixes()).toEqual([]);
+    });
+
+    it('keeps system-enabled stored IDs while dropping system-disabled ones', async () => {
+      // Mixed case: the system gate is a per-ID filter, not all-or-
+      // nothing. `alpha` (systemEnabledByDefault: true) survives,
+      // `beta` (false) is dropped.
+      const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
+      const manager = new DataSourceManager(new Set(['alpha', 'beta']));
+
+      expect(manager.isEnabled('alpha')).toBe(true);
+      expect(manager.isEnabled('beta')).toBe(false);
+      expect(manager.isEnabled('gamma')).toBe(false);
+      expect(manager.getEnabledPrefixes()).toEqual(['alpha-local', 'alpha-express']);
     });
 
     it('replaces the stored selection instead of unioning with it when URL params are present', async () => {
@@ -283,9 +307,13 @@ describe('DataSourceManager', () => {
     });
 
     it('treats all groups with the same id as enabled when the stored selection includes that id', async () => {
+      // Test target: duplicate-id semantic on the stored-selection path.
+      // Fixture keeps `systemEnabledByDefault: true` (so the system gate
+      // doesn't filter `'shared'` out) but sets `userEnabledByDefault:
+      // false` (so the stored path — NOT defaults — is what's exercised
+      // here).
       const groups = createDuplicateIdSettings().map((group) => ({
         ...group,
-        systemEnabledByDefault: false,
         userEnabledByDefault: false,
       }));
       const DataSourceManager = await importFreshDataSourceManager(groups);

--- a/src/config/__tests__/data-source-manager.test.ts
+++ b/src/config/__tests__/data-source-manager.test.ts
@@ -203,22 +203,32 @@ describe('DataSourceManager', () => {
       expect(manager.getEnabledPrefixes()).toEqual([]);
     });
 
-    it('falls through to the stored selection when `?sources=` has an empty value', () => {
+    it('treats `?sources=` (empty value) as a force-load-empty override and ignores the stored selection', () => {
+      // `?sources=` (empty value) is a URL-level explicit "force-load
+      // zero sources". DSM must NOT collapse this with "param absent"
+      // (= null) via truthy/falsy checks — the load layer in
+      // `resolveFetchDataSources` already treats empty as force-empty,
+      // and the UI's `isForcedSourcesMode` is true for empty too.
       setSearch('sources=');
       const manager = new DataSourceManager(new Set(['toei-bus']));
 
-      expect(manager.isEnabled('toei-bus')).toBe(true);
-      expect(manager.isEnabled('yurikamome')).toBe(false);
+      for (const group of settings) {
+        expect(manager.isEnabled(group.id)).toBe(false);
+      }
+      expect(manager.getEnabledPrefixes()).toEqual([]);
     });
 
     it('does not treat an empty `?sources=` value as `all`', async () => {
+      // Empty `?sources=` is force-empty, NOT a fallback to defaults.
+      // (Pre-Phase-1 DSM collapsed empty into null via `!sourcesParam`
+      // and fell through to defaults; that was the bug.)
       const DataSourceManager = await importFreshDataSourceManager(createCustomSettings());
       setSearch('sources=');
       const manager = new DataSourceManager(null);
 
-      expect(manager.isEnabled('default-on')).toBe(true);
+      expect(manager.isEnabled('default-on')).toBe(false);
       expect(manager.isEnabled('default-off')).toBe(false);
-      expect(manager.getEnabledPrefixes()).toEqual(['on']);
+      expect(manager.getEnabledPrefixes()).toEqual([]);
     });
 
     it('enables every group whose prefixes match a comma-separated list', () => {

--- a/src/config/data-source-manager.ts
+++ b/src/config/data-source-manager.ts
@@ -6,7 +6,6 @@ import {
   getDefaultEnabledIds,
   getEnabledIdsFromSourcesParam,
   getEnabledPrefixesFromGroups,
-  parseStoredEnabledIds,
 } from '../domain/datasource/data-source-selection';
 import type { SourceGroup } from '../types/app/source-group';
 
@@ -38,35 +37,31 @@ function resolveEnabledIdsFromQueryParams(groups: SourceGroup[]): Set<string> | 
   return getEnabledIdsFromSourcesParam(groups, sourcesParam);
 }
 
-function resolveEnabledIdsFromStorage(): Set<string> | null {
-  return parseStoredEnabledIds(localStorage.getItem(STORAGE_KEY));
-}
-
-function resolveInitialEnabledIds(groups: SourceGroup[]): Set<string> {
+function resolveInitialEnabledIds(
+  groups: SourceGroup[],
+  storedEnabledIds: Set<string> | null,
+): Set<string> {
   const enabledIdsFromQueryParams = resolveEnabledIdsFromQueryParams(groups);
   if (enabledIdsFromQueryParams) {
     return enabledIdsFromQueryParams;
   }
 
-  try {
-    const enabledIdsFromStorage = resolveEnabledIdsFromStorage();
-    if (enabledIdsFromStorage) {
-      return enabledIdsFromStorage;
-    }
-  } catch {
-    // fall through to default
+  if (storedEnabledIds) {
+    return storedEnabledIds;
   }
 
   return getDefaultEnabledIds(groups);
 }
 
-const STORAGE_KEY = 'enabled-sources';
-
 /**
  * Manages which source groups are enabled/disabled.
  *
  * The manager owns the SourceGroup-level state — it tracks which groups
- * are currently active and persists user preferences to `localStorage`.
+ * are currently active. localStorage I/O lives in the
+ * {@link import('../domain/datasource/data-source-selection-storage')}
+ * utility; this class only consumes the **already-parsed** value at
+ * construction time via the `storedEnabledIds` constructor parameter.
+ *
  * It deliberately does NOT decide the final fetch-target prefix list
  * when a `?sources=<prefixes>` URL is in play; that resolution lives in
  * {@link import('../domain/datasource/resolve-fetch-data-sources').resolveFetchDataSources}
@@ -81,13 +76,19 @@ export class DataSourceManager {
    * Creates a new manager.
    *
    * Source selection priority:
-   * 1. URL `?sources=prefix1,prefix2` or `?sources=all` — transient override (localStorage not updated)
-   * 2. localStorage — persisted user preferences
-   * 3. Default — only groups with `systemEnabledByDefault: true`
+   * 1. URL `?sources=prefix1,prefix2` or `?sources=all` — transient override (localStorage not consulted)
+   * 2. `storedEnabledIds` if provided — the caller's parsed `localStorage` snapshot
+   * 3. Default — only groups with `userEnabledByDefault: true`
+   *
+   * @param storedEnabledIds - The user's persisted preference (typically
+   *   from
+   *   {@link import('../domain/datasource/data-source-selection-storage').loadEnabledGroupIdsFromStorage}),
+   *   or `null` when no preference is recorded. An empty `Set` is
+   *   treated as a user-explicit "nothing enabled" choice.
    */
-  constructor() {
+  constructor(storedEnabledIds: Set<string> | null) {
     this.groups = settings;
-    this.enabledIds = resolveInitialEnabledIds(this.groups);
+    this.enabledIds = resolveInitialEnabledIds(this.groups, storedEnabledIds);
   }
 
   /**
@@ -107,21 +108,6 @@ export class DataSourceManager {
    */
   isEnabled(groupId: string): boolean {
     return this.enabledIds.has(groupId);
-  }
-
-  /**
-   * Enable or disable a source group and persist the change.
-   *
-   * @param groupId - The source group ID to update.
-   * @param enabled - Whether to enable (`true`) or disable (`false`).
-   */
-  setEnabled(groupId: string, enabled: boolean): void {
-    if (enabled) {
-      this.enabledIds.add(groupId);
-    } else {
-      this.enabledIds.delete(groupId);
-    }
-    localStorage.setItem(STORAGE_KEY, JSON.stringify([...this.enabledIds]));
   }
 
   /**

--- a/src/config/data-source-manager.ts
+++ b/src/config/data-source-manager.ts
@@ -17,7 +17,13 @@ function dedupePrefixes(prefixes: string[]): string[] {
 
 function resolveEnabledIdsFromQueryParams(groups: SourceGroup[]): Set<string> | null {
   const sourcesParam = getSourcesParam();
-  if (!sourcesParam) {
+  // Strict null check — DO NOT use `!sourcesParam`. `?sources=` (empty
+  // value) reaches us as `''` and MUST be treated as a force-load-empty
+  // override (returning a non-null empty Set below), not collapsed with
+  // "param absent" (`null`). The load layer in
+  // `resolveFetchDataSources` already treats `''` as force-empty, so
+  // DSM must agree or the UI / load layers disagree.
+  if (sourcesParam === null) {
     return null;
   }
 
@@ -41,12 +47,17 @@ function resolveInitialEnabledIds(
   groups: SourceGroup[],
   storedEnabledIds: Set<string> | null,
 ): Set<string> {
+  // Strict null checks — an empty `Set` is a *valid* user-explicit value
+  // ("nothing enabled", β semantic). Using truthy checks (`if (set)` is
+  // always true for Sets, but `if (enabledIdsFromQueryParams)` could
+  // mislead a future reader). Keep `=== null` to make the contract
+  // obvious: only `null` falls through.
   const enabledIdsFromQueryParams = resolveEnabledIdsFromQueryParams(groups);
-  if (enabledIdsFromQueryParams) {
+  if (enabledIdsFromQueryParams !== null) {
     return enabledIdsFromQueryParams;
   }
 
-  if (storedEnabledIds) {
+  if (storedEnabledIds !== null) {
     return storedEnabledIds;
   }
 

--- a/src/config/data-source-manager.ts
+++ b/src/config/data-source-manager.ts
@@ -43,6 +43,35 @@ function resolveEnabledIdsFromQueryParams(groups: SourceGroup[]): Set<string> | 
   return getEnabledIdsFromSourcesParam(groups, sourcesParam);
 }
 
+/**
+ * Drop any stored IDs whose group is `systemEnabledByDefault: false`.
+ *
+ * The system-disabled flag is an app-level retirement / hide mechanism
+ * for sources the maintainer no longer wants loaded by default. A user's
+ * stored selection (from before the maintainer flipped the flag) must
+ * not resurrect those sources on a normal boot — otherwise retiring a
+ * source becomes a no-op for returning users with stale localStorage.
+ *
+ * The URL `?sources=` override path is intentionally NOT routed through
+ * this filter — it remains the operator/debug escape hatch for
+ * force-loading any group, including system-disabled ones.
+ */
+function filterStoredEnabledIdsBySystemGate(
+  groups: readonly SourceGroup[],
+  ids: Set<string>,
+): Set<string> {
+  const systemEnabledGroupIds = new Set(
+    groups.filter((g) => g.systemEnabledByDefault).map((g) => g.id),
+  );
+  const filtered = new Set<string>();
+  for (const id of ids) {
+    if (systemEnabledGroupIds.has(id)) {
+      filtered.add(id);
+    }
+  }
+  return filtered;
+}
+
 function resolveInitialEnabledIds(
   groups: SourceGroup[],
   storedEnabledIds: Set<string> | null,
@@ -54,11 +83,13 @@ function resolveInitialEnabledIds(
   // obvious: only `null` falls through.
   const enabledIdsFromQueryParams = resolveEnabledIdsFromQueryParams(groups);
   if (enabledIdsFromQueryParams !== null) {
+    // URL override deliberately bypasses the system gate — see
+    // `filterStoredEnabledIdsBySystemGate` for the rationale.
     return enabledIdsFromQueryParams;
   }
 
   if (storedEnabledIds !== null) {
-    return storedEnabledIds;
+    return filterStoredEnabledIdsBySystemGate(groups, storedEnabledIds);
   }
 
   return getDefaultEnabledIds(groups);
@@ -87,9 +118,14 @@ export class DataSourceManager {
    * Creates a new manager.
    *
    * Source selection priority:
-   * 1. URL `?sources=prefix1,prefix2` or `?sources=all` — transient override (localStorage not consulted)
-   * 2. `storedEnabledIds` if provided — the caller's parsed `localStorage` snapshot
-   * 3. Default — only groups with `userEnabledByDefault: true`
+   * 1. URL `?sources=prefix1,prefix2` or `?sources=all` — transient
+   *    override (localStorage not consulted; bypasses the system gate
+   *    so debug/operator URLs can force-load system-disabled groups).
+   * 2. `storedEnabledIds` if provided — the caller's parsed
+   *    `localStorage` snapshot, **filtered by `systemEnabledByDefault`**
+   *    so a group retired at the config level cannot be resurrected by
+   *    a stale localStorage entry.
+   * 3. Default — only groups with `userEnabledByDefault: true`.
    *
    * @param storedEnabledIds - The user's persisted preference (typically
    *   from

--- a/src/contexts/source-load-state-context.tsx
+++ b/src/contexts/source-load-state-context.tsx
@@ -13,12 +13,11 @@ import type { SourceLoadState } from '../domain/datasource/source-load-state';
  *   without calling `useMemo` after a null guard (which the
  *   `react-hooks` lint rule flags as a conditional hook).
  * - `isForcedSourcesMode` is `true` when the URL `?sources=` query parameter
- *   was present at boot **with a non-empty value**. In this mode the URL
- *   overrides the user-settings layer entirely, so UI controls that mutate
- *   user preferences should be non-interactive until the URL override is
- *   cleared. The check intentionally treats `?sources=` (empty value) the
- *   same as the parameter being absent, matching the load-layer contract
- *   in `data-source-manager.ts`.
+ *   was present at boot — including the empty form `?sources=`, which the
+ *   load layer (`resolveFetchDataSources`) treats as "force-load zero
+ *   sources". The dialog therefore enters forced-mode for both
+ *   `?sources=<list>` and the bare `?sources=`, so the UI matches the
+ *   load layer's behavior.
  */
 export type SourceLoadStateContextValue = {
   startupLoadResult: LoadResult;

--- a/src/contexts/source-load-state-provider.tsx
+++ b/src/contexts/source-load-state-provider.tsx
@@ -47,12 +47,16 @@ export function SourceLoadStateProvider({
     return set;
   }, [loadStatusByPrefix]);
 
-  // Treat null OR empty string as "no override", matching the
-  // data-source-manager contract (`if (!sourcesParam) return null;`).
-  // `?sources=` with an empty value reaches us as `''` from
-  // `URLSearchParams.get`, but the load layer ignores it; the dialog must
-  // not enter forced mode in that case or the two layers would disagree.
-  const isForcedSourcesMode = sourcesParam !== null && sourcesParam !== '';
+  // Any presence of the `?sources=` parameter means the URL is overriding
+  // source selection — including the empty value `?sources=`, which
+  // `resolveFetchDataSources` treats as "force-load no sources" (returns
+  // `[]`). The dialog must match the load layer's interpretation, so an
+  // empty value is forced-mode true. (Earlier we excluded empty here to
+  // match `data-source-manager.ts`'s `if (!sourcesParam) return null`,
+  // but that DSM check was itself out of step with the load layer; the
+  // user-observable behavior is driven by the load layer, so the UI
+  // aligns to it.)
+  const isForcedSourcesMode = sourcesParam !== null;
 
   const value = useMemo(
     () => ({

--- a/src/datasources/fetch-data-source-v2.ts
+++ b/src/datasources/fetch-data-source-v2.ts
@@ -336,7 +336,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     const networkMs = Math.round(tNetwork - t0);
     const parseMs = Math.round(tParse - tNetwork);
     const sizeKB = (text.length / 1024).toFixed(1);
-    logger.info(`${path}: ${sizeKB}KB (network=${networkMs}ms, parse=${parseMs}ms)`);
+    logger.debug(`${path}: ${sizeKB}KB (network=${networkMs}ms, parse=${parseMs}ms)`);
 
     return { json, sizeApprox: text.length, networkMs, parseMs };
   }

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { DataSourceManager } from '../config/data-source-manager';
+import { loadEnabledGroupIdsFromStorage } from '../domain/datasource/data-source-selection-storage';
 import { createLogger } from '../lib/logger';
 import type { TransitRepository } from '../repositories/transit-repository';
 
@@ -20,7 +21,7 @@ const logger = createLogger('diagnostics');
  * @param repository - The active TransitRepository instance (for repo-bench).
  */
 export async function runDiagnostics(name: string, repository?: TransitRepository): Promise<void> {
-  const prefixes = new DataSourceManager().getEnabledPrefixes();
+  const prefixes = new DataSourceManager(loadEnabledGroupIdsFromStorage()).getEnabledPrefixes();
 
   switch (name) {
     case 'v2-load': {

--- a/src/domain/datasource/__tests__/data-source-selection-storage.test.ts
+++ b/src/domain/datasource/__tests__/data-source-selection-storage.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for data-source-selection-storage.ts.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearStoredEnabledGroupIds,
+  loadEnabledGroupIdsFromStorage,
+  saveEnabledGroupIdsToStorage,
+} from '../data-source-selection-storage';
+
+const STORAGE_KEY = 'enabled-sources';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('loadEnabledGroupIdsFromStorage', () => {
+  it('returns null when the localStorage key is missing', () => {
+    expect(loadEnabledGroupIdsFromStorage()).toBeNull();
+  });
+
+  it('returns the parsed Set for a valid stored array', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus', 'toei-train']));
+    const result = loadEnabledGroupIdsFromStorage();
+    expect(result).not.toBeNull();
+    expect([...result!]).toEqual(['toei-bus', 'toei-train']);
+  });
+
+  it('returns null and clears storage when a non-empty array has no resolvable IDs', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['gone-1', 123, null]));
+    const result = loadEnabledGroupIdsFromStorage();
+    expect(result).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('returns an empty Set for an explicit empty array (β semantic)', () => {
+    localStorage.setItem(STORAGE_KEY, '[]');
+    const result = loadEnabledGroupIdsFromStorage();
+    expect(result).not.toBeNull();
+    expect(result!.size).toBe(0);
+    // Storage must NOT be removed — empty Set is a user-explicit value.
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('[]');
+  });
+
+  it('filters stale IDs (not in config) and writes back the cleaned value', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus', 'unknown-stale', 'toei-train']));
+    const result = loadEnabledGroupIdsFromStorage();
+    expect(result).not.toBeNull();
+    expect([...result!].sort()).toEqual(['toei-bus', 'toei-train']);
+    // Storage write-back: cleaned value persisted so subsequent reads
+    // see the clean state.
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(['toei-bus', 'toei-train']);
+  });
+
+  it('dedupes repeated valid IDs and writes back the canonicalized value', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus', 'toei-bus', 'toei-train']));
+    const result = loadEnabledGroupIdsFromStorage();
+    expect(result).not.toBeNull();
+    expect([...result!]).toEqual(['toei-bus', 'toei-train']);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(['toei-bus', 'toei-train']);
+  });
+
+  it('filters non-string elements and writes back when some valid IDs remain', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus', 123, null, 'toei-train']));
+    const result = loadEnabledGroupIdsFromStorage();
+    expect([...result!].sort()).toEqual(['toei-bus', 'toei-train']);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(['toei-bus', 'toei-train']);
+  });
+
+  it('returns null and clears storage for an array whose elements are all non-string ([123])', () => {
+    // `[123]` is an array (so it dodges the non-array branch) but contains
+    // no resolvable group IDs. Without explicit handling this would
+    // collapse to an empty Set and be mistaken for user-explicit empty
+    // on the next load.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([123]));
+    const result = loadEnabledGroupIdsFromStorage();
+    expect(result).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('returns null and clears storage for [null, 123, true] (mixed unrecoverable)', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([null, 123, true]));
+    const result = loadEnabledGroupIdsFromStorage();
+    expect(result).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('returns null and clears storage for an array mixing stale IDs and non-strings (none resolve)', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['gone-stale', 42, null]));
+    const result = loadEnabledGroupIdsFromStorage();
+    expect(result).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('returns null and clears storage when every stored ID is stale', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['gone-1', 'gone-2']));
+    const result = loadEnabledGroupIdsFromStorage();
+    expect(result).toBeNull();
+    // The misleading stored value is removed so the next load falls
+    // back to defaults via caller-side handling.
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('returns null and clears storage for corrupt JSON', () => {
+    localStorage.setItem(STORAGE_KEY, 'not valid json');
+    const result = loadEnabledGroupIdsFromStorage();
+    expect(result).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('returns null and clears storage for non-array JSON (object)', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ foo: 'bar' }));
+    const result = loadEnabledGroupIdsFromStorage();
+    expect(result).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('still returns the cleaned Set when cleanup write-back throws during load', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus', 'toei-bus', 'toei-train']));
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    const result = loadEnabledGroupIdsFromStorage();
+
+    expect(result).not.toBeNull();
+    expect([...result!]).toEqual(['toei-bus', 'toei-train']);
+  });
+
+  it('still returns null when cleanup remove throws during load', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ foo: 'bar' }));
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+
+    expect(loadEnabledGroupIdsFromStorage()).toBeNull();
+  });
+
+  it('returns null silently when localStorage.getItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    expect(loadEnabledGroupIdsFromStorage()).toBeNull();
+  });
+});
+
+describe('saveEnabledGroupIdsToStorage', () => {
+  it('persists a non-empty Set as JSON array', () => {
+    saveEnabledGroupIdsToStorage(new Set(['toei-bus', 'toei-train']));
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(['toei-bus', 'toei-train']);
+  });
+
+  it("persists an empty Set as '[]' (NOT removeItem)", () => {
+    saveEnabledGroupIdsToStorage(new Set());
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('[]');
+  });
+
+  it('silently ignores when localStorage.setItem throws', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    expect(() => saveEnabledGroupIdsToStorage(new Set(['x']))).not.toThrow();
+  });
+});
+
+describe('clearStoredEnabledGroupIds', () => {
+  it('removes the localStorage key', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus']));
+    clearStoredEnabledGroupIds();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('is a no-op when the key does not exist', () => {
+    expect(() => clearStoredEnabledGroupIds()).not.toThrow();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('silently ignores when localStorage.removeItem throws', () => {
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    expect(() => clearStoredEnabledGroupIds()).not.toThrow();
+  });
+});

--- a/src/domain/datasource/__tests__/data-source-selection.test.ts
+++ b/src/domain/datasource/__tests__/data-source-selection.test.ts
@@ -12,7 +12,6 @@ import {
   getEnabledDataSourcesFromSourcesParam,
   getEnabledIdsFromSourcesParam,
   getEnabledPrefixesFromGroups,
-  parseStoredEnabledIds,
 } from '../data-source-selection';
 import type { SourceGroup } from '../../../types/app/source-group';
 
@@ -48,9 +47,69 @@ function createGroups(): SourceGroup[] {
   ];
 }
 
+function createOverlappingGroups(): SourceGroup[] {
+  return [
+    {
+      id: 'toei-bus',
+      prefixes: ['minkuru'],
+      routeTypes: [3],
+      systemEnabledByDefault: true,
+      userEnabledByDefault: true,
+      name: { name: 'Toei Bus', names: { en: 'Toei Bus' } },
+      countries: ['JP'],
+    },
+    {
+      id: 'toei-train',
+      prefixes: ['toaran'],
+      routeTypes: [0, 1, 2],
+      systemEnabledByDefault: true,
+      userEnabledByDefault: true,
+      name: { name: 'Toei Train', names: { en: 'Toei Train' } },
+      countries: ['JP'],
+    },
+    {
+      id: 'toko',
+      prefixes: ['minkuru', 'toaran'],
+      routeTypes: [0, 1, 2, 3],
+      systemEnabledByDefault: true,
+      userEnabledByDefault: true,
+      name: { name: 'Toei Transport', names: { en: 'Toei Transport' } },
+      countries: ['JP'],
+    },
+  ];
+}
+
 describe('getDefaultEnabledIds', () => {
   it('returns only groups marked enabled by default', () => {
     expect([...getDefaultEnabledIds(createGroups())]).toEqual(['alpha', 'gamma']);
+  });
+
+  it('drives defaults from userEnabledByDefault, not systemEnabledByDefault', () => {
+    // Phase 1 semantic split: a group whose system-availability is on but
+    // whose user-default is off must NOT appear in the defaults set, and
+    // vice versa. The fixtures elsewhere in this file align both fields,
+    // so this case has its own fixture to pin the independent semantic.
+    const groups: SourceGroup[] = [
+      {
+        id: 'system-on-user-off',
+        prefixes: ['p1'],
+        routeTypes: [3],
+        systemEnabledByDefault: true,
+        userEnabledByDefault: false,
+        name: { name: 'X', names: { en: 'X' } },
+        countries: ['JP'],
+      },
+      {
+        id: 'system-off-user-on',
+        prefixes: ['p2'],
+        routeTypes: [3],
+        systemEnabledByDefault: false,
+        userEnabledByDefault: true,
+        name: { name: 'Y', names: { en: 'Y' } },
+        countries: ['JP'],
+      },
+    ];
+    expect([...getDefaultEnabledIds(groups)]).toEqual(['system-off-user-on']);
   });
 });
 
@@ -70,11 +129,25 @@ describe('getEnabledIdsFromSourcesParam', () => {
     ]);
   });
 
+  it('enables every matching group when a requested prefix belongs to multiple groups', () => {
+    expect([...getEnabledIdsFromSourcesParam(createOverlappingGroups(), 'minkuru')]).toEqual([
+      'toei-bus',
+      'toko',
+    ]);
+  });
+
   it('trims whitespace around comma-separated prefixes', () => {
     expect([...getEnabledIdsFromSourcesParam(createGroups(), 'alpha-express, beta-main')]).toEqual([
       'alpha',
       'beta',
     ]);
+  });
+
+  it('treats all as a special keyword only on exact match', () => {
+    expect([...getEnabledIdsFromSourcesParam(createGroups(), 'all,alpha-local')]).toEqual([
+      'alpha',
+    ]);
+    expect([...getEnabledIdsFromSourcesParam(createGroups(), ' all ')]).toEqual([]);
   });
 
   it('returns an empty set when no requested prefix matches any group', () => {
@@ -83,38 +156,6 @@ describe('getEnabledIdsFromSourcesParam', () => {
 });
 
 describe('getEnabledDataSourcesFromSourcesParam', () => {
-  function createOverlappingGroups(): SourceGroup[] {
-    return [
-      {
-        id: 'toei-bus',
-        prefixes: ['minkuru'],
-        routeTypes: [3],
-        systemEnabledByDefault: true,
-        userEnabledByDefault: true,
-        name: { name: 'Toei Bus', names: { en: 'Toei Bus' } },
-        countries: ['JP'],
-      },
-      {
-        id: 'toei-train',
-        prefixes: ['toaran'],
-        routeTypes: [0, 1, 2],
-        systemEnabledByDefault: true,
-        userEnabledByDefault: true,
-        name: { name: 'Toei Train', names: { en: 'Toei Train' } },
-        countries: ['JP'],
-      },
-      {
-        id: 'toko',
-        prefixes: ['minkuru', 'toaran'],
-        routeTypes: [0, 1, 2, 3],
-        systemEnabledByDefault: true,
-        userEnabledByDefault: true,
-        name: { name: 'Toei Transport', names: { en: 'Toei Transport' } },
-        countries: ['JP'],
-      },
-    ];
-  }
-
   it('returns the exact prefixes the user requested when they are known', () => {
     expect(getEnabledDataSourcesFromSourcesParam(createGroups(), 'alpha-local,beta-main')).toEqual([
       'alpha-local',
@@ -268,16 +309,6 @@ describe('findUnknownPrefixesInSourcesParam', () => {
     expect(findUnknownPrefixesInSourcesParam(createGroups(), ',alpha-local,,nope,')).toEqual([
       'nope',
     ]);
-  });
-});
-
-describe('parseStoredEnabledIds', () => {
-  it('returns null when storage is empty', () => {
-    expect(parseStoredEnabledIds(null)).toBeNull();
-  });
-
-  it('parses stored group IDs into a set', () => {
-    expect([...parseStoredEnabledIds('["alpha","gamma"]')!]).toEqual(['alpha', 'gamma']);
   });
 });
 

--- a/src/domain/datasource/__tests__/dialog-display.test.ts
+++ b/src/domain/datasource/__tests__/dialog-display.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for dialog-display.ts.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, expect, it } from 'vitest';
+import { computeDialogDisplay } from '../dialog-display';
+import type { SourceLoadState } from '../source-load-state';
+import type { SourceGroup } from '../../../types/app/source-group';
+
+function group(
+  overrides: Partial<SourceGroup> & {
+    id: string;
+    prefixes: string[];
+    systemEnabledByDefault: boolean;
+    userEnabledByDefault: boolean;
+  },
+): SourceGroup {
+  return {
+    routeTypes: [3],
+    name: { name: overrides.id, names: { en: overrides.id } },
+    countries: ['JP'],
+    ...overrides,
+  };
+}
+
+function loadStatus(loaded: string[] = [], failed: string[] = []): SourceLoadState {
+  const map = new Map<string, { status: 'loaded' } | { status: 'failed'; error: Error }>();
+  for (const p of loaded) {
+    map.set(p, { status: 'loaded' });
+  }
+  for (const p of failed) {
+    map.set(p, { status: 'failed', error: new Error('test') });
+  }
+  return map;
+}
+
+describe('computeDialogDisplay — normal mode', () => {
+  it('shows system-enabled groups and groups with any attempted prefix', () => {
+    const groups = [
+      group({
+        id: 'a',
+        prefixes: ['ap'],
+        systemEnabledByDefault: true,
+        userEnabledByDefault: true,
+      }),
+      group({
+        id: 'b',
+        prefixes: ['bp'],
+        systemEnabledByDefault: false,
+        userEnabledByDefault: false,
+      }),
+      // c is system-disabled but its prefix has been attempted → still
+      // visible (so the user sees the load status of what actually
+      // ended up loaded).
+      group({
+        id: 'c',
+        prefixes: ['cp'],
+        systemEnabledByDefault: false,
+        userEnabledByDefault: false,
+      }),
+    ];
+    const { visibleGroups } = computeDialogDisplay(
+      groups,
+      loadStatus(['cp']),
+      false,
+      new Set(['a']),
+    );
+    expect(visibleGroups.map((g) => g.id)).toEqual(['a', 'c']);
+  });
+
+  it('uses the user-settings Set verbatim as effectiveEnabledIds', () => {
+    const groups = [
+      group({
+        id: 'a',
+        prefixes: ['ap'],
+        systemEnabledByDefault: true,
+        userEnabledByDefault: true,
+      }),
+      group({
+        id: 'b',
+        prefixes: ['bp'],
+        systemEnabledByDefault: true,
+        userEnabledByDefault: true,
+      }),
+    ];
+    const userEnabled = new Set(['a']);
+    const { effectiveEnabledIds } = computeDialogDisplay(groups, loadStatus(), false, userEnabled);
+    // In normal mode, `effectiveEnabledIds === userEnabledIds` — no
+    // mutation, no copy.
+    expect(effectiveEnabledIds).toBe(userEnabled);
+  });
+});
+
+describe('computeDialogDisplay — forced-sources mode', () => {
+  it('shows only groups with at least one attempted prefix', () => {
+    const groups = [
+      group({
+        id: 'a',
+        prefixes: ['ap'],
+        systemEnabledByDefault: true,
+        userEnabledByDefault: true,
+      }),
+      group({
+        id: 'b',
+        prefixes: ['bp'],
+        systemEnabledByDefault: true,
+        userEnabledByDefault: true,
+      }),
+    ];
+    const { visibleGroups } = computeDialogDisplay(groups, loadStatus(['ap']), true, new Set());
+    expect(visibleGroups.map((g) => g.id)).toEqual(['a']);
+  });
+
+  it('treats every visible group as enabled (ignores the user-settings Set)', () => {
+    const groups = [
+      group({
+        id: 'a',
+        prefixes: ['ap'],
+        systemEnabledByDefault: true,
+        userEnabledByDefault: true,
+      }),
+      group({
+        id: 'b',
+        prefixes: ['bp'],
+        systemEnabledByDefault: true,
+        userEnabledByDefault: true,
+      }),
+    ];
+    const userEnabled = new Set(['b']); // intentionally not aligned with the URL
+    const { visibleGroups, effectiveEnabledIds } = computeDialogDisplay(
+      groups,
+      loadStatus(['ap', 'bp']),
+      true,
+      userEnabled,
+    );
+    expect(visibleGroups.map((g) => g.id)).toEqual(['a', 'b']);
+    expect([...effectiveEnabledIds].sort()).toEqual(['a', 'b']);
+    // It must NOT just return userEnabledIds in forced mode.
+    expect(effectiveEnabledIds).not.toBe(userEnabled);
+  });
+
+  it('also surfaces system-disabled groups when their prefix was attempted (?sources=all path)', () => {
+    const groups = [
+      group({
+        id: 'a',
+        prefixes: ['ap'],
+        systemEnabledByDefault: true,
+        userEnabledByDefault: true,
+      }),
+      // System-disabled, but the URL forced it → loaded → must show.
+      group({
+        id: 'b',
+        prefixes: ['bp'],
+        systemEnabledByDefault: false,
+        userEnabledByDefault: false,
+      }),
+    ];
+    const { visibleGroups, effectiveEnabledIds } = computeDialogDisplay(
+      groups,
+      loadStatus(['ap', 'bp']),
+      true,
+      new Set(),
+    );
+    expect(visibleGroups.map((g) => g.id)).toEqual(['a', 'b']);
+    expect([...effectiveEnabledIds].sort()).toEqual(['a', 'b']);
+  });
+});

--- a/src/domain/datasource/data-source-selection-storage.ts
+++ b/src/domain/datasource/data-source-selection-storage.ts
@@ -1,0 +1,140 @@
+import settings from '../../config/data-source-settings';
+import { createLogger } from '../../lib/logger';
+
+const STORAGE_KEY = 'enabled-sources';
+const logger = createLogger('DataSourceSelectionStorage');
+
+/**
+ * Load the persisted user data-source selection from `localStorage`.
+ *
+ * Returns `null` when the user has no preference recorded (or when the
+ * recorded value is unrecoverable). Returns a `Set` (possibly empty)
+ * when the user has explicitly set a preference.
+ *
+ * Cases:
+ *
+ * - Missing key → `null` (defaults will be used by callers)
+ * - Empty array `'[]'` → empty `Set` (user-explicit empty, β semantic)
+ * - Valid array with some stale IDs (not in config) → cleaned `Set` +
+ *   storage write-back so the stored value matches the returned Set
+ * - Array whose elements all fail to resolve (config rename → all
+ *   stale, or non-string elements like `[123]` / `[null]`, or a mix)
+ *   → `removeItem` + `null`. An empty `Set` is only returned for the
+ *   genuine user-explicit `'[]'`; any other "input had stuff but
+ *   nothing valid came out" path is treated as unrecoverable.
+ * - Non-array / corrupt JSON → `removeItem` + `null` (self-repair)
+ * - `localStorage.getItem` throws (e.g. sandboxed iframe) → `null`, silent
+ *
+ * The cleanup write-back and self-repair happen as side effects inside
+ * this function; callers receive only the resolved value. Callers that
+ * need a default Set when this returns `null` (hook init / DSM
+ * constructor fallback) handle that themselves — keeping this utility
+ * free of `getDefaultEnabledIds` preserves the responsibility split.
+ *
+ * @returns The persisted selection, or `null` when none is recorded.
+ */
+export function loadEnabledGroupIdsFromStorage(): Set<string> | null {
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (raw === null) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    logger.warn(`Corrupt JSON in '${STORAGE_KEY}'; clearing.`);
+    safeRemove();
+    return null;
+  }
+
+  if (!Array.isArray(parsed)) {
+    logger.warn(`Non-array value in '${STORAGE_KEY}'; clearing.`);
+    safeRemove();
+    return null;
+  }
+
+  const stringIds = parsed.filter((x): x is string => typeof x === 'string');
+  const knownIds = new Set(settings.map((g) => g.id));
+  const cleaned = new Set<string>();
+  for (const id of stringIds) {
+    if (knownIds.has(id)) {
+      cleaned.add(id);
+    }
+  }
+
+  // Unrecoverable-array edge: the input had elements but filtering
+  // yielded an empty Set. This covers (a) all-stale IDs after a config
+  // rename, (b) all-non-string elements like `[123]` or `[null]`, and
+  // (c) any mix of stale and non-string. In every variant the stored
+  // value is meaningless, so treat it as "no preference" and clear
+  // storage. A genuine empty `'[]'` is preserved (user-explicit empty,
+  // β) because `parsed.length === 0` short-circuits before this branch.
+  if (parsed.length > 0 && cleaned.size === 0) {
+    logger.info(
+      `Stored value in '${STORAGE_KEY}' contains no resolvable source group IDs (${parsed.length.toString()} elements); clearing.`,
+    );
+    safeRemove();
+    return null;
+  }
+
+  // Cleanup write-back: persist the cleaned set so storage reflects what
+  // we returned. Includes the case where non-string elements were
+  // filtered out.
+  if (cleaned.size !== stringIds.length || stringIds.length !== parsed.length) {
+    logger.info(
+      `Pruned ${(parsed.length - cleaned.size).toString()} invalid/stale entries from '${STORAGE_KEY}'.`,
+    );
+    safeWrite(cleaned);
+  }
+
+  return cleaned;
+}
+
+/**
+ * Persist the user data-source selection to `localStorage`.
+ *
+ * - Non-empty Set → JSON-encoded array
+ * - Empty Set → JSON-encoded `'[]'` (user-explicit empty, β)
+ *
+ * Callers wanting to return to "no preference" (defaults on next load)
+ * use {@link clearStoredEnabledGroupIds} — saving an empty Set keeps
+ * the explicit-empty state, while clear returns to `null` on next load.
+ *
+ * @param ids - Group IDs to persist.
+ */
+export function saveEnabledGroupIdsToStorage(ids: ReadonlySet<string>): void {
+  safeWrite(ids);
+}
+
+/**
+ * Remove the persisted user data-source selection from `localStorage`.
+ *
+ * Used by `resetToDefaults` — clears the preference so the next load
+ * falls back to defaults.
+ */
+export function clearStoredEnabledGroupIds(): void {
+  safeRemove();
+}
+
+function safeWrite(ids: ReadonlySet<string>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...ids]));
+  } catch {
+    // Storage full or unavailable — silently ignore. The hook keeps the
+    // in-memory state up to date even when persistence fails.
+  }
+}
+
+function safeRemove(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore (same rationale as safeWrite)
+  }
+}

--- a/src/domain/datasource/data-source-selection-storage.ts
+++ b/src/domain/datasource/data-source-selection-storage.ts
@@ -84,11 +84,13 @@ export function loadEnabledGroupIdsFromStorage(): Set<string> | null {
   }
 
   // Cleanup write-back: persist the cleaned set so storage reflects what
-  // we returned. Includes the case where non-string elements were
-  // filtered out.
+  // we returned. The pruned count covers three reasons (non-string
+  // elements filtered, stale IDs not in config, and duplicate string
+  // IDs collapsed by the Set), so the log enumerates all three to stay
+  // accurate regardless of which one(s) actually applied this run.
   if (cleaned.size !== stringIds.length || stringIds.length !== parsed.length) {
     logger.info(
-      `Pruned ${(parsed.length - cleaned.size).toString()} invalid/stale entries from '${STORAGE_KEY}'.`,
+      `Pruned ${(parsed.length - cleaned.size).toString()} entries (invalid, stale, or duplicate) from '${STORAGE_KEY}'.`,
     );
     safeWrite(cleaned);
   }

--- a/src/domain/datasource/data-source-selection.ts
+++ b/src/domain/datasource/data-source-selection.ts
@@ -1,13 +1,19 @@
 import type { SourceGroup } from '../../types/app/source-group';
 
 /**
- * Return the IDs of all groups that are enabled by default.
+ * Return the IDs of all groups whose user-default is "on".
+ *
+ * Used when the user has no explicit preference recorded (e.g.,
+ * `localStorage` empty, `?sources=` absent). The result represents
+ * "what the user would see as enabled by default" and is therefore
+ * driven by `userEnabledByDefault`, NOT by `systemEnabledByDefault`
+ * (the latter is a separate app-level availability flag).
  *
  * @param groups - Source groups to inspect.
- * @returns Set of group IDs whose `systemEnabledByDefault` flag is `true`.
+ * @returns Set of group IDs whose `userEnabledByDefault` flag is `true`.
  */
 export function getDefaultEnabledIds(groups: readonly SourceGroup[]): Set<string> {
-  return new Set(groups.filter((group) => group.systemEnabledByDefault).map((group) => group.id));
+  return new Set(groups.filter((group) => group.userEnabledByDefault).map((group) => group.id));
 }
 
 /**
@@ -125,23 +131,6 @@ export function findUnknownPrefixesInSourcesParam(
   const knownPrefixes = new Set(groups.flatMap((group) => group.prefixes));
 
   return requestedPrefixes.filter((prefix) => !knownPrefixes.has(prefix));
-}
-
-/**
- * Parse a localStorage snapshot of enabled group IDs.
- *
- * This function preserves current behavior: any truthy JSON value is accepted
- * and passed to `Set`, while JSON parse errors are handled by the caller.
- *
- * @param stored - Raw localStorage value.
- * @returns Parsed enabled IDs, or `null` when storage is empty.
- */
-export function parseStoredEnabledIds(stored: string | null): Set<string> | null {
-  if (!stored) {
-    return null;
-  }
-
-  return new Set(JSON.parse(stored) as string[]);
 }
 
 /**

--- a/src/domain/datasource/dialog-display.ts
+++ b/src/domain/datasource/dialog-display.ts
@@ -1,0 +1,70 @@
+import type { SourceLoadState } from './source-load-state';
+import type { SourceGroup } from '../../types/app/source-group';
+
+/**
+ * Display-ready inputs for the Data Source Settings dialog.
+ *
+ * The dialog renders the same shape regardless of whether the URL is
+ * forcing source selection. {@link computeDialogDisplay} normalizes the
+ * two modes (forced / normal) into one Set + one list so the dialog
+ * body does not branch on `isForcedSourcesMode` for what to render.
+ */
+export interface DialogDisplay {
+  /**
+   * Groups to render in the dialog. The same group may be rendered in
+   * multiple sections (multi-routeType groups); section assignment is
+   * the caller's concern.
+   */
+  visibleGroups: SourceGroup[];
+  /**
+   * IDs that the dialog should show as "currently on" — used both for
+   * the per-row Switch `checked` state and for per-section enabled
+   * counts in the header.
+   *
+   * - Forced-sources mode: every visible group (the URL is the source
+   *   of truth; user-settings is bypassed).
+   * - Normal mode: the user-settings layer (`enabledGroupIds`).
+   */
+  effectiveEnabledIds: ReadonlySet<string>;
+}
+
+/**
+ * Normalize the two operating modes (forced-sources / normal) into a
+ * single {@link DialogDisplay} shape consumed by the dialog body.
+ *
+ * Pure function — no React, no hooks. The mode-dependent decisions
+ * (which groups are visible, which Switch is checked) live here, not
+ * sprinkled through the JSX.
+ *
+ * @param settings - All configured source groups (build-time config).
+ * @param loadStatusByPrefix - Per-prefix runtime load status.
+ * @param isForcedSourcesMode - Whether the URL `?sources=` override is
+ *   active for this session.
+ * @param userEnabledIds - The user-settings layer's enabled group IDs
+ *   (used only when `isForcedSourcesMode` is `false`).
+ * @returns Normalized display inputs.
+ */
+export function computeDialogDisplay(
+  settings: readonly SourceGroup[],
+  loadStatusByPrefix: SourceLoadState,
+  isForcedSourcesMode: boolean,
+  userEnabledIds: ReadonlySet<string>,
+): DialogDisplay {
+  const visibleGroups = settings.filter((g) => {
+    const anyAttempted = g.prefixes.some((prefix) => loadStatusByPrefix.has(prefix));
+    if (isForcedSourcesMode) {
+      // URL is in control; show only what was actually attempted.
+      return anyAttempted;
+    }
+    // Normal mode: app-level enabled groups are always shown; plus any
+    // group whose data ended up loaded for other reasons (e.g. stale
+    // localStorage referencing a system-disabled group).
+    return g.systemEnabledByDefault || anyAttempted;
+  });
+
+  const effectiveEnabledIds: ReadonlySet<string> = isForcedSourcesMode
+    ? new Set(visibleGroups.map((g) => g.id))
+    : userEnabledIds;
+
+  return { visibleGroups, effectiveEnabledIds };
+}

--- a/src/hooks/__tests__/use-is-forced-sources-mode.test.tsx
+++ b/src/hooks/__tests__/use-is-forced-sources-mode.test.tsx
@@ -37,16 +37,16 @@ describe('useIsForcedSourcesMode', () => {
     expect(result.current).toBe(true);
   });
 
-  it('returns `false` for an empty-string sourcesParam (matches load-layer contract)', () => {
-    // `?sources=` with no value reaches the boot path as `''`, but
-    // `data-source-manager.ts` treats it as "no URL override" via
-    // `if (!sourcesParam) return null;`. The dialog must agree —
-    // otherwise the load layer is in normal mode while the UI claims
-    // forced mode, and the two layers visibly disagree.
+  it('returns `true` for an empty-string sourcesParam (matches load-layer contract)', () => {
+    // `?sources=` with an empty value reaches the boot path as `''`.
+    // `resolveFetchDataSources` interprets that as a force-load-empty
+    // override (returns `[]`), so the dialog must also enter forced
+    // mode to match — otherwise the user would see "Switch ON" rows
+    // alongside a "0 sources loaded" status icons line.
     const { result } = renderHook(() => useIsForcedSourcesMode(), {
       wrapper: wrapper(emptyLoadResult, ''),
     });
-    expect(result.current).toBe(false);
+    expect(result.current).toBe(true);
   });
 
   it('throws when used outside a SourceLoadStateProvider', () => {

--- a/src/hooks/__tests__/use-user-data-source-settings.test.tsx
+++ b/src/hooks/__tests__/use-user-data-source-settings.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tests for use-user-data-source-settings.ts.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUserDataSourceSettings } from '../use-user-data-source-settings';
+import * as storage from '../../domain/datasource/data-source-selection-storage';
+import settings from '../../config/data-source-settings';
+import { getDefaultEnabledIds } from '../../domain/datasource/data-source-selection';
+
+const STORAGE_KEY = 'enabled-sources';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useUserDataSourceSettings', () => {
+  it('falls back to config defaults when storage returns null', () => {
+    const { result } = renderHook(() => useUserDataSourceSettings());
+    const defaults = getDefaultEnabledIds(settings);
+    expect([...result.current.enabledGroupIds].sort()).toEqual([...defaults].sort());
+  });
+
+  it('uses the stored Set when storage returns a value', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus', 'toei-train']));
+    const { result } = renderHook(() => useUserDataSourceSettings());
+    expect([...result.current.enabledGroupIds].sort()).toEqual(['toei-bus', 'toei-train']);
+  });
+
+  it('honours an explicit empty Set (β semantic) on initial load', () => {
+    localStorage.setItem(STORAGE_KEY, '[]');
+    const { result } = renderHook(() => useUserDataSourceSettings());
+    expect(result.current.enabledGroupIds.size).toBe(0);
+  });
+
+  it('setGroupEnabled(id, true) adds the id to the Set', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus']));
+    const { result } = renderHook(() => useUserDataSourceSettings());
+    act(() => {
+      result.current.setGroupEnabled('toei-train', true);
+    });
+    expect([...result.current.enabledGroupIds].sort()).toEqual(['toei-bus', 'toei-train']);
+  });
+
+  it('setGroupEnabled(id, false) removes the id from the Set', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus', 'toei-train']));
+    const { result } = renderHook(() => useUserDataSourceSettings());
+    act(() => {
+      result.current.setGroupEnabled('toei-bus', false);
+    });
+    expect([...result.current.enabledGroupIds]).toEqual(['toei-train']);
+  });
+
+  it('setGroupEnabled delegates persistence to the storage utility', () => {
+    const saveSpy = vi.spyOn(storage, 'saveEnabledGroupIdsToStorage');
+    const { result } = renderHook(() => useUserDataSourceSettings());
+    act(() => {
+      result.current.setGroupEnabled('toei-bus', false);
+    });
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    const arg = saveSpy.mock.calls[0]?.[0];
+    expect(arg).toBeInstanceOf(Set);
+    // The persisted Set must NOT contain the id that was just turned off.
+    expect((arg as Set<string>).has('toei-bus')).toBe(false);
+  });
+
+  it('toggling everything off persists an empty Set (not removeItem)', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus']));
+    const { result } = renderHook(() => useUserDataSourceSettings());
+    act(() => {
+      result.current.setGroupEnabled('toei-bus', false);
+    });
+    expect(result.current.enabledGroupIds.size).toBe(0);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('[]');
+  });
+
+  it('setGroupsEnabled([...], true) adds every passed id in a single update', () => {
+    const saveSpy = vi.spyOn(storage, 'saveEnabledGroupIdsToStorage');
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    const { result } = renderHook(() => useUserDataSourceSettings());
+    act(() => {
+      result.current.setGroupsEnabled(['toei-bus', 'toei-train', 'toko'], true);
+    });
+    expect([...result.current.enabledGroupIds].sort()).toEqual(['toei-bus', 'toei-train', 'toko']);
+    // Atomic: one save for the whole batch, not one per id.
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('setGroupsEnabled([...], false) removes every passed id in a single update', () => {
+    const saveSpy = vi.spyOn(storage, 'saveEnabledGroupIdsToStorage');
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(['toei-bus', 'toei-train', 'toko', 'yurikamome']),
+    );
+    const { result } = renderHook(() => useUserDataSourceSettings());
+    act(() => {
+      result.current.setGroupsEnabled(['toei-bus', 'toko'], false);
+    });
+    expect([...result.current.enabledGroupIds].sort()).toEqual(['toei-train', 'yurikamome']);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('setGroupsEnabled with an empty list is a no-op but still writes (single save)', () => {
+    const saveSpy = vi.spyOn(storage, 'saveEnabledGroupIdsToStorage');
+    const { result } = renderHook(() => useUserDataSourceSettings());
+    const before = result.current.enabledGroupIds;
+    act(() => {
+      result.current.setGroupsEnabled([], true);
+    });
+    // Set contents unchanged.
+    expect([...result.current.enabledGroupIds].sort()).toEqual([...before].sort());
+    // Persistence still triggered once (single write per call); the Set
+    // it persists is just identical to the prior one.
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resetToDefaults clears storage and restores defaults', () => {
+    const clearSpy = vi.spyOn(storage, 'clearStoredEnabledGroupIds');
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['toei-bus']));
+    const { result } = renderHook(() => useUserDataSourceSettings());
+    expect([...result.current.enabledGroupIds]).toEqual(['toei-bus']);
+    act(() => {
+      result.current.resetToDefaults();
+    });
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    const defaults = getDefaultEnabledIds(settings);
+    expect([...result.current.enabledGroupIds].sort()).toEqual([...defaults].sort());
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/src/hooks/use-is-forced-sources-mode.ts
+++ b/src/hooks/use-is-forced-sources-mode.ts
@@ -3,10 +3,11 @@ import { SourceLoadStateContext } from '../contexts/source-load-state-context';
 
 /**
  * Returns `true` when the URL `?sources=` query parameter was present at
- * boot **with a non-empty value**, meaning the URL overrides the
- * user-settings layer for source selection. An empty `?sources=` is
- * treated as no override (matching the load-layer contract in
- * `data-source-manager.ts`).
+ * boot in any form (including the empty `?sources=`), meaning the URL is
+ * overriding the user-settings layer for source selection. Even the
+ * empty form is treated as forced because the load layer
+ * (`resolveFetchDataSources`) interprets it as "force-load zero
+ * sources" — the dialog matches that.
  *
  * UI controls that mutate user preferences (toggle Switches, reset
  * buttons, etc.) must be non-interactive in this mode — letting users

--- a/src/hooks/use-user-data-source-settings.ts
+++ b/src/hooks/use-user-data-source-settings.ts
@@ -1,0 +1,117 @@
+import { useCallback, useState } from 'react';
+import settings from '../config/data-source-settings';
+import { getDefaultEnabledIds } from '../domain/datasource/data-source-selection';
+import {
+  clearStoredEnabledGroupIds,
+  loadEnabledGroupIdsFromStorage,
+  saveEnabledGroupIdsToStorage,
+} from '../domain/datasource/data-source-selection-storage';
+
+/**
+ * Return type for {@link useUserDataSourceSettings}.
+ */
+export interface UseUserDataSourceSettingsReturn {
+  /**
+   * Currently enabled source group IDs from the user preference.
+   *
+   * When the user has no explicit preference recorded, this returns
+   * the config defaults (the set of groups where
+   * `userEnabledByDefault === true`). After any explicit interaction
+   * (`setGroupEnabled` / `resetToDefaults`) it reflects the live state.
+   */
+  enabledGroupIds: ReadonlySet<string>;
+  /**
+   * Toggle a single group's enabled state.
+   *
+   * Updates the in-memory state and persists synchronously to
+   * `localStorage`. An empty resulting Set is persisted as `'[]'`
+   * (user-explicit empty); to clear the preference entirely, use
+   * {@link UseUserDataSourceSettingsReturn.resetToDefaults} instead.
+   */
+  setGroupEnabled: (groupId: string, enabled: boolean) => void;
+  /**
+   * Toggle multiple groups' enabled state in a single atomic update.
+   *
+   * One state transition and one persistence write are emitted no matter
+   * how many group IDs are passed. Used for bulk actions like
+   * "enable all" / "disable all" within a section. Behaves like
+   * {@link UseUserDataSourceSettingsReturn.setGroupEnabled} called for
+   * each id, except the React state and the `localStorage` write are
+   * coalesced.
+   */
+  setGroupsEnabled: (groupIds: readonly string[], enabled: boolean) => void;
+  /**
+   * Clear the persisted user preference and restore the in-memory state
+   * to the config defaults (`userEnabledByDefault === true` groups).
+   */
+  resetToDefaults: () => void;
+}
+
+/**
+ * Hook for managing the user's data-source selection preference.
+ *
+ * The hook owns React state and the `localStorage` write path; the
+ * boot-time reader lives in `main.tsx` (which calls the same
+ * storage utility before React mounts). Within a session, mutations
+ * via {@link UseUserDataSourceSettingsReturn.setGroupEnabled} persist
+ * immediately to `localStorage` but **do not** affect what is already
+ * loaded — the load layer reads `localStorage` only at boot, so user
+ * toggles take effect on next reload (this is intentional for Phase 1;
+ * the dialog surfaces a "development in progress" notice).
+ *
+ * **Multi-instance state**: this hook follows the `useUserSettings` /
+ * `useStopHistory` pattern of file-private `useState`. Calling it
+ * from multiple components yields independent state instances that do
+ * not sync until the next remount. Phase 1's only consumer is the
+ * Data Source Settings dialog, so this is not yet a problem. If a
+ * future phase adds another consumer, context-ify the hook then.
+ *
+ * **Cross-tab sync**: the hook does not listen for `storage` events,
+ * so a toggle in tab A is not propagated to tab B's hook state until
+ * tab B reloads. This matches the existing pattern; address only if
+ * a future phase needs cross-tab consistency.
+ *
+ * @returns The current preference and mutation callbacks.
+ */
+export function useUserDataSourceSettings(): UseUserDataSourceSettingsReturn {
+  const [enabledGroupIds, setEnabledGroupIds] = useState<ReadonlySet<string>>(
+    () => loadEnabledGroupIdsFromStorage() ?? getDefaultEnabledIds(settings),
+  );
+
+  const setGroupEnabled = useCallback((groupId: string, enabled: boolean): void => {
+    setEnabledGroupIds((prev) => {
+      const next = new Set(prev);
+      if (enabled) {
+        next.add(groupId);
+      } else {
+        next.delete(groupId);
+      }
+      saveEnabledGroupIdsToStorage(next);
+      return next;
+    });
+  }, []);
+
+  const setGroupsEnabled = useCallback((groupIds: readonly string[], enabled: boolean): void => {
+    setEnabledGroupIds((prev) => {
+      const next = new Set(prev);
+      if (enabled) {
+        for (const id of groupIds) {
+          next.add(id);
+        }
+      } else {
+        for (const id of groupIds) {
+          next.delete(id);
+        }
+      }
+      saveEnabledGroupIdsToStorage(next);
+      return next;
+    });
+  }, []);
+
+  const resetToDefaults = useCallback((): void => {
+    clearStoredEnabledGroupIds();
+    setEnabledGroupIds(getDefaultEnabledIds(settings));
+  }, []);
+
+  return { enabledGroupIds, setGroupEnabled, setGroupsEnabled, resetToDefaults };
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -191,11 +191,26 @@
       "fraction": "{{loaded}}/{{total}} loaded"
     },
     "toggle": {
-      "aria": "Enabled state of {{group}}"
+      "aria": "Enable {{group}}"
     },
     "forcedMode": {
       "title": "Specified data mode",
       "description": "In this mode, the target data cannot be changed."
+    },
+    "developmentNotice": {
+      "title": "Applied on reload",
+      "description": "Changes are not applied immediately. They take effect after reload."
+    },
+    "resetToDefaults": "Reset to defaults",
+    "bulkAction": {
+      "enableAll": {
+        "label": "All on",
+        "aria": "Enable all {{section}} groups"
+      },
+      "disableAll": {
+        "label": "All off",
+        "aria": "Disable all {{section}} groups"
+      }
     },
     "section": {
       "0": "Tram",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -205,11 +205,11 @@
     "bulkAction": {
       "enableAll": {
         "label": "全て ON",
-        "aria": "{{section}} 内の全 group を有効化"
+        "aria": "{{section}} 内の全グループを有効化"
       },
       "disableAll": {
         "label": "全て OFF",
-        "aria": "{{section}} 内の全 group を無効化"
+        "aria": "{{section}} 内の全グループを無効化"
       }
     },
     "section": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -191,11 +191,26 @@
       "fraction": "{{loaded}}/{{total}} 読込済"
     },
     "toggle": {
-      "aria": "{{group}} の有効化状態"
+      "aria": "{{group}} を有効化"
     },
     "forcedMode": {
       "title": "対象データ指定モード",
       "description": "このモードでは対象データを変更することは出来ません。"
+    },
+    "developmentNotice": {
+      "title": "リロード後に反映",
+      "description": "設定変更は即座に反映されません。アプリ再起動後に反映されます。"
+    },
+    "resetToDefaults": "初期値に戻す",
+    "bulkAction": {
+      "enableAll": {
+        "label": "全て ON",
+        "aria": "{{section}} 内の全 group を有効化"
+      },
+      "disableAll": {
+        "label": "全て OFF",
+        "aria": "{{section}} 内の全 group を無効化"
+      }
     },
     "section": {
       "0": "路面電車",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { SourceLoadStateProvider } from './contexts/source-load-state-provider';
 import { TransitRepositoryProvider } from './contexts/transit-repository-provider';
 import { DataSourceManager } from './config/data-source-manager';
 import { resolveFetchDataSources } from './domain/datasource/resolve-fetch-data-sources';
+import { loadEnabledGroupIdsFromStorage } from './domain/datasource/data-source-selection-storage';
 import type { TransitRepository } from './repositories/transit-repository';
 import { AthenaiRepositoryV2, type LoadResult } from './repositories/athenai-repository';
 import {
@@ -33,7 +34,7 @@ async function createRepository(): Promise<{
     return { repository: new MockRepository(), loadResult: { loaded: [], failed: [] } };
   }
 
-  const dsm = new DataSourceManager();
+  const dsm = new DataSourceManager(loadEnabledGroupIdsFromStorage());
   const prefixes = resolveFetchDataSources(
     dsm.getGroups(),
     dsm.getEnabledPrefixes(),

--- a/src/repositories/athenai-repository/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository/athenai-repository-v2.ts
@@ -164,10 +164,12 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       logger.info(`fetchSources: ${fetchMs}ms (${sources.length} sources)`);
     }
 
-    for (const source of sources) {
-      logger.info(
-        `[${source.prefix}] stops=${source.data.stops.data.length} routes=${source.data.routes.data.length} tripPatterns=${Object.keys(source.data.tripPatterns.data).length}`,
-      );
+    if (logger.isEnabled('debug')) {
+      for (const source of sources) {
+        logger.debug(
+          `[${source.prefix}] stops=${source.data.stops.data.length} routes=${source.data.routes.data.length} tripPatterns=${Object.keys(source.data.tripPatterns.data).length}`,
+        );
+      }
     }
 
     const merged = mergeSourcesV2(sources);

--- a/src/repositories/athenai-repository/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository/athenai-repository-v2.ts
@@ -160,8 +160,8 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     const { sources, loadResult } = await fetchSourcesV2(prefixes, dataSource);
     const tFetch = performance.now();
     const fetchMs = Math.round(tFetch - t0);
-    if (logger.isEnabled('debug')) {
-      logger.debug(`fetchSources: ${fetchMs}ms (${sources.length} sources)`);
+    if (logger.isEnabled('info')) {
+      logger.info(`fetchSources: ${fetchMs}ms (${sources.length} sources)`);
     }
 
     for (const source of sources) {


### PR DESCRIPTION
## Summary

Introduces the user-settings persistence layer for data-source selection — the next phase after PR #208 (Phase 0 field rename / placeholder).

- Dialog Switches become interactive in normal mode; users can toggle sources, bulk-toggle per section, and reset to defaults.
- Settings persist to `localStorage` and take effect after reload (the dialog's amber dev notice surfaces this scope: 「リロード後に反映」).
- Also fixes a 3-layer inconsistency for `?sources=` (empty value) where UI / DSM / load layers disagreed about whether empty means "no override" or "force-load zero sources".

## Phase 1 deliverables (4 commits)

1. **`feat(datasource): user-settings hook + storage utility (Phase 1)`** (`3f4b95d8`)
   - `data-source-selection-storage` utility — pure localStorage I/O with β-empty-Set semantic, self-repair on corrupt JSON, cleanup-all-stale → `removeItem` + `null`.
   - `useUserDataSourceSettings` hook — `enabledGroupIds`, `setGroupEnabled`, `setGroupsEnabled` (bulk), `resetToDefaults`.
   - `DataSourceManager` refactor — constructor accepts pre-parsed `Set<string> | null` instead of touching localStorage internally. Removed `STORAGE_KEY`, `setEnabled`, `parseStoredEnabledIds`.
   - `getDefaultEnabledIds` semantic switch — filters on `userEnabledByDefault` instead of `systemEnabledByDefault` (1:1 migration per Phase 0; current config unchanged).
   - `main.tsx` + `src/diagnostics/index.ts` read storage via the new utility.

2. **`feat(data-source-settings-dialog): interactive UI for Phase 1 user-settings`** (`8379d824`)
   - Interactive Switch in normal mode; disabled in forced mode.
   - New `Reset to defaults` button + per-section bulk `All on` / `All off` buttons (all disabled in forced mode).
   - Per-section enabled-count summary in dialog header.
   - Two `Alert` variants — amber `Under development` notice (normal mode) / sky `Forced sources mode` notice (`?sources=` override).
   - New pure `computeDialogDisplay` (`domain/datasource/dialog-display.ts`) normalizes forced/normal mode into one `{ visibleGroups, effectiveEnabledIds }` shape so the render body never branches on `isForcedSourcesMode`.
   - `aria-label` reverts to action-language now that the Switch is interactive.

3. **`fix(datasource): align ?sources= (empty) across UI, DSM, and load layer`** (`474b1549`)
   - Root cause: `if (!sourcesParam)` truthy/falsy collapse merged `null` (param absent) with `''` (param present with empty value). Load layer treats `''` as force-load-empty; DSM was falling through; UI's `isForcedSourcesMode` was excluding empty to "match the DSM contract" introduced in PR #208 review.
   - Fixed with strict `=== null` / `!== null` checks across DSM and UI. Now all three layers agree: `?sources=` → `[]` loaded / `isForcedSourcesMode: true` / dialog enters forced mode.

4. **`chore(logger): demote per-item fetch/source logs to DEBUG`** (`b4d81b4f`)
   - Aggregate summary stays at INFO (`fetchSources: Xms (N sources)`); per-item duplicates go to DEBUG so production logs are quieter without losing the breakdown when debug is enabled.

## Out of scope (Phase 2+)

- The hook is not yet wired to **runtime** load decisions. Settings only take effect on the next page reload (DSM reads localStorage during boot via `main.tsx`).
- No 「Reload to apply」 banner or auto-reload UI.
- No cross-tab sync (`storage` event not listened — same constraint as other localStorage-backed hooks in this project).
- No drift indicator (UI vs actually-loaded-set delta).
- `getEnabledPrefixesFromGroups` is not yet gated on `systemEnabledByDefault` (defensive belt-and-braces deferred).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test` — 3597 / 3597 pass
- [x] `npm run build` — clean

Browser walk-through via Chrome DevTools MCP:

- [x] `?sources=all` → forced mode + 36 sources loaded, all Switches disabled and checked, Reset disabled, sky Alert.
- [x] `?sources=minkuru` → forced mode + narrow visibility (都バス loaded ✅ + 東京都交通局 partial ⚠️ via shared `minkuru`), 4 sections show `toko`, others hidden.
- [x] `?sources=` (empty) → forced mode + 0 visible groups + 0 sources loaded.
- [x] `/` (normal) → 35 sources auto-loaded, Switches interactive, amber dev notice 「リロード後に反映」, Reset enabled, bulk action enabled, per-section counts displayed.
- [x] `?diag=repo-bench` → DSM inherits storage-utility resolution (35 sources reach diagnostics).
- [x] `?diag=repo-bench&sources=all` → URL override flows through diagnostics (36 sources reach diagnostics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)