### PR TITLE
feat(map-defaults): pickRandomHome filters by available data sources (#146)

### DIFF
--- a/src/config/__tests__/data-source-manager.test.ts
+++ b/src/config/__tests__/data-source-manager.test.ts
@@ -448,7 +448,7 @@ describe('DataSourceManager', () => {
     });
   });
 
-  describe('getEnabledPrefixes', () => {
+  describe('getEnabledDataSources', () => {
     it('returns prefixes from default-enabled groups in group order', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
       const manager = new DataSourceManager(null);

--- a/src/config/__tests__/data-source-manager.test.ts
+++ b/src/config/__tests__/data-source-manager.test.ts
@@ -131,7 +131,7 @@ describe('DataSourceManager', () => {
 
       expect(manager.isEnabled('default-on')).toBe(true);
       expect(manager.isEnabled('default-off')).toBe(false);
-      expect(manager.getEnabledPrefixes()).toEqual(['on']);
+      expect(manager.getEnabledDataSources()).toEqual(['on']);
     });
 
     it('enables every group including config-default-disabled ones when URL param is `?sources=all`', async () => {
@@ -141,7 +141,7 @@ describe('DataSourceManager', () => {
 
       expect(manager.isEnabled('default-on')).toBe(true);
       expect(manager.isEnabled('default-off')).toBe(true);
-      expect(manager.getEnabledPrefixes()).toEqual(['on', 'off']);
+      expect(manager.getEnabledDataSources()).toEqual(['on', 'off']);
     });
 
     it('enables only groups containing the requested prefix when URL param lists prefixes', () => {
@@ -167,7 +167,7 @@ describe('DataSourceManager', () => {
       expect(manager.isEnabled('alpha')).toBe(false);
       expect(manager.isEnabled('beta')).toBe(true);
       expect(manager.isEnabled('gamma')).toBe(false);
-      expect(manager.getEnabledPrefixes()).toEqual(['beta-main']);
+      expect(manager.getEnabledDataSources()).toEqual(['beta-main']);
     });
 
     it('hydrates the enabled set from the stored selection when no URL param is present', () => {
@@ -190,7 +190,7 @@ describe('DataSourceManager', () => {
       expect(manager.isEnabled('alpha')).toBe(false);
       expect(manager.isEnabled('beta')).toBe(false);
       expect(manager.isEnabled('gamma')).toBe(false);
-      expect(manager.getEnabledPrefixes()).toEqual([]);
+      expect(manager.getEnabledDataSources()).toEqual([]);
     });
 
     it('keeps system-enabled stored IDs while dropping system-disabled ones', async () => {
@@ -203,7 +203,7 @@ describe('DataSourceManager', () => {
       expect(manager.isEnabled('alpha')).toBe(true);
       expect(manager.isEnabled('beta')).toBe(false);
       expect(manager.isEnabled('gamma')).toBe(false);
-      expect(manager.getEnabledPrefixes()).toEqual(['alpha-local', 'alpha-express']);
+      expect(manager.getEnabledDataSources()).toEqual(['alpha-local', 'alpha-express']);
     });
 
     it('replaces the stored selection instead of unioning with it when URL params are present', async () => {
@@ -214,7 +214,7 @@ describe('DataSourceManager', () => {
       expect(manager.isEnabled('alpha')).toBe(false);
       expect(manager.isEnabled('beta')).toBe(true);
       expect(manager.isEnabled('gamma')).toBe(false);
-      expect(manager.getEnabledPrefixes()).toEqual(['beta-main']);
+      expect(manager.getEnabledDataSources()).toEqual(['beta-main']);
     });
 
     it('treats a no-match URL param as an explicit empty override even when the stored selection has enabled groups', () => {
@@ -224,7 +224,7 @@ describe('DataSourceManager', () => {
       for (const group of settings) {
         expect(manager.isEnabled(group.id)).toBe(false);
       }
-      expect(manager.getEnabledPrefixes()).toEqual([]);
+      expect(manager.getEnabledDataSources()).toEqual([]);
     });
 
     it('treats `?sources=` (empty value) as a force-load-empty override and ignores the stored selection', () => {
@@ -239,7 +239,7 @@ describe('DataSourceManager', () => {
       for (const group of settings) {
         expect(manager.isEnabled(group.id)).toBe(false);
       }
-      expect(manager.getEnabledPrefixes()).toEqual([]);
+      expect(manager.getEnabledDataSources()).toEqual([]);
     });
 
     it('does not treat an empty `?sources=` value as `all`', async () => {
@@ -252,7 +252,7 @@ describe('DataSourceManager', () => {
 
       expect(manager.isEnabled('default-on')).toBe(false);
       expect(manager.isEnabled('default-off')).toBe(false);
-      expect(manager.getEnabledPrefixes()).toEqual([]);
+      expect(manager.getEnabledDataSources()).toEqual([]);
     });
 
     it('enables every group whose prefixes match a comma-separated list', () => {
@@ -303,7 +303,7 @@ describe('DataSourceManager', () => {
       const manager = new DataSourceManager(null);
 
       expect(manager.isEnabled('shared')).toBe(true);
-      expect(manager.getEnabledPrefixes()).toEqual(['c', 'a', 'b']);
+      expect(manager.getEnabledDataSources()).toEqual(['c', 'a', 'b']);
     });
 
     it('treats all groups with the same id as enabled when the stored selection includes that id', async () => {
@@ -320,7 +320,7 @@ describe('DataSourceManager', () => {
       const manager = new DataSourceManager(new Set(['shared']));
 
       expect(manager.isEnabled('shared')).toBe(true);
-      expect(manager.getEnabledPrefixes()).toEqual(['c', 'a', 'b']);
+      expect(manager.getEnabledDataSources()).toEqual(['c', 'a', 'b']);
     });
 
     it('treats all groups with the same id as enabled when query param matches one of them', async () => {
@@ -333,7 +333,7 @@ describe('DataSourceManager', () => {
       // group expansion (not the URL-level prefix narrowing — that
       // narrowing is `resolveFetchDataSources`'s job, exercised in its
       // own test).
-      expect(manager.getEnabledPrefixes()).toEqual(['c', 'a', 'b']);
+      expect(manager.getEnabledDataSources()).toEqual(['c', 'a', 'b']);
     });
   });
 
@@ -453,14 +453,18 @@ describe('DataSourceManager', () => {
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
       const manager = new DataSourceManager(null);
 
-      expect(manager.getEnabledPrefixes()).toEqual(['alpha-local', 'alpha-express', 'gamma-main']);
+      expect(manager.getEnabledDataSources()).toEqual([
+        'alpha-local',
+        'alpha-express',
+        'gamma-main',
+      ]);
     });
 
     it('returns an empty array when nothing is enabled', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
       const manager = new DataSourceManager(new Set());
 
-      expect(manager.getEnabledPrefixes()).toEqual([]);
+      expect(manager.getEnabledDataSources()).toEqual([]);
     });
 
     it('returns prefixes only from explicitly enabled groups when URL param is used', async () => {
@@ -472,14 +476,22 @@ describe('DataSourceManager', () => {
       setSearch('sources=alpha-express,beta-main');
       const manager = new DataSourceManager(null);
 
-      expect(manager.getEnabledPrefixes()).toEqual(['alpha-local', 'alpha-express', 'beta-main']);
+      expect(manager.getEnabledDataSources()).toEqual([
+        'alpha-local',
+        'alpha-express',
+        'beta-main',
+      ]);
     });
 
     it('preserves group definition order instead of stored-selection insertion order', async () => {
       const DataSourceManager = await importFreshDataSourceManager(createMultiPrefixSettings());
       const manager = new DataSourceManager(new Set(['gamma', 'alpha']));
 
-      expect(manager.getEnabledPrefixes()).toEqual(['alpha-local', 'alpha-express', 'gamma-main']);
+      expect(manager.getEnabledDataSources()).toEqual([
+        'alpha-local',
+        'alpha-express',
+        'gamma-main',
+      ]);
     });
 
     it('deduplicates repeated prefixes before returning load targets', async () => {
@@ -506,7 +518,7 @@ describe('DataSourceManager', () => {
       const DataSourceManager = await importFreshDataSourceManager(groups);
       const manager = new DataSourceManager(null);
 
-      expect(manager.getEnabledPrefixes()).toEqual(['on', 'off']);
+      expect(manager.getEnabledDataSources()).toEqual(['on', 'off']);
     });
 
     it('deduplicates repeated prefixes within and across enabled groups', async () => {
@@ -533,7 +545,7 @@ describe('DataSourceManager', () => {
       const DataSourceManager = await importFreshDataSourceManager(groups);
       const manager = new DataSourceManager(null);
 
-      expect(manager.getEnabledPrefixes()).toEqual(['c', 'a', 'b']);
+      expect(manager.getEnabledDataSources()).toEqual(['c', 'a', 'b']);
     });
   });
 });

--- a/src/config/data-source-manager.ts
+++ b/src/config/data-source-manager.ts
@@ -158,17 +158,17 @@ export class DataSourceManager {
   }
 
   /**
-   * Returns the GTFS prefixes implied by the currently enabled group
-   * set (deduped).
+   * Returns the GTFS data sources implied by the currently enabled
+   * group set (deduped).
    *
-   * This is the *group-driven* view of the active prefixes. Callers that
-   * need the final fetch target (and therefore have to honour the
-   * prefix-level `?sources=<prefixes>` URL contract from PRD.md:118)
-   * should pass this through
+   * This is the *group-driven* view of the active data sources.
+   * Callers that need the final fetch target (and therefore have to
+   * honour the data-source-level `?sources=<data-sources>` URL
+   * contract from PRD.md:118) should pass this through
    * {@link import('../domain/datasource/resolve-fetch-data-sources').resolveFetchDataSources}
    * instead of using it directly.
    *
-   * @returns Flat array of prefixes from all enabled groups.
+   * @returns Flat array of data sources from all enabled groups.
    */
   getEnabledDataSources(): string[] {
     return dedupePrefixes(getEnabledPrefixesFromGroups(this.groups, this.enabledIds));

--- a/src/config/data-source-manager.ts
+++ b/src/config/data-source-manager.ts
@@ -170,7 +170,7 @@ export class DataSourceManager {
    *
    * @returns Flat array of prefixes from all enabled groups.
    */
-  getEnabledPrefixes(): string[] {
+  getEnabledDataSources(): string[] {
     return dedupePrefixes(getEnabledPrefixesFromGroups(this.groups, this.enabledIds));
   }
 }

--- a/src/config/map-defaults.ts
+++ b/src/config/map-defaults.ts
@@ -9,52 +9,209 @@
  * Each param is resolved independently — e.g. `?zm=14` with no lat/lng
  * will use random center but override zoom to 14.
  */
-import { parseQueryLat, parseQueryLng, parseQueryZoom } from '../lib/query-params';
+import { parseQueryLat, parseQueryLng, parseQueryZoom, getSourcesParam } from '../lib/query-params';
 import { createLogger } from '../lib/logger';
+import { DataSourceManager } from './data-source-manager';
+import { loadEnabledGroupIdsFromStorage } from '../domain/datasource/data-source-selection-storage';
+import { resolveFetchDataSources } from '../domain/datasource/resolve-fetch-data-sources';
+import { selectHomeCandidates } from '../domain/map/select-home-location';
+import type { HomeLocation } from '../types/app/home-location';
 
 /**
  * Curated locations for random initial display.
  *
  * Each entry is a place where multiple transit lines intersect or
  * interesting route patterns exist, giving first-time users an
- * immediate sense of "where can I go from here?".
+ * immediate sense of "where can I go from here?". `requiredDataSource`
+ * narrows the random pool to locations whose data is actually loaded
+ * (see {@link HomeLocation} for matching semantics).
  */
-const HOME_LOCATIONS = [
+const HOME_LOCATIONS: readonly HomeLocation[] = [
   /** Tokyo, Japan */
-  { name: 'Tokyo Station', lat: 35.6814, lng: 139.7674, zoom: 15 },
-  { name: 'Kumano-mae', lat: 35.7485, lng: 139.7699, zoom: 15 },
-  { name: 'Kinshicho Station', lat: 35.6967, lng: 139.814, zoom: 17 },
-  { name: 'Tokyo Big Sight', lat: 35.6302, lng: 139.793, zoom: 18 },
-  { name: 'Shibuya Station', lat: 35.6588, lng: 139.7012, zoom: 17 },
-  { name: 'Otsuka Station', lat: 35.731, lng: 139.7291, zoom: 18 },
-  { name: 'Nerima Station', lat: 35.7384, lng: 139.654, zoom: 18 },
-  { name: 'Chiyoda City Hall', lat: 35.6948, lng: 139.7533, zoom: 16 },
-  { name: 'Ikebukuro Station', lat: 35.73, lng: 139.7127, zoom: 16 },
-  { name: 'Shinjuku Station West (North)', lat: 35.6919, lng: 139.6987, zoom: 18 },
-  { name: 'Shinjuku Station West (South)', lat: 35.691, lng: 139.6985, zoom: 15 },
-  { name: 'Shinagawa Seaside', lat: 35.6103, lng: 139.7483, zoom: 15 },
-  { name: 'Shimbashi Station', lat: 35.6663, lng: 139.7596, zoom: 16 },
-  { name: 'Ome Station', lat: 35.7879, lng: 139.258, zoom: 16 },
+  {
+    name: 'Tokyo Station',
+    lat: 35.6814,
+    lng: 139.7674,
+    zoom: 15,
+    // requiredDataSource: ['minkuru', 'toaran'],
+  },
+  {
+    name: 'Kumano-mae',
+    lat: 35.7485,
+    lng: 139.7699,
+    zoom: 15,
+    // requiredDataSource: ['minkuru', 'toaran'],
+  },
+  {
+    name: 'Kinshicho Station',
+    lat: 35.6967,
+    lng: 139.814,
+    zoom: 17,
+    // requiredDataSource: ['minkuru', 'toaran', 'tome'],
+  },
+  {
+    name: 'Tokyo Big Sight',
+    lat: 35.6302,
+    lng: 139.793,
+    zoom: 18,
+    // requiredDataSource: ['yurimo', 'minkuru'],
+  },
+  {
+    name: 'Shibuya Station',
+    lat: 35.6588,
+    lng: 139.7012,
+    zoom: 17,
+    // requiredDataSource: ['minkuru', 'kobus'],
+  },
+  {
+    name: 'Otsuka Station',
+    lat: 35.731,
+    lng: 139.7291,
+    zoom: 18,
+    requiredDataSource: ['minkuru', 'toaran'],
+  },
+  {
+    name: 'Nerima Station',
+    lat: 35.7384,
+    lng: 139.654,
+    zoom: 18,
+    // requiredDataSource: ['minkuru', 'sbbus', 'kobus'],
+  },
+  {
+    name: 'Chiyoda City Hall',
+    lat: 35.6948,
+    lng: 139.7533,
+    zoom: 16,
+    requiredDataSource: ['kazag'],
+  },
+  {
+    name: 'Ikebukuro Station',
+    lat: 35.73,
+    lng: 139.7127,
+    zoom: 16,
+    // requiredDataSource: ['minkuru', 'tome', 'kobus', 'ntbus'],
+  },
+  {
+    name: 'Shinjuku Station West (North)',
+    lat: 35.6919,
+    lng: 139.6987,
+    zoom: 18,
+    // requiredDataSource: ['minkuru', 'tome', 'kobus', 'od9bus'],
+  },
+  {
+    name: 'Shinjuku Station West (South)',
+    lat: 35.691,
+    lng: 139.6985,
+    zoom: 15,
+    // requiredDataSource: ['minkuru', 'tome', 'kobus', 'od9bus'],
+  },
+  {
+    name: 'Shinagawa Seaside',
+    lat: 35.6103,
+    lng: 139.7483,
+    zoom: 15,
+    requiredDataSource: ['minkuru'],
+  },
+  {
+    name: 'Shimbashi Station',
+    lat: 35.6663,
+    lng: 139.7596,
+    zoom: 16,
+    // requiredDataSource: ['yurimo', 'tome', 'minkuru'],
+  },
+  {
+    name: 'Ome Station',
+    lat: 35.7879,
+    lng: 139.258,
+    zoom: 16,
+    requiredDataSource: ['minkuru', 'ntbus'],
+  },
   /** Oshima, Tokyo, Japan */
-  { name: 'Motomachi Port', lat: 34.7512, lng: 139.3546, zoom: 12 },
+  {
+    name: 'Motomachi Port',
+    lat: 34.7512,
+    lng: 139.3546,
+    zoom: 12,
+    // requiredDataSource: ['osmbus']
+  },
   /** Kanagawa, Japan */
-  { name: 'Kannai Sta, Kanagawa, Japan', lat: 35.4444, lng: 139.6407, zoom: 15 },
+  {
+    name: 'Kannai Sta, Kanagawa, Japan',
+    lat: 35.4444,
+    lng: 139.6407,
+    zoom: 15,
+    requiredDataSource: ['yhb', 'yht'],
+  },
   /** Nagoya, Japan */
-  { name: 'Nagoya', lat: 35.1697, lng: 136.8954, zoom: 13 },
+  { name: 'Nagoya', lat: 35.1697, lng: 136.8954, zoom: 13, requiredDataSource: ['nsrt'] },
   /** Kyoto, Japan */
-  { name: 'Kyoto Station', lat: 34.9868, lng: 135.7586, zoom: 19 },
-  { name: 'Kinkakuji Temple', lat: 35.0392, lng: 135.7319, zoom: 17 },
-  { name: 'Nishigamo Shako', lat: 35.06443711972482, lng: 135.74506404084843, zoom: 16 },
+  {
+    name: 'Kyoto Station',
+    lat: 34.9868,
+    lng: 135.7586,
+    zoom: 19,
+    requiredDataSource: ['kcbus', 'kytbus'],
+  },
+  {
+    name: 'Kinkakuji Temple',
+    lat: 35.0392,
+    lng: 135.7319,
+    zoom: 17,
+    requiredDataSource: ['kcbus'],
+  },
+  {
+    name: 'Nishigamo Shako',
+    lat: 35.06443711972482,
+    lng: 135.74506404084843,
+    zoom: 16,
+    // requiredDataSource: ['kcbus'],
+  },
   /** Ehime, Japan */
-  { name: 'Matsuyama (Okaido crossing)', lat: 33.8417, lng: 132.7703, zoom: 16 },
-  { name: 'Matsuyama City Station', lat: 33.8361, lng: 132.7632, zoom: 18 },
-  { name: 'Yawatahama Port', lat: 33.4605585, lng: 132.41714, zoom: 14 },
+  {
+    name: 'Matsuyama (Okaido crossing)',
+    lat: 33.8417,
+    lng: 132.7703,
+    zoom: 16,
+    // requiredDataSource: ['iyt2'],
+  },
+  {
+    name: 'Matsuyama City Station',
+    lat: 33.8361,
+    lng: 132.7632,
+    zoom: 18,
+    requiredDataSource: ['iyt2'],
+  },
+  {
+    name: 'Yawatahama Port',
+    lat: 33.4605585,
+    lng: 132.41714,
+    zoom: 14,
+    requiredDataSource: ['iyt2'],
+  },
   /** Germany */
-  { name: 'Freiburg Hauptbahnhof', lat: 47.99610302520502, lng: 7.840770083827948, zoom: 16 },
+  {
+    name: 'Freiburg Hauptbahnhof',
+    lat: 47.99610302520502,
+    lng: 7.840770083827948,
+    zoom: 16,
+    requiredDataSource: ['vagfr'],
+  },
   /** Italy */
-  { name: 'Venice Piazzale Roma', lat: 45.43391655307844, lng: 12.343352744453911, zoom: 16 },
-  { name: 'Venezia Santa Lucia', lat: 45.441, lng: 12.321, zoom: 15 },
-] as const;
+  {
+    name: 'Venice Piazzale Roma',
+    lat: 45.43391655307844,
+    lng: 12.343352744453911,
+    zoom: 16,
+    requiredDataSource: ['actvnav'],
+  },
+  {
+    name: 'Venezia Santa Lucia',
+    lat: 45.441,
+    lng: 12.321,
+    zoom: 15,
+    requiredDataSource: ['actvnav'],
+  },
+];
 
 const logger = createLogger('MapDefaults');
 
@@ -76,12 +233,44 @@ function parseEnvZoom(value: string | undefined): number | null {
 }
 
 /**
- * Pick a random location from HOME_LOCATIONS.
- * Returns center and zoom.
+ * Pick a random location from HOME_LOCATIONS, filtering by available
+ * data sources.
+ *
+ * A location is eligible when:
+ *
+ * - its {@link HomeLocation.requiredDataSource} is `undefined` or `[]`
+ *   (no requirement — vacuously matched), or
+ * - at least one listed prefix is in `loadedDataSources` (some-match).
+ *
+ * When no location matches (e.g. nothing is loaded), the full
+ * {@link HOME_LOCATIONS} list is used as a fallback so the caller
+ * always gets a place — better than returning null and leaving the
+ * caller to handle the empty case.
+ *
+ * @param loadedDataSources - GTFS prefixes that are currently loaded.
+ * @returns A random location's center coords and zoom.
  */
-export function pickRandomHome(): { center: [number, number]; zoom: number } {
-  const loc = HOME_LOCATIONS[Math.floor(Math.random() * HOME_LOCATIONS.length)];
-  return { center: [loc.lat, loc.lng], zoom: loc.zoom };
+export function pickRandomHome(loadedDataSources: ReadonlySet<string>): {
+  center: [number, number];
+  zoom: number;
+  name: string;
+} {
+  const pool = selectHomeCandidates(HOME_LOCATIONS, loadedDataSources);
+  const loc = pool[Math.floor(Math.random() * pool.length)];
+  return { center: [loc.lat, loc.lng], zoom: loc.zoom, name: loc.name };
+}
+
+/**
+ * Compute the GTFS prefixes that will be loaded at boot, using the
+ * same resolution as `main.tsx` (URL `?sources=` -> stored selection ->
+ * defaults). Used to filter {@link pickRandomHome} candidates at
+ * module-load time, before React mounts.
+ */
+function getBootLoadedDataSources(): ReadonlySet<string> {
+  const dsm = new DataSourceManager(loadEnabledGroupIdsFromStorage());
+  return new Set(
+    resolveFetchDataSources(dsm.getGroups(), dsm.getEnabledDataSources(), getSourcesParam()),
+  );
 }
 
 // --- Resolution: query params > env > random ---
@@ -96,7 +285,7 @@ const envCenter = parseEnvLatLng(import.meta.env.VITE_INITIAL_LAT_LNG);
 const envZoom = parseEnvZoom(import.meta.env.VITE_INITIAL_ZOOM_LEVEL);
 
 const DEFAULT_ZOOM = 16;
-const randomHome = (qCenter ?? envCenter) ? null : pickRandomHome();
+const randomHome = (qCenter ?? envCenter) ? null : pickRandomHome(getBootLoadedDataSources());
 
 const resolvedCenter: [number, number] = qCenter ?? envCenter ?? randomHome!.center;
 const resolvedZoom: number = qZoom ?? envZoom ?? randomHome?.zoom ?? DEFAULT_ZOOM;
@@ -111,9 +300,8 @@ if (qCenter) {
     `Initial position from env: [${resolvedCenter.join(', ')}] zoom=${String(resolvedZoom)}`,
   );
 } else if (randomHome) {
-  const name = HOME_LOCATIONS.find((l) => l.lat === randomHome.center[0])?.name ?? 'unknown';
   logger.info(
-    `Initial position from random: ${name} [${resolvedCenter.join(', ')}] zoom=${String(resolvedZoom)}`,
+    `Initial position from random: ${randomHome.name} [${resolvedCenter.join(', ')}] zoom=${String(resolvedZoom)}`,
   );
 }
 

--- a/src/config/map-defaults.ts
+++ b/src/config/map-defaults.ts
@@ -247,8 +247,11 @@ function parseEnvZoom(value: string | undefined): number | null {
  * always gets a place — better than returning null and leaving the
  * caller to handle the empty case.
  *
- * @param loadedDataSources - GTFS prefixes that are currently loaded.
- * @returns A random location's center coords and zoom.
+ * @param loadedDataSources - GTFS data sources (prefixes) that are
+ *   currently loaded.
+ * @returns The picked location's center coords, zoom, and name. The
+ *   `name` is included so callers can log which curated location was
+ *   chosen (it is not displayed to end users).
  */
 export function pickRandomHome(loadedDataSources: ReadonlySet<string>): {
   center: [number, number];

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -21,7 +21,7 @@ const logger = createLogger('diagnostics');
  * @param repository - The active TransitRepository instance (for repo-bench).
  */
 export async function runDiagnostics(name: string, repository?: TransitRepository): Promise<void> {
-  const prefixes = new DataSourceManager(loadEnabledGroupIdsFromStorage()).getEnabledPrefixes();
+  const prefixes = new DataSourceManager(loadEnabledGroupIdsFromStorage()).getEnabledDataSources();
 
   switch (name) {
     case 'v2-load': {

--- a/src/domain/map/__tests__/select-home-location.test.ts
+++ b/src/domain/map/__tests__/select-home-location.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { isHomeLocationUsable, selectHomeCandidates } from '../select-home-location';
+import type { HomeLocation } from '../../../types/app/home-location';
+
+const unconstrained: HomeLocation = {
+  name: 'Anywhere',
+  lat: 0,
+  lng: 0,
+  zoom: 10,
+};
+
+const constrainedSingle: HomeLocation = {
+  name: 'Single-prefix place',
+  lat: 1,
+  lng: 1,
+  zoom: 12,
+  requiredDataSource: ['only-this'],
+};
+
+const constrainedMulti: HomeLocation = {
+  name: 'Multi-prefix place',
+  lat: 2,
+  lng: 2,
+  zoom: 14,
+  requiredDataSource: ['a', 'b', 'c'],
+};
+
+describe('isHomeLocationUsable', () => {
+  it('returns true for a location with `requiredDataSource === undefined`, regardless of loaded prefixes', () => {
+    expect(isHomeLocationUsable(unconstrained, new Set())).toBe(true);
+    expect(isHomeLocationUsable(unconstrained, new Set(['anything']))).toBe(true);
+  });
+
+  it('returns true when the single required prefix is loaded', () => {
+    expect(isHomeLocationUsable(constrainedSingle, new Set(['only-this']))).toBe(true);
+  });
+
+  it('returns false when the single required prefix is not loaded', () => {
+    expect(isHomeLocationUsable(constrainedSingle, new Set(['other']))).toBe(false);
+    expect(isHomeLocationUsable(constrainedSingle, new Set())).toBe(false);
+  });
+
+  it('returns true when at least one of multiple required prefixes is loaded (some semantics)', () => {
+    expect(isHomeLocationUsable(constrainedMulti, new Set(['b']))).toBe(true);
+    expect(isHomeLocationUsable(constrainedMulti, new Set(['a', 'unrelated']))).toBe(true);
+    expect(isHomeLocationUsable(constrainedMulti, new Set(['a', 'b', 'c']))).toBe(true);
+  });
+
+  it('returns false when none of the required prefixes is loaded', () => {
+    expect(isHomeLocationUsable(constrainedMulti, new Set(['unrelated']))).toBe(false);
+    expect(isHomeLocationUsable(constrainedMulti, new Set())).toBe(false);
+  });
+
+  it('returns true for `requiredDataSource: []` (empty array = no required data source = vacuously matched)', () => {
+    // Semantic equivalence: `[]` and `undefined` both mean "this
+    // location has no data-source requirement". The vacuous-truth
+    // reading is the intuitive one and matches the field name's
+    // intent ("required" — there's nothing required).
+    const noRequirement: HomeLocation = {
+      name: 'Empty array',
+      lat: 0,
+      lng: 0,
+      zoom: 10,
+      requiredDataSource: [],
+    };
+    expect(isHomeLocationUsable(noRequirement, new Set(['anything']))).toBe(true);
+    expect(isHomeLocationUsable(noRequirement, new Set())).toBe(true);
+  });
+});
+
+describe('selectHomeCandidates', () => {
+  it('returns only the usable subset when some locations are filtered out', () => {
+    const result = selectHomeCandidates(
+      [unconstrained, constrainedSingle, constrainedMulti],
+      new Set(['b']), // matches constrainedMulti (has 'b'); not constrainedSingle ('only-this')
+    );
+    expect(result.map((l) => l.name)).toEqual(['Anywhere', 'Multi-prefix place']);
+  });
+
+  it('returns all locations when every entry is usable', () => {
+    const result = selectHomeCandidates(
+      [unconstrained, constrainedSingle, constrainedMulti],
+      new Set(['only-this', 'a']),
+    );
+    expect(result).toHaveLength(3);
+  });
+
+  it('falls back to the full input list when no location matches (so caller always has a candidate)', () => {
+    const result = selectHomeCandidates(
+      [constrainedSingle, constrainedMulti],
+      new Set(['something-else']), // matches neither
+    );
+    // Fallback: returns the input as-is.
+    expect(result.map((l) => l.name)).toEqual(['Single-prefix place', 'Multi-prefix place']);
+  });
+
+  it('returns only the unconstrained location when only unconstrained matches', () => {
+    const result = selectHomeCandidates(
+      [unconstrained, constrainedSingle, constrainedMulti],
+      new Set(), // empty loaded set; only `unconstrained` (no requiredDataSource) is usable
+    );
+    expect(result.map((l) => l.name)).toEqual(['Anywhere']);
+  });
+
+  it('returns an empty array for an empty input (no fallback when there is nothing to fall back to)', () => {
+    expect(selectHomeCandidates([], new Set())).toEqual([]);
+    expect(selectHomeCandidates([], new Set(['anything']))).toEqual([]);
+  });
+
+  it('keeps locations with `requiredDataSource: []` (empty = no requirement = `["*"]` wildcard)', () => {
+    // `[]` and `undefined` are equivalent: both mean "this location
+    // has no data-source requirement" — like a `['*']` wildcard
+    // matching any state. The location is always kept regardless of
+    // what is loaded.
+    const noRequirement: HomeLocation = {
+      name: 'Empty array place',
+      lat: 0,
+      lng: 0,
+      zoom: 10,
+      requiredDataSource: [],
+    };
+    const result = selectHomeCandidates([unconstrained, noRequirement], new Set(['anything']));
+    expect(result.map((l) => l.name)).toEqual(['Anywhere', 'Empty array place']);
+
+    // Even with empty `loadedDataSources`, both unconstrained and
+    // `[]`-requirement locations remain in the pool.
+    const emptyLoaded = selectHomeCandidates([unconstrained, noRequirement], new Set());
+    expect(emptyLoaded.map((l) => l.name)).toEqual(['Anywhere', 'Empty array place']);
+  });
+});

--- a/src/domain/map/select-home-location.ts
+++ b/src/domain/map/select-home-location.ts
@@ -1,0 +1,63 @@
+import type { HomeLocation } from '../../types/app/home-location';
+
+/**
+ * Whether a {@link HomeLocation} is usable given the set of currently
+ * loaded GTFS prefixes.
+ *
+ * Match semantics:
+ *
+ * - `requiredDataSource` is `undefined` → always usable (no requirement).
+ * - `requiredDataSource` is `[]` → always usable (empty requirement
+ *   list = no required data source at all = nothing to satisfy =
+ *   vacuously matched).
+ * - `requiredDataSource` is a non-empty array → usable when **at least
+ *   one** listed prefix is in `loadedDataSources` (some-match).
+ *
+ * `undefined` and `[]` are equivalent: both express "this location has
+ * no data-source requirement". Callers may use either, though omitting
+ * the field is the more idiomatic way to mark a location as
+ * unconstrained.
+ *
+ * @param location - The curated location to test.
+ * @param loadedDataSources - GTFS prefixes that are currently loaded.
+ * @returns `true` when the location should be a candidate, `false`
+ *   when it should be filtered out.
+ */
+export function isHomeLocationUsable(
+  location: HomeLocation,
+  loadedDataSources: ReadonlySet<string>,
+): boolean {
+  if (location.requiredDataSource === undefined || location.requiredDataSource.length === 0) {
+    return true;
+  }
+  return location.requiredDataSource.some((prefix) => loadedDataSources.has(prefix));
+}
+
+/**
+ * Filter a curated location list down to the subset usable given the
+ * current load state. Falls back to the full input list when nothing
+ * matches, so callers always get at least one candidate (better than
+ * returning empty and forcing the caller to handle null).
+ *
+ * The fallback is intentional: if a user has disabled every data
+ * source we know about, sending them to a random place is still
+ * better than crashing or showing nothing. They will see an empty
+ * map, but the app structure stays intact.
+ *
+ * Empty input → empty output (no fallback). Callers must pass a
+ * non-empty list of locations.
+ *
+ * @param locations - The full curated location list to filter.
+ * @param loadedDataSources - GTFS prefixes that are currently loaded.
+ * @returns The filtered list, or the full input when nothing matches.
+ */
+export function selectHomeCandidates(
+  locations: readonly HomeLocation[],
+  loadedDataSources: ReadonlySet<string>,
+): readonly HomeLocation[] {
+  const candidates = locations.filter((loc) => isHomeLocationUsable(loc, loadedDataSources));
+  if (candidates.length > 0) {
+    return candidates;
+  }
+  return locations;
+}

--- a/src/hooks/use-map-navigation-actions.ts
+++ b/src/hooks/use-map-navigation-actions.ts
@@ -3,6 +3,7 @@ import type L from 'leaflet';
 import type { UserLocation } from '../types/app/map';
 import { smoothMoveTo } from '../lib/leaflet-helpers';
 import { pickRandomHome } from '../config/map-defaults';
+import { useLoadedSources } from './use-loaded-sources';
 import { useMapLocate } from './use-map-locate';
 
 interface UseMapNavigationActionsOptions {
@@ -41,11 +42,13 @@ export function useMapNavigationActions(
     onError: options?.onError,
   });
 
+  const loadedDataSources = useLoadedSources();
+
   const handleRandomJump = useCallback(() => {
     onDeselectStop();
-    const { center, zoom } = pickRandomHome();
+    const { center, zoom } = pickRandomHome(loadedDataSources);
     smoothMoveTo(map, center, zoom);
-  }, [map, onDeselectStop]);
+  }, [map, onDeselectStop, loadedDataSources]);
 
   return {
     locating,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -37,7 +37,7 @@ async function createRepository(): Promise<{
   const dsm = new DataSourceManager(loadEnabledGroupIdsFromStorage());
   const prefixes = resolveFetchDataSources(
     dsm.getGroups(),
-    dsm.getEnabledPrefixes(),
+    dsm.getEnabledDataSources(),
     getSourcesParam(),
   );
 

--- a/src/types/app/home-location.ts
+++ b/src/types/app/home-location.ts
@@ -1,0 +1,51 @@
+/**
+ * One curated initial-display location, used by `pickRandomHome` in
+ * `src/config/map-defaults.ts` to seed the map at app start and when
+ * the user hits the random-jump button.
+ *
+ * `requiredDataSource` lists the GTFS prefixes whose stops/routes give
+ * this location something to show. When set, the location is only
+ * included in the random pool if at least ONE listed prefix is in the
+ * caller's "loaded" set (some-match); if none is, the location is
+ * filtered out so the user never lands on an empty map. Locations
+ * with no `requiredDataSource` are always available (no constraint).
+ *
+ * The shape is intentionally minimal — it carries only what the random
+ * picker needs. No display metadata (icons, captions, etc.) lives
+ * here; those would go on a separate UI-facing type if needed.
+ */
+export interface HomeLocation {
+  /**
+   * Short human-readable identifier, used only for logging
+   * ("Initial position from random: {{name}} ..."). Not displayed to
+   * end users.
+   */
+  name: string;
+
+  /** Latitude (WGS84) of the map center to seed. */
+  lat: number;
+
+  /** Longitude (WGS84) of the map center to seed. */
+  lng: number;
+
+  /**
+   * Initial zoom level for this location. Picked per-location because
+   * a dense urban station works at zoom 17-18 while a sparse port or
+   * region overview reads better at 12-15.
+   */
+  zoom: number;
+
+  /**
+   * GTFS prefixes whose data is needed for this location to be
+   * meaningful. Filtering is `some` (any loaded prefix is enough), so
+   * listing multiple prefixes acts as an OR — for example,
+   * `['kcbus', 'kytbus']` means "this Kyoto location is useful if
+   * Kyoto City Bus OR Kyoto Bus data is loaded".
+   *
+   * `undefined` and `[]` are equivalent: both express "no
+   * requirement" — the location is unconditionally available, like a
+   * `['*']` wildcard. Omitting the field is the more idiomatic way
+   * to mark a location as unconstrained.
+   */
+  requiredDataSource?: readonly string[];
+}


### PR DESCRIPTION
## Summary

Closes #146.

`pickRandomHome` no longer sends the user to a place where their loaded data has nothing to show. Each curated `HOME_LOCATIONS` entry can declare which GTFS prefixes give it something interesting; the random picker drops candidates whose required data isn't loaded.

Example before:
- User disables Kyoto City Bus + Kyoto Bus
- Boot picks 「Kyoto Station」 randomly
- Map opens with no stops, looks broken

After:
- Boot filters Kyoto Station out of the pool because neither `kcbus` nor `kytbus` is loaded
- A Tokyo (or other available-region) location is picked instead

## Changes

### New type

- `src/types/app/home-location.ts` — `HomeLocation` interface with `requiredDataSource?: readonly string[]`. Full TSDoc covering wildcard semantics (undefined / `[]`)、 some-match for non-empty arrays、 fallback contract.

### Pure helper

- `src/domain/map/select-home-location.ts` — `isHomeLocationUsable(location, loadedDataSources): boolean` and `selectHomeCandidates(locations, loadedDataSources): readonly HomeLocation[]`. Logic is fully isolated from `Math.random` / module-level evaluation so it's directly testable.
- `src/domain/map/__tests__/select-home-location.test.ts` — 12 cases covering every match path (undefined、 `[]` wildcard、 single prefix、 multi-prefix some-match、 mixed loaded state、 empty-input edge、 fallback when no candidates match).

### Wildcard semantics

| `requiredDataSource` | Match? |
|---|---|
| `undefined` | always (no requirement) |
| `[]` | always (vacuously matched — equivalent to `['*']` wildcard) |
| `['a', 'b']` | when at least one of `a` / `b` is loaded |

Empty array and undefined are intentionally equivalent — both express \"no requirement\".

### Caller updates

- `src/config/map-defaults.ts` — `pickRandomHome` now takes `loadedDataSources: ReadonlySet<string>` and composes `selectHomeCandidates` with `Math.random`. Boot-time pick uses internal `getBootLoadedDataSources()` (mirrors `main.tsx`'s URL → stored → defaults resolution via `DataSourceManager` + `resolveFetchDataSources`) so the random pick is filtered correctly even before React mounts.
- `src/hooks/use-map-navigation-actions.ts` — random-jump button reads `useLoadedSources()` and passes the loaded set into `pickRandomHome`. Reflects live load state.

### Tagging

Region-specific locations tagged with `requiredDataSource`. Tokyo locations stay unconstrained for now (most user configs load at least one Tokyo source). Concrete tagging:

- `Otsuka Station` → `['minkuru', 'toaran']`
- `Chiyoda City Hall` → `['kazag']`
- `Shinagawa Seaside` → `['minkuru']`
- `Ome Station` → `['minkuru', 'ntbus']`
- `Kannai Sta, Kanagawa, Japan` → `['yhb', 'yht']`
- `Nagoya` → `['nsrt']`
- `Kyoto Station` → `['kcbus', 'kytbus']`
- `Kinkakuji Temple` → `['kcbus']`
- `Matsuyama City Station` → `['iyt2']`
- `Yawatahama Port` → `['iyt2']`
- `Freiburg Hauptbahnhof` → `['vagfr']`
- `Venice Piazzale Roma` / `Venezia Santa Lucia` → `['actvnav']`

Tagging is conservative — easy to expand later without breaking the type contract.

### Drive-by rename

- `DataSourceManager.getEnabledPrefixes` → `getEnabledDataSources`. The old \"prefix\" terminology was inside-baseball; \"data source\" matches the user-facing terminology of the settings dialog and the source-group model. Updated callers: `main.tsx`、 `diagnostics/index.ts`、 `map-defaults.ts`、 and DSM unit tests.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test` — 3613 / 3613 pass
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)