### PR TITLE
Add summarize-v2-outputs dev tool

### DIFF
--- a/pipeline/scripts/dev/README.md
+++ b/pipeline/scripts/dev/README.md
@@ -4,17 +4,17 @@
 
 ## スクリプト一覧
 
-| スクリプト                          | 対象データ                                                   | 概要                                                                                                                        |
-| ----------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| `describe-resources.ts`             | `pipeline/config/resources/` (リソース定義)                  | リソース定義の一覧表示 (`npm run pipeline:describe`)                                                                        |
-| `find-joint-routes.ts`              | `public/data/` (生成済み JSON)                               | 共同運行路線の検出。ソース間で route_short_name が一致する路線を検出し、停留所名の突き合わせと座標による近接分析を行う      |
-| `analyze-gtfs-stop-times.ts`        | `pipeline/workspace/_build/db/` (SQLite DB)                  | GTFS stop_times パターン分析 (terminal-only stops, circular routes, pickup/drop-off types 等)                               |
-| `analyze-gtfs-routes.ts`            | `pipeline/workspace/data/gtfs/` (`routes.txt`)               | GTFS `routes.txt` の names / route_type / colors / cEMV / continuous fields 等を source ごとに集計する                      |
-| `analyze-odpt-station-timetable.ts` | `pipeline/workspace/data/odpt-json/` (ODPT JSON)             | ODPT StationTimetable データパターン分析 (time field availability, station/direction/calendar coverage 等)                  |
-| `analyze-v2-name-fields.ts`         | `public/data-v2/` (生成済み V2 DataBundle)                   | 定義済みの名称系調査対象について、V2 JSON 上の `nonEmpty` / `empty` 件数を source ごとに集計する                            |
-| `analyze-v2-insights.ts`            | `public/data-v2/<source>/insights.json` (InsightsBundle)     | InsightsBundle の 4 セクション (serviceGroups / tripPatternStats / tripPatternGeo / stopStats) を source 別に集計する       |
-| `analyze-v2-global-insights.ts`     | `public/data-v2/global/insights.json` (GlobalInsightsBundle) | GlobalInsightsBundle の `stopGeo` を source 別に集計する (stop 件数、`wp`/`cn` カバレッジ、`nr` 分布)                       |
-| `summarize-v2-outputs.ts`           | `public/data-v2/<source>/{data,insights,shapes}.json`        | V2 pipeline 出力を bundle 横断で source 別に要約する (file size / gzip size / DataBundle 件数 / InsightsBundle tripsMedian) |
+| スクリプト                          | 対象データ                                                   | 概要                                                                                                                                  |
+| ----------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `describe-resources.ts`             | `pipeline/config/resources/` (リソース定義)                  | リソース定義の一覧表示 (`npm run pipeline:describe`)                                                                                  |
+| `find-joint-routes.ts`              | `public/data/` (生成済み JSON)                               | 共同運行路線の検出。ソース間で route_short_name が一致する路線を検出し、停留所名の突き合わせと座標による近接分析を行う                |
+| `analyze-gtfs-stop-times.ts`        | `pipeline/workspace/_build/db/` (SQLite DB)                  | GTFS stop_times パターン分析 (terminal-only stops, circular routes, pickup/drop-off types 等)                                         |
+| `analyze-gtfs-routes.ts`            | `pipeline/workspace/data/gtfs/` (`routes.txt`)               | GTFS `routes.txt` の names / route_type / colors / cEMV / continuous fields 等を source ごとに集計する                                |
+| `analyze-odpt-station-timetable.ts` | `pipeline/workspace/data/odpt-json/` (ODPT JSON)             | ODPT StationTimetable データパターン分析 (time field availability, station/direction/calendar coverage 等)                            |
+| `analyze-v2-name-fields.ts`         | `public/data-v2/` (生成済み V2 DataBundle)                   | 定義済みの名称系調査対象について、V2 JSON 上の `nonEmpty` / `empty` 件数を source ごとに集計する                                      |
+| `analyze-v2-insights.ts`            | `public/data-v2/<source>/insights.json` (InsightsBundle)     | InsightsBundle の 4 セクション (serviceGroups / tripPatternStats / tripPatternGeo / stopStats) を source 別に集計する                 |
+| `analyze-v2-global-insights.ts`     | `public/data-v2/global/insights.json` (GlobalInsightsBundle) | GlobalInsightsBundle の `stopGeo` を source 別に集計する (stop 件数、`wp`/`cn` カバレッジ、`nr` 分布)                                 |
+| `summarize-v2-outputs.ts`           | `public/data-v2/<source>/{data,insights,shapes}.json`        | V2 pipeline 出力を bundle 横断で source 別に要約する (file size / gzip size / DataBundle 件数 / InsightsBundle tripsTotal / tripsMax) |
 
 ## `analyze-v2-name-fields.ts`
 
@@ -113,11 +113,10 @@ ODPT Train source ごとの `StationTimetable` JSON を読み、時刻 field / c
     - `periods` ・・・ 期間に関する情報を統合 (feedValidity / servicePeriod / exceptionRange)。 feedInfo + calendar.services + calendar.exceptions の 3 軸を 1 行で横並びにし、 「feedInfo は空でも calendar が補う」等の対応関係が見える
     - `trip-volume` ・・・ InsightsBundle 由来の trip 量 2 値: `tripsTotal` (= 全 sg × pattern の freq 合算 = trips.txt 行数、 day-agnostic) と `tripsMax` (= 最も賑わう sg の便数 = peak day)。 sg 分布が heavy-tailed な source (vagfr 等) で median が破綻していた問題を解消した max 寄り 2 値
     - `shapes-counts` ・・・ ShapesBundle 由来の routes / polylines / points / totalLengthKm (allocation-free Haversine 合計)
-    - `global-insights` ・・・ GlobalInsightsBundle (`global/insights.json`) の raw / gzip サイズと stopGeo entry count (per-source ではない単一行ブロック)
+    - `global-insights` ・・・ GlobalInsightsBundle (`global/insights.json`) の stopGeo カバレッジ ── `wp` (parent_station 距離) / `cn` (300m connectivity、 service group 別) を持つ stop の割合。 per-source ではない単一ブロック。 stopGeo の entry 数自体は `global-insights-counts` に出す
 - `shapes.json` / `insights.json` / `global/insights.json` が存在しない場合は対応欄を `-` で表示する (`0` は空ファイルを意味する別状態)
 - `global-insights` セクションは datasource-id 指定の有無に関わらず常時処理される (single artifact のため source 軸でフィルタする概念がない)
 - byte 表記は 1024 進数 (>=1 MiB は MB、 >=1 KiB は KB、 それ未満は B)
-- median を採るのは、 source によってはサービス日種別が多数 (年末年始臨時便等) 存在しうるため。 中央値は外れ値耐性があり、 列数を膨らませずに「典型値」を出せる
 
 ## 実行方法
 

--- a/pipeline/scripts/dev/README.md
+++ b/pipeline/scripts/dev/README.md
@@ -4,16 +4,17 @@
 
 ## スクリプト一覧
 
-| スクリプト                          | 対象データ                                                   | 概要                                                                                                                   |
-| ----------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| `describe-resources.ts`             | `pipeline/config/resources/` (リソース定義)                  | リソース定義の一覧表示 (`npm run pipeline:describe`)                                                                   |
-| `find-joint-routes.ts`              | `public/data/` (生成済み JSON)                               | 共同運行路線の検出。ソース間で route_short_name が一致する路線を検出し、停留所名の突き合わせと座標による近接分析を行う |
-| `analyze-gtfs-stop-times.ts`        | `pipeline/workspace/_build/db/` (SQLite DB)                  | GTFS stop_times パターン分析 (terminal-only stops, circular routes, pickup/drop-off types 等)                          |
-| `analyze-gtfs-routes.ts`            | `pipeline/workspace/data/gtfs/` (`routes.txt`)               | GTFS `routes.txt` の names / route_type / colors / cEMV / continuous fields 等を source ごとに集計する                 |
-| `analyze-odpt-station-timetable.ts` | `pipeline/workspace/data/odpt-json/` (ODPT JSON)             | ODPT StationTimetable データパターン分析 (time field availability, station/direction/calendar coverage 等)             |
-| `analyze-v2-name-fields.ts`         | `public/data-v2/` (生成済み V2 DataBundle)                   | 定義済みの名称系調査対象について、V2 JSON 上の `nonEmpty` / `empty` 件数を source ごとに集計する                       |
-| `analyze-v2-insights.ts`            | `public/data-v2/<source>/insights.json` (InsightsBundle)     | InsightsBundle の 4 セクション (serviceGroups / tripPatternStats / tripPatternGeo / stopStats) を source 別に集計する  |
-| `analyze-v2-global-insights.ts`     | `public/data-v2/global/insights.json` (GlobalInsightsBundle) | GlobalInsightsBundle の `stopGeo` を source 別に集計する (stop 件数、`wp`/`cn` カバレッジ、`nr` 分布)                  |
+| スクリプト                          | 対象データ                                                   | 概要                                                                                                                        |
+| ----------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `describe-resources.ts`             | `pipeline/config/resources/` (リソース定義)                  | リソース定義の一覧表示 (`npm run pipeline:describe`)                                                                        |
+| `find-joint-routes.ts`              | `public/data/` (生成済み JSON)                               | 共同運行路線の検出。ソース間で route_short_name が一致する路線を検出し、停留所名の突き合わせと座標による近接分析を行う      |
+| `analyze-gtfs-stop-times.ts`        | `pipeline/workspace/_build/db/` (SQLite DB)                  | GTFS stop_times パターン分析 (terminal-only stops, circular routes, pickup/drop-off types 等)                               |
+| `analyze-gtfs-routes.ts`            | `pipeline/workspace/data/gtfs/` (`routes.txt`)               | GTFS `routes.txt` の names / route_type / colors / cEMV / continuous fields 等を source ごとに集計する                      |
+| `analyze-odpt-station-timetable.ts` | `pipeline/workspace/data/odpt-json/` (ODPT JSON)             | ODPT StationTimetable データパターン分析 (time field availability, station/direction/calendar coverage 等)                  |
+| `analyze-v2-name-fields.ts`         | `public/data-v2/` (生成済み V2 DataBundle)                   | 定義済みの名称系調査対象について、V2 JSON 上の `nonEmpty` / `empty` 件数を source ごとに集計する                            |
+| `analyze-v2-insights.ts`            | `public/data-v2/<source>/insights.json` (InsightsBundle)     | InsightsBundle の 4 セクション (serviceGroups / tripPatternStats / tripPatternGeo / stopStats) を source 別に集計する       |
+| `analyze-v2-global-insights.ts`     | `public/data-v2/global/insights.json` (GlobalInsightsBundle) | GlobalInsightsBundle の `stopGeo` を source 別に集計する (stop 件数、`wp`/`cn` カバレッジ、`nr` 分布)                       |
+| `summarize-v2-outputs.ts`           | `public/data-v2/<source>/{data,insights,shapes}.json`        | V2 pipeline 出力を bundle 横断で source 別に要約する (file size / gzip size / DataBundle 件数 / InsightsBundle tripsMedian) |
 
 ## `analyze-v2-name-fields.ts`
 
@@ -80,6 +81,44 @@ ODPT Train source ごとの `StationTimetable` JSON を読み、時刻 field / c
 - 引数: `--list-sections`、`--section <name>`
 - 主な section: - `summary` - `nr-distribution` - `isolation-buckets` - `connectivity` - `hub-counts` - `walkable-portal` - `most-isolated-stops` - `most-connected-stops` - `busiest-neighborhoods`
 
+## `summarize-v2-outputs.ts`
+
+生成済み V2 pipeline 出力 (`public/data-v2/<source>/`) を bundle 横断で source 別に要約する text report を出す。
+構造は **entry → main lib → sub libs** の 3 層:
+
+- entry: `pipeline/scripts/dev/summarize-v2-outputs.ts` (I/O のみ)
+- main lib: `pipeline/scripts/dev/dev-lib/v2-outputs-summary.ts` (section dispatch、 union 化、 全体整形)
+- sub libs (per data source):
+    - `pipeline/scripts/dev/dev-lib/v2-data-summary.ts` (DataBundle + file-sizes / gzip-sizes)
+    - `pipeline/scripts/dev/dev-lib/v2-insights-summary.ts` (InsightsBundle 由来の trip-volume)
+    - `pipeline/scripts/dev/dev-lib/v2-shapes-summary.ts` (ShapesBundle 由来の geometry 件数)
+- sub lib (per all data sources):
+    - `pipeline/scripts/dev/dev-lib/v2-global-insights-summary.ts` (GlobalInsightsBundle 由来、 single artifact)
+
+各 sub lib は 1 bundle に責務を持ち、 main lib は sub lib を組み合わせて section を直列出力する。 global-insights は per-source ではない単一 artifact なので main lib の dispatch が分岐 (rows ではなく単一値オブジェクトを受ける render を呼ぶ)。 sub libs だけでは作れない合成派生指標 (例: bytes-per-trip) は main lib に置ける。
+
+- 入力: `public/data-v2/<source>/data.json`、 `insights.json` (任意)、 `shapes.json` (任意)、 `public/data-v2/global/insights.json` (任意)
+- 出力形式: text report
+- 引数: 0 個で全 source、 1 個以上で指定 source 群のみ、 `--list-sources`、 `--list-sections`、 `--section <name>`
+- 主な section:
+    - `file-sizes` ・・・ data.json / insights.json / shapes.json の raw byte 数
+    - `gzip-sizes` ・・・ 同 3 ファイルの gzip 圧縮後 byte 数 (配信ペイロードの目安)
+    - `counts` ・・・ DataBundle 由来の件数 (stops / routes / agency / calendar / feedInfo / timetable / tripPatterns / translations / lookup)。 配列 → length、 オブジェクト → top-level キー数の generic ルール。 schema 変更に追従
+    - `feed-info` ・・・ FeedInfoJson のみから抽出した feed 識別情報 (publisher / lang / feedValidity)。 `pu` / `v` は summary では割愛
+    - `agencies` ・・・ AgencyV2Json 由来の事業者 identity (count / names / timezones)。 多 agency source (ntbus=5 等) は names を `, ` 結合、 timezones は重複除去
+    - `routes` ・・・ RouteV2Json 由来の route inventory。 detail sub-section (Route types / Naming / Colors / Description) + roll-up Summary 構造。 各 facet は presence count のみ (組合せ分類は analyze-gtfs-routes 担当)
+    - `stops` ・・・ StopV2Json 由来の per-stop 属性集約。 detail sub-section (Location types / Hierarchy / Accessibility / Supplementary fields / Geography) + roll-up Summary 構造。 location_type 分布・lat/lon bbox を Summary に、 parent_station coverage・`wheelchair_boarding === 1` 件数・supplementary fields (platform_code / stop_desc / stop_url の coverage) は個別 sub-section に出す。 stop_desc / stop_url は `lookup` セクション在住だが stop_id キーの per-stop 属性なので stops 側で集計する
+    - `trip-patterns` ・・・ TripPatternJson 由来の trip pattern inventory。 tripPattern は GTFS 標準ではなく Athenai 内部の抽象 (route + headsign + direction + stop 列のユニーク組合せ)。 TripPatternJson は summarize 対象の情報が少ないので単一 Summary テーブル (sub-section 化しない)。 `directionCounts` は direction_id の `0:X, 1:Y, none:Z` breakdown (ODPT 系は direction_id を持たず全て none)、 `withTripHeadsign` / `withStopHeadsign` は trip-level (`h`) / stop-level (`stops[].sh`) headsign を持つパターン数 (両者で source の headsign 慣習が分かる ── kobus 等は trip_headsign が空で stop_headsign 慣習)
+    - `i18n-coverage` ・・・ TranslationsJson 由来の多言語カバレッジ (`langs` union + 6 マップそれぞれの entry 件数)
+    - `periods` ・・・ 期間に関する情報を統合 (feedValidity / servicePeriod / exceptionRange)。 feedInfo + calendar.services + calendar.exceptions の 3 軸を 1 行で横並びにし、 「feedInfo は空でも calendar が補う」等の対応関係が見える
+    - `trip-volume` ・・・ InsightsBundle 由来の trip 量 2 値: `tripsTotal` (= 全 sg × pattern の freq 合算 = trips.txt 行数、 day-agnostic) と `tripsMax` (= 最も賑わう sg の便数 = peak day)。 sg 分布が heavy-tailed な source (vagfr 等) で median が破綻していた問題を解消した max 寄り 2 値
+    - `shapes-counts` ・・・ ShapesBundle 由来の routes / polylines / points / totalLengthKm (allocation-free Haversine 合計)
+    - `global-insights` ・・・ GlobalInsightsBundle (`global/insights.json`) の raw / gzip サイズと stopGeo entry count (per-source ではない単一行ブロック)
+- `shapes.json` / `insights.json` / `global/insights.json` が存在しない場合は対応欄を `-` で表示する (`0` は空ファイルを意味する別状態)
+- `global-insights` セクションは datasource-id 指定の有無に関わらず常時処理される (single artifact のため source 軸でフィルタする概念がない)
+- byte 表記は 1024 進数 (>=1 MiB は MB、 >=1 KiB は KB、 それ未満は B)
+- median を採るのは、 source によってはサービス日種別が多数 (年末年始臨時便等) 存在しうるため。 中央値は外れ値耐性があり、 列数を膨らませずに「典型値」を出せる
+
 ## 実行方法
 
 ```bash
@@ -95,4 +134,5 @@ npx tsx pipeline/scripts/dev/analyze-odpt-station-timetable.ts
 npx tsx pipeline/scripts/dev/analyze-v2-name-fields.ts
 npx tsx pipeline/scripts/dev/analyze-v2-insights.ts
 npx tsx pipeline/scripts/dev/analyze-v2-global-insights.ts
+npx tsx pipeline/scripts/dev/summarize-v2-outputs.ts
 ```

--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-data-summary.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-data-summary.test.ts
@@ -1,0 +1,719 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  V2_DATA_VOLUME_SECTION_NAMES,
+  V2_DATA_VOLUME_SECTIONS,
+  analyzeV2DataVolume,
+  formatBytes,
+} from '../v2-data-summary';
+import type { DataBundle } from '../../../../../src/types/data/transit-v2-json';
+
+/**
+ * Smoke tests for the DataBundle sub lib. The combined formatter
+ * lives in v2-outputs-summary, so here we exercise the analyse
+ * function, the byte formatter, and each section's render in
+ * isolation.
+ */
+
+function createDataBundle(overrides?: Partial<DataBundle>): DataBundle {
+  return {
+    bundle_version: 3,
+    kind: 'data',
+    stops: {
+      v: 2,
+      data: [
+        { v: 2, i: 'src:s1', n: 'Stop One', a: 35.0, o: 139.0, l: 0 },
+        { v: 2, i: 'src:s2', n: 'Stop Two', a: 35.1, o: 139.1, l: 0 },
+      ],
+    },
+    routes: {
+      v: 2,
+      data: [{ v: 2, i: 'src:r1', s: 'R1', l: 'Route 1', t: 3, c: '', tc: '', ai: 'src:a1' }],
+    },
+    agency: {
+      v: 2,
+      data: [{ v: 2, i: 'src:a1', n: 'Agency 1', u: 'https://example.com', tz: 'Asia/Tokyo' }],
+    },
+    calendar: {
+      v: 1,
+      data: {
+        services: [{ i: 'src:wd', d: [1, 1, 1, 1, 1, 0, 0], s: '20260101', e: '20261231' }],
+        exceptions: [{ i: 'src:wd', d: '20260101', t: 1 }],
+      },
+    },
+    feedInfo: {
+      v: 1,
+      data: {
+        pn: 'Test Publisher',
+        pu: 'https://example.com',
+        l: 'ja',
+        s: '20260101',
+        e: '20261231',
+        v: '1.0',
+      },
+    },
+    timetable: {
+      v: 2,
+      data: {
+        'src:p1': [
+          { v: 2, tp: 'src:p1', si: 0, d: { 'src:wd': [600] }, a: { 'src:wd': [600] } },
+          { v: 2, tp: 'src:p1', si: 1, d: { 'src:wd': [605] }, a: { 'src:wd': [605] } },
+        ],
+        'src:p2': [{ v: 2, tp: 'src:p2', si: 0, d: { 'src:wd': [700] }, a: { 'src:wd': [700] } }],
+      },
+    },
+    tripPatterns: {
+      v: 2,
+      data: {
+        'src:p1': { v: 2, r: 'src:r1', h: 'A', stops: [] },
+        'src:p2': { v: 2, r: 'src:r1', h: 'B', stops: [] },
+      },
+    },
+    translations: {
+      v: 1,
+      data: {
+        agency_names: { 'src:a1': { en: 'Agency 1' } },
+        route_long_names: {},
+        route_short_names: {},
+        stop_names: { 'src:s1': { en: 'Stop One' }, 'src:s2': { en: 'Stop Two' } },
+        trip_headsigns: {},
+        stop_headsigns: {},
+      },
+    },
+    lookup: {
+      v: 2,
+      data: {
+        stopUrls: { 'src:s1': 'https://example.com/s1' },
+        routeUrls: { 'src:r1': 'https://example.com/r1' },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('analyzeV2DataVolume', () => {
+  it('counts one number per DataBundle top-level section', () => {
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 1000, insights: 200, shapes: 300, total: 1500 },
+      gzipSizes: { data: 400, insights: 80, shapes: 120, total: 600 },
+    });
+    expect(stats.prefix).toBe('src');
+    expect(stats.fileSizes.total).toBe(1500);
+    expect(stats.gzipSizes.total).toBe(600);
+    // Array .data → array length:
+    expect(stats.counts.stops).toBe(2);
+    expect(stats.counts.routes).toBe(1);
+    expect(stats.counts.agency).toBe(1);
+    // Record .data → keys count:
+    expect(stats.counts.timetable).toBe(2);
+    expect(stats.counts.tripPatterns).toBe(2);
+    // Plain-object .data → top-level keys count (mechanical):
+    expect(stats.counts.calendar).toBe(2); // services + exceptions
+    expect(stats.counts.feedInfo).toBe(6); // pn / pu / l / s / e / v
+    expect(stats.counts.translations).toBe(6); // 6 translation maps
+    expect(stats.counts.lookup).toBe(2); // stopUrls + routeUrls (stopDescs omitted)
+  });
+
+  it('excludes bundle_version and kind from the counts result', () => {
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.counts).not.toHaveProperty('bundle_version');
+    expect(stats.counts).not.toHaveProperty('kind');
+  });
+
+  it('reports nested-object counts by their TOP-LEVEL keys, not inner contents', () => {
+    // Empty inner maps do NOT drop the top-level count — translations
+    // still reports 6 (the number of named maps), lookup reports 0
+    // because the lookup container itself is the empty object {}.
+    const bundle = createDataBundle({
+      translations: {
+        v: 1,
+        data: {
+          agency_names: {},
+          route_long_names: {},
+          route_short_names: {},
+          stop_names: {},
+          trip_headsigns: {},
+          stop_headsigns: {},
+        },
+      },
+      lookup: { v: 2, data: {} },
+    });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.counts.translations).toBe(6);
+    expect(stats.counts.lookup).toBe(0);
+    expect(stats.fileSizes.shapes).toBeNull();
+  });
+});
+
+describe('formatBytes', () => {
+  it('renders byte boundaries with adaptive units', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(2048)).toBe('2.0 KB');
+    expect(formatBytes(1024 * 1024)).toBe('1.00 MB');
+    expect(formatBytes(1.5 * 1024 * 1024)).toBe('1.50 MB');
+  });
+
+  it('returns a dash for null (missing file)', () => {
+    expect(formatBytes(null)).toBe('-');
+  });
+});
+
+describe('feed-info summary', () => {
+  it('extracts publisher / lang / feed validity from feedInfo only', () => {
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.feedInfo.publisher).toBe('Test Publisher');
+    expect(stats.feedInfo.lang).toBe('ja');
+    expect(stats.feedInfo.feedStart).toBe('20260101');
+    expect(stats.feedInfo.feedEnd).toBe('20261231');
+  });
+});
+
+describe('periods summary', () => {
+  it('echoes feedValidity and computes servicePeriod / exceptionRange from calendar', () => {
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.periods.feedStart).toBe('20260101');
+    expect(stats.periods.feedEnd).toBe('20261231');
+    expect(stats.periods.serviceStart).toBe('20260101');
+    expect(stats.periods.serviceEnd).toBe('20261231');
+    // fixture has 1 exception at d='20260101':
+    expect(stats.periods.exceptionStart).toBe('20260101');
+    expect(stats.periods.exceptionEnd).toBe('20260101');
+  });
+
+  it('returns null axes when corresponding sections are empty', () => {
+    const bundle = createDataBundle({
+      calendar: { v: 1, data: { services: [], exceptions: [] } },
+    });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.periods.serviceStart).toBeNull();
+    expect(stats.periods.serviceEnd).toBeNull();
+    expect(stats.periods.exceptionStart).toBeNull();
+    expect(stats.periods.exceptionEnd).toBeNull();
+    // feedValidity is still populated from feedInfo:
+    expect(stats.periods.feedStart).toBe('20260101');
+  });
+
+  it('takes min start and max end across multiple service entries', () => {
+    const bundle = createDataBundle({
+      calendar: {
+        v: 1,
+        data: {
+          services: [
+            { i: 'src:wd', d: [1, 1, 1, 1, 1, 0, 0], s: '20260301', e: '20261231' },
+            { i: 'src:sa', d: [0, 0, 0, 0, 0, 1, 0], s: '20260101', e: '20260930' },
+            { i: 'src:su', d: [0, 0, 0, 0, 0, 0, 1], s: '20260415', e: '20270101' },
+          ],
+          exceptions: [
+            { i: 'src:wd', d: '20260501', t: 2 },
+            { i: 'src:wd', d: '20271231', t: 1 },
+          ],
+        },
+      },
+    });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.periods.serviceStart).toBe('20260101');
+    expect(stats.periods.serviceEnd).toBe('20270101');
+    expect(stats.periods.exceptionStart).toBe('20260501');
+    expect(stats.periods.exceptionEnd).toBe('20271231');
+  });
+});
+
+describe('stops summary', () => {
+  it('captures count, location_type, bbox, wheelchair_boarding, and parent_station coverage', () => {
+    const bundle = createDataBundle({
+      stops: {
+        v: 2,
+        data: [
+          // Child stop with parent_station, wheelchair_boarding=1, platform_code.
+          {
+            v: 2,
+            i: 'src:s1',
+            n: 'Platform A',
+            a: 35.5,
+            o: 139.5,
+            l: 0,
+            wb: 1,
+            ps: 'src:st',
+            pc: '1',
+          },
+          // Child stop with parent_station, wheelchair_boarding=2 (not accessible).
+          { v: 2, i: 'src:s2', n: 'Platform B', a: 35.6, o: 139.6, l: 0, wb: 2, ps: 'src:st' },
+          // Standalone stop without parent_station.
+          { v: 2, i: 'src:s3', n: 'Stop C', a: 35.55, o: 139.55, l: 0 },
+          // Station (parent itself).
+          { v: 2, i: 'src:st', n: 'Station', a: 35.55, o: 139.55, l: 1 },
+        ],
+      },
+      lookup: {
+        v: 2,
+        data: {
+          stopUrls: { 'src:s1': 'https://example.com/s1', 'src:s2': 'https://example.com/s2' },
+          stopDescs: { 'src:s1': 'Near the railway transfer' },
+        },
+      },
+    });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.stops.count).toBe(4);
+    expect(stats.stops.locationTypeCounts).toEqual({ '0': 3, '1': 1 });
+    expect(stats.stops.bbox).toEqual({
+      latMin: 35.5,
+      latMax: 35.6,
+      lonMin: 139.5,
+      lonMax: 139.6,
+    });
+    // Only s1 has wheelchair_boarding=1; s2 (wb=2) and the rest are excluded.
+    expect(stats.stops.wheelchairAccessibleCount).toBe(1);
+    // s1 and s2 reference a parent_station; s3 and the station itself do not.
+    expect(stats.stops.withParentCount).toBe(2);
+    // Only s1 carries platform_code.
+    expect(stats.stops.withPlatformCodeCount).toBe(1);
+    // stop_desc / stop_url counts come from the lookup section entries.
+    expect(stats.stops.withStopDescCount).toBe(1);
+    expect(stats.stops.withStopUrlCount).toBe(2);
+  });
+
+  it('returns null bbox and zero counts for an empty stops array', () => {
+    const bundle = createDataBundle({
+      stops: { v: 2, data: [] },
+      // Empty lookup so the supplementary-field counts are also zero.
+      lookup: { v: 2, data: {} },
+    });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.stops.count).toBe(0);
+    expect(stats.stops.locationTypeCounts).toEqual({});
+    expect(stats.stops.bbox).toBeNull();
+    expect(stats.stops.wheelchairAccessibleCount).toBe(0);
+    expect(stats.stops.withParentCount).toBe(0);
+    expect(stats.stops.withPlatformCodeCount).toBe(0);
+    expect(stats.stops.withStopDescCount).toBe(0);
+    expect(stats.stops.withStopUrlCount).toBe(0);
+  });
+
+  it('renders sub-sections (Location types / Hierarchy / Accessibility / Geography) plus Summary', () => {
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    const body = V2_DATA_VOLUME_SECTIONS.stops.render([stats]);
+    expect(body).toContain('### Summary');
+    expect(body).toContain('### Location types');
+    expect(body).toContain('### Hierarchy');
+    expect(body).toContain('### Accessibility');
+    expect(body).toContain('### Supplementary fields');
+    expect(body).toContain('### Geography');
+    expect(body).toContain('locationTypes');
+    expect(body).toContain('latRange');
+    expect(body).toContain('wheelchairAccessible');
+    expect(body).toContain('withParent');
+    expect(body).toContain('withPlatformCode');
+    expect(body).toContain('withStopDesc');
+    expect(body).toContain('withStopUrl');
+  });
+});
+
+describe('routes summary', () => {
+  it('captures count, route_type distribution, and per-facet coverage', () => {
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    // Fixture has 1 route: t=3 (bus), s='R1', l='Route 1', c='', tc='', no desc.
+    expect(stats.routes.count).toBe(1);
+    expect(stats.routes.typeCounts).toEqual({ '3': 1 });
+    expect(stats.routes.withShortName).toBe(1);
+    expect(stats.routes.withLongName).toBe(1);
+    expect(stats.routes.withColor).toBe(0);
+    expect(stats.routes.withTextColor).toBe(0);
+    expect(stats.routes.withDesc).toBe(0);
+  });
+
+  it('counts mixed route_type values and each facet independently', () => {
+    const bundle = createDataBundle({
+      routes: {
+        v: 2,
+        data: [
+          // short + long + color + textColor + desc
+          {
+            v: 2,
+            i: 'src:r1',
+            s: 'R1',
+            l: 'Route 1',
+            t: 3,
+            c: 'FF0000',
+            tc: '000000',
+            ai: 'src:a1',
+            desc: 'first route',
+          },
+          // short only, no color
+          { v: 2, i: 'src:r2', s: 'R2', l: '', t: 3, c: '', tc: '', ai: 'src:a1' },
+          // long only, color only (no text color)
+          {
+            v: 2,
+            i: 'src:r3',
+            s: '',
+            l: 'Route 3',
+            t: 2,
+            c: '00FF00',
+            tc: '',
+            ai: 'src:a1',
+          },
+          // short + long, color + textColor
+          {
+            v: 2,
+            i: 'src:r4',
+            s: 'R4',
+            l: 'Route 4',
+            t: 1,
+            c: '0000FF',
+            tc: 'FFFFFF',
+            ai: 'src:a1',
+          },
+        ],
+      },
+    });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.routes.count).toBe(4);
+    expect(stats.routes.typeCounts).toEqual({ '1': 1, '2': 1, '3': 2 });
+    // r1, r2, r4 have non-empty s → 3
+    expect(stats.routes.withShortName).toBe(3);
+    // r1, r3, r4 have non-empty l → 3
+    expect(stats.routes.withLongName).toBe(3);
+    // r1, r3, r4 have non-empty c → 3
+    expect(stats.routes.withColor).toBe(3);
+    // r1, r4 have non-empty tc → 2
+    expect(stats.routes.withTextColor).toBe(2);
+    // only r1 has desc → 1
+    expect(stats.routes.withDesc).toBe(1);
+  });
+
+  it('returns zeros when the routes array is empty', () => {
+    const bundle = createDataBundle({ routes: { v: 2, data: [] } });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.routes.count).toBe(0);
+    expect(stats.routes.typeCounts).toEqual({});
+    expect(stats.routes.withShortName).toBe(0);
+    expect(stats.routes.withLongName).toBe(0);
+    expect(stats.routes.withColor).toBe(0);
+    expect(stats.routes.withTextColor).toBe(0);
+    expect(stats.routes.withDesc).toBe(0);
+  });
+
+  it('renders sub-sections (Route types / Naming / Colors / Description) plus Summary', () => {
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    const body = V2_DATA_VOLUME_SECTIONS.routes.render([stats]);
+    expect(body).toContain('### Route types');
+    expect(body).toContain('### Naming');
+    expect(body).toContain('### Colors');
+    expect(body).toContain('### Description');
+    expect(body).toContain('### Summary');
+    expect(body).toContain('withShortName');
+    expect(body).toContain('withTextColor');
+    expect(body).toContain('withDesc');
+  });
+});
+
+describe('trip patterns summary', () => {
+  it('captures count, direction_id split, and trip/stop headsign coverage', () => {
+    const bundle = createDataBundle({
+      tripPatterns: {
+        v: 2,
+        data: {
+          // direction_id=0, trip headsign + stop headsign on a stop.
+          'src:p1': {
+            v: 2,
+            r: 'src:r1',
+            h: 'Downtown',
+            dir: 0,
+            stops: [{ id: 'src:s1', sh: 'Downtown via Center' }],
+          },
+          // direction_id=1, trip headsign only (no stop_headsign).
+          'src:p2': { v: 2, r: 'src:r1', h: 'Uptown', dir: 1, stops: [{ id: 'src:s2' }] },
+          // direction_id omitted, trip headsign + a mix of sh / no-sh stops.
+          'src:p3': {
+            v: 2,
+            r: 'src:r1',
+            h: 'Loop',
+            stops: [{ id: 'src:s1' }, { id: 'src:s2', sh: 'Loop branch' }],
+          },
+          // direction_id omitted, empty trip headsign, stop_headsign only
+          // (the keio-bus convention).
+          'src:p4': {
+            v: 2,
+            r: 'src:r1',
+            h: '',
+            stops: [{ id: 'src:s1', sh: 'Terminal' }],
+          },
+        },
+      },
+    });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.tripPatterns.count).toBe(4);
+    expect(stats.tripPatterns.direction0Count).toBe(1);
+    expect(stats.tripPatterns.direction1Count).toBe(1);
+    // p3 and p4 omit direction_id.
+    expect(stats.tripPatterns.directionNoneCount).toBe(2);
+    // p1-p3 have a non-empty trip headsign; p4 is empty.
+    expect(stats.tripPatterns.withTripHeadsignCount).toBe(3);
+    // p1, p3, p4 have at least one stop carrying sh; p2 has none.
+    expect(stats.tripPatterns.withStopHeadsignCount).toBe(3);
+  });
+
+  it('returns zero counts for an empty tripPatterns record', () => {
+    const bundle = createDataBundle({ tripPatterns: { v: 2, data: {} } });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.tripPatterns.count).toBe(0);
+    expect(stats.tripPatterns.direction0Count).toBe(0);
+    expect(stats.tripPatterns.direction1Count).toBe(0);
+    expect(stats.tripPatterns.directionNoneCount).toBe(0);
+    expect(stats.tripPatterns.withTripHeadsignCount).toBe(0);
+    expect(stats.tripPatterns.withStopHeadsignCount).toBe(0);
+  });
+
+  it('renders a single Summary table with every facet column', () => {
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    const body = V2_DATA_VOLUME_SECTIONS['trip-patterns'].render([stats]);
+    expect(body).toContain('### Summary');
+    expect(body).toContain('directionCounts');
+    expect(body).toContain('withTripHeadsign');
+    expect(body).toContain('withStopHeadsign');
+    // directionCounts breakdown string keeps all three keys.
+    expect(body).toContain('none:');
+    // Flat section — no detail sub-sections.
+    expect(body).not.toContain('### Direction');
+    expect(body).not.toContain('### Headsign');
+  });
+});
+
+describe('i18n-coverage summary', () => {
+  it('counts entries per TranslationsJson map and collects language union', () => {
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    // Fixture provides agency_names (1 entry) and stop_names (2 entries), all 'en':
+    expect(stats.i18nCoverage.languages).toEqual(['en']);
+    expect(stats.i18nCoverage.agencyNames).toBe(1);
+    expect(stats.i18nCoverage.routeLongNames).toBe(0);
+    expect(stats.i18nCoverage.routeShortNames).toBe(0);
+    expect(stats.i18nCoverage.stopNames).toBe(2);
+    expect(stats.i18nCoverage.tripHeadsigns).toBe(0);
+    expect(stats.i18nCoverage.stopHeadsigns).toBe(0);
+  });
+
+  it('unions multiple languages across maps and sorts the result', () => {
+    const bundle = createDataBundle({
+      translations: {
+        v: 1,
+        data: {
+          agency_names: { 'src:a1': { ja: 'A1', en: 'A1' } },
+          route_long_names: {},
+          route_short_names: {},
+          stop_names: { 'src:s1': { 'zh-Hans': 'S1', en: 'S1' } },
+          trip_headsigns: {},
+          stop_headsigns: {},
+        },
+      },
+    });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.i18nCoverage.languages).toEqual(['en', 'ja', 'zh-Hans']);
+  });
+
+  it('produces an empty array when no translations are present', () => {
+    const bundle = createDataBundle({
+      translations: {
+        v: 1,
+        data: {
+          agency_names: {},
+          route_long_names: {},
+          route_short_names: {},
+          stop_names: {},
+          trip_headsigns: {},
+          stop_headsigns: {},
+        },
+      },
+    });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.i18nCoverage.languages).toEqual([]);
+    expect(stats.i18nCoverage.agencyNames).toBe(0);
+  });
+});
+
+describe('agencies summary', () => {
+  it('extracts count / names / timezones from agency.data', () => {
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.agencies.count).toBe(1);
+    expect(stats.agencies.names).toBe('Agency 1');
+    expect(stats.agencies.timezones).toBe('Asia/Tokyo');
+  });
+
+  it('joins multiple agency names and dedupes timezones', () => {
+    const bundle = createDataBundle({
+      agency: {
+        v: 2,
+        data: [
+          { v: 2, i: 'src:a1', n: 'Agency A', u: 'https://a.example.com', tz: 'Asia/Tokyo' },
+          { v: 2, i: 'src:a2', n: 'Agency B', u: 'https://b.example.com', tz: 'Asia/Tokyo' },
+          { v: 2, i: 'src:a3', n: 'Agency C', u: 'https://c.example.com', tz: 'Europe/Berlin' },
+        ],
+      },
+    });
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: bundle,
+      fileSizes: { data: 100, insights: 0, shapes: null, total: 100 },
+      gzipSizes: { data: 50, insights: 0, shapes: null, total: 50 },
+    });
+    expect(stats.agencies.count).toBe(3);
+    expect(stats.agencies.names).toBe('Agency A, Agency B, Agency C');
+    // Asia/Tokyo dedupes to one entry; Europe/Berlin appears once:
+    expect(stats.agencies.timezones).toBe('Asia/Tokyo, Europe/Berlin');
+  });
+});
+
+describe('V2_DATA_VOLUME_SECTIONS', () => {
+  it('orders sections by meta → single → composite', () => {
+    expect(V2_DATA_VOLUME_SECTION_NAMES).toEqual([
+      'file-sizes',
+      'gzip-sizes',
+      'counts',
+      'feed-info',
+      'agencies',
+      'routes',
+      'stops',
+      'trip-patterns',
+      'i18n-coverage',
+      'periods',
+    ]);
+  });
+
+  it("each section's render returns a string with a totals row", () => {
+    const stats = analyzeV2DataVolume({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 1500, insights: 300, shapes: 200, total: 2000 },
+      gzipSizes: { data: 700, insights: 120, shapes: 80, total: 900 },
+    });
+    for (const name of V2_DATA_VOLUME_SECTION_NAMES) {
+      const body = V2_DATA_VOLUME_SECTIONS[name].render([stats]);
+      expect(body).toContain('totals');
+    }
+  });
+});

--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-data-summary.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-data-summary.test.ts
@@ -716,4 +716,26 @@ describe('V2_DATA_VOLUME_SECTIONS', () => {
       expect(body).toContain('totals');
     }
   });
+
+  it('file-sizes treats a missing insights.json as null without breaking the totals row', () => {
+    const missing = analyzeV2DataVolume({
+      prefix: 'miss',
+      nameEn: 'Missing Insights',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 1000, insights: null, shapes: null, total: 1000 },
+      gzipSizes: { data: 400, insights: null, shapes: null, total: 400 },
+    });
+    const present = analyzeV2DataVolume({
+      prefix: 'pres',
+      nameEn: 'Present Insights',
+      dataBundle: createDataBundle(),
+      fileSizes: { data: 1000, insights: 500, shapes: null, total: 1500 },
+      gzipSizes: { data: 400, insights: 200, shapes: null, total: 600 },
+    });
+    const body = V2_DATA_VOLUME_SECTIONS['file-sizes'].render([missing, present]);
+    expect(body).toContain('Missing Insights');
+    // Nullable insights sizes sum cleanly in the totals row: only the
+    // present source's 500 B counts (the missing one contributes 0).
+    expect(body).toContain('500 B');
+  });
 });

--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-global-insights-summary.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-global-insights-summary.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  V2_GLOBAL_INSIGHTS_SUMMARY_SECTION_NAMES,
+  V2_GLOBAL_INSIGHTS_SUMMARY_SECTIONS,
+  analyzeV2GlobalInsightsSummary,
+} from '../v2-global-insights-summary';
+import type { GlobalInsightsBundle } from '../../../../../src/types/data/transit-v2-json';
+
+/**
+ * Smoke tests for the GlobalInsightsBundle sub lib.
+ */
+
+function createGlobalBundle(): GlobalInsightsBundle {
+  return {
+    bundle_version: 3,
+    kind: 'global-insights',
+    stopGeo: {
+      v: 1,
+      data: {
+        // 3 stops: s1 has wp + cn, s2 has wp only, s3 has neither.
+        'src:s1': { nr: 0.5, wp: 0.2, cn: { ho: { rc: 3, freq: 200, sc: 5 } } },
+        'src:s2': { nr: 1.2, wp: 0.4 },
+        'src:s3': { nr: 0 },
+      },
+    },
+  };
+}
+
+describe('analyzeV2GlobalInsightsSummary', () => {
+  it('counts stopGeo entries plus wp / cn coverage when the bundle is present', () => {
+    const summary = analyzeV2GlobalInsightsSummary({
+      bundle: createGlobalBundle(),
+      fileSize: 5000,
+      gzipSize: 1200,
+    });
+    expect(summary.fileSize).toBe(5000);
+    expect(summary.gzipSize).toBe(1200);
+    expect(summary.stopGeoEntries).toBe(3);
+    // s1 and s2 have wp; s3 does not.
+    expect(summary.stopsWithWp).toBe(2);
+    // Only s1 has cn[ho].
+    expect(summary.stopsWithCnByGroup).toEqual({ ho: 1 });
+  });
+
+  it('returns null entries and empty coverage when the bundle is missing', () => {
+    const summary = analyzeV2GlobalInsightsSummary({
+      bundle: null,
+      fileSize: null,
+      gzipSize: null,
+    });
+    expect(summary.fileSize).toBeNull();
+    expect(summary.gzipSize).toBeNull();
+    expect(summary.stopGeoEntries).toBeNull();
+    expect(summary.stopsWithWp).toBeNull();
+    expect(summary.stopsWithCnByGroup).toEqual({});
+  });
+
+  it('returns null stopGeoEntries when bundle exists but stopGeo section is omitted', () => {
+    const summary = analyzeV2GlobalInsightsSummary({
+      bundle: { bundle_version: 3, kind: 'global-insights' },
+      fileSize: 200,
+      gzipSize: 80,
+    });
+    expect(summary.fileSize).toBe(200);
+    expect(summary.stopGeoEntries).toBeNull();
+    expect(summary.stopsWithWp).toBeNull();
+    expect(summary.stopsWithCnByGroup).toEqual({});
+  });
+});
+
+describe('V2_GLOBAL_INSIGHTS_SUMMARY_SECTIONS', () => {
+  it('exposes global-insights-counts and global-insights in a stable order', () => {
+    expect(V2_GLOBAL_INSIGHTS_SUMMARY_SECTION_NAMES).toEqual([
+      'global-insights-counts',
+      'global-insights',
+    ]);
+  });
+
+  it("the section's render reports 'not found' when bundle is absent", () => {
+    const summary = analyzeV2GlobalInsightsSummary({
+      bundle: null,
+      fileSize: null,
+      gzipSize: null,
+    });
+    const body = V2_GLOBAL_INSIGHTS_SUMMARY_SECTIONS['global-insights'].render(summary);
+    expect(body).toContain('not found');
+    expect(body).toContain('-');
+  });
+
+  it("the section's render reports wp and cn[group] coverage with percentages", () => {
+    const summary = analyzeV2GlobalInsightsSummary({
+      bundle: createGlobalBundle(),
+      fileSize: 5000,
+      gzipSize: 1200,
+    });
+    const body = V2_GLOBAL_INSIGHTS_SUMMARY_SECTIONS['global-insights'].render(summary);
+    expect(body).toContain('found');
+    // 2 of 3 stops carry wp → 66.7%.
+    expect(body).toContain('stops with wp:        2 (66.7%)');
+    // 1 of 3 stops has cn[ho] → 33.3%.
+    expect(body).toContain('stops with cn[ho]:  1 (33.3%)');
+  });
+});

--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-global-insights-summary.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-global-insights-summary.test.ts
@@ -41,6 +41,8 @@ describe('analyzeV2GlobalInsightsSummary', () => {
     expect(summary.stopsWithWp).toBe(2);
     // Only s1 has cn[ho].
     expect(summary.stopsWithCnByGroup).toEqual({ ho: 1 });
+    // counts reflects the present stopGeo section (3 entries).
+    expect(summary.counts).toEqual({ stopGeo: 3 });
   });
 
   it('returns null entries and empty coverage when the bundle is missing', () => {
@@ -54,6 +56,9 @@ describe('analyzeV2GlobalInsightsSummary', () => {
     expect(summary.stopGeoEntries).toBeNull();
     expect(summary.stopsWithWp).toBeNull();
     expect(summary.stopsWithCnByGroup).toEqual({});
+    // A missing bundle yields an empty count set — not { stopGeo: 0 },
+    // which would be indistinguishable from a present-but-empty bundle.
+    expect(summary.counts).toEqual({});
   });
 
   it('returns null stopGeoEntries when bundle exists but stopGeo section is omitted', () => {
@@ -86,6 +91,19 @@ describe('V2_GLOBAL_INSIGHTS_SUMMARY_SECTIONS', () => {
     const body = V2_GLOBAL_INSIGHTS_SUMMARY_SECTIONS['global-insights'].render(summary);
     expect(body).toContain('not found');
     expect(body).toContain('-');
+  });
+
+  it('global-insights-counts reports sections=0 when the bundle is absent', () => {
+    const summary = analyzeV2GlobalInsightsSummary({
+      bundle: null,
+      fileSize: null,
+      gzipSize: null,
+    });
+    const body = V2_GLOBAL_INSIGHTS_SUMMARY_SECTIONS['global-insights-counts'].render(summary);
+    // Empty count set → sections=0, with no `stopGeo: 0` line that
+    // would otherwise look like a present-but-empty bundle.
+    expect(body).toContain('sections=0');
+    expect(body).not.toContain('stopGeo');
   });
 
   it("the section's render reports wp and cn[group] coverage with percentages", () => {

--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-insights-summary.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-insights-summary.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  V2_INSIGHTS_SUMMARY_SECTION_NAMES,
+  V2_INSIGHTS_SUMMARY_SECTIONS,
+  analyzeV2InsightsSummary,
+  computeTripCountsPerServiceGroup,
+} from '../v2-insights-summary';
+import type { InsightsBundle } from '../../../../../src/types/data/transit-v2-json';
+
+/**
+ * Smoke tests for the InsightsBundle sub lib. Asserts the two
+ * max-leaning indicators (`tripsTotal`, `tripsMax`) on a couple of
+ * representative distributions plus the missing-insights branch.
+ */
+
+function createInsightsBundle(overrides?: Partial<InsightsBundle>): InsightsBundle {
+  return {
+    bundle_version: 3,
+    kind: 'insights',
+    serviceGroups: {
+      v: 1,
+      data: [
+        { key: 'wd', serviceIds: ['svc:weekday'] },
+        { key: 'sa', serviceIds: ['svc:saturday'] },
+        { key: 'su', serviceIds: ['svc:sunday'] },
+      ],
+    },
+    tripPatternStats: {
+      v: 1,
+      data: {
+        wd: {
+          'src:p1': { freq: 100, rd: [30, 15, 0] },
+          'src:p2': { freq: 80, rd: [45, 20, 0] },
+        },
+        sa: { 'src:p1': { freq: 60, rd: [30, 15, 0] } },
+        su: { 'src:p1': { freq: 40, rd: [30, 15, 0] } },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('computeTripCountsPerServiceGroup', () => {
+  it('returns one total per service group, summed across patterns', () => {
+    const result = computeTripCountsPerServiceGroup(createInsightsBundle());
+    expect(result.sort((a, b) => a - b)).toEqual([40, 60, 180]);
+  });
+
+  it('returns empty array when tripPatternStats is missing', () => {
+    expect(
+      computeTripCountsPerServiceGroup(createInsightsBundle({ tripPatternStats: undefined })),
+    ).toEqual([]);
+  });
+
+  it('returns empty array when insights is null', () => {
+    expect(computeTripCountsPerServiceGroup(null)).toEqual([]);
+  });
+});
+
+describe('analyzeV2InsightsSummary', () => {
+  it('computes tripsTotal as the grand sum and tripsMax as the busiest sg', () => {
+    const result = analyzeV2InsightsSummary({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      insights: createInsightsBundle(),
+    });
+    // per-sg totals: wd=180, sa=60, su=40
+    expect(result.tripVolume.tripsTotal).toBe(280);
+    expect(result.tripVolume.tripsMax).toBe(180);
+    expect(result.tripVolume.serviceGroupCount).toBe(3);
+  });
+
+  it('returns nulls when tripPatternStats is missing', () => {
+    const result = analyzeV2InsightsSummary({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      insights: createInsightsBundle({ tripPatternStats: undefined }),
+    });
+    expect(result.tripVolume.tripsTotal).toBeNull();
+    expect(result.tripVolume.tripsMax).toBeNull();
+    expect(result.tripVolume.serviceGroupCount).toBe(0);
+  });
+
+  it('returns nulls when insights is null', () => {
+    const result = analyzeV2InsightsSummary({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      insights: null,
+    });
+    expect(result.tripVolume.tripsTotal).toBeNull();
+    expect(result.tripVolume.tripsMax).toBeNull();
+  });
+
+  it('survives a heavy-tailed sg distribution where median would mislead', () => {
+    // Simulate vagfr-style: many tiny sg + few large sg. Median across
+    // sg sums would collapse toward the tail; tripsMax surfaces the
+    // actual peak day, tripsTotal aggregates the whole feed.
+    const result = analyzeV2InsightsSummary({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      insights: createInsightsBundle({
+        tripPatternStats: {
+          v: 1,
+          data: {
+            wd: { 'src:p1': { freq: 5000, rd: [10, 0] } },
+            sa: { 'src:p1': { freq: 4000, rd: [10, 0] } },
+            su: { 'src:p1': { freq: 3000, rd: [10, 0] } },
+            sp1: { 'src:p1': { freq: 5, rd: [10, 0] } },
+            sp2: { 'src:p1': { freq: 3, rd: [10, 0] } },
+            sp3: { 'src:p1': { freq: 1, rd: [10, 0] } },
+          },
+        },
+      }),
+    });
+    expect(result.tripVolume.tripsTotal).toBe(5000 + 4000 + 3000 + 5 + 3 + 1);
+    expect(result.tripVolume.tripsMax).toBe(5000);
+    expect(result.tripVolume.serviceGroupCount).toBe(6);
+  });
+
+  it('handles single-sg sources by setting both indicators to the same value', () => {
+    const result = analyzeV2InsightsSummary({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      insights: createInsightsBundle({
+        tripPatternStats: {
+          v: 1,
+          data: { d1000111: { 'src:p1': { freq: 12, rd: [10, 0] } } },
+        },
+      }),
+    });
+    expect(result.tripVolume.tripsTotal).toBe(12);
+    expect(result.tripVolume.tripsMax).toBe(12);
+    expect(result.tripVolume.serviceGroupCount).toBe(1);
+  });
+});
+
+describe('V2_INSIGHTS_SUMMARY_SECTIONS', () => {
+  it('exposes insights-counts and trip-volume in a stable order', () => {
+    expect(V2_INSIGHTS_SUMMARY_SECTION_NAMES).toEqual(['insights-counts', 'trip-volume']);
+  });
+
+  it("the section's render returns a string with a totals row", () => {
+    const result = analyzeV2InsightsSummary({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      insights: createInsightsBundle(),
+    });
+    const body = V2_INSIGHTS_SUMMARY_SECTIONS['trip-volume'].render([result]);
+    expect(body).toContain('Src Transit');
+    expect(body).toContain('totals');
+  });
+});

--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-insights-summary.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-insights-summary.test.ts
@@ -69,6 +69,7 @@ describe('analyzeV2InsightsSummary', () => {
     expect(result.tripVolume.tripsTotal).toBe(280);
     expect(result.tripVolume.tripsMax).toBe(180);
     expect(result.tripVolume.serviceGroupCount).toBe(3);
+    expect(result.bundlePresent).toBe(true);
   });
 
   it('returns nulls when tripPatternStats is missing', () => {
@@ -79,7 +80,12 @@ describe('analyzeV2InsightsSummary', () => {
     });
     expect(result.tripVolume.tripsTotal).toBeNull();
     expect(result.tripVolume.tripsMax).toBeNull();
-    expect(result.tripVolume.serviceGroupCount).toBe(0);
+    // serviceGroupCount comes from the required `serviceGroups`
+    // section, so it stays accurate even when the optional
+    // `tripPatternStats` section is absent. bundlePresent is still
+    // true — the bundle exists, it just carries no trip stats.
+    expect(result.tripVolume.serviceGroupCount).toBe(3);
+    expect(result.bundlePresent).toBe(true);
   });
 
   it('returns nulls when insights is null', () => {
@@ -90,16 +96,31 @@ describe('analyzeV2InsightsSummary', () => {
     });
     expect(result.tripVolume.tripsTotal).toBeNull();
     expect(result.tripVolume.tripsMax).toBeNull();
+    expect(result.tripVolume.serviceGroupCount).toBe(0);
+    expect(result.bundlePresent).toBe(false);
   });
 
   it('survives a heavy-tailed sg distribution where median would mislead', () => {
     // Simulate vagfr-style: many tiny sg + few large sg. Median across
     // sg sums would collapse toward the tail; tripsMax surfaces the
     // actual peak day, tripsTotal aggregates the whole feed.
+    // serviceGroups must enumerate every group keyed in
+    // tripPatternStats — a valid InsightsBundle keeps the two in sync.
     const result = analyzeV2InsightsSummary({
       prefix: 'src',
       nameEn: 'Src Transit',
       insights: createInsightsBundle({
+        serviceGroups: {
+          v: 1,
+          data: [
+            { key: 'wd', serviceIds: ['svc:wd'] },
+            { key: 'sa', serviceIds: ['svc:sa'] },
+            { key: 'su', serviceIds: ['svc:su'] },
+            { key: 'sp1', serviceIds: ['svc:sp1'] },
+            { key: 'sp2', serviceIds: ['svc:sp2'] },
+            { key: 'sp3', serviceIds: ['svc:sp3'] },
+          ],
+        },
         tripPatternStats: {
           v: 1,
           data: {
@@ -123,6 +144,10 @@ describe('analyzeV2InsightsSummary', () => {
       prefix: 'src',
       nameEn: 'Src Transit',
       insights: createInsightsBundle({
+        serviceGroups: {
+          v: 1,
+          data: [{ key: 'd1000111', serviceIds: ['svc:d1000111'] }],
+        },
         tripPatternStats: {
           v: 1,
           data: { d1000111: { 'src:p1': { freq: 12, rd: [10, 0] } } },

--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-outputs-summary.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-outputs-summary.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  V2_OUTPUTS_SECTION_DESCRIPTIONS,
+  V2_OUTPUTS_SECTION_NAMES,
+  analyzeV2GlobalSummary,
+  analyzeV2Outputs,
+  formatV2OutputsAnalysis,
+  type V2OutputsRow,
+} from '../v2-outputs-summary';
+import type {
+  DataBundle,
+  GlobalInsightsBundle,
+  InsightsBundle,
+  ShapesBundle,
+} from '../../../../../src/types/data/transit-v2-json';
+import type { GlobalInsightsBundleSummary } from '../v2-global-insights-summary';
+
+/**
+ * Smoke tests for the main lib. Coordinates four sub libs (data /
+ * insights / shapes / global-insights), so the focus here is
+ * section composition, dispatch correctness, and combined Overall
+ * summary — not the underlying analysis logic (which is covered in
+ * each sub lib's test file).
+ */
+
+function createDataBundle(overrides?: Partial<DataBundle>): DataBundle {
+  return {
+    bundle_version: 3,
+    kind: 'data',
+    stops: {
+      v: 2,
+      data: [{ v: 2, i: 'src:s1', n: 'Stop One', a: 35.0, o: 139.0, l: 0 }],
+    },
+    routes: {
+      v: 2,
+      data: [{ v: 2, i: 'src:r1', s: 'R1', l: 'Route 1', t: 3, c: '', tc: '', ai: 'src:a1' }],
+    },
+    agency: {
+      v: 2,
+      data: [{ v: 2, i: 'src:a1', n: 'Agency 1', u: 'https://example.com', tz: 'Asia/Tokyo' }],
+    },
+    calendar: { v: 1, data: { services: [], exceptions: [] } },
+    feedInfo: {
+      v: 1,
+      data: { pn: '', pu: '', l: 'ja', s: '20260101', e: '20261231', v: '1.0' },
+    },
+    timetable: { v: 2, data: {} },
+    tripPatterns: { v: 2, data: {} },
+    translations: {
+      v: 1,
+      data: {
+        agency_names: {},
+        route_long_names: {},
+        route_short_names: {},
+        stop_names: {},
+        trip_headsigns: {},
+        stop_headsigns: {},
+      },
+    },
+    lookup: { v: 2, data: {} },
+    ...overrides,
+  };
+}
+
+function createInsightsBundle(): InsightsBundle {
+  return {
+    bundle_version: 3,
+    kind: 'insights',
+    serviceGroups: {
+      v: 1,
+      data: [
+        { key: 'wd', serviceIds: ['svc:wd'] },
+        { key: 'sa', serviceIds: ['svc:sa'] },
+        { key: 'su', serviceIds: ['svc:su'] },
+      ],
+    },
+    tripPatternStats: {
+      v: 1,
+      data: {
+        wd: { 'src:p1': { freq: 100, rd: [10, 0] } },
+        sa: { 'src:p1': { freq: 60, rd: [10, 0] } },
+        su: { 'src:p1': { freq: 40, rd: [10, 0] } },
+      },
+    },
+  };
+}
+
+function createShapesBundle(): ShapesBundle {
+  return {
+    bundle_version: 3,
+    kind: 'shapes',
+    shapes: {
+      v: 2,
+      data: {
+        'src:r1': [
+          [
+            [35.0, 139.0],
+            [35.1, 139.1],
+          ],
+        ],
+      },
+    },
+  };
+}
+
+function createGlobalBundle(): GlobalInsightsBundle {
+  return {
+    bundle_version: 3,
+    kind: 'global-insights',
+    stopGeo: {
+      v: 1,
+      data: {
+        'src:s1': { nr: 0.5 },
+        'src:s2': { nr: 1.2 },
+      },
+    },
+  };
+}
+
+function makeRow(
+  prefix: string,
+  nameEn: string,
+  dataSize: number,
+  insights: InsightsBundle | null,
+  shapesBundle: ShapesBundle | null = null,
+): V2OutputsRow {
+  return analyzeV2Outputs({
+    prefix,
+    nameEn,
+    dataBundle: createDataBundle(),
+    insights,
+    shapesBundle,
+    fileSizes: { data: dataSize, insights: 200, shapes: null, total: dataSize + 200 },
+    gzipSizes: {
+      data: Math.floor(dataSize / 4),
+      insights: 60,
+      shapes: null,
+      total: Math.floor(dataSize / 4) + 60,
+    },
+  });
+}
+
+function emptyGlobal(): GlobalInsightsBundleSummary {
+  return analyzeV2GlobalSummary({ bundle: null, fileSize: null, gzipSize: null });
+}
+
+describe('analyzeV2Outputs', () => {
+  it('produces a combined row with every per-source sub lib filled', () => {
+    const row = makeRow('src', 'Src Transit', 1000, createInsightsBundle(), createShapesBundle());
+    expect(row.prefix).toBe('src');
+    expect(row.data.counts.stops).toBe(1);
+    // Fixture: wd=100, sa=60, su=40 → total=200, max=100
+    expect(row.insights.tripVolume.tripsTotal).toBe(200);
+    expect(row.insights.tripVolume.tripsMax).toBe(100);
+    expect(row.insights.tripVolume.serviceGroupCount).toBe(3);
+    expect(row.shapes.shapes.routes).toBe(1);
+    expect(row.shapes.shapes.polylines).toBe(1);
+    expect(row.shapes.shapes.points).toBe(2);
+  });
+
+  it('marks insights and shapes as null when their bundles are absent', () => {
+    const row = makeRow('src', 'Src Transit', 1000, null, null);
+    expect(row.insights.tripVolume.tripsTotal).toBeNull();
+    expect(row.insights.tripVolume.tripsMax).toBeNull();
+    expect(row.shapes.shapes.routes).toBeNull();
+  });
+});
+
+describe('analyzeV2GlobalSummary', () => {
+  it('computes stopGeo entry count from the bundle', () => {
+    const summary = analyzeV2GlobalSummary({
+      bundle: createGlobalBundle(),
+      fileSize: 12345,
+      gzipSize: 4321,
+    });
+    expect(summary.fileSize).toBe(12345);
+    expect(summary.gzipSize).toBe(4321);
+    expect(summary.stopGeoEntries).toBe(2);
+  });
+
+  it('returns null entries when the bundle is missing', () => {
+    const summary = analyzeV2GlobalSummary({
+      bundle: null,
+      fileSize: null,
+      gzipSize: null,
+    });
+    expect(summary.fileSize).toBeNull();
+    expect(summary.gzipSize).toBeNull();
+    expect(summary.stopGeoEntries).toBeNull();
+  });
+});
+
+describe('formatV2OutputsAnalysis', () => {
+  it('returns the no-data sentinel when both rows and global are empty', () => {
+    expect(formatV2OutputsAnalysis([], emptyGlobal())).toBe('No v2 outputs found.');
+  });
+
+  it('emits header, Overall summary, and every default section (including global)', () => {
+    const rows = [
+      makeRow('a', 'Source A', 2_000_000, createInsightsBundle(), createShapesBundle()),
+      makeRow('b', 'Source B', 500_000, null, null),
+    ];
+    const global = analyzeV2GlobalSummary({
+      bundle: createGlobalBundle(),
+      fileSize: 9999,
+      gzipSize: 1234,
+    });
+    const output = formatV2OutputsAnalysis(rows, global, {
+      analyzedAt: new Date('2026-01-01T00:00:00Z'),
+    });
+    expect(output).toContain('# Athenai Transit — V2 outputs summary');
+    expect(output).toContain('## Overall summary');
+    expect(output).toContain('sources=2, sourcesWithInsights=1, sourcesWithShapes=1');
+    expect(output).toContain('## File sizes (raw)');
+    expect(output).toContain('## File sizes (gzip)');
+    expect(output).toContain('## DataBundle counts (data.json)');
+    expect(output).toContain('## InsightsBundle trip volume (insights.json)');
+    expect(output).toContain('## ShapesBundle counts (shapes.json)');
+    expect(output).toContain('## GlobalInsightsBundle counts (global/insights.json)');
+    expect(output).toContain('## GlobalInsightsBundle (global/insights.json)');
+    // global-insights-counts renders the stopGeo entry count.
+    expect(output).toContain('stopGeo:  2');
+  });
+
+  it('sorts rows by prefix ascending regardless of file size', () => {
+    const rows = [
+      // Prefixes deliberately chosen so size order disagrees with
+      // alphabetic order: 'zeta' is large, 'alpha' is small. A
+      // size-based sort would put zeta first; the summarise tool
+      // sorts by prefix, so alpha must come first.
+      makeRow('zeta', 'Zeta Source', 5_000_000, createInsightsBundle()),
+      makeRow('alpha', 'Alpha Source', 1000, createInsightsBundle()),
+    ];
+    const output = formatV2OutputsAnalysis(rows, emptyGlobal(), {
+      analyzedAt: new Date('2026-01-01T00:00:00Z'),
+    });
+    const alphaIndex = output.indexOf('Alpha Source');
+    const zetaIndex = output.indexOf('Zeta Source');
+    expect(alphaIndex).toBeGreaterThan(-1);
+    expect(zetaIndex).toBeGreaterThan(alphaIndex);
+  });
+
+  it('filters output to a single requested section across sub libs', () => {
+    const rows = [makeRow('src', 'Src Transit', 1000, createInsightsBundle())];
+    const output = formatV2OutputsAnalysis(rows, emptyGlobal(), {
+      analyzedAt: new Date('2026-01-01T00:00:00Z'),
+      sections: ['trip-volume'],
+    });
+    expect(output).toContain('## InsightsBundle trip volume (insights.json)');
+    expect(output).not.toContain('## File sizes (raw)');
+    expect(output).not.toContain('## DataBundle counts (data.json)');
+    expect(output).not.toContain('## ShapesBundle counts');
+    expect(output).not.toContain('## GlobalInsightsBundle');
+  });
+
+  it('routes a global section request even when rows are empty', () => {
+    const global = analyzeV2GlobalSummary({
+      bundle: createGlobalBundle(),
+      fileSize: 100,
+      gzipSize: 30,
+    });
+    const output = formatV2OutputsAnalysis([], global, {
+      analyzedAt: new Date('2026-01-01T00:00:00Z'),
+      sections: ['global-insights'],
+    });
+    expect(output).toContain('## GlobalInsightsBundle (global/insights.json)');
+    // The renamed global-insights section now shows wp / cn coverage,
+    // not entry counts (those live in global-insights-counts).
+    expect(output).toContain('stops with wp:');
+  });
+});
+
+describe('V2_OUTPUTS_SECTION_NAMES', () => {
+  it('unions all four sub libs in a stable order', () => {
+    expect(V2_OUTPUTS_SECTION_NAMES).toEqual([
+      // Cross-bundle file size meta first.
+      'file-sizes',
+      'gzip-sizes',
+      // Per-bundle generic counts (meta).
+      'counts',
+      'shapes-counts',
+      'insights-counts',
+      'global-insights-counts',
+      // DataBundle detail.
+      'feed-info',
+      'agencies',
+      'routes',
+      'stops',
+      'trip-patterns',
+      'i18n-coverage',
+      'periods',
+      // Per-bundle detail (shapes, insights, global).
+      'shapes-volume',
+      'trip-volume',
+      'global-insights',
+    ]);
+  });
+
+  it('exposes a description entry per section', () => {
+    const names = V2_OUTPUTS_SECTION_DESCRIPTIONS.map((entry) => entry.name);
+    expect(names).toEqual(V2_OUTPUTS_SECTION_NAMES);
+  });
+});

--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-shapes-summary.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-shapes-summary.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  V2_SHAPES_SUMMARY_SECTION_NAMES,
+  V2_SHAPES_SUMMARY_SECTIONS,
+  analyzeV2ShapesSummary,
+} from '../v2-shapes-summary';
+import type { ShapesBundle } from '../../../../../src/types/data/transit-v2-json';
+
+/**
+ * Smoke tests for the ShapesBundle sub lib.
+ */
+
+function createShapesBundle(): ShapesBundle {
+  return {
+    bundle_version: 3,
+    kind: 'shapes',
+    shapes: {
+      v: 2,
+      data: {
+        'src:r1': [
+          [
+            [35.0, 139.0],
+            [35.1, 139.1],
+            [35.2, 139.2],
+          ],
+        ],
+        'src:r2': [
+          [
+            [36.0, 140.0],
+            [36.1, 140.1],
+          ],
+          [
+            [36.2, 140.2],
+            [36.3, 140.3],
+            [36.4, 140.4],
+            [36.5, 140.5],
+          ],
+        ],
+      },
+    },
+  };
+}
+
+describe('analyzeV2ShapesSummary', () => {
+  it('counts routes, polylines, points, and total length', () => {
+    const result = analyzeV2ShapesSummary({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      shapesBundle: createShapesBundle(),
+    });
+    // src:r1 has 1 polyline of 3 points; src:r2 has 2 polylines of 2 + 4 points
+    expect(result.shapes.routes).toBe(2);
+    expect(result.shapes.polylines).toBe(3);
+    expect(result.shapes.points).toBe(3 + 2 + 4);
+    // Total length sums Haversine segments across every polyline.
+    // The fixture coordinates are roughly 0.1 deg apart, so the value
+    // is positive and well under 100 km (loose bound — exact value is
+    // covered by geo-utils tests).
+    expect(result.shapes.totalLengthKm).toBeGreaterThan(0);
+    expect(result.shapes.totalLengthKm).toBeLessThan(100);
+  });
+
+  it('returns null counts when shapes bundle is missing', () => {
+    const result = analyzeV2ShapesSummary({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      shapesBundle: null,
+    });
+    expect(result.shapes.routes).toBeNull();
+    expect(result.shapes.polylines).toBeNull();
+    expect(result.shapes.points).toBeNull();
+    expect(result.shapes.totalLengthKm).toBeNull();
+  });
+});
+
+describe('V2_SHAPES_SUMMARY_SECTIONS', () => {
+  it('exposes shapes-counts and shapes-volume in a stable order', () => {
+    expect(V2_SHAPES_SUMMARY_SECTION_NAMES).toEqual(['shapes-counts', 'shapes-volume']);
+  });
+
+  it('shapes-counts renders generic top-level counts with a totals row', () => {
+    const result = analyzeV2ShapesSummary({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      shapesBundle: createShapesBundle(),
+    });
+    const body = V2_SHAPES_SUMMARY_SECTIONS['shapes-counts'].render([result]);
+    expect(body).toContain('Src Transit');
+    expect(body).toContain('totals');
+    expect(body).toContain('shapes'); // column header
+  });
+
+  it('shapes-volume includes routes / polylines / points / totalLengthKm', () => {
+    const result = analyzeV2ShapesSummary({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      shapesBundle: createShapesBundle(),
+    });
+    const body = V2_SHAPES_SUMMARY_SECTIONS['shapes-volume'].render([result]);
+    expect(body).toContain('Src Transit');
+    expect(body).toContain('routes');
+    expect(body).toContain('polylines');
+    expect(body).toContain('points');
+    expect(body).toContain('totalLengthKm');
+  });
+
+  it("shapes-volume renders '-' for sources without shapes", () => {
+    const result = analyzeV2ShapesSummary({
+      prefix: 'src',
+      nameEn: 'Src Transit',
+      shapesBundle: null,
+    });
+    const body = V2_SHAPES_SUMMARY_SECTIONS['shapes-volume'].render([result]);
+    expect(body).toContain('sourcesMissingShapes=1');
+  });
+});

--- a/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
@@ -1,0 +1,1523 @@
+/**
+ * Pure helpers for summarising per-source v2 DataBundle artifacts.
+ *
+ * Produces three kinds of basic facts per source:
+ *
+ *   1. Raw file sizes (data.json / insights.json / shapes.json)
+ *   2. gzip-compressed sizes (proxy for transfer cost)
+ *   3. Counts derived from DataBundle (entity volume)
+ *
+ * File-size sections cover all three v2 bundle files (data / insights /
+ * shapes) for cross-bundle comparison, even though this module's
+ * `counts` section is DataBundle-only. The CLI orchestrator can mix
+ * these sections with sections from other bundle-summary libs.
+ *
+ * The CLI wrapper is responsible for locating sources, reading files,
+ * measuring sizes, and gzip-compressing buffers. The functions here
+ * are pure and deterministic.
+ */
+
+import type { DataBundle } from '../../../../src/types/data/transit-v2-json';
+import { type AnalysisSectionDefinition } from './analysis-sections';
+import { renderTable } from './render-utils';
+
+/**
+ * Sizes of the three v2 bundle files for one source.
+ *
+ * `shapes` is nullable because some sources do not emit a shapes file
+ * (no GTFS shapes.txt and no KSJ railway fallback). Treating a missing
+ * file as `null` keeps `0` reserved for "file exists but is empty" —
+ * the two states are not equivalent for the data-licensing or
+ * pipeline-output audit perspective.
+ */
+export interface FileSizeStats {
+  data: number;
+  insights: number;
+  shapes: number | null;
+  total: number;
+}
+
+/**
+ * Counts per DataBundle top-level section.
+ *
+ * One entry per key in the DataBundle interface, excluding metadata
+ * keys (`bundle_version`, `kind`). The count rule is intentionally
+ * naive so the section stays generic across schema changes:
+ *
+ *   - if `.data` is an array → array length
+ *   - if `.data` is a plain object (record or struct) → top-level key count
+ *
+ * This means semantically heterogeneous values appear together:
+ * `stops` (array of stops) reads as "number of stops", while
+ * `calendar` (struct with `services` / `exceptions` arrays) reads as
+ * `2` (= number of top-level keys in CalendarJson). Sections whose
+ * top-level count is mechanically derived (`calendar` / `feedInfo` /
+ * `translations` / `lookup`) are kept for completeness — see the
+ * separate non-count section for richer breakdowns.
+ *
+ * Keyed as `Record<string, number>` rather than a fixed struct so
+ * adding a new DataBundle key automatically produces a new column.
+ */
+export type DataBundleCounts = Record<string, number>;
+
+const EXCLUDED_DATA_BUNDLE_KEYS = new Set(['bundle_version', 'kind']);
+
+/**
+ * Feed identity + declared validity, drawn strictly from feedInfo.
+ *
+ * `feedStart` / `feedEnd` are the raw `feedInfo.data.s` / `.e`
+ * strings ("YYYYMMDD"; empty when the source omits them). Period
+ * information aggregated across feedInfo + calendar lives in a
+ * separate section ({@link PeriodsSummary}) so that `feed-info`
+ * stays scoped to a single source-of-truth (FeedInfoJson).
+ *
+ * `feedInfo.pu` (publisher URL) and `feedInfo.v` (feed version) are
+ * deliberately omitted. They are useful in a detail view but add
+ * width without aiding "is this the right source?" identification
+ * in a per-row summary.
+ */
+export interface FeedInfoSummary {
+  publisher: string;
+  lang: string;
+  feedStart: string;
+  feedEnd: string;
+}
+
+/**
+ * Agency identity per source.
+ *
+ * `names` joins every agency name with `", "` (in source order).
+ * `timezones` deduplicates first because real-world feeds typically
+ * share a single timezone across all agencies in a single feed;
+ * carrying duplicates would add noise without insight. Multi-agency
+ * sources (e.g. ntbus has five agencies) therefore render as a
+ * long `names` string but a short `timezones` string.
+ */
+export interface AgenciesSummary {
+  count: number;
+  names: string;
+  timezones: string;
+}
+
+/**
+ * Stops summary per source — every per-stop attribute lives here.
+ *
+ * Single section because every field is unambiguously a property of
+ * one stop (location_type, lat/lon, wheelchair_boarding). Splitting
+ * into geography / accessibility sub sections was considered but
+ * rejected: an `accessibility` section is awkward in GTFS because
+ * `wheelchair_boarding` exists on both stops and trips, so a unified
+ * "accessibility" view would have to span sources.
+ *
+ * `locationTypeCounts` is keyed by the stringified `l` value
+ * (matching the routes section's convention).
+ *
+ * `bbox` is `null` when the source has no stops; otherwise the four
+ * numeric extents of `a` (lat) and `o` (lon). Two-decimal display
+ * granularity (~1 km) is applied at render time only.
+ *
+ * `wheelchairAccessibleCount` is the number of stops whose
+ * `wheelchair_boarding === 1` — confirmed wheelchair accessible.
+ * Values of 0 / 2 / undefined are excluded from this count; readers
+ * who care about the "no info" vs "not accessible" split can drop
+ * to `analyze-v2-*` for distributions.
+ *
+ * `withParentCount` is the number of stops carrying a `ps`
+ * (parent_station) reference — a proxy for how richly the source
+ * models station / platform hierarchy. l=2 (entrance), l=3 (node),
+ * l=4 (boarding area) always need `ps` per GTFS spec; l=0
+ * (stop/platform) optionally references its parent station.
+ *
+ * The remaining three are coverage counts for optional supplementary
+ * fields. `withPlatformCodeCount` counts stops carrying a `pc`
+ * (platform_code). `withStopDescCount` / `withStopUrlCount` count
+ * entries in the DataBundle `lookup` section's `stopDescs` /
+ * `stopUrls` maps — these GTFS fields are normalized into `lookup`
+ * for de-duplication, but each entry is keyed by stop_id so the
+ * entry count equals the number of stops carrying that field.
+ */
+export interface StopsSummary {
+  count: number;
+  locationTypeCounts: Record<string, number>;
+  bbox: { latMin: number; latMax: number; lonMin: number; lonMax: number } | null;
+  wheelchairAccessibleCount: number;
+  withParentCount: number;
+  withPlatformCodeCount: number;
+  withStopDescCount: number;
+  withStopUrlCount: number;
+}
+
+/**
+ * Routes summary per source.
+ *
+ * Drives the multi-subsection `routes` section: route_type mix,
+ * naming coverage, color coverage, and description coverage, plus a
+ * compact roll-up.
+ *
+ * `typeCounts` is a raw map keyed by GTFS `route_type` value (as
+ * string); the formatter applies a human-readable label per type.
+ * The `with*` counters count routes carrying a non-empty value for
+ * the corresponding RouteV2Json field (`s`, `l`, `c`, `tc`, `desc`).
+ */
+export interface RoutesSummary {
+  count: number;
+  typeCounts: Record<string, number>;
+  withShortName: number;
+  withLongName: number;
+  withColor: number;
+  withTextColor: number;
+  withDesc: number;
+}
+
+/**
+ * Trip patterns summary per source.
+ *
+ * `tripPatterns` is an Athenai-internal abstraction (not a GTFS
+ * concept): one record per unique route + headsign + direction +
+ * ordered stop-sequence combination. Multiple GTFS trips collapse
+ * into one pattern when they follow the same stops in the same order.
+ *
+ * `count` is the number of patterns.
+ *
+ * `direction0Count` / `direction1Count` / `directionNoneCount` split
+ * patterns by `TripPatternJson.dir` (GTFS direction_id). `dir` is
+ * `0 | 1 | undefined`; `undefined` (counted as `none`) means the
+ * source does not provide direction_id — ODPT sources omit it
+ * entirely, so they read as all-`none`.
+ *
+ * GTFS exposes a headsign at two levels, so both are counted:
+ *   - `withTripHeadsignCount` — patterns whose trip-level headsign
+ *     (`h`) is a non-empty string.
+ *   - `withStopHeadsignCount` — patterns where at least one stop in
+ *     the sequence carries a `stop_headsign` (`stops[].sh`). This is
+ *     a pattern-level presence flag — the 1:n stop axis is collapsed
+ *     with `some()`; per-stop coverage detail is left to `analyze-*`.
+ *
+ * The two together reveal a source's headsign convention: some
+ * sources populate only `h`, some (e.g. keio-bus) leave `h` blank
+ * and rely entirely on `sh`, and some populate both.
+ */
+export interface TripPatternsSummary {
+  count: number;
+  direction0Count: number;
+  direction1Count: number;
+  directionNoneCount: number;
+  withTripHeadsignCount: number;
+  withStopHeadsignCount: number;
+}
+
+/**
+ * Translations coverage per source.
+ *
+ * Mirrors the six maps of {@link TranslationsJson} one-to-one so the
+ * counts stay legible without aggregation across categories that
+ * could otherwise mask zero-coverage segments.
+ *
+ * `languages` is the sorted union of every BCP-47 code observed
+ * inside any of the six maps' value records (e.g. ["en", "ja"]).
+ * Sources with no translations at all yield an empty array and zero
+ * counts.
+ */
+export interface I18nCoverageSummary {
+  languages: string[];
+  agencyNames: number;
+  routeLongNames: number;
+  routeShortNames: number;
+  stopNames: number;
+  tripHeadsigns: number;
+  stopHeadsigns: number;
+}
+
+/**
+ * Consolidated period information across feedInfo and calendar.
+ *
+ * Brings three period axes onto one row for cross-comparison:
+ *
+ *   - `feedStart` / `feedEnd`        ← feedInfo.s / .e (declared)
+ *   - `serviceStart` / `serviceEnd`  ← min/max of calendar.services s/e
+ *   - `exceptionStart` / `exceptionEnd` ← min/max of calendar.exceptions[].d
+ *
+ * `feedValidity` is **also** rendered in the per-source `feed-info`
+ * section (as feed-level metadata identity); the redundancy is
+ * intentional. Reading them side-by-side reveals real-world
+ * misalignment: feed validity stale relative to calendar, services
+ * empty but exceptions populated (od9bus), or the inverse (vagfr,
+ * where feedInfo is absent but calendar exists).
+ *
+ * `null` entries mean the corresponding section is empty in the
+ * DataBundle (e.g. od9bus has no services, so serviceStart/End =
+ * null).
+ */
+export interface PeriodsSummary {
+  feedStart: string;
+  feedEnd: string;
+  serviceStart: string | null;
+  serviceEnd: string | null;
+  exceptionStart: string | null;
+  exceptionEnd: string | null;
+}
+
+export interface V2DataVolumeStats {
+  prefix: string;
+  nameEn: string;
+  fileSizes: FileSizeStats;
+  gzipSizes: FileSizeStats;
+  counts: DataBundleCounts;
+  feedInfo: FeedInfoSummary;
+  agencies: AgenciesSummary;
+  routes: RoutesSummary;
+  stops: StopsSummary;
+  tripPatterns: TripPatternsSummary;
+  i18nCoverage: I18nCoverageSummary;
+  periods: PeriodsSummary;
+}
+
+export interface AnalyzeV2DataVolumeInput {
+  prefix: string;
+  nameEn: string;
+  dataBundle: DataBundle;
+  fileSizes: FileSizeStats;
+  gzipSizes: FileSizeStats;
+}
+
+export type V2DataVolumeSectionName =
+  | 'counts'
+  | 'feed-info'
+  | 'agencies'
+  | 'routes'
+  | 'stops'
+  | 'trip-patterns'
+  | 'i18n-coverage'
+  | 'periods'
+  | 'file-sizes'
+  | 'gzip-sizes';
+
+export type V2DataVolumeSectionDefinition = AnalysisSectionDefinition<
+  V2DataVolumeStats[],
+  V2DataVolumeSectionName
+>;
+
+const KIB = 1024;
+const MIB = 1024 * 1024;
+
+/**
+ * Naive section-count rule used uniformly across every DataBundle key.
+ *
+ * Returns:
+ *   - `data.length` when `.data` is an array
+ *   - `Object.keys(.data).length` when `.data` is a plain object
+ *   - `0` otherwise (defensive)
+ *
+ * The lack of recursion is intentional. This keeps the rule legible
+ * (one number per section), schema-resilient (any new key is counted
+ * the same way), and consistent (no per-section special-casing).
+ */
+function countSection(section: unknown): number {
+  if (typeof section !== 'object' || section === null) {
+    return 0;
+  }
+  const data = (section as { data?: unknown }).data;
+  if (Array.isArray(data)) {
+    return data.length;
+  }
+  if (typeof data === 'object' && data !== null) {
+    return Object.keys(data as Record<string, unknown>).length;
+  }
+  return 0;
+}
+
+/**
+ * Build counts for every DataBundle top-level section, skipping
+ * metadata keys (`bundle_version`, `kind`). Section order follows
+ * `Object.entries(bundle)` (= declaration order in serialised JSON),
+ * which propagates through to the rendered column order.
+ */
+function buildDataBundleCounts(bundle: DataBundle): DataBundleCounts {
+  const result: DataBundleCounts = {};
+  for (const [key, value] of Object.entries(bundle)) {
+    if (EXCLUDED_DATA_BUNDLE_KEYS.has(key)) {
+      continue;
+    }
+    result[key] = countSection(value);
+  }
+  return result;
+}
+
+/**
+ * Build a FeedInfoSummary from a DataBundle.
+ *
+ * Carries empty `feedInfo` fields through as empty strings so the
+ * renderer can replace them with the dash sentinel uniformly.
+ */
+function buildFeedInfoSummary(bundle: DataBundle): FeedInfoSummary {
+  const fi = bundle.feedInfo.data;
+  return {
+    publisher: fi.pn,
+    lang: fi.l,
+    feedStart: fi.s,
+    feedEnd: fi.e,
+  };
+}
+
+/**
+ * Collect the sorted union of language codes seen inside any of the
+ * six translation maps.
+ *
+ * Each map's value is `Record<lang, translation>`, so the keys of
+ * the inner record give the languages used for that entry. Empty
+ * maps contribute nothing; an entirely empty TranslationsJson
+ * yields an empty array.
+ */
+function extractTranslationLanguages(translations: DataBundle['translations']['data']): string[] {
+  const langs = new Set<string>();
+  const collect = (map: Record<string, Record<string, string>>) => {
+    for (const langMap of Object.values(map)) {
+      for (const lang of Object.keys(langMap)) {
+        langs.add(lang);
+      }
+    }
+  };
+  collect(translations.agency_names);
+  collect(translations.route_long_names);
+  collect(translations.route_short_names);
+  collect(translations.stop_names);
+  collect(translations.trip_headsigns);
+  collect(translations.stop_headsigns);
+  return Array.from(langs).sort();
+}
+
+/**
+ * Build an I18nCoverageSummary from a DataBundle.
+ *
+ * Counts are raw entry counts of each TranslationsJson map (= number
+ * of primary keys, not number of translated languages). Sources
+ * with no translations still produce a structurally valid summary
+ * (all-zero counts, empty languages array).
+ */
+/**
+ * Build a StopsSummary from a DataBundle.
+ *
+ * One pass through the stops array collects every aggregate to keep
+ * cost linear in the stop count. Empty arrays produce zero counts,
+ * an empty distribution, and a `null` bbox.
+ */
+function buildStopsSummary(bundle: DataBundle): StopsSummary {
+  const stops = bundle.stops.data;
+  const locationTypeCounts: Record<string, number> = {};
+  let latMin = Number.POSITIVE_INFINITY;
+  let latMax = Number.NEGATIVE_INFINITY;
+  let lonMin = Number.POSITIVE_INFINITY;
+  let lonMax = Number.NEGATIVE_INFINITY;
+  let wheelchairAccessibleCount = 0;
+  let withParentCount = 0;
+  let withPlatformCodeCount = 0;
+  for (const stop of stops) {
+    const key = String(stop.l);
+    locationTypeCounts[key] = (locationTypeCounts[key] ?? 0) + 1;
+    if (stop.a < latMin) {
+      latMin = stop.a;
+    }
+    if (stop.a > latMax) {
+      latMax = stop.a;
+    }
+    if (stop.o < lonMin) {
+      lonMin = stop.o;
+    }
+    if (stop.o > lonMax) {
+      lonMax = stop.o;
+    }
+    if (stop.wb === 1) {
+      wheelchairAccessibleCount += 1;
+    }
+    if (stop.ps !== undefined) {
+      withParentCount += 1;
+    }
+    if (stop.pc !== undefined) {
+      withPlatformCodeCount += 1;
+    }
+  }
+  // stop_desc / stop_url are normalized into the `lookup` section
+  // (keyed by stop_id) for de-duplication; the entry count equals
+  // the number of stops carrying each field.
+  const lookup = bundle.lookup.data;
+  const withStopDescCount =
+    lookup.stopDescs === undefined ? 0 : Object.keys(lookup.stopDescs).length;
+  const withStopUrlCount = lookup.stopUrls === undefined ? 0 : Object.keys(lookup.stopUrls).length;
+  return {
+    count: stops.length,
+    locationTypeCounts,
+    bbox: stops.length === 0 ? null : { latMin, latMax, lonMin, lonMax },
+    wheelchairAccessibleCount,
+    withParentCount,
+    withPlatformCodeCount,
+    withStopDescCount,
+    withStopUrlCount,
+  };
+}
+
+/**
+ * Build a RoutesSummary from a DataBundle.
+ *
+ * `typeCounts` is keyed by the stringified GTFS route_type value
+ * (matching analyse-gtfs-routes.ts' convention). Empty `c` strings
+ * count as no-color (= not included in `withColor`).
+ */
+function buildRoutesSummary(bundle: DataBundle): RoutesSummary {
+  const routes = bundle.routes.data;
+  const typeCounts: Record<string, number> = {};
+  let withShortName = 0;
+  let withLongName = 0;
+  let withColor = 0;
+  let withTextColor = 0;
+  let withDesc = 0;
+  for (const route of routes) {
+    const key = String(route.t);
+    typeCounts[key] = (typeCounts[key] ?? 0) + 1;
+    if (route.s !== '') {
+      withShortName += 1;
+    }
+    if (route.l !== '') {
+      withLongName += 1;
+    }
+    if (route.c !== '') {
+      withColor += 1;
+    }
+    if (route.tc !== '') {
+      withTextColor += 1;
+    }
+    if (route.desc !== undefined && route.desc !== '') {
+      withDesc += 1;
+    }
+  }
+  return {
+    count: routes.length,
+    typeCounts,
+    withShortName,
+    withLongName,
+    withColor,
+    withTextColor,
+    withDesc,
+  };
+}
+
+/**
+ * Build a TripPatternsSummary from a DataBundle.
+ *
+ * One pass over the `tripPatterns` records collects the direction_id
+ * split and the headsign coverage count. `dir` is `0 | 1 | undefined`;
+ * anything other than `0` / `1` (i.e. omitted) falls into
+ * `directionNoneCount`.
+ */
+function buildTripPatternsSummary(bundle: DataBundle): TripPatternsSummary {
+  const patterns = Object.values(bundle.tripPatterns.data);
+  let direction0Count = 0;
+  let direction1Count = 0;
+  let directionNoneCount = 0;
+  let withTripHeadsignCount = 0;
+  let withStopHeadsignCount = 0;
+  for (const pattern of patterns) {
+    if (pattern.dir === 0) {
+      direction0Count += 1;
+    } else if (pattern.dir === 1) {
+      direction1Count += 1;
+    } else {
+      directionNoneCount += 1;
+    }
+    if (pattern.h !== '') {
+      withTripHeadsignCount += 1;
+    }
+    // `sh` is omitted (undefined) when absent; per the v2 schema it
+    // is never an empty string, so an undefined check suffices.
+    if (pattern.stops.some((stop) => stop.sh !== undefined)) {
+      withStopHeadsignCount += 1;
+    }
+  }
+  return {
+    count: patterns.length,
+    direction0Count,
+    direction1Count,
+    directionNoneCount,
+    withTripHeadsignCount,
+    withStopHeadsignCount,
+  };
+}
+
+function buildI18nCoverageSummary(bundle: DataBundle): I18nCoverageSummary {
+  const t = bundle.translations.data;
+  return {
+    languages: extractTranslationLanguages(t),
+    agencyNames: Object.keys(t.agency_names).length,
+    routeLongNames: Object.keys(t.route_long_names).length,
+    routeShortNames: Object.keys(t.route_short_names).length,
+    stopNames: Object.keys(t.stop_names).length,
+    tripHeadsigns: Object.keys(t.trip_headsigns).length,
+    stopHeadsigns: Object.keys(t.stop_headsigns).length,
+  };
+}
+
+/**
+ * Build an AgenciesSummary from a DataBundle.
+ *
+ * Joins names in source order; deduplicates timezones (real-world
+ * feeds typically share one timezone across all agencies).
+ */
+function buildAgenciesSummary(bundle: DataBundle): AgenciesSummary {
+  const agencies = bundle.agency.data;
+  const names = agencies.map((a) => a.n).filter((n) => n !== '');
+  const uniqueTimezones: string[] = [];
+  for (const a of agencies) {
+    if (a.tz !== '' && !uniqueTimezones.includes(a.tz)) {
+      uniqueTimezones.push(a.tz);
+    }
+  }
+  return {
+    count: agencies.length,
+    names: names.join(', '),
+    timezones: uniqueTimezones.join(', '),
+  };
+}
+
+/**
+ * Find the min/max of a date axis across an array of GTFS-style
+ * "YYYYMMDD" strings.
+ *
+ * Empty input yields `[null, null]` — distinguishable from a
+ * present-but-empty zero date.
+ */
+function dateRange(dates: readonly string[]): [string | null, string | null] {
+  let min: string | null = null;
+  let max: string | null = null;
+  for (const d of dates) {
+    if (min === null || d < min) {
+      min = d;
+    }
+    if (max === null || d > max) {
+      max = d;
+    }
+  }
+  return [min, max];
+}
+
+/**
+ * Build a PeriodsSummary from a DataBundle.
+ *
+ * `feedStart` / `feedEnd` are echoed straight from feedInfo for
+ * cross-comparison with the calendar-derived ranges. Empty calendar
+ * arrays produce `null` for the corresponding range (no aggregation
+ * fallback — empty means empty).
+ */
+function buildPeriodsSummary(bundle: DataBundle): PeriodsSummary {
+  const fi = bundle.feedInfo.data;
+  const services = bundle.calendar.data.services;
+  const exceptions = bundle.calendar.data.exceptions;
+  const [serviceStart, serviceEnd] = dateRange(services.flatMap((s) => [s.s, s.e]));
+  const [exceptionStart, exceptionEnd] = dateRange(exceptions.map((e) => e.d));
+  return {
+    feedStart: fi.s,
+    feedEnd: fi.e,
+    serviceStart,
+    serviceEnd,
+    exceptionStart,
+    exceptionEnd,
+  };
+}
+
+export function analyzeV2DataVolume(input: AnalyzeV2DataVolumeInput): V2DataVolumeStats {
+  return {
+    prefix: input.prefix,
+    nameEn: input.nameEn,
+    fileSizes: input.fileSizes,
+    gzipSizes: input.gzipSizes,
+    counts: buildDataBundleCounts(input.dataBundle),
+    feedInfo: buildFeedInfoSummary(input.dataBundle),
+    agencies: buildAgenciesSummary(input.dataBundle),
+    routes: buildRoutesSummary(input.dataBundle),
+    stops: buildStopsSummary(input.dataBundle),
+    tripPatterns: buildTripPatternsSummary(input.dataBundle),
+    i18nCoverage: buildI18nCoverageSummary(input.dataBundle),
+    periods: buildPeriodsSummary(input.dataBundle),
+  };
+}
+
+function sumNumber(
+  results: V2DataVolumeStats[],
+  select: (result: V2DataVolumeStats) => number,
+): number {
+  return results.reduce((acc, result) => acc + select(result), 0);
+}
+
+function sumNullableNumber(
+  results: V2DataVolumeStats[],
+  select: (result: V2DataVolumeStats) => number | null,
+): number {
+  return results.reduce((acc, result) => {
+    const value = select(result);
+    return acc + (value ?? 0);
+  }, 0);
+}
+
+/**
+ * Format a byte count as a human-readable string with an adaptive unit.
+ *
+ * Uses KB/MB rather than KiB/MiB despite the 1024-based divisor to
+ * match the conventions used by browser DevTools and most release
+ * notes. The unit boundaries (>=1 MiB → MB, >=1 KiB → KB, else B)
+ * keep small files readable instead of collapsing to "0.00 MB".
+ *
+ * Returns `'-'` for `null` to distinguish "file does not exist" from
+ * a zero-byte file (which is rendered as `'0 B'`).
+ */
+export function formatBytes(value: number | null): string {
+  if (value === null) {
+    return '-';
+  }
+  if (value >= MIB) {
+    return `${(value / MIB).toFixed(2)} MB`;
+  }
+  if (value >= KIB) {
+    return `${(value / KIB).toFixed(1)} KB`;
+  }
+  return `${value} B`;
+}
+
+export function formatCompressionRatio(rawTotal: number, gzipTotal: number): string {
+  if (rawTotal === 0) {
+    return '-';
+  }
+  const ratio = gzipTotal / rawTotal;
+  return `${(ratio * 100).toFixed(1)}%`;
+}
+
+function renderFileSizeRows(
+  results: V2DataVolumeStats[],
+  pick: (result: V2DataVolumeStats) => FileSizeStats,
+): string {
+  const header = ['source', 'prefix', 'data', 'insights', 'shapes', 'total'];
+  const rows = results.map((result) => {
+    const sizes = pick(result);
+    return [
+      result.nameEn,
+      result.prefix,
+      formatBytes(sizes.data),
+      formatBytes(sizes.insights),
+      formatBytes(sizes.shapes),
+      formatBytes(sizes.total),
+    ];
+  });
+  const totalData = sumNumber(results, (result) => pick(result).data);
+  const totalInsights = sumNumber(results, (result) => pick(result).insights);
+  const totalShapes = sumNullableNumber(results, (result) => pick(result).shapes);
+  const totalAll = sumNumber(results, (result) => pick(result).total);
+  rows.push([
+    'totals',
+    '',
+    formatBytes(totalData),
+    formatBytes(totalInsights),
+    formatBytes(totalShapes),
+    formatBytes(totalAll),
+  ]);
+  return renderTable(header, rows, 2);
+}
+
+function formatFileSizesSectionBody(results: V2DataVolumeStats[]): string {
+  const totalRaw = sumNumber(results, (result) => result.fileSizes.total);
+  const lines = [
+    '### Totals',
+    '',
+    `sources=${results.length}, totalRaw=${formatBytes(totalRaw)}`,
+    '',
+    '### Summary',
+    '',
+    renderFileSizeRows(results, (result) => result.fileSizes),
+  ];
+  return lines.join('\n');
+}
+
+function formatGzipSizesSectionBody(results: V2DataVolumeStats[]): string {
+  const totalRaw = sumNumber(results, (result) => result.fileSizes.total);
+  const totalGzip = sumNumber(results, (result) => result.gzipSizes.total);
+  const ratio = formatCompressionRatio(totalRaw, totalGzip);
+  const lines = [
+    '### Totals',
+    '',
+    `sources=${results.length}, totalRaw=${formatBytes(totalRaw)}, totalGzip=${formatBytes(totalGzip)}, ratio=${ratio}`,
+    '',
+    '### Summary',
+    '',
+    renderFileSizeRows(results, (result) => result.gzipSizes),
+  ];
+  return lines.join('\n');
+}
+
+/**
+ * Collect the union of DataBundle section keys seen across `results`.
+ *
+ * In practice every source emits the same set of keys (the DataBundle
+ * interface is fixed) so the union equals the keys of any single row.
+ * Building it as a union still lets the formatter cope gracefully if
+ * sources from incompatible schema versions are ever passed in.
+ *
+ * Order follows the first occurrence in `results[*].counts`, which
+ * itself follows the JSON serialisation order (= DataBundle interface
+ * declaration order). New keys flow through automatically.
+ */
+function collectDataBundleKeys(results: V2DataVolumeStats[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const result of results) {
+    for (const key of Object.keys(result.counts)) {
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      ordered.push(key);
+    }
+  }
+  return ordered;
+}
+
+function formatCountsSectionBody(results: V2DataVolumeStats[]): string {
+  const dataBundleKeys = collectDataBundleKeys(results);
+  const header = ['source', 'prefix', ...dataBundleKeys];
+  const rows: string[][] = results.map((result) => [
+    result.nameEn,
+    result.prefix,
+    ...dataBundleKeys.map((key) => String(result.counts[key] ?? 0)),
+  ]);
+  rows.push([
+    'totals',
+    '',
+    ...dataBundleKeys.map((key) => String(sumNumber(results, (r) => r.counts[key] ?? 0))),
+  ]);
+  const lines = [
+    '### Totals',
+    '',
+    `sources=${results.length}, sections=${dataBundleKeys.length}`,
+    '',
+    '### Summary',
+    '',
+    renderTable(header, rows, 2),
+  ];
+  return lines.join('\n');
+}
+
+/**
+ * Format a GTFS-style "YYYYMMDD" string as "YYYY-MM-DD".
+ *
+ * Returns `-` for an empty / nullish / malformed input. The dash
+ * keeps absent-vs-zero distinguishable in the same render pipeline as
+ * the byte / count formatters elsewhere in this module.
+ */
+function formatGtfsDate(date: string | null | undefined): string {
+  if (date === null || date === undefined || date.length !== 8) {
+    return '-';
+  }
+  return `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`;
+}
+
+function formatDateRange(start: string | null, end: string | null): string {
+  const formattedStart = formatGtfsDate(start);
+  const formattedEnd = formatGtfsDate(end);
+  if (formattedStart === '-' && formattedEnd === '-') {
+    return '-';
+  }
+  return `${formattedStart} → ${formattedEnd}`;
+}
+
+function formatFeedInfoSectionBody(results: V2DataVolumeStats[]): string {
+  const header = ['source', 'prefix', 'publisher', 'lang', 'feedValidity'];
+  const rows: string[][] = results.map((result) => {
+    const fi = result.feedInfo;
+    return [
+      result.nameEn,
+      result.prefix,
+      fi.publisher === '' ? '-' : fi.publisher,
+      fi.lang === '' ? '-' : fi.lang,
+      formatDateRange(
+        fi.feedStart === '' ? null : fi.feedStart,
+        fi.feedEnd === '' ? null : fi.feedEnd,
+      ),
+    ];
+  });
+  // Totals row marker for visual consistency with the other sections;
+  // string fields are not summable, so every data cell is rendered as '-'.
+  rows.push(['totals', '', '-', '-', '-']);
+  const missingFeed = results.filter(
+    (r) => r.feedInfo.feedStart === '' && r.feedInfo.feedEnd === '',
+  ).length;
+  const lines = [
+    '### Totals',
+    '',
+    `sources=${results.length}, sourcesMissingFeedValidity=${missingFeed}`,
+    '',
+    '### Summary',
+    '',
+    renderTable(header, rows, header.length),
+  ];
+  return lines.join('\n');
+}
+
+/**
+ * Human label for GTFS stops.txt `location_type` values.
+ *
+ * Mirrors the GTFS spec; unknown values fall back to the raw code
+ * via the formatter.
+ */
+const LOCATION_TYPE_LABELS: Record<string, string> = {
+  '0': 'stop',
+  '1': 'station',
+  '2': 'entrance',
+  '3': 'node',
+  '4': 'boardingArea',
+};
+
+function formatLocationTypeCounts(counts: Record<string, number>): string {
+  const entries = Object.entries(counts).sort(([left], [right]) => Number(left) - Number(right));
+  if (entries.length === 0) {
+    return '-';
+  }
+  return entries
+    .map(([value, count]) => {
+      const label = LOCATION_TYPE_LABELS[value];
+      return label === undefined ? `${value}:${count}` : `${label}:${count}`;
+    })
+    .join(', ');
+}
+
+/**
+ * Format a numeric coordinate range with 2-decimal precision.
+ *
+ * 2 decimals (~1 km granularity) is a deliberate trade-off: it fits
+ * comfortably in the table while still revealing source extents.
+ * Readers who need sub-km precision can drop to `analyze-v2-*` or
+ * read the bundle directly.
+ */
+function formatCoordRange(min: number, max: number): string {
+  return `${min.toFixed(2)}..${max.toFixed(2)}`;
+}
+
+/**
+ * Render the `stops` section as detail sub-sections + a roll-up
+ * Summary.
+ *
+ * Sub-section structure (per the "Section = sub-sections + Summary"
+ * design intent): each facet of StopV2Json gets its own light table.
+ * Location types and geography form the roll-up Summary (the "how
+ * many and where" view); the sparser accessibility / hierarchy facets
+ * and the optional supplementary fields (platform_code / stop_desc /
+ * stop_url) stay in their own detail sub-sections.
+ */
+function formatStopsSectionBody(results: V2DataVolumeStats[]): string {
+  const totalStops = results.reduce((acc, r) => acc + r.stops.count, 0);
+  const totalWheelchairAccessible = results.reduce(
+    (acc, r) => acc + r.stops.wheelchairAccessibleCount,
+    0,
+  );
+  const totalWithParent = results.reduce((acc, r) => acc + r.stops.withParentCount, 0);
+  const totalWithPlatformCode = results.reduce((acc, r) => acc + r.stops.withPlatformCodeCount, 0);
+  const totalWithStopDesc = results.reduce((acc, r) => acc + r.stops.withStopDescCount, 0);
+  const totalWithStopUrl = results.reduce((acc, r) => acc + r.stops.withStopUrlCount, 0);
+  const aggregatedTypes: Record<string, number> = {};
+  const distinctTypes = new Set<string>();
+  for (const r of results) {
+    for (const [key, count] of Object.entries(r.stops.locationTypeCounts)) {
+      aggregatedTypes[key] = (aggregatedTypes[key] ?? 0) + count;
+      distinctTypes.add(key);
+    }
+  }
+  // Cross-source bbox: union of all per-source bboxes (= overall geographic extent).
+  let unionLatMin = Number.POSITIVE_INFINITY;
+  let unionLatMax = Number.NEGATIVE_INFINITY;
+  let unionLonMin = Number.POSITIVE_INFINITY;
+  let unionLonMax = Number.NEGATIVE_INFINITY;
+  let hasAnyBbox = false;
+  for (const r of results) {
+    if (r.stops.bbox === null) {
+      continue;
+    }
+    hasAnyBbox = true;
+    if (r.stops.bbox.latMin < unionLatMin) {
+      unionLatMin = r.stops.bbox.latMin;
+    }
+    if (r.stops.bbox.latMax > unionLatMax) {
+      unionLatMax = r.stops.bbox.latMax;
+    }
+    if (r.stops.bbox.lonMin < unionLonMin) {
+      unionLonMin = r.stops.bbox.lonMin;
+    }
+    if (r.stops.bbox.lonMax > unionLonMax) {
+      unionLonMax = r.stops.bbox.lonMax;
+    }
+  }
+  const unionLatRange = hasAnyBbox ? formatCoordRange(unionLatMin, unionLatMax) : '-';
+  const unionLonRange = hasAnyBbox ? formatCoordRange(unionLonMin, unionLonMax) : '-';
+  const latRangeOf = (s: StopsSummary): string =>
+    s.bbox === null ? '-' : formatCoordRange(s.bbox.latMin, s.bbox.latMax);
+  const lonRangeOf = (s: StopsSummary): string =>
+    s.bbox === null ? '-' : formatCoordRange(s.bbox.lonMin, s.bbox.lonMax);
+
+  // --- Location types sub-section ---
+  const typesHeader = ['source', 'prefix', 'count', 'locationTypes'];
+  const typesRows: string[][] = results.map((r) => [
+    r.nameEn,
+    r.prefix,
+    String(r.stops.count),
+    formatLocationTypeCounts(r.stops.locationTypeCounts),
+  ]);
+  typesRows.push(['totals', '', String(totalStops), formatLocationTypeCounts(aggregatedTypes)]);
+
+  // --- Geography sub-section ---
+  const geoHeader = ['source', 'prefix', 'latRange', 'lonRange'];
+  const geoRows: string[][] = results.map((r) => [
+    r.nameEn,
+    r.prefix,
+    latRangeOf(r.stops),
+    lonRangeOf(r.stops),
+  ]);
+  geoRows.push(['totals', '', unionLatRange, unionLonRange]);
+
+  // --- Accessibility sub-section ---
+  const accessibilityHeader = ['source', 'prefix', 'wheelchairAccessible'];
+  const accessibilityRows: string[][] = results.map((r) => [
+    r.nameEn,
+    r.prefix,
+    String(r.stops.wheelchairAccessibleCount),
+  ]);
+  accessibilityRows.push(['totals', '', String(totalWheelchairAccessible)]);
+
+  // --- Hierarchy sub-section ---
+  const hierarchyHeader = ['source', 'prefix', 'withParent'];
+  const hierarchyRows: string[][] = results.map((r) => [
+    r.nameEn,
+    r.prefix,
+    String(r.stops.withParentCount),
+  ]);
+  hierarchyRows.push(['totals', '', String(totalWithParent)]);
+
+  // --- Supplementary fields sub-section ---
+  // Coverage counts for optional GTFS fields: platform_code (on the
+  // stop record) and stop_desc / stop_url (normalized into `lookup`).
+  const supplementaryHeader = [
+    'source',
+    'prefix',
+    'withPlatformCode',
+    'withStopDesc',
+    'withStopUrl',
+  ];
+  const supplementaryRows: string[][] = results.map((r) => [
+    r.nameEn,
+    r.prefix,
+    String(r.stops.withPlatformCodeCount),
+    String(r.stops.withStopDescCount),
+    String(r.stops.withStopUrlCount),
+  ]);
+  supplementaryRows.push([
+    'totals',
+    '',
+    String(totalWithPlatformCode),
+    String(totalWithStopDesc),
+    String(totalWithStopUrl),
+  ]);
+
+  // --- Summary sub-section (roll-up) ---
+  const summaryHeader = ['source', 'prefix', 'count', 'locationTypes', 'latRange', 'lonRange'];
+  const summaryRows: string[][] = results.map((r) => [
+    r.nameEn,
+    r.prefix,
+    String(r.stops.count),
+    formatLocationTypeCounts(r.stops.locationTypeCounts),
+    latRangeOf(r.stops),
+    lonRangeOf(r.stops),
+  ]);
+  summaryRows.push([
+    'totals',
+    '',
+    String(totalStops),
+    formatLocationTypeCounts(aggregatedTypes),
+    unionLatRange,
+    unionLonRange,
+  ]);
+
+  // Section layout: Totals → Summary (the roll-up, shown first so the
+  // reader gets the whole picture) → detail sub-sections.
+  return [
+    '### Totals',
+    '',
+    `sources=${results.length}, totalStops=${totalStops}, distinctLocationTypes=${distinctTypes.size}, totalWheelchairAccessible=${totalWheelchairAccessible}, totalWithParent=${totalWithParent}`,
+    '',
+    '### Summary',
+    '',
+    renderTable(summaryHeader, summaryRows, summaryHeader.length),
+    '',
+    '### Location types',
+    '',
+    renderTable(typesHeader, typesRows, typesHeader.length),
+    '',
+    '### Hierarchy',
+    '',
+    renderTable(hierarchyHeader, hierarchyRows, 2),
+    '',
+    '### Accessibility',
+    '',
+    renderTable(accessibilityHeader, accessibilityRows, 2),
+    '',
+    '### Supplementary fields',
+    '',
+    renderTable(supplementaryHeader, supplementaryRows, 2),
+    '',
+    '### Geography',
+    '',
+    renderTable(geoHeader, geoRows, geoHeader.length),
+  ].join('\n');
+}
+
+/**
+ * Render the `direction_id` split as a compact breakdown string
+ * (`0:X, 1:Y, none:Z`), mirroring the location-type / route-type
+ * breakdown convention. All three keys are always shown so the
+ * column stays predictable and `none:0` vs `none:5` reads as a
+ * meaningful "is direction_id complete?" signal.
+ */
+function formatDirectionCounts(s: TripPatternsSummary): string {
+  return `0:${s.direction0Count}, 1:${s.direction1Count}, none:${s.directionNoneCount}`;
+}
+
+/**
+ * Render the `trip-patterns` section as a single Summary table.
+ *
+ * `TripPatternJson` carries little summarisable data — just the
+ * direction_id split and the two headsign-level presence counts.
+ * That is four data columns, which fits one table comfortably, so
+ * the section stays flat (Totals → Summary) rather than adopting the
+ * sub-section structure that pays off only for facet-rich sections
+ * (routes, stops). The route / stop-sequence facets are left out:
+ * distinct route count duplicates the routes section, and per-pattern
+ * stop counts are distribution-style analysis (see `analyze-*`).
+ */
+function formatTripPatternsSectionBody(results: V2DataVolumeStats[]): string {
+  const totalPatterns = results.reduce((acc, r) => acc + r.tripPatterns.count, 0);
+  const totalDirection0 = results.reduce((acc, r) => acc + r.tripPatterns.direction0Count, 0);
+  const totalDirection1 = results.reduce((acc, r) => acc + r.tripPatterns.direction1Count, 0);
+  const totalDirectionNone = results.reduce((acc, r) => acc + r.tripPatterns.directionNoneCount, 0);
+  const totalWithTripHeadsign = results.reduce(
+    (acc, r) => acc + r.tripPatterns.withTripHeadsignCount,
+    0,
+  );
+  const totalWithStopHeadsign = results.reduce(
+    (acc, r) => acc + r.tripPatterns.withStopHeadsignCount,
+    0,
+  );
+  const totalsDirectionCounts = `0:${totalDirection0}, 1:${totalDirection1}, none:${totalDirectionNone}`;
+
+  const header = [
+    'source',
+    'prefix',
+    'count',
+    'directionCounts',
+    'withTripHeadsign',
+    'withStopHeadsign',
+  ];
+  const rows: string[][] = results.map((r) => [
+    r.nameEn,
+    r.prefix,
+    String(r.tripPatterns.count),
+    formatDirectionCounts(r.tripPatterns),
+    String(r.tripPatterns.withTripHeadsignCount),
+    String(r.tripPatterns.withStopHeadsignCount),
+  ]);
+  rows.push([
+    'totals',
+    '',
+    String(totalPatterns),
+    totalsDirectionCounts,
+    String(totalWithTripHeadsign),
+    String(totalWithStopHeadsign),
+  ]);
+
+  return [
+    '### Totals',
+    '',
+    `sources=${results.length}, totalTripPatterns=${totalPatterns}`,
+    '',
+    '### Summary',
+    '',
+    // directionCounts is a wide text column → all columns left-aligned.
+    renderTable(header, rows, header.length),
+  ].join('\n');
+}
+
+/**
+ * Human label for the standard GTFS route_type values.
+ *
+ * Duplicated from `gtfs-routes-analysis.ts` rather than imported to
+ * keep each dev-lib module self-contained. Unknown values fall back
+ * to the raw numeric code (no label suffix).
+ */
+const ROUTE_TYPE_LABELS: Record<string, string> = {
+  '0': 'tram',
+  '1': 'subway',
+  '2': 'rail',
+  '3': 'bus',
+  '4': 'ferry',
+  '5': 'cable-tram',
+  '6': 'aerial-lift',
+  '7': 'funicular',
+  '11': 'trolleybus',
+  '12': 'monorail',
+};
+
+function formatTypeCounts(counts: Record<string, number>): string {
+  const entries = Object.entries(counts).sort(([left], [right]) => Number(left) - Number(right));
+  if (entries.length === 0) {
+    return '-';
+  }
+  return entries
+    .map(([value, count]) => {
+      const label = ROUTE_TYPE_LABELS[value];
+      return label === undefined ? `${value}:${count}` : `${label}:${count}`;
+    })
+    .join(', ');
+}
+
+/**
+ * Render the `routes` section as detail sub-sections + a roll-up
+ * Summary.
+ *
+ * Sub-section structure (per the "Section = sub-sections + Summary"
+ * design intent): each facet of RouteV2Json gets its own light table
+ * (2-4 columns), deliberately coarser than `analyze-gtfs-routes.ts`
+ * — combination breakdowns (shortOnly / both / samePair / distinct
+ * colors) stay in the analyze tool; here each facet is just a
+ * presence count.
+ */
+function formatRoutesSectionBody(results: V2DataVolumeStats[]): string {
+  const totalRoutes = results.reduce((acc, r) => acc + r.routes.count, 0);
+  const aggregatedTypes: Record<string, number> = {};
+  const distinctTypes = new Set<string>();
+  for (const r of results) {
+    for (const [key, count] of Object.entries(r.routes.typeCounts)) {
+      aggregatedTypes[key] = (aggregatedTypes[key] ?? 0) + count;
+      distinctTypes.add(key);
+    }
+  }
+  const sum = (pick: (routes: RoutesSummary) => number): number =>
+    results.reduce((acc, r) => acc + pick(r.routes), 0);
+
+  // --- Route types sub-section ---
+  const typesHeader = ['source', 'prefix', 'count', 'types'];
+  const typesRows: string[][] = results.map((r) => [
+    r.nameEn,
+    r.prefix,
+    String(r.routes.count),
+    formatTypeCounts(r.routes.typeCounts),
+  ]);
+  typesRows.push(['totals', '', String(totalRoutes), formatTypeCounts(aggregatedTypes)]);
+
+  // --- Naming sub-section ---
+  const namingHeader = ['source', 'prefix', 'withShortName', 'withLongName'];
+  const namingRows: string[][] = results.map((r) => [
+    r.nameEn,
+    r.prefix,
+    String(r.routes.withShortName),
+    String(r.routes.withLongName),
+  ]);
+  namingRows.push([
+    'totals',
+    '',
+    String(sum((routes) => routes.withShortName)),
+    String(sum((routes) => routes.withLongName)),
+  ]);
+
+  // --- Colors sub-section ---
+  const colorsHeader = ['source', 'prefix', 'withColor', 'withTextColor'];
+  const colorsRows: string[][] = results.map((r) => [
+    r.nameEn,
+    r.prefix,
+    String(r.routes.withColor),
+    String(r.routes.withTextColor),
+  ]);
+  colorsRows.push([
+    'totals',
+    '',
+    String(sum((routes) => routes.withColor)),
+    String(sum((routes) => routes.withTextColor)),
+  ]);
+
+  // --- Description sub-section ---
+  const descHeader = ['source', 'prefix', 'withDesc'];
+  const descRows: string[][] = results.map((r) => [r.nameEn, r.prefix, String(r.routes.withDesc)]);
+  descRows.push(['totals', '', String(sum((routes) => routes.withDesc))]);
+
+  // --- Summary sub-section (roll-up) ---
+  const summaryHeader = ['source', 'prefix', 'count', 'types', 'withColor'];
+  const summaryRows: string[][] = results.map((r) => [
+    r.nameEn,
+    r.prefix,
+    String(r.routes.count),
+    formatTypeCounts(r.routes.typeCounts),
+    String(r.routes.withColor),
+  ]);
+  summaryRows.push([
+    'totals',
+    '',
+    String(totalRoutes),
+    formatTypeCounts(aggregatedTypes),
+    String(sum((routes) => routes.withColor)),
+  ]);
+
+  // Section layout: Totals → Summary (the roll-up, shown first so the
+  // reader gets the whole picture) → detail sub-sections.
+  return [
+    '### Totals',
+    '',
+    `sources=${results.length}, totalRoutes=${totalRoutes}, distinctRouteTypes=${distinctTypes.size}`,
+    '',
+    '### Summary',
+    '',
+    renderTable(summaryHeader, summaryRows, summaryHeader.length),
+    '',
+    '### Route types',
+    '',
+    // types is a wide text column → all columns left-aligned.
+    renderTable(typesHeader, typesRows, typesHeader.length),
+    '',
+    '### Naming',
+    '',
+    renderTable(namingHeader, namingRows, 2),
+    '',
+    '### Colors',
+    '',
+    renderTable(colorsHeader, colorsRows, 2),
+    '',
+    '### Description',
+    '',
+    renderTable(descHeader, descRows, 2),
+  ].join('\n');
+}
+
+/** Sum of the six TranslationsJson maps' entry counts. */
+function i18nRowTotal(c: I18nCoverageSummary): number {
+  return (
+    c.agencyNames +
+    c.routeLongNames +
+    c.routeShortNames +
+    c.stopNames +
+    c.tripHeadsigns +
+    c.stopHeadsigns
+  );
+}
+
+function formatI18nCoverageSectionBody(results: V2DataVolumeStats[]): string {
+  const header = [
+    'source',
+    'prefix',
+    'langs',
+    'langCount',
+    'agencyNames',
+    'routeLongNames',
+    'routeShortNames',
+    'stopNames',
+    'tripHeadsigns',
+    'stopHeadsigns',
+    'total',
+  ];
+  const rows: string[][] = results.map((result) => {
+    const c = result.i18nCoverage;
+    return [
+      result.nameEn,
+      result.prefix,
+      c.languages.length === 0 ? '-' : c.languages.join(', '),
+      String(c.languages.length),
+      String(c.agencyNames),
+      String(c.routeLongNames),
+      String(c.routeShortNames),
+      String(c.stopNames),
+      String(c.tripHeadsigns),
+      String(c.stopHeadsigns),
+      String(i18nRowTotal(c)),
+    ];
+  });
+  const sumPer = (pick: (c: I18nCoverageSummary) => number): number =>
+    results.reduce((acc, r) => acc + pick(r.i18nCoverage), 0);
+  rows.push([
+    'totals',
+    '',
+    '-',
+    // langCount sum is the per-source-count sum, not the distinct lang count
+    // (= distinctLangs is shown in the Totals subsection above).
+    String(sumPer((c) => c.languages.length)),
+    String(sumPer((c) => c.agencyNames)),
+    String(sumPer((c) => c.routeLongNames)),
+    String(sumPer((c) => c.routeShortNames)),
+    String(sumPer((c) => c.stopNames)),
+    String(sumPer((c) => c.tripHeadsigns)),
+    String(sumPer((c) => c.stopHeadsigns)),
+    String(sumPer(i18nRowTotal)),
+  ]);
+  const sourcesWithI18n = results.filter((r) => r.i18nCoverage.languages.length > 0).length;
+  const allLangs = new Set<string>();
+  for (const r of results) {
+    for (const l of r.i18nCoverage.languages) {
+      allLangs.add(l);
+    }
+  }
+  const lines = [
+    '### Totals',
+    '',
+    `sources=${results.length}, sourcesWithI18n=${sourcesWithI18n}, distinctLangs=${allLangs.size}`,
+    '',
+    '### Summary',
+    '',
+    // 3 left-aligned label columns (source / prefix / langs); remaining
+    // 8 numeric columns are right-aligned.
+    renderTable(header, rows, 3),
+  ];
+  return lines.join('\n');
+}
+
+function formatAgenciesSectionBody(results: V2DataVolumeStats[]): string {
+  const header = ['source', 'prefix', 'count', 'names', 'timezones'];
+  const rows: string[][] = results.map((result) => [
+    result.nameEn,
+    result.prefix,
+    String(result.agencies.count),
+    result.agencies.names === '' ? '-' : result.agencies.names,
+    result.agencies.timezones === '' ? '-' : result.agencies.timezones,
+  ]);
+  const totalAgencies = results.reduce((acc, r) => acc + r.agencies.count, 0);
+  rows.push(['totals', '', String(totalAgencies), '-', '-']);
+  const multiAgencySources = results.filter((r) => r.agencies.count > 1).length;
+  const lines = [
+    '### Totals',
+    '',
+    `sources=${results.length}, totalAgencies=${totalAgencies}, multiAgencySources=${multiAgencySources}`,
+    '',
+    '### Summary',
+    '',
+    renderTable(header, rows, header.length),
+  ];
+  return lines.join('\n');
+}
+
+function formatPeriodsSectionBody(results: V2DataVolumeStats[]): string {
+  const header = ['source', 'prefix', 'feedValidity', 'servicePeriod', 'exceptionRange'];
+  const rows: string[][] = results.map((result) => {
+    const p = result.periods;
+    return [
+      result.nameEn,
+      result.prefix,
+      formatDateRange(p.feedStart === '' ? null : p.feedStart, p.feedEnd === '' ? null : p.feedEnd),
+      formatDateRange(p.serviceStart, p.serviceEnd),
+      formatDateRange(p.exceptionStart, p.exceptionEnd),
+    ];
+  });
+  rows.push(['totals', '', '-', '-', '-']);
+  const missingFeed = results.filter(
+    (r) => r.periods.feedStart === '' && r.periods.feedEnd === '',
+  ).length;
+  const missingService = results.filter(
+    (r) => r.periods.serviceStart === null && r.periods.serviceEnd === null,
+  ).length;
+  const missingException = results.filter(
+    (r) => r.periods.exceptionStart === null && r.periods.exceptionEnd === null,
+  ).length;
+  const lines = [
+    '### Totals',
+    '',
+    `sources=${results.length}, missingFeed=${missingFeed}, missingService=${missingService}, missingException=${missingException}`,
+    '',
+    '### Summary',
+    '',
+    renderTable(header, rows, header.length),
+  ];
+  return lines.join('\n');
+}
+
+export const V2_DATA_VOLUME_SECTIONS = {
+  'file-sizes': {
+    name: 'file-sizes',
+    title: 'File sizes (raw)',
+    description: 'Raw byte size of data.json, insights.json, and shapes.json per source.',
+    render: formatFileSizesSectionBody,
+  },
+  'gzip-sizes': {
+    name: 'gzip-sizes',
+    title: 'File sizes (gzip)',
+    description: 'gzip-compressed size of each bundle file, approximating transfer payload.',
+    render: formatGzipSizesSectionBody,
+  },
+  counts: {
+    name: 'counts',
+    title: 'DataBundle counts (data.json)',
+    description: 'Entity counts derived from each source DataBundle.',
+    render: formatCountsSectionBody,
+  },
+  'feed-info': {
+    name: 'feed-info',
+    title: 'DataBundle feed-info (data.json)',
+    description: 'Feed identity from feedInfo only: publisher / lang / declared validity (s..e).',
+    render: formatFeedInfoSectionBody,
+  },
+  agencies: {
+    name: 'agencies',
+    title: 'DataBundle agencies (data.json)',
+    description:
+      'Agency identity per source: count / names (joined) / timezones (deduped). Multi-agency sources (e.g. ntbus=5) join values with ", ".',
+    render: formatAgenciesSectionBody,
+  },
+  routes: {
+    name: 'routes',
+    title: 'DataBundle routes (data.json)',
+    description:
+      'Route inventory in detail sub-sections (Route types / Naming / Colors / Description) plus a roll-up Summary. Each facet is a presence count; combination breakdowns stay in analyze-gtfs-routes.',
+    render: formatRoutesSectionBody,
+  },
+  stops: {
+    name: 'stops',
+    title: 'DataBundle stops (data.json)',
+    description:
+      'Summary of basic attributes in stops data: count, location_type distribution, parent_station coverage, wheelchair_boarding accessible count, platform_code / stop_desc / stop_url coverage, and lat/lon bbox.',
+    render: formatStopsSectionBody,
+  },
+  'trip-patterns': {
+    name: 'trip-patterns',
+    title: 'DataBundle trip patterns (data.json)',
+    description:
+      'Trip pattern inventory (Athenai abstraction: unique route + headsign + direction + stop-sequence combination). Single Summary table. `directionCounts` is the direction_id 0/1/none split (ODPT sources omit direction_id so they read as all-none); `withTripHeadsign` / `withStopHeadsign` count patterns carrying a trip-level (`h`) / stop-level (`stops[].sh`) headsign, revealing the source headsign convention.',
+    render: formatTripPatternsSectionBody,
+  },
+  'i18n-coverage': {
+    name: 'i18n-coverage',
+    title: 'DataBundle i18n-coverage (data.json)',
+    description:
+      'Translation coverage per TranslationsJson map. `langs` is the sorted union of language codes; the six count columns mirror the JSON fields one-to-one.',
+    render: formatI18nCoverageSectionBody,
+  },
+  periods: {
+    name: 'periods',
+    title: 'DataBundle periods (data.json)',
+    description:
+      'Three date axes side-by-side: feedValidity (feedInfo), servicePeriod (calendar.services min..max), and exceptionRange (calendar.exceptions min..max). Empty axes appear as "-".',
+    render: formatPeriodsSectionBody,
+  },
+} satisfies Record<V2DataVolumeSectionName, V2DataVolumeSectionDefinition>;
+
+export const V2_DATA_VOLUME_SECTION_NAMES: readonly V2DataVolumeSectionName[] = [
+  // Cross-bundle meta first: gives the overall "shape and weight"
+  // before any per-content section, so later sections read in that
+  // context.
+  'file-sizes',
+  'gzip-sizes',
+  // Single-source sections within DataBundle (each cell maps to one
+  // DataBundle key) — "what's in this bundle".
+  'counts',
+  'feed-info',
+  'agencies',
+  'routes',
+  'stops',
+  'trip-patterns',
+  'i18n-coverage',
+  // Composite sections within DataBundle (combine multiple keys) —
+  // synthesis / interpretation comes last.
+  'periods',
+];

--- a/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
@@ -24,15 +24,19 @@ import { renderTable } from './render-utils';
 /**
  * Sizes of the three v2 bundle files for one source.
  *
- * `shapes` is nullable because some sources do not emit a shapes file
- * (no GTFS shapes.txt and no KSJ railway fallback). Treating a missing
- * file as `null` keeps `0` reserved for "file exists but is empty" —
- * the two states are not equivalent for the data-licensing or
- * pipeline-output audit perspective.
+ * `insights` and `shapes` are nullable because both files are
+ * optional per-source: a source may emit no shapes file (no GTFS
+ * shapes.txt and no KSJ railway fallback), and `insights.json` is an
+ * optional precomputed-analytics bundle. Treating a missing file as
+ * `null` keeps `0` reserved for "file exists but is empty" — the two
+ * states are not equivalent for the data-licensing or pipeline-output
+ * audit perspective. `data` is always present (the only required
+ * bundle file). `total` sums the present files, counting absent ones
+ * as 0.
  */
 export interface FileSizeStats {
   data: number;
-  insights: number;
+  insights: number | null;
   shapes: number | null;
   total: number;
 }
@@ -705,7 +709,7 @@ function renderFileSizeRows(
     ];
   });
   const totalData = sumNumber(results, (result) => pick(result).data);
-  const totalInsights = sumNumber(results, (result) => pick(result).insights);
+  const totalInsights = sumNullableNumber(results, (result) => pick(result).insights);
   const totalShapes = sumNullableNumber(results, (result) => pick(result).shapes);
   const totalAll = sumNumber(results, (result) => pick(result).total);
   rows.push([

--- a/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
@@ -387,14 +387,6 @@ function extractTranslationLanguages(translations: DataBundle['translations']['d
 }
 
 /**
- * Build an I18nCoverageSummary from a DataBundle.
- *
- * Counts are raw entry counts of each TranslationsJson map (= number
- * of primary keys, not number of translated languages). Sources
- * with no translations still produce a structurally valid summary
- * (all-zero counts, empty languages array).
- */
-/**
  * Build a StopsSummary from a DataBundle.
  *
  * One pass through the stops array collects every aggregate to keep
@@ -542,6 +534,14 @@ function buildTripPatternsSummary(bundle: DataBundle): TripPatternsSummary {
   };
 }
 
+/**
+ * Build an I18nCoverageSummary from a DataBundle.
+ *
+ * Counts are raw entry counts of each TranslationsJson map (= number
+ * of primary keys, not number of translated languages). Sources
+ * with no translations still produce a structurally valid summary
+ * (all-zero counts, empty languages array).
+ */
 function buildI18nCoverageSummary(bundle: DataBundle): I18nCoverageSummary {
   const t = bundle.translations.data;
   return {

--- a/pipeline/scripts/dev/dev-lib/v2-global-insights-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-global-insights-summary.ts
@@ -22,9 +22,12 @@ import { type AnalysisSectionDefinition } from './analysis-sections';
 /**
  * Summary for a single GlobalInsightsBundle artifact.
  *
- * All fields are `null` when `global/insights.json` is missing, which
- * is informative on its own (the bundle may not have been generated
- * for the current dataset).
+ * When `global/insights.json` is missing, the nullable scalar fields
+ * (`fileSize`, `gzipSize`, `stopGeoEntries`, `stopsWithWp`) are
+ * `null`, and the collection fields (`counts`, `stopsWithCnByGroup`)
+ * are empty objects — distinct from a present-but-empty bundle. The
+ * absence is informative on its own (the bundle may not have been
+ * generated for the current dataset).
  */
 export interface GlobalInsightsBundleSummary {
   /** Raw byte size of global/insights.json (or null when missing). */
@@ -88,10 +91,13 @@ function countSection(section: unknown): number {
 export function buildGlobalInsightsBundleCounts(
   bundle: GlobalInsightsBundle | null,
 ): GlobalInsightsBundleCounts {
-  const result: GlobalInsightsBundleCounts = { stopGeo: 0 };
+  // A missing bundle yields an empty count set, distinct from a
+  // present-but-empty bundle (which still reports its section keys,
+  // e.g. `stopGeo: 0`).
   if (bundle === null) {
-    return result;
+    return {};
   }
+  const result: GlobalInsightsBundleCounts = {};
   for (const [key, value] of Object.entries(bundle)) {
     if (GLOBAL_INSIGHTS_EXCLUDED_KEYS.has(key)) {
       continue;

--- a/pipeline/scripts/dev/dev-lib/v2-global-insights-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-global-insights-summary.ts
@@ -1,0 +1,203 @@
+/**
+ * Pure helpers for summarising the v2 GlobalInsightsBundle.
+ *
+ * GlobalInsightsBundle is a **per-all-datasources** artifact: a single
+ * `public/data-v2/global/insights.json` file that consolidates
+ * cross-source spatial metrics (stopGeo). It has no per-source axis,
+ * so this sub lib's render takes a singleton summary object instead
+ * of an array of per-source rows.
+ *
+ * Minimum-viable stub: raw file size, gzip file size, and the number
+ * of stopGeo entries. These three numbers answer "how big is the
+ * global artifact and how many stops does it cover", which is the
+ * baseline question before deciding what richer indicators to add.
+ *
+ * The CLI orchestrator loads the bundle and measures sizes once;
+ * this module does not perform I/O.
+ */
+
+import type { GlobalInsightsBundle } from '../../../../src/types/data/transit-v2-json';
+import { type AnalysisSectionDefinition } from './analysis-sections';
+
+/**
+ * Summary for a single GlobalInsightsBundle artifact.
+ *
+ * All fields are `null` when `global/insights.json` is missing, which
+ * is informative on its own (the bundle may not have been generated
+ * for the current dataset).
+ */
+export interface GlobalInsightsBundleSummary {
+  /** Raw byte size of global/insights.json (or null when missing). */
+  fileSize: number | null;
+  /** gzip-compressed byte size of global/insights.json (or null when missing). */
+  gzipSize: number | null;
+  /** Number of `stopGeo` entries (or null when missing / section omitted). */
+  stopGeoEntries: number | null;
+  /** Generic top-level counts (same rule as DataBundle counts). */
+  counts: GlobalInsightsBundleCounts;
+  /** Number of stops carrying `wp` (parent_station distance). */
+  stopsWithWp: number | null;
+  /**
+   * Stops carrying `cn` (300m connectivity) bucketed by service-group
+   * key. The map is empty when no stops have `cn`.
+   */
+  stopsWithCnByGroup: Record<string, number>;
+}
+
+export interface AnalyzeV2GlobalInsightsSummaryInput {
+  /** `null` when global/insights.json is missing. */
+  bundle: GlobalInsightsBundle | null;
+  /** Raw file size in bytes, or null when missing. */
+  fileSize: number | null;
+  /** gzip-compressed file size in bytes, or null when missing. */
+  gzipSize: number | null;
+}
+
+export type V2GlobalInsightsSummarySectionName = 'global-insights-counts' | 'global-insights';
+
+export type V2GlobalInsightsSummarySectionDefinition = AnalysisSectionDefinition<
+  GlobalInsightsBundleSummary,
+  V2GlobalInsightsSummarySectionName
+>;
+
+/**
+ * Counts per GlobalInsightsBundle top-level section.
+ *
+ * Same generic rule as DataBundleCounts: `.data` is either an array
+ * (length) or a Record (top-level key count). GlobalInsightsBundle
+ * currently has only `stopGeo` so this is a single-column view.
+ */
+export type GlobalInsightsBundleCounts = Record<string, number>;
+
+const GLOBAL_INSIGHTS_EXCLUDED_KEYS = new Set(['bundle_version', 'kind']);
+
+function countSection(section: unknown): number {
+  if (typeof section !== 'object' || section === null) {
+    return 0;
+  }
+  const data = (section as { data?: unknown }).data;
+  if (Array.isArray(data)) {
+    return data.length;
+  }
+  if (typeof data === 'object' && data !== null) {
+    return Object.keys(data as Record<string, unknown>).length;
+  }
+  return 0;
+}
+
+export function buildGlobalInsightsBundleCounts(
+  bundle: GlobalInsightsBundle | null,
+): GlobalInsightsBundleCounts {
+  const result: GlobalInsightsBundleCounts = { stopGeo: 0 };
+  if (bundle === null) {
+    return result;
+  }
+  for (const [key, value] of Object.entries(bundle)) {
+    if (GLOBAL_INSIGHTS_EXCLUDED_KEYS.has(key)) {
+      continue;
+    }
+    result[key] = countSection(value);
+  }
+  return result;
+}
+
+export function analyzeV2GlobalInsightsSummary(
+  input: AnalyzeV2GlobalInsightsSummaryInput,
+): GlobalInsightsBundleSummary {
+  const stopGeoData =
+    input.bundle === null || input.bundle.stopGeo === undefined ? null : input.bundle.stopGeo.data;
+  const stopGeoEntries = stopGeoData === null ? null : Object.keys(stopGeoData).length;
+  let stopsWithWp: number | null = null;
+  const stopsWithCnByGroup: Record<string, number> = {};
+  if (stopGeoData !== null) {
+    stopsWithWp = 0;
+    for (const stopGeo of Object.values(stopGeoData)) {
+      if (stopGeo.wp !== undefined) {
+        stopsWithWp += 1;
+      }
+      if (stopGeo.cn !== undefined) {
+        for (const groupKey of Object.keys(stopGeo.cn)) {
+          stopsWithCnByGroup[groupKey] = (stopsWithCnByGroup[groupKey] ?? 0) + 1;
+        }
+      }
+    }
+  }
+  return {
+    fileSize: input.fileSize,
+    gzipSize: input.gzipSize,
+    stopGeoEntries,
+    counts: buildGlobalInsightsBundleCounts(input.bundle),
+    stopsWithWp,
+    stopsWithCnByGroup,
+  };
+}
+
+function formatGlobalInsightsCountsSectionBody(summary: GlobalInsightsBundleSummary): string {
+  // Singleton block: GlobalInsightsBundle is per-all-datasources, not
+  // per-source, so rendered as a key/value list rather than a table.
+  const lines = [
+    '### Totals',
+    '',
+    `sections=${Object.keys(summary.counts).length}`,
+    '',
+    '### Summary',
+    '',
+  ];
+  for (const [key, count] of Object.entries(summary.counts)) {
+    lines.push(`- ${key}:  ${count}`);
+  }
+  return lines.join('\n');
+}
+
+function formatCoverage(count: number | null, denominator: number | null): string {
+  if (count === null) {
+    return '-';
+  }
+  if (denominator === null || denominator === 0) {
+    return String(count);
+  }
+  const pct = ((count / denominator) * 100).toFixed(1);
+  return `${count} (${pct}%)`;
+}
+
+function formatGlobalInsightsSectionBody(summary: GlobalInsightsBundleSummary): string {
+  const lines = [
+    '### Totals',
+    '',
+    summary.fileSize === null ? 'global/insights.json: not found' : 'global/insights.json: found',
+    '',
+    '### Summary',
+    '',
+    `- stops with wp:        ${formatCoverage(summary.stopsWithWp, summary.stopGeoEntries)}`,
+  ];
+  const cnKeys = Object.keys(summary.stopsWithCnByGroup).sort();
+  if (cnKeys.length === 0) {
+    lines.push(`- stops with cn:        -`);
+  } else {
+    for (const groupKey of cnKeys) {
+      lines.push(
+        `- stops with cn[${groupKey}]:  ${formatCoverage(summary.stopsWithCnByGroup[groupKey], summary.stopGeoEntries)}`,
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+export const V2_GLOBAL_INSIGHTS_SUMMARY_SECTIONS = {
+  'global-insights-counts': {
+    name: 'global-insights-counts',
+    title: 'GlobalInsightsBundle counts (global/insights.json)',
+    description: 'Entity counts derived from the GlobalInsightsBundle.',
+    render: formatGlobalInsightsCountsSectionBody,
+  },
+  'global-insights': {
+    name: 'global-insights',
+    title: 'GlobalInsightsBundle (global/insights.json)',
+    description:
+      'Cross-source stopGeo coverage. Reports the share of stops carrying `wp` (parent_station distance) and `cn` (300m connectivity, per service group).',
+    render: formatGlobalInsightsSectionBody,
+  },
+} satisfies Record<V2GlobalInsightsSummarySectionName, V2GlobalInsightsSummarySectionDefinition>;
+
+export const V2_GLOBAL_INSIGHTS_SUMMARY_SECTION_NAMES: readonly V2GlobalInsightsSummarySectionName[] =
+  ['global-insights-counts', 'global-insights'];

--- a/pipeline/scripts/dev/dev-lib/v2-insights-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-insights-summary.ts
@@ -1,0 +1,284 @@
+/**
+ * Pure helpers for summarising per-source v2 InsightsBundle files.
+ *
+ * Per-source trip volume is captured by two max-leaning indicators so
+ * a sg-tail-heavy source (e.g. VAG Freiburg, 20 service groups) is not
+ * misrepresented by a median that gets pulled toward niche-day values.
+ *
+ * For distribution-style analysis (mean / p90 / std of ride durations
+ * etc.), see `analyze-v2-insights.ts` — this module is the
+ * "summary" counterpart, not a replacement.
+ *
+ * The CLI orchestrator is responsible for locating sources and reading
+ * files. The functions here are pure and deterministic.
+ */
+
+import type { InsightsBundle } from '../../../../src/types/data/transit-v2-json';
+import { type AnalysisSectionDefinition } from './analysis-sections';
+import { renderTable } from './render-utils';
+
+/**
+ * Per-source trip-volume summary derived from a single InsightsBundle.
+ *
+ * Two max-leaning indicators replace the previous median-based view,
+ * which silently misrepresented sources whose service-group axis is
+ * heavy-tailed (the median collapses toward a handful of niche-day
+ * groups even when the source's actual operational scale is on a few
+ * dominant groups):
+ *
+ *   - `tripsTotal` ・・・ `Σ_{sg, pattern} freq`. Because every GTFS
+ *     trip_id belongs to exactly one (service_id, pattern) tuple,
+ *     this sum equals the trip_id row count in trips.txt. It is
+ *     **day-agnostic** and serves as a pure data-volume indicator.
+ *   - `tripsMax` ・・・ `max_{sg} (Σ_{pattern} freq)`. Trip count on
+ *     the source's busiest operational day. Captures the peak
+ *     processing load and the realistic per-day scale.
+ *
+ * Both fields are `null` when the source has no `tripPatternStats`
+ * section (e.g. insights.json is missing). `0` is reserved for
+ * "section present but no trips", which should not occur given the
+ * pipeline filters out empty groups, but is handled defensively.
+ */
+export interface TripVolumeSummary {
+  tripsTotal: number | null;
+  tripsMax: number | null;
+  /** Number of service groups defined for this source. */
+  serviceGroupCount: number;
+}
+
+/**
+ * Counts per InsightsBundle top-level section.
+ *
+ * Same generic rule as DataBundleCounts: `.data` is either an array
+ * (length) or a Record (top-level key count). Excludes metadata
+ * fields (`bundle_version`, `kind`). Optional sections (e.g.
+ * `tripPatternStats`) that are absent from the bundle contribute a
+ * `0` count rather than being omitted from the result — the section
+ * list stays uniform across sources.
+ */
+export type InsightsBundleCounts = Record<string, number>;
+
+export interface V2InsightsSummary {
+  prefix: string;
+  nameEn: string;
+  counts: InsightsBundleCounts;
+  tripVolume: TripVolumeSummary;
+}
+
+export interface AnalyzeV2InsightsSummaryInput {
+  prefix: string;
+  nameEn: string;
+  /**
+   * Loaded InsightsBundle, or `null` when insights.json is missing or
+   * fails to parse. `null` propagates to {@link TripVolumeSummary}'s
+   * `tripsTotal` and `tripsMax` as `null`, and `serviceGroupCount` as `0`.
+   */
+  insights: InsightsBundle | null;
+}
+
+export type V2InsightsSummarySectionName = 'insights-counts' | 'trip-volume';
+
+const INSIGHTS_BUNDLE_EXCLUDED_KEYS = new Set(['bundle_version', 'kind']);
+
+/**
+ * Naive section-count rule, identical to the DataBundle version.
+ * Kept locally to keep this sub lib self-contained.
+ */
+function countSection(section: unknown): number {
+  if (typeof section !== 'object' || section === null) {
+    return 0;
+  }
+  const data = (section as { data?: unknown }).data;
+  if (Array.isArray(data)) {
+    return data.length;
+  }
+  if (typeof data === 'object' && data !== null) {
+    return Object.keys(data as Record<string, unknown>).length;
+  }
+  return 0;
+}
+
+/**
+ * Build counts for every InsightsBundle top-level section.
+ *
+ * Visits every key declared on `InsightsBundle` (via the type union)
+ * so optional-but-absent sections still appear with a `0` count —
+ * matching the uniform-column behaviour of the DataBundle counts.
+ */
+function buildInsightsBundleCounts(insights: InsightsBundle | null): InsightsBundleCounts {
+  const result: InsightsBundleCounts = {
+    serviceGroups: 0,
+    tripPatternStats: 0,
+    tripPatternGeo: 0,
+    stopStats: 0,
+  };
+  if (insights === null) {
+    return result;
+  }
+  for (const [key, value] of Object.entries(insights)) {
+    if (INSIGHTS_BUNDLE_EXCLUDED_KEYS.has(key)) {
+      continue;
+    }
+    result[key] = countSection(value);
+  }
+  return result;
+}
+
+export type V2InsightsSummarySectionDefinition = AnalysisSectionDefinition<
+  V2InsightsSummary[],
+  V2InsightsSummarySectionName
+>;
+
+/**
+ * Compute the per-service-group trip-count totals for a source.
+ *
+ * Returns one entry per service group present in `tripPatternStats`.
+ * Each value is the sum of `freq` across every pattern in that group.
+ *
+ * Returns an empty array when `tripPatternStats` is absent.
+ */
+export function computeTripCountsPerServiceGroup(insights: InsightsBundle | null): number[] {
+  if (insights === null || insights.tripPatternStats === undefined) {
+    return [];
+  }
+  const result: number[] = [];
+  for (const groupStats of Object.values(insights.tripPatternStats.data)) {
+    let sum = 0;
+    for (const stats of Object.values(groupStats)) {
+      sum += stats.freq;
+    }
+    result.push(sum);
+  }
+  return result;
+}
+
+export function analyzeV2InsightsSummary(input: AnalyzeV2InsightsSummaryInput): V2InsightsSummary {
+  const perGroupTrips = computeTripCountsPerServiceGroup(input.insights);
+  const hasInsights = perGroupTrips.length > 0;
+  // tripsTotal sums every (sg, pattern) freq; each GTFS trip_id is
+  // counted exactly once because trip → service_id → sg is 1:1:1.
+  // tripsMax picks the busiest sg's total — the source's peak day.
+  const tripsTotal = hasInsights ? perGroupTrips.reduce((a, b) => a + b, 0) : null;
+  const tripsMax = hasInsights ? Math.max(...perGroupTrips) : null;
+  return {
+    prefix: input.prefix,
+    nameEn: input.nameEn,
+    counts: buildInsightsBundleCounts(input.insights),
+    tripVolume: {
+      tripsTotal,
+      tripsMax,
+      serviceGroupCount: perGroupTrips.length,
+    },
+  };
+}
+
+function formatInteger(value: number | null): string {
+  return value === null ? '-' : String(value);
+}
+
+function sumNumber(
+  results: V2InsightsSummary[],
+  select: (result: V2InsightsSummary) => number,
+): number {
+  return results.reduce((acc, result) => acc + select(result), 0);
+}
+
+function sumNullable(
+  results: V2InsightsSummary[],
+  select: (result: V2InsightsSummary) => number | null,
+): number {
+  return results.reduce((acc, result) => acc + (select(result) ?? 0), 0);
+}
+
+function collectInsightsBundleKeys(results: V2InsightsSummary[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const result of results) {
+    for (const key of Object.keys(result.counts)) {
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      ordered.push(key);
+    }
+  }
+  return ordered;
+}
+
+function formatInsightsCountsSectionBody(results: V2InsightsSummary[]): string {
+  const insightsKeys = collectInsightsBundleKeys(results);
+  const header = ['source', 'prefix', ...insightsKeys];
+  const rows: string[][] = results.map((result) => [
+    result.nameEn,
+    result.prefix,
+    ...insightsKeys.map((key) => String(result.counts[key] ?? 0)),
+  ]);
+  rows.push([
+    'totals',
+    '',
+    ...insightsKeys.map((key) => String(sumNumber(results, (r) => r.counts[key] ?? 0))),
+  ]);
+  const lines = [
+    '### Totals',
+    '',
+    `sources=${results.length}, sections=${insightsKeys.length}`,
+    '',
+    '### Summary',
+    '',
+    renderTable(header, rows, 2),
+  ];
+  return lines.join('\n');
+}
+
+function formatTripVolumeSectionBody(results: V2InsightsSummary[]): string {
+  const header = ['source', 'prefix', 'tripsTotal', 'tripsMax', 'serviceGroups'];
+  const rows = results.map((result) => [
+    result.nameEn,
+    result.prefix,
+    formatInteger(result.tripVolume.tripsTotal),
+    formatInteger(result.tripVolume.tripsMax),
+    String(result.tripVolume.serviceGroupCount),
+  ]);
+  // Totals row: tripsTotal sums naturally (= overall trip_id count
+  // across all sources). tripsMax is a per-source peak, so the sum
+  // would conflate different peak days — show '-' instead.
+  rows.push([
+    'totals',
+    '',
+    String(sumNullable(results, (r) => r.tripVolume.tripsTotal)),
+    '-',
+    String(sumNumber(results, (r) => r.tripVolume.serviceGroupCount)),
+  ]);
+  const missing = results.filter((result) => result.tripVolume.tripsTotal === null).length;
+  const lines = [
+    '### Totals',
+    '',
+    `sources=${results.length}, sourcesMissingInsights=${missing}`,
+    '',
+    '### Summary',
+    '',
+    renderTable(header, rows, 2),
+  ];
+  return lines.join('\n');
+}
+
+export const V2_INSIGHTS_SUMMARY_SECTIONS = {
+  'insights-counts': {
+    name: 'insights-counts',
+    title: 'InsightsBundle counts (insights.json)',
+    description: 'Entity counts derived from each source InsightsBundle.',
+    render: formatInsightsCountsSectionBody,
+  },
+  'trip-volume': {
+    name: 'trip-volume',
+    title: 'InsightsBundle trip volume (insights.json)',
+    description:
+      'Two max-leaning indicators per source: tripsTotal (day-agnostic, = trips.txt row count) and tripsMax (busiest service group). Median view was withdrawn because it misrepresented sources with heavy-tailed service-group distributions.',
+    render: formatTripVolumeSectionBody,
+  },
+} satisfies Record<V2InsightsSummarySectionName, V2InsightsSummarySectionDefinition>;
+
+export const V2_INSIGHTS_SUMMARY_SECTION_NAMES: readonly V2InsightsSummarySectionName[] = [
+  'insights-counts',
+  'trip-volume',
+];

--- a/pipeline/scripts/dev/dev-lib/v2-insights-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-insights-summary.ts
@@ -61,6 +61,12 @@ export type InsightsBundleCounts = Record<string, number>;
 export interface V2InsightsSummary {
   prefix: string;
   nameEn: string;
+  /**
+   * Whether `insights.json` was present on disk for this source.
+   * Distinct from "has trip volume": a bundle can be present yet
+   * carry no `tripPatternStats` section, leaving `tripsTotal` null.
+   */
+  bundlePresent: boolean;
   counts: InsightsBundleCounts;
   tripVolume: TripVolumeSummary;
 }
@@ -163,11 +169,16 @@ export function analyzeV2InsightsSummary(input: AnalyzeV2InsightsSummaryInput): 
   return {
     prefix: input.prefix,
     nameEn: input.nameEn,
+    bundlePresent: input.insights !== null,
     counts: buildInsightsBundleCounts(input.insights),
     tripVolume: {
       tripsTotal,
       tripsMax,
-      serviceGroupCount: perGroupTrips.length,
+      // `serviceGroups` is a required InsightsBundle section, so its
+      // length is the authoritative count of groups defined for the
+      // source — distinct from the number of groups that happen to
+      // appear in the optional `tripPatternStats` section.
+      serviceGroupCount: input.insights === null ? 0 : input.insights.serviceGroups.data.length,
     },
   };
 }
@@ -249,7 +260,7 @@ function formatTripVolumeSectionBody(results: V2InsightsSummary[]): string {
     '-',
     String(sumNumber(results, (r) => r.tripVolume.serviceGroupCount)),
   ]);
-  const missing = results.filter((result) => result.tripVolume.tripsTotal === null).length;
+  const missing = results.filter((result) => !result.bundlePresent).length;
   const lines = [
     '### Totals',
     '',

--- a/pipeline/scripts/dev/dev-lib/v2-outputs-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-outputs-summary.ts
@@ -274,7 +274,10 @@ function formatOverallSummary(rows: V2OutputsRow[], global: GlobalInsightsBundle
     totalStops += row.data.counts.stops ?? 0;
     totalRoutes += row.data.counts.routes ?? 0;
     totalTripPatterns += row.data.counts.tripPatterns ?? 0;
-    if (row.insights.tripVolume.tripsTotal !== null) {
+    // Count actual InsightsBundle presence — not `tripsTotal !== null`,
+    // which would also exclude a present bundle that simply has no
+    // `tripPatternStats` section.
+    if (row.insights.bundlePresent) {
       withInsights += 1;
     }
     if (row.shapes.shapes.routes !== null) {

--- a/pipeline/scripts/dev/dev-lib/v2-outputs-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-outputs-summary.ts
@@ -1,0 +1,333 @@
+/**
+ * Top-level coordinator for v2 output summaries.
+ *
+ * Layered structure:
+ *
+ *   entry script (summarize-v2-outputs.ts)
+ *       │
+ *       ▼
+ *   v2-outputs-summary.ts  (this module: combines per-bundle summaries)
+ *       │
+ *       ▼
+ *   v2-data-summary.ts / v2-insights-summary.ts / v2-shapes-summary.ts
+ *   v2-global-insights-summary.ts                                ... (per-bundle sub libs)
+ *
+ * Each sub lib owns one bundle type's analyse + render. This module
+ * defines the combined row type, exposes the union of section names,
+ * dispatches section rendering to the right sub lib, and produces
+ * the complete report (header + Overall summary + selected sections).
+ *
+ * Two dispatch styles exist because not every bundle is per-source:
+ *
+ *   - per-source sub libs (data / insights / shapes) feed off the
+ *     `V2OutputsRow[]` array. The combined row holds one slot per
+ *     sub lib so rows stay row-aligned across sections.
+ *   - per-all-datasources sub libs (global-insights) feed off a single
+ *     summary object passed alongside the rows array. There is no
+ *     per-source axis to iterate over.
+ *
+ * Composed indicators that draw on multiple sub libs (e.g.
+ * "bytes per trip" = data.fileSizes.data / insights.tripsTotal)
+ * belong in this module, not in any single sub lib — sub libs do not
+ * know about each other.
+ */
+
+import type {
+  DataBundle,
+  GlobalInsightsBundle,
+  InsightsBundle,
+  ShapesBundle,
+} from '../../../../src/types/data/transit-v2-json';
+import {
+  analyzeV2DataVolume,
+  formatBytes,
+  formatCompressionRatio,
+  V2_DATA_VOLUME_SECTIONS,
+  V2_DATA_VOLUME_SECTION_NAMES,
+  type FileSizeStats,
+  type V2DataVolumeSectionName,
+  type V2DataVolumeStats,
+} from './v2-data-summary';
+import {
+  analyzeV2InsightsSummary,
+  V2_INSIGHTS_SUMMARY_SECTIONS,
+  V2_INSIGHTS_SUMMARY_SECTION_NAMES,
+  type V2InsightsSummary,
+  type V2InsightsSummarySectionName,
+} from './v2-insights-summary';
+import {
+  analyzeV2ShapesSummary,
+  V2_SHAPES_SUMMARY_SECTIONS,
+  V2_SHAPES_SUMMARY_SECTION_NAMES,
+  type V2ShapesSummary,
+  type V2ShapesSummarySectionName,
+} from './v2-shapes-summary';
+import {
+  analyzeV2GlobalInsightsSummary,
+  V2_GLOBAL_INSIGHTS_SUMMARY_SECTIONS,
+  V2_GLOBAL_INSIGHTS_SUMMARY_SECTION_NAMES,
+  type GlobalInsightsBundleSummary,
+  type V2GlobalInsightsSummarySectionName,
+} from './v2-global-insights-summary';
+
+/** Union of section names contributed by every sub lib. */
+export type V2OutputsSectionName =
+  | V2DataVolumeSectionName
+  | V2InsightsSummarySectionName
+  | V2ShapesSummarySectionName
+  | V2GlobalInsightsSummarySectionName;
+
+/**
+ * Meta-counts sections, one per bundle. Grouped together at the
+ * front of the report so the reader gets the "shape of every bundle"
+ * before drilling into per-bundle detail.
+ */
+const META_COUNTS_SECTION_NAMES: readonly V2OutputsSectionName[] = [
+  'counts', // DataBundle
+  'shapes-counts', // ShapesBundle
+  'insights-counts', // InsightsBundle
+  'global-insights-counts', // GlobalInsightsBundle
+];
+
+export const V2_OUTPUTS_SECTION_NAMES: readonly V2OutputsSectionName[] = [
+  // Cross-bundle file size meta first.
+  'file-sizes',
+  'gzip-sizes',
+  // Per-bundle generic counts (also meta — "shape of each bundle").
+  ...META_COUNTS_SECTION_NAMES,
+  // DataBundle detail sections (after counts).
+  ...V2_DATA_VOLUME_SECTION_NAMES.filter(
+    (n) => n !== 'counts' && n !== 'file-sizes' && n !== 'gzip-sizes',
+  ),
+  // ShapesBundle detail (volume).
+  ...V2_SHAPES_SUMMARY_SECTION_NAMES.filter((n) => n !== 'shapes-counts'),
+  // InsightsBundle detail (trip-volume).
+  ...V2_INSIGHTS_SUMMARY_SECTION_NAMES.filter((n) => n !== 'insights-counts'),
+  // GlobalInsightsBundle file-size block (last — single-artifact tail).
+  ...V2_GLOBAL_INSIGHTS_SUMMARY_SECTION_NAMES.filter((n) => n !== 'global-insights-counts'),
+];
+
+/**
+ * Compact description records for `--list-sections` output, ordered
+ * to match {@link V2_OUTPUTS_SECTION_NAMES}.
+ */
+function describeOne(name: V2OutputsSectionName): {
+  name: V2OutputsSectionName;
+  title: string;
+  description: string;
+} {
+  if (isDataSectionName(name)) {
+    const s = V2_DATA_VOLUME_SECTIONS[name];
+    return { name, title: s.title, description: s.description };
+  }
+  if (isShapesSectionName(name)) {
+    const s = V2_SHAPES_SUMMARY_SECTIONS[name];
+    return { name, title: s.title, description: s.description };
+  }
+  if (isInsightsSectionName(name)) {
+    const s = V2_INSIGHTS_SUMMARY_SECTIONS[name];
+    return { name, title: s.title, description: s.description };
+  }
+  if (isGlobalSectionName(name)) {
+    const s = V2_GLOBAL_INSIGHTS_SUMMARY_SECTIONS[name];
+    return { name, title: s.title, description: s.description };
+  }
+  const _exhaustive: never = name;
+  return _exhaustive;
+}
+
+export const V2_OUTPUTS_SECTION_DESCRIPTIONS: readonly {
+  name: V2OutputsSectionName;
+  title: string;
+  description: string;
+}[] = V2_OUTPUTS_SECTION_NAMES.map(describeOne);
+
+/** Combined per-source result row, one slot per per-source sub lib. */
+export interface V2OutputsRow {
+  prefix: string;
+  nameEn: string;
+  /** DataBundle-derived stats and per-file sizes. */
+  data: V2DataVolumeStats;
+  /** InsightsBundle-derived trip-volume summary. */
+  insights: V2InsightsSummary;
+  /** ShapesBundle-derived geometry counts. */
+  shapes: V2ShapesSummary;
+}
+
+export interface AnalyzeV2OutputsInput {
+  prefix: string;
+  nameEn: string;
+  dataBundle: DataBundle;
+  /** `null` when insights.json is missing for this source. */
+  insights: InsightsBundle | null;
+  /** `null` when shapes.json is missing for this source. */
+  shapesBundle: ShapesBundle | null;
+  fileSizes: FileSizeStats;
+  gzipSizes: FileSizeStats;
+}
+
+export function analyzeV2Outputs(input: AnalyzeV2OutputsInput): V2OutputsRow {
+  const data = analyzeV2DataVolume({
+    prefix: input.prefix,
+    nameEn: input.nameEn,
+    dataBundle: input.dataBundle,
+    fileSizes: input.fileSizes,
+    gzipSizes: input.gzipSizes,
+  });
+  const insights = analyzeV2InsightsSummary({
+    prefix: input.prefix,
+    nameEn: input.nameEn,
+    insights: input.insights,
+  });
+  const shapes = analyzeV2ShapesSummary({
+    prefix: input.prefix,
+    nameEn: input.nameEn,
+    shapesBundle: input.shapesBundle,
+  });
+  return { prefix: input.prefix, nameEn: input.nameEn, data, insights, shapes };
+}
+
+export interface AnalyzeV2GlobalInput {
+  bundle: GlobalInsightsBundle | null;
+  fileSize: number | null;
+  gzipSize: number | null;
+}
+
+export function analyzeV2GlobalSummary(input: AnalyzeV2GlobalInput): GlobalInsightsBundleSummary {
+  return analyzeV2GlobalInsightsSummary({
+    bundle: input.bundle,
+    fileSize: input.fileSize,
+    gzipSize: input.gzipSize,
+  });
+}
+
+function isDataSectionName(name: V2OutputsSectionName): name is V2DataVolumeSectionName {
+  return (V2_DATA_VOLUME_SECTION_NAMES as readonly string[]).includes(name);
+}
+
+function isInsightsSectionName(name: V2OutputsSectionName): name is V2InsightsSummarySectionName {
+  return (V2_INSIGHTS_SUMMARY_SECTION_NAMES as readonly string[]).includes(name);
+}
+
+function isShapesSectionName(name: V2OutputsSectionName): name is V2ShapesSummarySectionName {
+  return (V2_SHAPES_SUMMARY_SECTION_NAMES as readonly string[]).includes(name);
+}
+
+function isGlobalSectionName(
+  name: V2OutputsSectionName,
+): name is V2GlobalInsightsSummarySectionName {
+  return (V2_GLOBAL_INSIGHTS_SUMMARY_SECTION_NAMES as readonly string[]).includes(name);
+}
+
+function wrapSection(title: string, description: string, body: string): string {
+  return [`## ${title}`, '', description, '', body].join('\n');
+}
+
+function renderSection(
+  rows: V2OutputsRow[],
+  global: GlobalInsightsBundleSummary,
+  sectionName: V2OutputsSectionName,
+): string {
+  if (isDataSectionName(sectionName)) {
+    const section = V2_DATA_VOLUME_SECTIONS[sectionName];
+    return wrapSection(
+      section.title,
+      section.description,
+      section.render(rows.map((row) => row.data)),
+    );
+  }
+  if (isInsightsSectionName(sectionName)) {
+    const section = V2_INSIGHTS_SUMMARY_SECTIONS[sectionName];
+    return wrapSection(
+      section.title,
+      section.description,
+      section.render(rows.map((row) => row.insights)),
+    );
+  }
+  if (isShapesSectionName(sectionName)) {
+    const section = V2_SHAPES_SUMMARY_SECTIONS[sectionName];
+    return wrapSection(
+      section.title,
+      section.description,
+      section.render(rows.map((row) => row.shapes)),
+    );
+  }
+  if (isGlobalSectionName(sectionName)) {
+    const section = V2_GLOBAL_INSIGHTS_SUMMARY_SECTIONS[sectionName];
+    return wrapSection(section.title, section.description, section.render(global));
+  }
+  const _exhaustive: never = sectionName;
+  return _exhaustive;
+}
+
+function formatOverallSummary(rows: V2OutputsRow[], global: GlobalInsightsBundleSummary): string {
+  let totalRaw = 0;
+  let totalGzip = 0;
+  let totalStops = 0;
+  let totalRoutes = 0;
+  let totalTripPatterns = 0;
+  let withInsights = 0;
+  let withShapes = 0;
+  for (const row of rows) {
+    totalRaw += row.data.fileSizes.total;
+    totalGzip += row.data.gzipSizes.total;
+    totalStops += row.data.counts.stops ?? 0;
+    totalRoutes += row.data.counts.routes ?? 0;
+    totalTripPatterns += row.data.counts.tripPatterns ?? 0;
+    if (row.insights.tripVolume.tripsTotal !== null) {
+      withInsights += 1;
+    }
+    if (row.shapes.shapes.routes !== null) {
+      withShapes += 1;
+    }
+  }
+  const globalLabel =
+    global.fileSize === null
+      ? 'absent'
+      : `${formatBytes(global.fileSize)} (gzip ${formatBytes(global.gzipSize)})`;
+  return [
+    '## Overall summary',
+    '',
+    'Per-source overview of payload size, DataBundle entity counts, and InsightsBundle / ShapesBundle availability. Cross-source GlobalInsightsBundle status is appended.',
+    '',
+    `sources=${rows.length}, sourcesWithInsights=${withInsights}, sourcesWithShapes=${withShapes}`,
+    `totalRaw=${formatBytes(totalRaw)}, totalGzip=${formatBytes(totalGzip)}, ratio=${formatCompressionRatio(totalRaw, totalGzip)}`,
+    `entities: stops=${totalStops}, routes=${totalRoutes}, tripPatterns=${totalTripPatterns}`,
+    `global/insights.json: ${globalLabel}`,
+  ].join('\n');
+}
+
+export function formatV2OutputsAnalysis(
+  rows: V2OutputsRow[],
+  global: GlobalInsightsBundleSummary,
+  options: { analyzedAt?: Date; sections?: V2OutputsSectionName[] } = {},
+): string {
+  if (rows.length === 0 && global.fileSize === null) {
+    return 'No v2 outputs found.';
+  }
+  const analyzedAt = options.analyzedAt ?? new Date();
+  // Stable ascending sort by `prefix`. This is a *summarise* tool —
+  // its row order should be reproducible across runs, not driven by
+  // an analytic dimension (size, freq, etc.). Same key for every
+  // per-source section so rows align horizontally across the report.
+  const sorted = [...rows].sort((a, b) => a.prefix.localeCompare(b.prefix));
+  const requestedSections =
+    options.sections === undefined || options.sections.length === 0
+      ? V2_OUTPUTS_SECTION_NAMES
+      : options.sections;
+  const renderedSections = requestedSections.map((sectionName) =>
+    renderSection(sorted, global, sectionName),
+  );
+  return [
+    '# Athenai Transit — V2 outputs summary',
+    '',
+    `# Analyzed at: ${analyzedAt.toISOString()}`,
+    '# Reads public/data-v2/{prefix}/{data,insights,shapes}.json and public/data-v2/global/insights.json',
+    '# Sizes are in KB (1024 B) and MB (1024 KB); shapes "-" means no shapes.json on disk.',
+    "# 'tripsTotal' = Σ tripPatternStats[sg][p].freq (= trips.txt row count, day-agnostic); 'tripsMax' = busiest sg's total.",
+    '',
+    formatOverallSummary(sorted, global),
+    '',
+    ...renderedSections.flatMap((section, index) => (index === 0 ? [section] : ['', section])),
+  ].join('\n');
+}

--- a/pipeline/scripts/dev/dev-lib/v2-shapes-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-shapes-summary.ts
@@ -1,0 +1,267 @@
+/**
+ * Pure helpers for summarising per-source v2 ShapesBundle files.
+ *
+ * Minimum-viable stub: reports the number of routes that have shapes,
+ * the total polyline count, and the total point count. These three
+ * numbers double as a proxy for "render cost on the map" since
+ * polyline / point counts drive Canvas / SVG vertex processing.
+ *
+ * File size for `shapes.json` is already covered by
+ * `v2-data-summary.ts`'s file-sizes / gzip-sizes sections, so it is
+ * intentionally NOT duplicated here.
+ *
+ * The CLI orchestrator is responsible for locating sources and reading
+ * files. The functions here are pure and deterministic.
+ */
+
+import type { ShapesBundle } from '../../../../src/types/data/transit-v2-json';
+import { getDistanceKmLight } from '../../../src/lib/geo-utils';
+import { type AnalysisSectionDefinition } from './analysis-sections';
+import { renderTable } from './render-utils';
+
+/**
+ * Per-source shape-volume summary derived from a single ShapesBundle.
+ *
+ * All four fields are `null` when shapes.json is missing for the
+ * source (distinguishable from `0` which means the file exists but is
+ * empty).
+ *
+ * `totalLengthKm` is the sum of Haversine distances between
+ * consecutive points across every polyline. It surfaces the physical
+ * scale of the network (= draw distance, tile prefetch range) which
+ * the per-source point count alone cannot reveal — a dense city
+ * network can have more points than a long-distance rail line of the
+ * same physical extent.
+ *
+ * `routes` is duplicated in the generic `ShapesBundleCounts` view
+ * (= the same number) but kept here so the volume section is
+ * self-contained.
+ */
+export interface ShapesBundleSummary {
+  /** Number of routes that carry shape geometry. */
+  routes: number | null;
+  /** Total polyline count across every route. */
+  polylines: number | null;
+  /** Total point count across every polyline. */
+  points: number | null;
+  /** Sum of Haversine segment lengths in km across every polyline. */
+  totalLengthKm: number | null;
+}
+
+/**
+ * Counts per ShapesBundle top-level section.
+ *
+ * Same generic rule as DataBundleCounts: `.data` is either an array
+ * (length) or a Record (top-level key count). For ShapesBundle there
+ * is only one section (`shapes`) so this collapses to a single
+ * column matching DataBundle counts' shape ("which top-level keys
+ * exist and how big is each").
+ *
+ * Optional shapes.json absent from disk results in `shapes: 0`. The
+ * CLI orchestrator sets the entire `shapes` slot rather than
+ * propagating `null` through every count, mirroring how DataBundle
+ * counts treat missing-section semantics.
+ */
+export type ShapesBundleCounts = Record<string, number>;
+
+export interface V2ShapesSummary {
+  prefix: string;
+  nameEn: string;
+  counts: ShapesBundleCounts;
+  shapes: ShapesBundleSummary;
+}
+
+export interface AnalyzeV2ShapesSummaryInput {
+  prefix: string;
+  nameEn: string;
+  /** `null` when shapes.json is missing for this source. */
+  shapesBundle: ShapesBundle | null;
+}
+
+export type V2ShapesSummarySectionName = 'shapes-counts' | 'shapes-volume';
+
+const SHAPES_BUNDLE_EXCLUDED_KEYS = new Set(['bundle_version', 'kind']);
+
+function countSection(section: unknown): number {
+  if (typeof section !== 'object' || section === null) {
+    return 0;
+  }
+  const data = (section as { data?: unknown }).data;
+  if (Array.isArray(data)) {
+    return data.length;
+  }
+  if (typeof data === 'object' && data !== null) {
+    return Object.keys(data as Record<string, unknown>).length;
+  }
+  return 0;
+}
+
+function buildShapesBundleCounts(bundle: ShapesBundle | null): ShapesBundleCounts {
+  const result: ShapesBundleCounts = { shapes: 0 };
+  if (bundle === null) {
+    return result;
+  }
+  for (const [key, value] of Object.entries(bundle)) {
+    if (SHAPES_BUNDLE_EXCLUDED_KEYS.has(key)) {
+      continue;
+    }
+    result[key] = countSection(value);
+  }
+  return result;
+}
+
+export type V2ShapesSummarySectionDefinition = AnalysisSectionDefinition<
+  V2ShapesSummary[],
+  V2ShapesSummarySectionName
+>;
+
+export function analyzeV2ShapesSummary(input: AnalyzeV2ShapesSummaryInput): V2ShapesSummary {
+  const bundle = input.shapesBundle;
+  const counts = buildShapesBundleCounts(bundle);
+  if (bundle === null) {
+    return {
+      prefix: input.prefix,
+      nameEn: input.nameEn,
+      counts,
+      shapes: { routes: null, polylines: null, points: null, totalLengthKm: null },
+    };
+  }
+  let routes = 0;
+  let polylines = 0;
+  let points = 0;
+  let totalLengthKm = 0;
+  for (const routePolylines of Object.values(bundle.shapes.data)) {
+    routes += 1;
+    polylines += routePolylines.length;
+    for (const polyline of routePolylines) {
+      points += polyline.length;
+      // Sum Haversine segment lengths within this polyline.
+      // Allocation-free helper keeps total cost linear in the point count.
+      for (let i = 1; i < polyline.length; i++) {
+        const prev = polyline[i - 1];
+        const curr = polyline[i];
+        totalLengthKm += getDistanceKmLight(prev[0], prev[1], curr[0], curr[1]);
+      }
+    }
+  }
+  return {
+    prefix: input.prefix,
+    nameEn: input.nameEn,
+    counts,
+    shapes: { routes, polylines, points, totalLengthKm },
+  };
+}
+
+function formatInteger(value: number | null): string {
+  return value === null ? '-' : String(value);
+}
+
+/**
+ * Format a distance in km with 2-decimal precision; `null` → dash.
+ *
+ * 2 decimals (= 10 m granularity) matches the precision of the
+ * Haversine helper itself and keeps the column width predictable.
+ */
+function formatKm(value: number | null): string {
+  return value === null ? '-' : value.toFixed(2);
+}
+
+function sumNullableNumber(
+  results: V2ShapesSummary[],
+  select: (result: V2ShapesSummary) => number | null,
+): number {
+  return results.reduce((acc, result) => {
+    const value = select(result);
+    return acc + (value ?? 0);
+  }, 0);
+}
+
+function collectShapesBundleKeys(results: V2ShapesSummary[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const result of results) {
+    for (const key of Object.keys(result.counts)) {
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      ordered.push(key);
+    }
+  }
+  return ordered;
+}
+
+function formatShapesCountsSectionBody(results: V2ShapesSummary[]): string {
+  const shapesKeys = collectShapesBundleKeys(results);
+  const header = ['source', 'prefix', ...shapesKeys];
+  const rows: string[][] = results.map((result) => [
+    result.nameEn,
+    result.prefix,
+    ...shapesKeys.map((key) => String(result.counts[key] ?? 0)),
+  ]);
+  const sumPerKey = (key: string): number =>
+    results.reduce((acc, r) => acc + (r.counts[key] ?? 0), 0);
+  rows.push(['totals', '', ...shapesKeys.map((key) => String(sumPerKey(key)))]);
+  const lines = [
+    '### Totals',
+    '',
+    `sources=${results.length}, sections=${shapesKeys.length}`,
+    '',
+    '### Summary',
+    '',
+    renderTable(header, rows, 2),
+  ];
+  return lines.join('\n');
+}
+
+function formatShapesVolumeSectionBody(results: V2ShapesSummary[]): string {
+  const header = ['source', 'prefix', 'routes', 'polylines', 'points', 'totalLengthKm'];
+  const rows = results.map((result) => [
+    result.nameEn,
+    result.prefix,
+    formatInteger(result.shapes.routes),
+    formatInteger(result.shapes.polylines),
+    formatInteger(result.shapes.points),
+    formatKm(result.shapes.totalLengthKm),
+  ]);
+  rows.push([
+    'totals',
+    '',
+    String(sumNullableNumber(results, (r) => r.shapes.routes)),
+    String(sumNullableNumber(results, (r) => r.shapes.polylines)),
+    String(sumNullableNumber(results, (r) => r.shapes.points)),
+    formatKm(sumNullableNumber(results, (r) => r.shapes.totalLengthKm)),
+  ]);
+  const missing = results.filter((result) => result.shapes.routes === null).length;
+  const lines = [
+    '### Totals',
+    '',
+    `sources=${results.length}, sourcesMissingShapes=${missing}`,
+    '',
+    '### Summary',
+    '',
+    renderTable(header, rows, 2),
+  ];
+  return lines.join('\n');
+}
+
+export const V2_SHAPES_SUMMARY_SECTIONS = {
+  'shapes-counts': {
+    name: 'shapes-counts',
+    title: 'ShapesBundle counts (shapes.json)',
+    description: 'Entity counts derived from each source ShapesBundle.',
+    render: formatShapesCountsSectionBody,
+  },
+  'shapes-volume': {
+    name: 'shapes-volume',
+    title: 'ShapesBundle volume (shapes.json)',
+    description:
+      'Per-source shape volume detail: routes / polylines / points (render-cost proxies) plus totalLengthKm (network physical scale via allocation-free Haversine).',
+    render: formatShapesVolumeSectionBody,
+  },
+} satisfies Record<V2ShapesSummarySectionName, V2ShapesSummarySectionDefinition>;
+
+export const V2_SHAPES_SUMMARY_SECTION_NAMES: readonly V2ShapesSummarySectionName[] = [
+  'shapes-counts',
+  'shapes-volume',
+];

--- a/pipeline/scripts/dev/dev-tools.ts
+++ b/pipeline/scripts/dev/dev-tools.ts
@@ -64,6 +64,12 @@ const SCRIPTS: AnalysisScript[] = [
     file: './analyze-v2-global-insights.ts',
     description: 'V2 GlobalInsightsBundle 集計 (stopGeo の source 別カバレッジと nr 分布)',
   },
+  {
+    name: 'summarize-v2-outputs',
+    file: './summarize-v2-outputs.ts',
+    description:
+      'V2 出力 (data / insights / shapes) を source 別に横断要約 (file size / gzip / DataBundle 件数 / tripsMedian)',
+  },
 ];
 
 const SCRIPT_DIR = import.meta.dirname;

--- a/pipeline/scripts/dev/dev-tools.ts
+++ b/pipeline/scripts/dev/dev-tools.ts
@@ -68,7 +68,7 @@ const SCRIPTS: AnalysisScript[] = [
     name: 'summarize-v2-outputs',
     file: './summarize-v2-outputs.ts',
     description:
-      'V2 出力 (data / insights / shapes) を source 別に横断要約 (file size / gzip / DataBundle 件数 / tripsMedian)',
+      'V2 出力 (data / insights / shapes) を source 別に横断要約 (file size / gzip / DataBundle 件数 / tripsTotal / tripsMax)',
   },
 ];
 

--- a/pipeline/scripts/dev/summarize-v2-outputs.ts
+++ b/pipeline/scripts/dev/summarize-v2-outputs.ts
@@ -1,0 +1,318 @@
+#!/usr/bin/env -S npx tsx
+
+/**
+ * Summarise v2 pipeline outputs across all bundle files.
+ *
+ * Reads `public/data-v2/<source>/data.json`, `insights.json`, and
+ * (optionally) `shapes.json` for each source under `public/data-v2/`,
+ * measures raw and gzip-compressed sizes, and emits a per-source
+ * text report combining DataBundle entity counts with InsightsBundle
+ * trip-volume figures.
+ *
+ * Structure: this entry only does I/O orchestration. All analysis
+ * and rendering logic lives under `dev-lib/v2-outputs-summary.ts`,
+ * which delegates to per-bundle sub libs (v2-data-summary.ts,
+ * v2-insights-summary.ts, ...).
+ *
+ * Usage:
+ *   npx tsx pipeline/scripts/dev/summarize-v2-outputs.ts                # all sources
+ *   npx tsx pipeline/scripts/dev/summarize-v2-outputs.ts <source>       # single source
+ *   npx tsx pipeline/scripts/dev/summarize-v2-outputs.ts <a> <b>        # selected sources
+ *   npx tsx pipeline/scripts/dev/summarize-v2-outputs.ts --list-sources
+ *   npx tsx pipeline/scripts/dev/summarize-v2-outputs.ts --list-sections
+ *   npx tsx pipeline/scripts/dev/summarize-v2-outputs.ts --section file-sizes
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+import type {
+  DataBundle,
+  GlobalInsightsBundle,
+  InsightsBundle,
+  ShapesBundle,
+} from '../../../src/types/data/transit-v2-json';
+import {
+  analyzeV2GlobalSummary,
+  analyzeV2Outputs,
+  formatV2OutputsAnalysis,
+  V2_OUTPUTS_SECTION_DESCRIPTIONS,
+  V2_OUTPUTS_SECTION_NAMES,
+  type V2OutputsRow,
+  type V2OutputsSectionName,
+} from './dev-lib/v2-outputs-summary';
+import type { FileSizeStats } from './dev-lib/v2-data-summary';
+import type { GlobalInsightsBundleSummary } from './dev-lib/v2-global-insights-summary';
+import { truncateSectionDescription } from './dev-lib/analysis-sections';
+import {
+  listGtfsSourceNames,
+  loadAllGtfsSources,
+  loadGtfsSource,
+} from '../../src/lib/resources/load-gtfs-sources';
+import {
+  listOdptJsonSourceNames,
+  loadAllOdptJsonSources,
+  loadOdptJsonSource,
+} from '../../src/lib/resources/load-odpt-json-sources';
+import { PIPELINE_ROOT } from '../../src/lib/paths';
+import { runMain } from '../../src/lib/pipeline/pipeline-utils';
+import { parseArgsForMultiSources } from './dev-lib/parse-args';
+
+const PUBLIC_V2_DIR = join(PIPELINE_ROOT, '..', 'public', 'data-v2');
+
+interface SourceName {
+  nameEn: string;
+}
+
+function isV2OutputsSectionName(value: string): value is V2OutputsSectionName {
+  return (V2_OUTPUTS_SECTION_NAMES as readonly string[]).includes(value);
+}
+
+/**
+ * List source prefixes under public/data-v2 that have a data.json.
+ *
+ * `insights.json` and `shapes.json` are optional per-source — their
+ * absence is informative and surfaces in the report rather than
+ * filtering the source out.
+ */
+function listSourcePrefixes(): string[] {
+  return readdirSync(PUBLIC_V2_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== 'global')
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(join(PUBLIC_V2_DIR, name, 'data.json')))
+    .sort();
+}
+
+function readFileIfExists(path: string): Buffer | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+  return readFileSync(path);
+}
+
+function statSizeIfExists(path: string): number | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+  return statSync(path).size;
+}
+
+interface MeasuredSource {
+  dataBundle: DataBundle;
+  insights: InsightsBundle | null;
+  shapesBundle: ShapesBundle | null;
+  fileSizes: FileSizeStats;
+  gzipSizes: FileSizeStats;
+}
+
+function measureSource(prefix: string): MeasuredSource {
+  const dir = join(PUBLIC_V2_DIR, prefix);
+  const dataPath = join(dir, 'data.json');
+  const insightsPath = join(dir, 'insights.json');
+  const shapesPath = join(dir, 'shapes.json');
+
+  const dataBuffer = readFileIfExists(dataPath);
+  if (dataBuffer === null) {
+    throw new Error(`data.json not found for prefix: ${prefix} (${dataPath})`);
+  }
+  const insightsBuffer = readFileIfExists(insightsPath);
+  const shapesBuffer = readFileIfExists(shapesPath);
+
+  const dataSize = dataBuffer.length;
+  const insightsSize = insightsBuffer?.length ?? 0;
+  const shapesSize = statSizeIfExists(shapesPath);
+
+  const gzipData = gzipSync(dataBuffer).length;
+  const gzipInsights = insightsBuffer === null ? 0 : gzipSync(insightsBuffer).length;
+  const gzipShapes = shapesBuffer === null ? null : gzipSync(shapesBuffer).length;
+
+  const fileSizes: FileSizeStats = {
+    data: dataSize,
+    insights: insightsSize,
+    shapes: shapesSize,
+    total: dataSize + insightsSize + (shapesSize ?? 0),
+  };
+  const gzipSizes: FileSizeStats = {
+    data: gzipData,
+    insights: gzipInsights,
+    shapes: gzipShapes,
+    total: gzipData + gzipInsights + (gzipShapes ?? 0),
+  };
+
+  const dataBundle = JSON.parse(dataBuffer.toString('utf-8')) as DataBundle;
+  if (dataBundle.kind !== 'data') {
+    throw new Error(`Expected data bundle at ${dataPath} but got kind=${String(dataBundle.kind)}`);
+  }
+  let insights: InsightsBundle | null = null;
+  if (insightsBuffer !== null) {
+    const parsed = JSON.parse(insightsBuffer.toString('utf-8')) as InsightsBundle;
+    if (parsed.kind !== 'insights') {
+      throw new Error(
+        `Expected insights bundle at ${insightsPath} but got kind=${String(parsed.kind)}`,
+      );
+    }
+    insights = parsed;
+  }
+  let shapesBundle: ShapesBundle | null = null;
+  if (shapesBuffer !== null) {
+    const parsed = JSON.parse(shapesBuffer.toString('utf-8')) as ShapesBundle;
+    if (parsed.kind !== 'shapes') {
+      throw new Error(
+        `Expected shapes bundle at ${shapesPath} but got kind=${String(parsed.kind)}`,
+      );
+    }
+    shapesBundle = parsed;
+  }
+
+  return { dataBundle, insights, shapesBundle, fileSizes, gzipSizes };
+}
+
+/**
+ * Load and summarise the cross-source GlobalInsightsBundle.
+ *
+ * Always invoked regardless of which per-source prefixes are
+ * requested. When the file is absent the summary carries nulls,
+ * surfacing the absence in the report rather than failing the run.
+ */
+function measureGlobalSummary(): GlobalInsightsBundleSummary {
+  const path = join(PUBLIC_V2_DIR, 'global', 'insights.json');
+  const buffer = readFileIfExists(path);
+  if (buffer === null) {
+    return analyzeV2GlobalSummary({ bundle: null, fileSize: null, gzipSize: null });
+  }
+  const parsed = JSON.parse(buffer.toString('utf-8')) as GlobalInsightsBundle;
+  if (parsed.kind !== 'global-insights') {
+    throw new Error(
+      `Expected global-insights bundle at ${path} but got kind=${String(parsed.kind)}`,
+    );
+  }
+  return analyzeV2GlobalSummary({
+    bundle: parsed,
+    fileSize: buffer.length,
+    gzipSize: gzipSync(buffer).length,
+  });
+}
+
+/** Build prefix -> nameEn map from every resource definition (all mode). */
+async function buildNameMapAll(): Promise<Map<string, SourceName>> {
+  const map = new Map<string, SourceName>();
+  const gtfs = await loadAllGtfsSources();
+  for (const def of gtfs) {
+    map.set(def.pipeline.prefix, { nameEn: def.resource.nameEn });
+  }
+  const odpt = await loadAllOdptJsonSources();
+  for (const def of odpt) {
+    map.set(def.pipeline.prefix, { nameEn: def.resource.nameEn });
+  }
+  return map;
+}
+
+/** Lazy lookup for a single prefix (source mode). */
+async function resolveNameForPrefix(prefix: string): Promise<SourceName | null> {
+  for (const name of listGtfsSourceNames()) {
+    const def = await loadGtfsSource(name);
+    if (def.pipeline.prefix === prefix) {
+      return { nameEn: def.resource.nameEn };
+    }
+  }
+  for (const name of listOdptJsonSourceNames()) {
+    const def = await loadOdptJsonSource(name);
+    if (def.pipeline.prefix === prefix) {
+      return { nameEn: def.resource.nameEn };
+    }
+  }
+  return null;
+}
+
+function printHelp(): void {
+  console.log('Usage: summarize-v2-outputs.ts [source-name ...] [--section <name> ...]');
+  console.log('  No args    Summarise all public/data-v2 sources (excluding global/)');
+  console.log('  <source>   Summarise one or more sources (by prefix)');
+  console.log('  --list-sources  List available source prefixes');
+  console.log('  --list-sections List available section names with short descriptions');
+  console.log('  --section <name> Limit output to the selected section (repeatable)');
+  console.log('  --help     Show this help');
+}
+
+function printSectionList(): void {
+  const nameWidth = V2_OUTPUTS_SECTION_DESCRIPTIONS.reduce(
+    (max, entry) => Math.max(max, entry.name.length),
+    0,
+  );
+  for (const entry of V2_OUTPUTS_SECTION_DESCRIPTIONS) {
+    const description = truncateSectionDescription(entry.description, 72);
+    console.log(`${entry.name.padEnd(nameWidth)}  ${description}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const mode = parseArgsForMultiSources(process.argv.slice(2));
+
+  if (mode.kind === 'help') {
+    printHelp();
+    return;
+  }
+
+  const invalidSections = mode.sections.filter((section) => !isV2OutputsSectionName(section));
+  if (invalidSections.length > 0) {
+    console.error(`Unknown section name: ${invalidSections.join(', ')}`);
+    console.error('Run with --list-sections to see available section names.');
+    process.exitCode = 1;
+    return;
+  }
+  const sections = mode.sections as V2OutputsSectionName[];
+
+  const prefixes = listSourcePrefixes();
+
+  if (mode.kind === 'list') {
+    if (mode.target === 'sections') {
+      printSectionList();
+      return;
+    }
+    for (const p of prefixes) {
+      console.log(p);
+    }
+    return;
+  }
+
+  // Global insights is always loaded — it is not per-source so it
+  // does not participate in the `mode.names` filter. When absent
+  // from disk the summary carries nulls and the section reports
+  // "not found".
+  const global = measureGlobalSummary();
+
+  if (mode.kind === 'sources') {
+    const missingSources = mode.names.filter((name) => !prefixes.includes(name));
+    if (missingSources.length > 0) {
+      console.error(`Source not found: ${missingSources.join(', ')}`);
+      console.error('Run with --list-sources to see available sources.');
+      process.exitCode = 1;
+      return;
+    }
+    const rows: V2OutputsRow[] = [];
+    for (const prefix of mode.names) {
+      const name = await resolveNameForPrefix(prefix);
+      if (name === null) {
+        console.warn(`Could not resolve resource name for source: ${prefix}`);
+      }
+      const nameEn = name?.nameEn ?? prefix;
+      const measured = measureSource(prefix);
+      rows.push(analyzeV2Outputs({ prefix, nameEn, ...measured }));
+    }
+    console.log(formatV2OutputsAnalysis(rows, global, { sections }));
+    return;
+  }
+
+  // All-sources mode
+  const nameMap = await buildNameMapAll();
+  const rows: V2OutputsRow[] = [];
+  for (const prefix of prefixes) {
+    const nameEn = nameMap.get(prefix)?.nameEn ?? prefix;
+    const measured = measureSource(prefix);
+    rows.push(analyzeV2Outputs({ prefix, nameEn, ...measured }));
+  }
+  console.log(formatV2OutputsAnalysis(rows, global, { sections }));
+}
+
+runMain(main);

--- a/pipeline/scripts/dev/summarize-v2-outputs.ts
+++ b/pipeline/scripts/dev/summarize-v2-outputs.ts
@@ -263,13 +263,18 @@ async function main(): Promise<void> {
   }
   const sections = mode.sections as V2OutputsSectionName[];
 
+  // `--list-sections` needs no output files — handle it before any
+  // filesystem access so it works even when public/data-v2 has not
+  // been generated yet.
+  if (mode.kind === 'list' && mode.target === 'sections') {
+    printSectionList();
+    return;
+  }
+
   const prefixes = listSourcePrefixes();
 
   if (mode.kind === 'list') {
-    if (mode.target === 'sections') {
-      printSectionList();
-      return;
-    }
+    // mode.target === 'sources'
     for (const p of prefixes) {
       console.log(p);
     }

--- a/pipeline/scripts/dev/summarize-v2-outputs.ts
+++ b/pipeline/scripts/dev/summarize-v2-outputs.ts
@@ -23,7 +23,7 @@
  *   npx tsx pipeline/scripts/dev/summarize-v2-outputs.ts --section file-sizes
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { gzipSync } from 'node:zlib';
 
@@ -91,13 +91,6 @@ function readFileIfExists(path: string): Buffer | null {
   return readFileSync(path);
 }
 
-function statSizeIfExists(path: string): number | null {
-  if (!existsSync(path)) {
-    return null;
-  }
-  return statSync(path).size;
-}
-
 interface MeasuredSource {
   dataBundle: DataBundle;
   insights: InsightsBundle | null;
@@ -119,25 +112,29 @@ function measureSource(prefix: string): MeasuredSource {
   const insightsBuffer = readFileIfExists(insightsPath);
   const shapesBuffer = readFileIfExists(shapesPath);
 
+  // Optional files (insights.json / shapes.json) measure as `null`
+  // when absent — `0` is reserved for a file that exists but is
+  // empty. The buffers are already in memory, so `.length` is the
+  // size with no extra filesystem stat.
   const dataSize = dataBuffer.length;
-  const insightsSize = insightsBuffer?.length ?? 0;
-  const shapesSize = statSizeIfExists(shapesPath);
+  const insightsSize = insightsBuffer === null ? null : insightsBuffer.length;
+  const shapesSize = shapesBuffer === null ? null : shapesBuffer.length;
 
   const gzipData = gzipSync(dataBuffer).length;
-  const gzipInsights = insightsBuffer === null ? 0 : gzipSync(insightsBuffer).length;
+  const gzipInsights = insightsBuffer === null ? null : gzipSync(insightsBuffer).length;
   const gzipShapes = shapesBuffer === null ? null : gzipSync(shapesBuffer).length;
 
   const fileSizes: FileSizeStats = {
     data: dataSize,
     insights: insightsSize,
     shapes: shapesSize,
-    total: dataSize + insightsSize + (shapesSize ?? 0),
+    total: dataSize + (insightsSize ?? 0) + (shapesSize ?? 0),
   };
   const gzipSizes: FileSizeStats = {
     data: gzipData,
     insights: gzipInsights,
     shapes: gzipShapes,
-    total: gzipData + gzipInsights + (gzipShapes ?? 0),
+    total: gzipData + (gzipInsights ?? 0) + (gzipShapes ?? 0),
   };
 
   const dataBundle = JSON.parse(dataBuffer.toString('utf-8')) as DataBundle;

--- a/src/config/data-source-settings.ts
+++ b/src/config/data-source-settings.ts
@@ -37,7 +37,7 @@ const settings: SourceGroup[] = [
   {
     id: 'toei-train',
     prefixes: ['toaran'],
-    routeTypes: [0, 1, 2],
+    routeTypes: [0, 2, 1],
     systemEnabledByDefault: true,
     userEnabledByDefault: true,
     name: { name: 'Toei Train', names: { ja: '都営交通(鉄道)', en: 'Toei Train' } },
@@ -46,7 +46,7 @@ const settings: SourceGroup[] = [
   {
     id: 'toko',
     prefixes: ['minkuru', 'toaran'],
-    routeTypes: [0, 1, 2, 3],
+    routeTypes: [3, 0, 2, 1],
     systemEnabledByDefault: true,
     userEnabledByDefault: true,
     name: { name: 'Toei Transport', names: { ja: '東京都交通局', en: 'Toei Transport' } },
@@ -389,7 +389,7 @@ const settings: SourceGroup[] = [
   {
     id: 'vag-freiburg',
     prefixes: ['vagfr'],
-    routeTypes: [0, 3],
+    routeTypes: [3, 0],
     systemEnabledByDefault: true,
     userEnabledByDefault: true,
     name: {


### PR DESCRIPTION
## Summary

- Adds `summarize-v2-outputs`, a dev tool that catalogs v2 pipeline outputs per source — a "manifest of data sources". Reads `public/data-v2/<prefix>/{data,insights,shapes}.json` plus `global/insights.json` and reports file sizes, per-bundle entity counts, and per-section detail (feed-info, agencies, routes, stops, trip-patterns, i18n-coverage, periods, shapes-volume, trip-volume, global-insights).
- Layered as entry script -> main lib -> per-bundle sub libs; each sub lib owns one bundle type's analyze + render.
- Also includes a small unrelated config fix (`ae32806b`): reorder `routeTypes` for consistency in `data-source-settings.ts` source groups.

Related: #212 (this tool is the reference groundwork for the proposed `DataSourceCatalogBundle`).

## Test plan

- [x] `npx vitest run pipeline/scripts/dev/dev-lib/__tests__/` — 158 tests pass
- [x] `npx tsc --noEmit` — no errors
- [x] `npx eslint` / `npx prettier --check` on changed files — clean
- [x] `npx tsx pipeline/scripts/dev/summarize-v2-outputs.ts` — runs and produces the report
- [x] `npx tsx pipeline/scripts/dev/summarize-v2-outputs.ts --list-sections` — lists all sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)