### PR TITLE
Add data source catalog bundle schema types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ### Added
 
+- Data source catalog: pipeline-generated `data-source-catalog.json` 用の wire-format 型定義を `src/types/data/transit-v2-catalog-json.ts` に追加。Issue #212 の第1段階として、source-level の curated summary と bundle-backed summary を `summary` / `bundles` に整理し、`shapesBundle` を optional、`dataBundle` / `insightsBundle` を required とする catalog schema を導入した。
 - Data source settings dialog: footer に **再起動 (Restart) ボタン** を追加。設定変更後 1 click でアプリを再起動して反映できるようにした (実体は `location.reload()`)。 forced-sources mode (`?sources=`) では disabled。 開発中 notice の文言も 「再起動で反映」 に更新し、 ユーザーが手動で browser refresh するか再起動ボタンを押すかの 2 通りを案内する。
 
 ### Changed

--- a/pipeline/scripts/dev/summarize-v2-outputs.ts
+++ b/pipeline/scripts/dev/summarize-v2-outputs.ts
@@ -4,7 +4,7 @@
  * Summarise v2 pipeline outputs across all bundle files.
  *
  * Reads `public/data-v2/<source>/data.json`, `insights.json`, and
- * (optionally) `shapes.json` for each source under `public/data-v2/`,
+ * optionally `shapes.json` for each source under `public/data-v2/`,
  * measures raw and gzip-compressed sizes, and emits a per-source
  * text report combining DataBundle entity counts with InsightsBundle
  * trip-volume figures.
@@ -72,8 +72,8 @@ function isV2OutputsSectionName(value: string): value is V2OutputsSectionName {
 /**
  * List source prefixes under public/data-v2 that have a data.json.
  *
- * `insights.json` and `shapes.json` are optional per-source — their
- * absence is informative and surfaces in the report rather than
+ * `insights.json` is required per-source. `shapes.json` remains
+ * optional and its absence surfaces in the report rather than
  * filtering the source out.
  */
 function listSourcePrefixes(): string[] {
@@ -93,7 +93,7 @@ function readFileIfExists(path: string): Buffer | null {
 
 interface MeasuredSource {
   dataBundle: DataBundle;
-  insights: InsightsBundle | null;
+  insights: InsightsBundle;
   shapesBundle: ShapesBundle | null;
   fileSizes: FileSizeStats;
   gzipSizes: FileSizeStats;
@@ -110,18 +110,21 @@ function measureSource(prefix: string): MeasuredSource {
     throw new Error(`data.json not found for prefix: ${prefix} (${dataPath})`);
   }
   const insightsBuffer = readFileIfExists(insightsPath);
+  if (insightsBuffer === null) {
+    throw new Error(`insights.json not found for prefix: ${prefix} (${insightsPath})`);
+  }
   const shapesBuffer = readFileIfExists(shapesPath);
 
-  // Optional files (insights.json / shapes.json) measure as `null`
-  // when absent — `0` is reserved for a file that exists but is
-  // empty. The buffers are already in memory, so `.length` is the
-  // size with no extra filesystem stat.
+  // Optional files (shapes.json) measure as `null` when absent —
+  // `0` is reserved for a file that exists but is empty. The buffers
+  // are already in memory, so `.length` is the size with no extra
+  // filesystem stat.
   const dataSize = dataBuffer.length;
-  const insightsSize = insightsBuffer === null ? null : insightsBuffer.length;
+  const insightsSize = insightsBuffer.length;
   const shapesSize = shapesBuffer === null ? null : shapesBuffer.length;
 
   const gzipData = gzipSync(dataBuffer).length;
-  const gzipInsights = insightsBuffer === null ? null : gzipSync(insightsBuffer).length;
+  const gzipInsights = gzipSync(insightsBuffer).length;
   const gzipShapes = shapesBuffer === null ? null : gzipSync(shapesBuffer).length;
 
   const fileSizes: FileSizeStats = {
@@ -141,15 +144,11 @@ function measureSource(prefix: string): MeasuredSource {
   if (dataBundle.kind !== 'data') {
     throw new Error(`Expected data bundle at ${dataPath} but got kind=${String(dataBundle.kind)}`);
   }
-  let insights: InsightsBundle | null = null;
-  if (insightsBuffer !== null) {
-    const parsed = JSON.parse(insightsBuffer.toString('utf-8')) as InsightsBundle;
-    if (parsed.kind !== 'insights') {
-      throw new Error(
-        `Expected insights bundle at ${insightsPath} but got kind=${String(parsed.kind)}`,
-      );
-    }
-    insights = parsed;
+  const insights = JSON.parse(insightsBuffer.toString('utf-8')) as InsightsBundle;
+  if (insights.kind !== 'insights') {
+    throw new Error(
+      `Expected insights bundle at ${insightsPath} but got kind=${String(insights.kind)}`,
+    );
   }
   let shapesBundle: ShapesBundle | null = null;
   if (shapesBuffer !== null) {

--- a/src/types/data/transit-v2-catalog-json.ts
+++ b/src/types/data/transit-v2-catalog-json.ts
@@ -26,73 +26,74 @@ export interface DataSourceCatalogMetadata {
   createdAt: string;
 }
 
-/** Entity counts derived from the GlobalInsightsBundle. */
-export interface DataSourceCatalogGlobalInsightsBundleCounts {
-  stopGeo: number;
-}
-
-/** Cross-source summary derived from `global/insights.json`. */
-export interface DataSourceCatalogGlobalInsights extends DataSourceCatalogFileBackedSummary {
-  /** Entity counts derived from the GlobalInsightsBundle. */
-  counts: DataSourceCatalogGlobalInsightsBundleCounts;
-}
-
-/** Metadata for one emitted v2 JSON file. */
-export interface DataSourceCatalogFileMetadata {
-  /** File size in raw bytes on disk. */
-  sizeBytes: number;
-}
-
 /** Shared file metadata for one emitted bundle-backed summary. */
 export interface DataSourceCatalogFileBackedSummary {
   /** File metadata for the emitted JSON bundle. */
-  file: DataSourceCatalogFileMetadata;
+  file: {
+    /** File size in raw bytes on disk. */
+    sizeBytes: number;
+  };
 }
 
-/** Entity counts derived from one source's DataBundle. */
-export interface DataSourceCatalogDataBundleCounts {
-  stops: number;
-  routes: number;
-  agency: number;
-  calendar: number;
-  feedInfo: number;
-  timetable: number;
-  tripPatterns: number;
-  translations: number;
-  lookup: number;
+/** Summary derived from one source's InsightsBundle file and contents. */
+export interface DataSourceCatalogInsightsBundleSummary extends DataSourceCatalogFileBackedSummary {
+  /** Entity counts derived from one source's InsightsBundle. */
+  counts: {
+    serviceGroups: number;
+    tripPatternStats: number;
+    tripPatternGeo: number;
+    stopStats: number;
+  };
 }
 
-/** Entity counts derived from one source's ShapesBundle. */
-export interface DataSourceCatalogShapesBundleCounts {
-  shapes: number;
+/** Emitted bundle-backed summaries grouped by bundle type for one source. */
+export interface DataSourceCatalogSourceBundles {
+  /** Summary derived from this source's data.json bundle. */
+  dataBundle: DataSourceCatalogDataBundleSummary;
+  /** Summary derived from this source's insights.json bundle. */
+  insightsBundle: DataSourceCatalogInsightsBundleSummary;
+  /** Summary derived from this source's shapes.json bundle, when present. */
+  shapesBundle?: DataSourceCatalogShapesBundleSummary;
 }
 
-/** Entity counts derived from one source's InsightsBundle. */
-export interface DataSourceCatalogInsightsBundleCounts {
-  serviceGroups: number;
-  tripPatternStats: number;
-  tripPatternGeo: number;
-  stopStats: number;
+/** Summary derived from one source's DataBundle file and contents. */
+export interface DataSourceCatalogDataBundleSummary extends DataSourceCatalogFileBackedSummary {
+  /** Entity counts derived from one source's DataBundle. */
+  counts: {
+    stops: number;
+    routes: number;
+    agency: number;
+    calendar: number;
+    feedInfo: number;
+    timetable: number;
+    tripPatterns: number;
+    translations: number;
+    lookup: number;
+  };
 }
 
-/** Translation languages summary derived from one source's TranslationsJson. */
-export interface DataSourceCatalogI18nSummary {
-  /** Sorted union of language codes observed across all translation maps. */
-  languages: string[];
+/** Summary derived from one source's ShapesBundle file and contents. */
+export interface DataSourceCatalogShapesBundleSummary extends DataSourceCatalogFileBackedSummary {
+  /** Counts derived from this source's shapes.json bundle. */
+  counts: {
+    /** Number of routes that carry shape geometry. */
+    routes: number;
+  };
+  /** Shape volume summary derived from this source's shapes.json bundle. */
+  volume: {
+    /** Total polyline count across every route. */
+    polylines: number;
+    /** Total point count across every polyline. */
+    points: number;
+    /** Sum of segment lengths in km across every polyline. */
+    totalLengthKm: number;
+  };
 }
 
-/** Route summary derived from one source's DataBundle routes data. */
-export interface DataSourceCatalogRoutesSummary {
-  /** Counts keyed by the stringified GTFS `route_type` value. */
-  typeCounts: Record<string, number>;
-}
-
-/** Stops summary derived from one source's DataBundle stops data. */
-export interface DataSourceCatalogStopsSummary {
-  /** Per-`location_type` stop counts and parent-station coverage. */
-  locationTypes: Record<string, DataSourceCatalogStopLocationTypeSummary>;
-  /** Stop geographic summary derived from stop coordinates. */
-  geo: DataSourceCatalogStopsGeoSummary;
+/** Nullable date range derived from feedInfo or calendar data. */
+export interface DataSourceCatalogDateRange {
+  start: string | null;
+  end: string | null;
 }
 
 /** Per-`location_type` stop counts and parent-station coverage. */
@@ -103,51 +104,59 @@ export interface DataSourceCatalogStopLocationTypeSummary {
   hasParentCount: number;
 }
 
-/** Bounding box summary derived from one source's stop coordinates. */
-export interface DataSourceCatalogBoundingBox {
-  latMin: number;
-  latMax: number;
-  lonMin: number;
-  lonMax: number;
+/** Curated source-level summaries derived from one source's data.json bundle. */
+export interface DataSourceCatalogSourceSummary {
+  /** Period summary derived from this source's data.json bundle. */
+  periods: {
+    /** Declared feed validity derived from `feedInfo`. */
+    feedValidity: DataSourceCatalogDateRange;
+    /** Min/max service dates derived from `calendar.services`. */
+    servicePeriod: DataSourceCatalogDateRange;
+    /** Min/max exception dates derived from `calendar.exceptions`. */
+    exceptionRange: DataSourceCatalogDateRange;
+  };
+  /** Agencies derived from this source's data.json bundle. */
+  agencies: {
+    /** Agency name as published in the source data. */
+    name: string;
+    /** Agency language code when available in the source data. */
+    lang: string;
+    /** Agency timezone from the source data. */
+    timezone: string;
+  }[];
+  /** Translation languages summary derived from this source's data.json bundle. */
+  i18n: {
+    /** Sorted union of language codes observed across all translation maps. */
+    languages: string[];
+  };
+  /** Route summary derived from this source's data.json bundle. */
+  routes: {
+    /** Counts keyed by the stringified GTFS `route_type` value. */
+    typeCounts: Record<string, number>;
+  };
+  /** Stops summary derived from this source's data.json bundle. */
+  stops: {
+    /** Per-`location_type` stop counts and parent-station coverage. */
+    locationTypes: Record<string, DataSourceCatalogStopLocationTypeSummary>;
+    /** Stop geographic summary derived from stop coordinates. */
+    geo: {
+      /** Bounding box of all stops, or null when the source has no stops. */
+      bbox: null | {
+        latMin: number;
+        latMax: number;
+        lonMin: number;
+        lonMax: number;
+      };
+    };
+  };
 }
 
-/** Stop geographic summary derived from one source's DataBundle stops data. */
-export interface DataSourceCatalogStopsGeoSummary {
-  /** Bounding box of all stops, or null when the source has no stops. */
-  bbox: DataSourceCatalogBoundingBox | null;
-}
-
-/** One agency summary derived from `agency.txt` / DataBundle agency data. */
-export interface DataSourceCatalogAgencySummary {
-  /** Agency name as published in the source data. */
-  name: string;
-  /** Agency language code when available in the source data. */
-  lang: string;
-  /** Agency timezone from the source data. */
-  timezone: string;
-}
-
-/** Agency summaries derived from one source's `agency.txt` / DataBundle agency data. */
-export interface DataSourceCatalogAgenciesSummary {
-  items: DataSourceCatalogAgencySummary[];
-}
-
-/** Summary derived from one source's DataBundle file and contents. */
-export interface DataSourceCatalogDataBundleSummary extends DataSourceCatalogFileBackedSummary {
-  /** Entity counts derived from this source's data.json bundle. */
-  counts: DataSourceCatalogDataBundleCounts;
-}
-
-/** Summary derived from one source's ShapesBundle file and contents. */
-export interface DataSourceCatalogShapesBundleSummary extends DataSourceCatalogFileBackedSummary {
-  /** Entity counts derived from this source's shapes.json bundle. */
-  counts: DataSourceCatalogShapesBundleCounts;
-}
-
-/** Summary derived from one source's InsightsBundle file and contents. */
-export interface DataSourceCatalogInsightsBundleSummary extends DataSourceCatalogFileBackedSummary {
-  /** Entity counts derived from this source's insights.json bundle. */
-  counts: DataSourceCatalogInsightsBundleCounts;
+export interface DataSourceCatalogGlobalInsights extends DataSourceCatalogFileBackedSummary {
+  /** Entity counts derived from the GlobalInsightsBundle. */
+  counts: {
+    /** Cross-source summary derived from `global/insights.json`. */
+    stopGeo: number;
+  };
 }
 
 /**
@@ -159,20 +168,10 @@ export interface DataSourceCatalogInsightsBundleSummary extends DataSourceCatalo
  * license copy intentionally remain outside this schema.
  */
 export interface DataSourceCatalogSource {
-  /** Agency summaries derived from this source's data.json bundle. */
-  agencies: DataSourceCatalogAgenciesSummary;
-  /** Translation languages summary derived from this source's data.json bundle. */
-  i18n: DataSourceCatalogI18nSummary;
-  /** Route summary derived from this source's data.json bundle. */
-  routes: DataSourceCatalogRoutesSummary;
-  /** Stops summary derived from this source's data.json bundle. */
-  stops: DataSourceCatalogStopsSummary;
-  /** Summary derived from this source's data.json bundle. */
-  data: DataSourceCatalogDataBundleSummary;
-  /** Summary derived from this source's shapes.json bundle, when present. */
-  shapes?: DataSourceCatalogShapesBundleSummary;
-  /** Summary derived from this source's insights.json bundle. */
-  insights: DataSourceCatalogInsightsBundleSummary;
+  /** Curated source-level summaries derived from this source's data.json bundle. */
+  summary: DataSourceCatalogSourceSummary;
+  /** Emitted bundle-backed summaries grouped by bundle type. */
+  bundles: DataSourceCatalogSourceBundles;
 }
 
 /**

--- a/src/types/data/transit-v2-catalog-json.ts
+++ b/src/types/data/transit-v2-catalog-json.ts
@@ -1,0 +1,66 @@
+/**
+ * Wire-format types for the pipeline-generated v2 data-source catalog.
+ *
+ * This schema is intentionally separate from `transit-v2-json.ts`.
+ * The catalog is not a per-source transit payload like DataBundle /
+ * ShapesBundle / InsightsBundle; it is a curated global artifact built
+ * from those outputs after the v2 pipeline has finished.
+ */
+
+/**
+ * Versioned section wrapper inside the catalog bundle.
+ *
+ * Kept local to this file so the catalog schema remains self-contained
+ * and can evolve on its own axis without coupling to transit payload
+ * bundle internals.
+ */
+interface BundleSection<V extends number, T> {
+  /** Schema version for this section's data type. */
+  v: V;
+  data: T;
+}
+
+/** Whole-bundle metadata for the generated catalog artifact. */
+export interface DataSourceCatalogMetadata {
+  /** Catalog build timestamp in UTC ISO 8601 / RFC 3339 format. */
+  createdAt: string;
+}
+
+/**
+ * Pipeline-generated catalog payload for a single source prefix.
+ *
+ * This is a curated subset of cross-bundle derived facts intended for
+ * discovery and comparison by any v2 JSON consumer. Editorial fields
+ * such as display labels, brand colors, enable/disable defaults, and
+ * license copy intentionally remain outside this schema.
+ */
+export interface DataSourceCatalogSource {
+  /** Placeholder to keep the outline type object-shaped until sections are added. */
+  _reserved?: never;
+}
+
+/**
+ * `global/data-source-catalog.json` — pipeline-generated source catalog.
+ *
+ * Contains one curated catalog entry per source prefix, derived from
+ * the already-built v2 bundle files. This bundle is intentionally not
+ * a serialization of the full `summarize-v2-outputs` audit output;
+ * it contains only stable discovery-oriented facts that are useful to
+ * generic v2 JSON consumers.
+ *
+ * Delivered as a single file independent of any source prefix.
+ *
+ * `sources.data` is keyed by the source prefix / output directory name
+ * (e.g. `minkuru`, `kobus`). Keys MUST be unique within the bundle.
+ */
+export interface DataSourceCatalogBundle {
+  /** Bundle format version. */
+  bundle_version: 3;
+  /** Discriminated union tag. */
+  kind: 'data-source-catalog';
+
+  /** Whole-bundle metadata such as build timestamp. */
+  metadata: BundleSection<1, DataSourceCatalogMetadata>;
+  /** Per-source metadata and summary payloads keyed by source prefix. */
+  sources: BundleSection<1, Record<string, DataSourceCatalogSource>>;
+}

--- a/src/types/data/transit-v2-catalog-json.ts
+++ b/src/types/data/transit-v2-catalog-json.ts
@@ -120,7 +120,7 @@ export interface DataSourceCatalogSourceSummary {
     /** Agency name as published in the source data. */
     name: string;
     /** Agency language code when available in the source data. */
-    lang: string;
+    lang?: string;
     /** Agency timezone from the source data. */
     timezone: string;
   }[];

--- a/src/types/data/transit-v2-catalog-json.ts
+++ b/src/types/data/transit-v2-catalog-json.ts
@@ -26,6 +26,24 @@ export interface DataSourceCatalogMetadata {
   createdAt: string;
 }
 
+/** Metadata for one emitted v2 JSON file. */
+export interface DataSourceCatalogFileMetadata {
+  /** File size in raw bytes on disk. */
+  sizeBytes: number;
+}
+
+/** File-related metadata for one source's emitted bundle files. */
+export interface DataSourceCatalogFilesMetadata {
+  /** Required startup payload: `{prefix}/data.json`. */
+  data: DataSourceCatalogFileMetadata;
+  /** Optional geometry payload: `{prefix}/shapes.json`. */
+  shapes?: DataSourceCatalogFileMetadata;
+  /** Sum of all present file sizes in raw bytes. */
+  /** Optional analytics payload: `{prefix}/insights.json`. */
+  insights?: DataSourceCatalogFileMetadata;
+  totalSizeBytes: number;
+}
+
 /**
  * Pipeline-generated catalog payload for a single source prefix.
  *
@@ -35,8 +53,8 @@ export interface DataSourceCatalogMetadata {
  * license copy intentionally remain outside this schema.
  */
 export interface DataSourceCatalogSource {
-  /** Placeholder to keep the outline type object-shaped until sections are added. */
-  _reserved?: never;
+  /** File-related metadata for this source's emitted v2 bundle files. */
+  files: DataSourceCatalogFilesMetadata;
 }
 
 /**

--- a/src/types/data/transit-v2-catalog-json.ts
+++ b/src/types/data/transit-v2-catalog-json.ts
@@ -75,6 +75,63 @@ export interface DataSourceCatalogInsightsBundleCounts {
   stopStats: number;
 }
 
+/** Translation languages summary derived from one source's TranslationsJson. */
+export interface DataSourceCatalogI18nSummary {
+  /** Sorted union of language codes observed across all translation maps. */
+  languages: string[];
+}
+
+/** Route summary derived from one source's DataBundle routes data. */
+export interface DataSourceCatalogRoutesSummary {
+  /** Counts keyed by the stringified GTFS `route_type` value. */
+  typeCounts: Record<string, number>;
+}
+
+/** Stops summary derived from one source's DataBundle stops data. */
+export interface DataSourceCatalogStopsSummary {
+  /** Per-`location_type` stop counts and parent-station coverage. */
+  locationTypes: Record<string, DataSourceCatalogStopLocationTypeSummary>;
+  /** Stop geographic summary derived from stop coordinates. */
+  geo: DataSourceCatalogStopsGeoSummary;
+}
+
+/** Per-`location_type` stop counts and parent-station coverage. */
+export interface DataSourceCatalogStopLocationTypeSummary {
+  /** Number of stops with this GTFS `location_type` value. */
+  count: number;
+  /** Number of those stops carrying a GTFS `parent_station` reference. */
+  hasParentCount: number;
+}
+
+/** Bounding box summary derived from one source's stop coordinates. */
+export interface DataSourceCatalogBoundingBox {
+  latMin: number;
+  latMax: number;
+  lonMin: number;
+  lonMax: number;
+}
+
+/** Stop geographic summary derived from one source's DataBundle stops data. */
+export interface DataSourceCatalogStopsGeoSummary {
+  /** Bounding box of all stops, or null when the source has no stops. */
+  bbox: DataSourceCatalogBoundingBox | null;
+}
+
+/** One agency summary derived from `agency.txt` / DataBundle agency data. */
+export interface DataSourceCatalogAgencySummary {
+  /** Agency name as published in the source data. */
+  name: string;
+  /** Agency language code when available in the source data. */
+  lang: string;
+  /** Agency timezone from the source data. */
+  timezone: string;
+}
+
+/** Agency summaries derived from one source's `agency.txt` / DataBundle agency data. */
+export interface DataSourceCatalogAgenciesSummary {
+  items: DataSourceCatalogAgencySummary[];
+}
+
 /** Summary derived from one source's DataBundle file and contents. */
 export interface DataSourceCatalogDataBundleSummary extends DataSourceCatalogFileBackedSummary {
   /** Entity counts derived from this source's data.json bundle. */
@@ -102,6 +159,14 @@ export interface DataSourceCatalogInsightsBundleSummary extends DataSourceCatalo
  * license copy intentionally remain outside this schema.
  */
 export interface DataSourceCatalogSource {
+  /** Agency summaries derived from this source's data.json bundle. */
+  agencies: DataSourceCatalogAgenciesSummary;
+  /** Translation languages summary derived from this source's data.json bundle. */
+  i18n: DataSourceCatalogI18nSummary;
+  /** Route summary derived from this source's data.json bundle. */
+  routes: DataSourceCatalogRoutesSummary;
+  /** Stops summary derived from this source's data.json bundle. */
+  stops: DataSourceCatalogStopsSummary;
   /** Summary derived from this source's data.json bundle. */
   data: DataSourceCatalogDataBundleSummary;
   /** Summary derived from this source's shapes.json bundle, when present. */

--- a/src/types/data/transit-v2-catalog-json.ts
+++ b/src/types/data/transit-v2-catalog-json.ts
@@ -35,27 +35,6 @@ export interface DataSourceCatalogFileBackedSummary {
   };
 }
 
-/** Summary derived from one source's InsightsBundle file and contents. */
-export interface DataSourceCatalogInsightsBundleSummary extends DataSourceCatalogFileBackedSummary {
-  /** Entity counts derived from one source's InsightsBundle. */
-  counts: {
-    serviceGroups: number;
-    tripPatternStats: number;
-    tripPatternGeo: number;
-    stopStats: number;
-  };
-}
-
-/** Emitted bundle-backed summaries grouped by bundle type for one source. */
-export interface DataSourceCatalogSourceBundles {
-  /** Summary derived from this source's data.json bundle. */
-  dataBundle: DataSourceCatalogDataBundleSummary;
-  /** Summary derived from this source's insights.json bundle. */
-  insightsBundle: DataSourceCatalogInsightsBundleSummary;
-  /** Summary derived from this source's shapes.json bundle, when present. */
-  shapesBundle?: DataSourceCatalogShapesBundleSummary;
-}
-
 /** Summary derived from one source's DataBundle file and contents. */
 export interface DataSourceCatalogDataBundleSummary extends DataSourceCatalogFileBackedSummary {
   /** Entity counts derived from one source's DataBundle. */
@@ -69,6 +48,17 @@ export interface DataSourceCatalogDataBundleSummary extends DataSourceCatalogFil
     tripPatterns: number;
     translations: number;
     lookup: number;
+  };
+}
+
+/** Summary derived from one source's InsightsBundle file and contents. */
+export interface DataSourceCatalogInsightsBundleSummary extends DataSourceCatalogFileBackedSummary {
+  /** Entity counts derived from one source's InsightsBundle. */
+  counts: {
+    serviceGroups: number;
+    tripPatternStats: number;
+    tripPatternGeo: number;
+    stopStats: number;
   };
 }
 
@@ -88,6 +78,16 @@ export interface DataSourceCatalogShapesBundleSummary extends DataSourceCatalogF
     /** Sum of segment lengths in km across every polyline. */
     totalLengthKm: number;
   };
+}
+
+/** Emitted bundle-backed summaries grouped by bundle type for one source. */
+export interface DataSourceCatalogSourceBundles {
+  /** Summary derived from this source's data.json bundle. */
+  dataBundle: DataSourceCatalogDataBundleSummary;
+  /** Summary derived from this source's insights.json bundle. */
+  insightsBundle: DataSourceCatalogInsightsBundleSummary;
+  /** Summary derived from this source's shapes.json bundle, when present. */
+  shapesBundle?: DataSourceCatalogShapesBundleSummary;
 }
 
 /** Nullable date range derived from feedInfo or calendar data. */
@@ -151,7 +151,7 @@ export interface DataSourceCatalogSourceSummary {
   };
 }
 
-export interface DataSourceCatalogGlobalInsights extends DataSourceCatalogFileBackedSummary {
+export interface DataSourceCatalogGlobalInsightsSummary extends DataSourceCatalogFileBackedSummary {
   /** Entity counts derived from the GlobalInsightsBundle. */
   counts: {
     /** Cross-source summary derived from `global/insights.json`. */
@@ -199,5 +199,5 @@ export interface DataSourceCatalogBundle {
   /** Per-source metadata and summary payloads keyed by source prefix. */
   sources: BundleSection<1, Record<string, DataSourceCatalogSource>>;
   /** Cross-source summary derived from `global/insights.json`. */
-  globalInsights: BundleSection<1, DataSourceCatalogGlobalInsights>;
+  globalInsights: BundleSection<1, DataSourceCatalogGlobalInsightsSummary>;
 }

--- a/src/types/data/transit-v2-catalog-json.ts
+++ b/src/types/data/transit-v2-catalog-json.ts
@@ -26,22 +26,71 @@ export interface DataSourceCatalogMetadata {
   createdAt: string;
 }
 
+/** Entity counts derived from the GlobalInsightsBundle. */
+export interface DataSourceCatalogGlobalInsightsBundleCounts {
+  stopGeo: number;
+}
+
+/** Cross-source summary derived from `global/insights.json`. */
+export interface DataSourceCatalogGlobalInsights extends DataSourceCatalogFileBackedSummary {
+  /** Entity counts derived from the GlobalInsightsBundle. */
+  counts: DataSourceCatalogGlobalInsightsBundleCounts;
+}
+
 /** Metadata for one emitted v2 JSON file. */
 export interface DataSourceCatalogFileMetadata {
   /** File size in raw bytes on disk. */
   sizeBytes: number;
 }
 
-/** File-related metadata for one source's emitted bundle files. */
-export interface DataSourceCatalogFilesMetadata {
-  /** Required startup payload: `{prefix}/data.json`. */
-  data: DataSourceCatalogFileMetadata;
-  /** Optional geometry payload: `{prefix}/shapes.json`. */
-  shapes?: DataSourceCatalogFileMetadata;
-  /** Sum of all present file sizes in raw bytes. */
-  /** Optional analytics payload: `{prefix}/insights.json`. */
-  insights?: DataSourceCatalogFileMetadata;
-  totalSizeBytes: number;
+/** Shared file metadata for one emitted bundle-backed summary. */
+export interface DataSourceCatalogFileBackedSummary {
+  /** File metadata for the emitted JSON bundle. */
+  file: DataSourceCatalogFileMetadata;
+}
+
+/** Entity counts derived from one source's DataBundle. */
+export interface DataSourceCatalogDataBundleCounts {
+  stops: number;
+  routes: number;
+  agency: number;
+  calendar: number;
+  feedInfo: number;
+  timetable: number;
+  tripPatterns: number;
+  translations: number;
+  lookup: number;
+}
+
+/** Entity counts derived from one source's ShapesBundle. */
+export interface DataSourceCatalogShapesBundleCounts {
+  shapes: number;
+}
+
+/** Entity counts derived from one source's InsightsBundle. */
+export interface DataSourceCatalogInsightsBundleCounts {
+  serviceGroups: number;
+  tripPatternStats: number;
+  tripPatternGeo: number;
+  stopStats: number;
+}
+
+/** Summary derived from one source's DataBundle file and contents. */
+export interface DataSourceCatalogDataBundleSummary extends DataSourceCatalogFileBackedSummary {
+  /** Entity counts derived from this source's data.json bundle. */
+  counts: DataSourceCatalogDataBundleCounts;
+}
+
+/** Summary derived from one source's ShapesBundle file and contents. */
+export interface DataSourceCatalogShapesBundleSummary extends DataSourceCatalogFileBackedSummary {
+  /** Entity counts derived from this source's shapes.json bundle. */
+  counts: DataSourceCatalogShapesBundleCounts;
+}
+
+/** Summary derived from one source's InsightsBundle file and contents. */
+export interface DataSourceCatalogInsightsBundleSummary extends DataSourceCatalogFileBackedSummary {
+  /** Entity counts derived from this source's insights.json bundle. */
+  counts: DataSourceCatalogInsightsBundleCounts;
 }
 
 /**
@@ -53,8 +102,12 @@ export interface DataSourceCatalogFilesMetadata {
  * license copy intentionally remain outside this schema.
  */
 export interface DataSourceCatalogSource {
-  /** File-related metadata for this source's emitted v2 bundle files. */
-  files: DataSourceCatalogFilesMetadata;
+  /** Summary derived from this source's data.json bundle. */
+  data: DataSourceCatalogDataBundleSummary;
+  /** Summary derived from this source's shapes.json bundle, when present. */
+  shapes?: DataSourceCatalogShapesBundleSummary;
+  /** Summary derived from this source's insights.json bundle. */
+  insights: DataSourceCatalogInsightsBundleSummary;
 }
 
 /**
@@ -77,8 +130,10 @@ export interface DataSourceCatalogBundle {
   /** Discriminated union tag. */
   kind: 'data-source-catalog';
 
-  /** Whole-bundle metadata such as build timestamp. */
+  /** Whole-bundle artifact metadata such as build timestamp. */
   metadata: BundleSection<1, DataSourceCatalogMetadata>;
   /** Per-source metadata and summary payloads keyed by source prefix. */
   sources: BundleSection<1, Record<string, DataSourceCatalogSource>>;
+  /** Cross-source summary derived from `global/insights.json`. */
+  globalInsights: BundleSection<1, DataSourceCatalogGlobalInsights>;
 }

--- a/src/types/data/transit-v2-json.ts
+++ b/src/types/data/transit-v2-json.ts
@@ -37,7 +37,7 @@
  * | ------------------------ | ---------------------------------------------- |
  * | `{prefix}/data.json`     | All data needed at startup (DataBundle)         |
  * | `{prefix}/shapes.json`   | Route shapes, lazy-loaded (ShapesBundle)        |
- * | `{prefix}/insights.json` | Precomputed analytics, optional (InsightsBundle) |
+ * | `{prefix}/insights.json` | Precomputed analytics, lazy-loaded (InsightsBundle) |
  *
  * Global bundle (cross-source):
  *

--- a/src/types/data/transit-v2-json.ts
+++ b/src/types/data/transit-v2-json.ts
@@ -29,21 +29,21 @@
  * | tripPatterns   | Route + headsign + direction + ordered per-stop records |
  * | lookup         | Normalized lookup tables (URLs, descriptions, etc.) |
  *
- * ### Bundle structure
+ * ### File layout
  *
- * Per-source bundles (`{prefix}/` directory):
+ * Per-source files (`{prefix}/` directory):
  *
- * | File                     | Contents                                       |
- * | ------------------------ | ---------------------------------------------- |
- * | `{prefix}/data.json`     | All data needed at startup (DataBundle)         |
- * | `{prefix}/shapes.json`   | Route shapes, lazy-loaded (ShapesBundle)        |
- * | `{prefix}/insights.json` | Precomputed analytics, lazy-loaded (InsightsBundle) |
+ * | File                     | Bundle type            | Contents                      |
+ * | ------------------------ | ---------------------- | ----------------------------- |
+ * | `{prefix}/data.json`     | `DataBundle`           | Core per-source transit data  |
+ * | `{prefix}/shapes.json`   | `ShapesBundle`         | Route shape geometry          |
+ * | `{prefix}/insights.json` | `InsightsBundle`       | Precomputed per-source analytics |
  *
- * Global bundle (cross-source):
+ * Global files:
  *
- * | File                     | Contents                                       |
- * | ------------------------ | ---------------------------------------------- |
- * | `global/insights.json`   | Cross-source spatial analytics (GlobalInsightsBundle) |
+ * | File                   | Bundle type              | Contents                      |
+ * | ---------------------- | ------------------------ | ----------------------------- |
+ * | `global/insights.json` | `GlobalInsightsBundle`   | Cross-source spatial analytics |
  *
  * InsightsBundle sections (per-source, all optional except serviceGroups):
  *


### PR DESCRIPTION
## Summary
Create the first-stage type definitions for issue #212 by shaping the wire-format schema for the pipeline-generated data source catalog.

## What changed
- add and refine the source-level catalog schema in `src/types/data/transit-v2-catalog-json.ts`
- separate curated source summaries from bundle-backed summaries with `summary` and `bundles`
- keep `shapesBundle` optional while keeping `dataBundle` and `insightsBundle` required
- inline small leaf shapes where dedicated exported types were no longer buying clarity

## Validation
- `npm run format`
- `npm run lint`
- `npm run build`

Refs: #212