### PR TITLE
feat(repo): load data-source catalog at boot

### DIFF
--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -151,6 +151,7 @@ export function makeRepo(overrides: Partial<TransitRepository> = {}): TransitRep
     }),
     resolveStopStats: vi.fn().mockReturnValue(undefined),
     resolveRouteFreq: vi.fn().mockReturnValue(undefined),
+    getDataSourceCatalog: vi.fn().mockReturnValue(null),
     ...overrides,
   } as TransitRepository;
 }

--- a/src/datasources/__tests__/fetch-data-source-v2.test.ts
+++ b/src/datasources/__tests__/fetch-data-source-v2.test.ts
@@ -337,6 +337,26 @@ describe('FetchDataSourceV2', () => {
         expect.objectContaining({ signal: expect.any(AbortSignal) as AbortSignal }),
       );
     });
+
+    it('uses the catalog-specific 5s timeout, not the instance default', async () => {
+      // The PR keeps catalog-related boot delay bounded by passing
+      // { timeoutMs: CATALOG_TIMEOUT_MS } (5_000) to fetchOptionalBundle.
+      // This regression test asserts the override actually flows to the
+      // abort timer; without it, removing the override would silently fall
+      // back to the (much longer) instance default and no test would notice.
+      const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+      fetchMock.mockResolvedValueOnce(jsonResponse(makeDataSourceCatalogBundle()));
+      // Use a non-default instance timeout so the assertion is not satisfied
+      // by accident (e.g. if CATALOG_TIMEOUT_MS happened to equal the default).
+      const ds = new FetchDataSourceV2('/data-v2', 60_000);
+      await ds.loadDataSourceCatalog();
+
+      const timeoutValues = setTimeoutSpy.mock.calls
+        .map(([, ms]) => ms)
+        .filter((v): v is number => typeof v === 'number');
+      expect(timeoutValues).toContain(5_000);
+      expect(timeoutValues).not.toContain(60_000);
+    });
   });
 });
 

--- a/src/datasources/__tests__/fetch-data-source-v2.test.ts
+++ b/src/datasources/__tests__/fetch-data-source-v2.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FetchDataSourceV2, validateBasePath } from '../fetch-data-source-v2';
 
 // ---------------------------------------------------------------------------
@@ -48,6 +48,17 @@ function makeInsightsBundle() {
 /** Create a minimal valid GlobalInsightsBundle JSON. */
 function makeGlobalInsightsBundle() {
   return { bundle_version: 3, kind: 'global-insights' };
+}
+
+/** Create a minimal valid DataSourceCatalogBundle JSON. */
+function makeDataSourceCatalogBundle() {
+  return {
+    bundle_version: 3,
+    kind: 'data-source-catalog',
+    metadata: { v: 1, data: { createdAt: '2026-05-15T00:00:00Z' } },
+    sources: { v: 1, data: {} },
+    globalInsights: { v: 1, data: { file: { sizeBytes: 0 }, counts: { stopGeo: 0 } } },
+  };
 }
 
 /** Create a mock Response with JSON body and application/json content-type. */
@@ -280,6 +291,49 @@ describe('FetchDataSourceV2', () => {
       await expect(ds.loadGlobalInsights()).resolves.not.toBeNull();
       expect(fetchMock).toHaveBeenCalledWith(
         '/data-v2/global/insights.json',
+        expect.objectContaining({ signal: expect.any(AbortSignal) as AbortSignal }),
+      );
+    });
+  });
+
+  // --- loadDataSourceCatalog (optional) ---
+
+  describe('loadDataSourceCatalog', () => {
+    it('returns DataSourceCatalogBundle for a valid response', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(makeDataSourceCatalogBundle()));
+      const ds = new FetchDataSourceV2();
+      const result = await ds.loadDataSourceCatalog();
+
+      expect(result).not.toBeNull();
+      expect(result!.kind).toBe('data-source-catalog');
+    });
+
+    it('returns null on 404', async () => {
+      fetchMock.mockResolvedValueOnce(notFoundResponse());
+      const ds = new FetchDataSourceV2();
+      expect(await ds.loadDataSourceCatalog()).toBeNull();
+    });
+
+    it('throws on invalid bundle_version', async () => {
+      const bad = { ...makeDataSourceCatalogBundle(), bundle_version: 2 };
+      fetchMock.mockResolvedValueOnce(jsonResponse(bad));
+      const ds = new FetchDataSourceV2();
+      await expect(ds.loadDataSourceCatalog()).rejects.toThrow('invalid bundle_version');
+    });
+
+    it('throws on invalid bundle kind', async () => {
+      const bad = { ...makeDataSourceCatalogBundle(), kind: 'data' };
+      fetchMock.mockResolvedValueOnce(jsonResponse(bad));
+      const ds = new FetchDataSourceV2();
+      await expect(ds.loadDataSourceCatalog()).rejects.toThrow('invalid bundle kind');
+    });
+
+    it('fetches from global/data-source-catalog.json', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(makeDataSourceCatalogBundle()));
+      const ds = new FetchDataSourceV2();
+      await expect(ds.loadDataSourceCatalog()).resolves.not.toBeNull();
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/data-v2/global/data-source-catalog.json',
         expect.objectContaining({ signal: expect.any(AbortSignal) as AbortSignal }),
       );
     });

--- a/src/datasources/fetch-data-source-v2.ts
+++ b/src/datasources/fetch-data-source-v2.ts
@@ -59,6 +59,18 @@ const EXPECTED_BUNDLE_VERSION = 3;
  */
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+/**
+ * Per-call timeout for the data-source catalog fetch.
+ *
+ * Catalog is derived metadata: its absence degrades catalog-related UI
+ * only and does not affect transit query. To avoid blocking app boot on
+ * a slow or stuck catalog request (e.g. partial outage where only the
+ * catalog URL is unreachable), we use a much shorter timeout than the
+ * default. 5s is comfortably above normal RTT-bound response times for
+ * the ~36KB catalog file.
+ */
+const CATALOG_TIMEOUT_MS = 5_000;
+
 /** Pattern for valid source prefixes. */
 const PREFIX_PATTERN = /^[a-z0-9_-]+$/;
 
@@ -112,9 +124,9 @@ function validatePrefix(prefix: string): void {
 /**
  * Result of fetching a bundle file.
  *
- * For optional bundles, `fetchBundle` returns `null` when the data
- * is unavailable (404, HTTP error, timeout, network error, non-JSON
- * content-type, or JSON parse error). See {@link FetchDataSourceV2.fetchBundle}.
+ * For optional bundles, {@link FetchDataSourceV2.fetchOptionalBundle}
+ * returns `null` when the data is unavailable (404, HTTP error, timeout,
+ * network error, non-JSON content-type, or JSON parse error).
  */
 interface FetchBundleResult {
   /** Parsed JSON content. */
@@ -129,6 +141,15 @@ interface FetchBundleResult {
   networkMs: number;
   /** Time spent on JSON.parse (ms). */
   parseMs: number;
+}
+
+/** Per-call options for bundle fetch helpers. */
+interface FetchBundleOptions {
+  /**
+   * Override the instance default timeout for this call (milliseconds).
+   * When omitted, the instance's {@link FetchDataSourceV2.timeoutMs} is used.
+   */
+  timeoutMs?: number;
 }
 
 /**
@@ -160,7 +181,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     validatePrefix(prefix);
 
     const path = `${prefix}/data.json`;
-    const result = await this.fetchBundle(path, false);
+    const result = await this.fetchRequiredBundle(path);
 
     validateBundleEnvelope(result.json, 'data', path);
     return { prefix, data: result.json as DataBundle };
@@ -170,7 +191,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
   async loadShapes(prefix: string): Promise<ShapesBundle | null> {
     validatePrefix(prefix);
 
-    const result = await this.fetchBundle(`${prefix}/shapes.json`, true);
+    const result = await this.fetchOptionalBundle(`${prefix}/shapes.json`);
     if (!result) {
       return null;
     }
@@ -183,7 +204,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
   async loadInsights(prefix: string): Promise<InsightsBundle | null> {
     validatePrefix(prefix);
 
-    const result = await this.fetchBundle(`${prefix}/insights.json`, true);
+    const result = await this.fetchOptionalBundle(`${prefix}/insights.json`);
     if (!result) {
       return null;
     }
@@ -195,7 +216,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
   /** {@inheritDoc TransitDataSourceV2.loadGlobalInsights} */
   async loadGlobalInsights(): Promise<GlobalInsightsBundle | null> {
     const path = 'global/insights.json';
-    const result = await this.fetchBundle(path, true);
+    const result = await this.fetchOptionalBundle(path);
     if (!result) {
       return null;
     }
@@ -207,7 +228,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
   /** {@inheritDoc TransitDataSourceV2.loadDataSourceCatalog} */
   async loadDataSourceCatalog(): Promise<DataSourceCatalogBundle | null> {
     const path = 'global/data-source-catalog.json';
-    const result = await this.fetchBundle(path, true);
+    const result = await this.fetchOptionalBundle(path, { timeoutMs: CATALOG_TIMEOUT_MS });
     if (!result) {
       return null;
     }
@@ -217,33 +238,66 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
   }
 
   /**
+   * Fetch a required bundle.
+   *
+   * @param path - Relative path under base (e.g. "tobus/data.json").
+   * @param options - Per-call options. `timeoutMs` overrides the instance default.
+   * @returns Parsed result with timing metrics.
+   * @throws On network error, timeout, HTTP error, non-JSON content-type
+   *         (possible SPA fallback), or JSON parse error.
+   */
+  private async fetchRequiredBundle(
+    path: string,
+    options: FetchBundleOptions = {},
+  ): Promise<FetchBundleResult> {
+    const result = await this.doFetch(path, false, options);
+    if (result === null) {
+      // Required fetch never returns null from doFetch — either succeeds or
+      // throws. Guard kept as a defensive invariant assertion.
+      throw new Error(`${path}: unexpected null from required fetch`);
+    }
+    return result;
+  }
+
+  /**
+   * Fetch an optional bundle.
+   *
+   * @param path - Relative path under base (e.g. "tobus/shapes.json").
+   * @param options - Per-call options. `timeoutMs` overrides the instance default.
+   * @returns Parsed result with timing metrics, or `null` when unavailable
+   *          (404, HTTP error, timeout, network error, non-JSON content-type,
+   *          or JSON parse error). Bundle envelope validation is the caller's
+   *          responsibility and still throws on mismatch.
+   */
+  private async fetchOptionalBundle(
+    path: string,
+    options: FetchBundleOptions = {},
+  ): Promise<FetchBundleResult | null> {
+    return this.doFetch(path, true, options);
+  }
+
+  /**
    * Fetch, validate content-type, and parse a JSON bundle file.
    *
    * All outcomes are logged at the appropriate level:
-   * - Success: info (path, size, network/parse timing)
+   * - Success: debug (path, size, network/parse timing)
    * - Timeout: error (always, regardless of optional flag)
    * - Other failures: warn for required, debug for optional
-   *
-   * @param path - Relative path under base (e.g. "tobus/data.json").
-   * @param optional - When true, returns `null` on any non-OK HTTP status,
-   *                   non-JSON content-type, network error, timeout, or
-   *                   JSON parse error.
-   * @returns Parsed result with timing metrics, or `null` for unavailable optional files.
-   * @throws On network error, timeout, or HTTP error for required files.
-   * @throws On non-JSON content-type for required files (SPA fallback detection).
-   * @throws On JSON parse error for required files.
    */
-  private async fetchBundle(path: string, optional: true): Promise<FetchBundleResult | null>;
-  private async fetchBundle(path: string, optional: false): Promise<FetchBundleResult>;
-  private async fetchBundle(path: string, optional: boolean): Promise<FetchBundleResult | null> {
+  private async doFetch(
+    path: string,
+    optional: boolean,
+    options: FetchBundleOptions,
+  ): Promise<FetchBundleResult | null> {
     const url = `${this.basePath}/${path}`;
+    const timeoutMs = options.timeoutMs ?? this.timeoutMs;
     const t0 = performance.now();
 
     // --- Network request with timeout ---
     const controller = new AbortController();
     const timeoutId = setTimeout(() => {
       controller.abort();
-    }, this.timeoutMs);
+    }, timeoutMs);
 
     let response: Response;
     try {
@@ -253,11 +307,11 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       const isTimeout = e instanceof DOMException && e.name === 'AbortError';
       if (isTimeout) {
         // Timeout is always logged as error regardless of optional flag
-        logger.error(`${path}: timeout after ${this.timeoutMs}ms`);
+        logger.error(`${path}: timeout after ${timeoutMs}ms`);
         if (optional) {
           return null;
         }
-        throw new Error(`${path}: timeout after ${this.timeoutMs}ms`);
+        throw new Error(`${path}: timeout after ${timeoutMs}ms`);
       }
       if (optional) {
         logger.debug(`${path}: network error (optional, skipping)`);
@@ -319,11 +373,11 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       clearTimeout(timeoutId);
       const isTimeout = e instanceof DOMException && e.name === 'AbortError';
       if (isTimeout) {
-        logger.error(`${path}: timeout after ${this.timeoutMs}ms (during body download)`);
+        logger.error(`${path}: timeout after ${timeoutMs}ms (during body download)`);
         if (optional) {
           return null;
         }
-        throw new Error(`${path}: timeout after ${this.timeoutMs}ms (during body download)`);
+        throw new Error(`${path}: timeout after ${timeoutMs}ms (during body download)`);
       }
       if (optional) {
         logger.debug(`${path}: body read error (optional, skipping)`);

--- a/src/datasources/fetch-data-source-v2.ts
+++ b/src/datasources/fetch-data-source-v2.ts
@@ -4,10 +4,11 @@
  * Loads v2 bundle JSON data via HTTP fetch.
  *
  * Bundle file layout (relative to {@link BASE_PATH}):
- * - `{prefix}/data.json`     — required at startup
- * - `{prefix}/shapes.json`   — lazy-loaded
- * - `{prefix}/insights.json` — lazy-loaded
- * - `global/insights.json`   — lazy-loaded, cross-source
+ * - `{prefix}/data.json`              — required at startup
+ * - `{prefix}/shapes.json`            — lazy-loaded
+ * - `{prefix}/insights.json`          — lazy-loaded
+ * - `global/insights.json`            — lazy-loaded, cross-source
+ * - `global/data-source-catalog.json` — derived per-source metadata, optional
  *
  * Each bundle is validated for `bundle_version` and `kind` after parsing.
  * Required bundles throw on failure; optional bundles return `null`.
@@ -16,6 +17,7 @@
  * (e.g. Vercel returning 200 + HTML for missing static files).
  */
 
+import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
 import type {
   DataBundle,
   GlobalInsightsBundle,
@@ -200,6 +202,18 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
 
     validateBundleEnvelope(result.json, 'global-insights', path);
     return result.json as GlobalInsightsBundle;
+  }
+
+  /** {@inheritDoc TransitDataSourceV2.loadDataSourceCatalog} */
+  async loadDataSourceCatalog(): Promise<DataSourceCatalogBundle | null> {
+    const path = 'global/data-source-catalog.json';
+    const result = await this.fetchBundle(path, true);
+    if (!result) {
+      return null;
+    }
+
+    validateBundleEnvelope(result.json, 'data-source-catalog', path);
+    return result.json as DataSourceCatalogBundle;
   }
 
   /**

--- a/src/datasources/transit-data-source-v2.ts
+++ b/src/datasources/transit-data-source-v2.ts
@@ -11,8 +11,10 @@
  * - shapes.json: lazy-loaded when the shapes layer is toggled on
  * - insights.json: lazy-loaded when analytics views are accessed
  * - global/insights.json: lazy-loaded, cross-source spatial analytics
+ * - global/data-source-catalog.json: derived per-source metadata, optional
  */
 
+import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
 import type {
   DataBundle,
   GlobalInsightsBundle,
@@ -100,4 +102,19 @@ export interface TransitDataSourceV2 {
    * @throws When bundle envelope is invalid (wrong bundle_version or kind).
    */
   loadGlobalInsights(): Promise<GlobalInsightsBundle | null>;
+
+  /**
+   * Load the data-source catalog bundle (global, source-prefix-independent).
+   *
+   * Contains pipeline-derived per-source summary metadata (bundle sizes,
+   * counts, agency/period/route-type/locationType/shapes facts) keyed by
+   * source prefix. The catalog is treated as an optional derived bundle:
+   * its absence degrades catalog-related UI only and does not affect
+   * transit query.
+   *
+   * @returns The parsed catalog bundle, or `null` if unavailable
+   *          (not found, network error, timeout, non-JSON, or parse error).
+   * @throws When bundle envelope is invalid (wrong bundle_version or kind).
+   */
+  loadDataSourceCatalog(): Promise<DataSourceCatalogBundle | null>;
 }

--- a/src/diagnostics/repo-benchmark.ts
+++ b/src/diagnostics/repo-benchmark.ts
@@ -15,10 +15,10 @@
  *   ?diag=repo-bench&repo=v2   → benchmark v2 repo
  */
 
+import { getServiceDay } from '../domain/transit/service-day';
 import { createLogger } from '../lib/logger';
 import type { TransitRepository } from '../repositories/transit-repository';
 import type { StopWithMeta } from '../types/app/transit-composed';
-import { getServiceDay } from '../domain/transit/service-day';
 
 const logger = createLogger('diag:repo-bench');
 
@@ -287,6 +287,16 @@ export async function runRepoBenchmark(repository: TransitRepository): Promise<v
     logger.info(
       `Dataset: ${meta.value.data.length} sources, ${allStops.value.data.length} stops, ${totalRoutes} routes, ${totalTripPatterns} trip patterns`,
     );
+  }
+
+  const catalog = timed(() => repository.getDataSourceCatalog());
+  if (catalog.value) {
+    const sourceCount = Object.keys(catalog.value.sources.data).length;
+    logger.info(
+      `getDataSourceCatalog: ${catalog.ms.toFixed(2)}ms (${sourceCount} sources, createdAt=${catalog.value.metadata.data.createdAt})`,
+    );
+  } else {
+    logger.info(`getDataSourceCatalog: ${catalog.ms.toFixed(2)}ms (unavailable)`);
   }
 
   // --- Per-location accumulators ---

--- a/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
@@ -1,20 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
+import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
+
 import { AthenaiRepositoryV2 } from '..';
+import { minutesToDate } from '../../../domain/transit/calendar-utils';
 import { getEffectiveHeadsign } from '../../../domain/transit/get-effective-headsign';
 import { getServiceDay } from '../../../domain/transit/service-day';
 import {
-  TestDataSourceV2,
-  createFixtureV2,
-  createShapesFixtureV2,
-  createInsightsFixtureV2,
-  WEEKDAY,
-  SATURDAY,
-  WEEKDAY_OVERNIGHT,
   AFTER_BOUNDARY,
   AFTER_BOUNDARY_PAST,
+  createFixtureV2,
+  createInsightsFixtureV2,
+  createShapesFixtureV2,
   EXCEPTION_HOLIDAY,
+  SATURDAY,
+  TestDataSourceV2,
+  WEEKDAY,
+  WEEKDAY_OVERNIGHT,
 } from './fixtures/test-data-source-v2';
-import { minutesToDate } from '../../../domain/transit/calendar-utils';
 
 /** Assert result is successful and preserve the successful result shape. */
 function assertSuccess<T extends { success: boolean }>(
@@ -1228,5 +1231,101 @@ describe('resolveStopStats service group selection', () => {
     const stats = repository.resolveStopStats('bus_01', EXCEPTION_HOLIDAY);
     expect(stats).toBeDefined();
     expect(stats!.freq).toBe(80); // ho group freq, not wd (200)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDataSourceCatalog
+// ---------------------------------------------------------------------------
+
+function makeCatalogFixture(): DataSourceCatalogBundle {
+  return {
+    bundle_version: 3,
+    kind: 'data-source-catalog',
+    metadata: { v: 1, data: { createdAt: '2026-05-15T00:00:00Z' } },
+    sources: {
+      v: 1,
+      data: {
+        test: {
+          bundles: {
+            dataBundle: {
+              file: { sizeBytes: 1024 },
+              counts: {
+                stops: 12,
+                routes: 5,
+                agency: 2,
+                calendar: 4,
+                feedInfo: 1,
+                timetable: 12,
+                tripPatterns: 13,
+                translations: 0,
+                lookup: 0,
+              },
+            },
+            insightsBundle: {
+              file: { sizeBytes: 256 },
+              counts: { serviceGroups: 2, tripPatternStats: 2, tripPatternGeo: 0, stopStats: 2 },
+            },
+          },
+          summary: {
+            periods: {
+              feedValidity: { start: '20260101', end: '20261231' },
+              servicePeriod: { start: '20260101', end: '20261231' },
+              exceptionRange: { start: '20260304', end: '20260304' },
+            },
+            agencies: [{ name: 'Test Agency', lang: 'ja', timezone: 'Asia/Tokyo' }],
+            i18n: { languages: ['ja', 'en'] },
+            routes: { typeCounts: { '0': 1, '1': 1, '2': 1, '3': 2 } },
+            stops: {
+              locationTypes: {
+                '0': { count: 8, hasParentCount: 1 },
+                '1': { count: 4, hasParentCount: 0 },
+              },
+              geo: { bbox: { latMin: 35.7, latMax: 35.8, lonMin: 139.7, lonMax: 139.8 } },
+            },
+            service: { maxTripsPerDay: 100 },
+            shapes: { available: false, routeCount: 0 },
+          },
+        },
+      },
+    },
+    globalInsights: {
+      v: 1,
+      data: { file: { sizeBytes: 0 }, counts: { stopGeo: 0 } },
+    },
+  };
+}
+
+describe('getDataSourceCatalog', () => {
+  it('returns the catalog when the data source provides one', async () => {
+    const fixture = createFixtureV2();
+    const catalog = makeCatalogFixture();
+    const ds = new TestDataSourceV2({ test: fixture }, {}, {}, catalog);
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    expect(repository.getDataSourceCatalog()).toBe(catalog);
+  });
+
+  it('returns null when the data source has no catalog', async () => {
+    const fixture = createFixtureV2();
+    const ds = new TestDataSourceV2({ test: fixture });
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    expect(repository.getDataSourceCatalog()).toBeNull();
+  });
+
+  it('returns null when loadDataSourceCatalog throws (e.g. envelope mismatch)', async () => {
+    const fixture = createFixtureV2();
+    const envelopeError = new Error(
+      'global/data-source-catalog.json: invalid bundle_version (expected 3, got 2)',
+    );
+    const ds = new TestDataSourceV2({ test: fixture }, {}, {}, null, envelopeError);
+    const { repository } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    // Repository must still be usable; catalog is treated as unavailable.
+    expect(repository.getDataSourceCatalog()).toBeNull();
+    const sourceMeta = await repository.getAllSourceMeta();
+    assertSuccess(sourceMeta);
+    expect(sourceMeta.data).toHaveLength(1);
   });
 });

--- a/src/repositories/athenai-repository/__tests__/enrich-stop-insights.test.ts
+++ b/src/repositories/athenai-repository/__tests__/enrich-stop-insights.test.ts
@@ -129,6 +129,42 @@ describe('enrichStopInsights', () => {
     expect(stopInsightsMap.get('bus_01')?.stats.ho?.freq).toBe(80);
   });
 
+  it('absorbs synchronous throws from a non-async loadInsights impl (per-prefix)', async () => {
+    // A non-async impl that throws synchronously inside the
+    // `prefixes.map(...)` callback would bypass `Promise.allSettled`
+    // unless the map callback wraps the call. enrichStopInsights must
+    // continue with the surviving prefix and treat the thrown one as a
+    // per-prefix failure.
+    const merged = mergeSourcesV2([createFixtureV2()]);
+    const stopInsightsMap = new Map<string, StopInsightsEntry>();
+    const insights = createInsightsFixtureV2();
+    const dataSource: TransitDataSourceV2 = {
+      loadData() {
+        return Promise.reject(new Error('loadData is not used in this test'));
+      },
+      loadShapes() {
+        return Promise.resolve(null);
+      },
+      loadInsights(prefix) {
+        if (prefix === 'test') {
+          return Promise.resolve(insights);
+        }
+        throw new Error('sync throw before Promise construction');
+      },
+      loadGlobalInsights() {
+        return Promise.resolve(null);
+      },
+      loadDataSourceCatalog() {
+        return Promise.resolve(null);
+      },
+    };
+
+    await enrichStopInsights(merged.stopsMetaMap, ['test', 'bad'], dataSource, stopInsightsMap);
+
+    // Surviving prefix's stats applied
+    expect(stopInsightsMap.get('bus_01')?.stats.wd?.freq).toBe(200);
+  });
+
   it('absorbs synchronous throws from a non-async loadGlobalInsights impl', async () => {
     // The TransitDataSourceV2 contract returns a Promise but does not
     // preclude implementations from throwing synchronously before the

--- a/src/repositories/athenai-repository/__tests__/enrich-stop-insights.test.ts
+++ b/src/repositories/athenai-repository/__tests__/enrich-stop-insights.test.ts
@@ -128,4 +128,38 @@ describe('enrichStopInsights', () => {
 
     expect(stopInsightsMap.get('bus_01')?.stats.ho?.freq).toBe(80);
   });
+
+  it('absorbs synchronous throws from a non-async loadGlobalInsights impl', async () => {
+    // The TransitDataSourceV2 contract returns a Promise but does not
+    // preclude implementations from throwing synchronously before the
+    // Promise is constructed. enrichStopInsights must still complete
+    // and treat global insights as unavailable in that case.
+    const merged = mergeSourcesV2([createFixtureV2()]);
+    const stopInsightsMap = new Map<string, StopInsightsEntry>();
+    const insights = createInsightsFixtureV2();
+    const dataSource: TransitDataSourceV2 = {
+      loadData() {
+        return Promise.reject(new Error('loadData is not used in this test'));
+      },
+      loadShapes() {
+        return Promise.resolve(null);
+      },
+      loadInsights() {
+        return Promise.resolve(insights);
+      },
+      loadGlobalInsights() {
+        throw new Error('sync throw before Promise construction');
+      },
+      loadDataSourceCatalog() {
+        return Promise.resolve(null);
+      },
+    };
+
+    await enrichStopInsights(merged.stopsMetaMap, ['test'], dataSource, stopInsightsMap);
+
+    // per-source stats still applied because per-source loadInsights succeeded
+    expect(stopInsightsMap.get('bus_01')?.stats.wd?.freq).toBe(200);
+    // stop.geo not populated because global insights threw — but no crash
+    expect(merged.stopsMetaMap.get('bus_01')?.geo).toBeUndefined();
+  });
 });

--- a/src/repositories/athenai-repository/__tests__/enrich-stop-insights.test.ts
+++ b/src/repositories/athenai-repository/__tests__/enrich-stop-insights.test.ts
@@ -25,6 +25,9 @@ function createDataSource(
     loadGlobalInsights() {
       return Promise.resolve(globalInsights);
     },
+    loadDataSourceCatalog() {
+      return Promise.resolve(null);
+    },
   };
 }
 
@@ -114,6 +117,9 @@ describe('enrichStopInsights', () => {
         return Promise.reject(new Error('failed insight load'));
       },
       loadGlobalInsights() {
+        return Promise.resolve(null);
+      },
+      loadDataSourceCatalog() {
         return Promise.resolve(null);
       },
     };

--- a/src/repositories/athenai-repository/__tests__/fetch-data-source-catalog.test.ts
+++ b/src/repositories/athenai-repository/__tests__/fetch-data-source-catalog.test.ts
@@ -1,5 +1,6 @@
 import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
 import { describe, expect, it } from 'vitest';
+import type { TransitDataSourceV2 } from '../../../datasources/transit-data-source-v2';
 import { fetchDataSourceCatalog } from '../fetch-data-source-catalog';
 import { createFixtureV2, TestDataSourceV2 } from './fixtures/test-data-source-v2';
 
@@ -44,6 +45,27 @@ describe('fetchDataSourceCatalog', () => {
     );
     const fixture = createFixtureV2();
     const dataSource = new TestDataSourceV2({ test: fixture }, {}, {}, null, envelopeError);
+
+    const result = await fetchDataSourceCatalog(dataSource);
+
+    expect(result.catalog).toBeNull();
+    expect(result.ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('normalizes synchronous throws from non-async impls to null catalog', async () => {
+    // The TransitDataSourceV2 contract only requires a Promise return type;
+    // an implementation that omits the `async` keyword and throws before
+    // constructing a Promise would bypass a chained `.catch(...)`. The
+    // try/catch wrapper in fetchDataSourceCatalog must still absorb it.
+    const dataSource: TransitDataSourceV2 = {
+      loadData: () => Promise.reject(new Error('not used in this test')),
+      loadShapes: () => Promise.resolve(null),
+      loadInsights: () => Promise.resolve(null),
+      loadGlobalInsights: () => Promise.resolve(null),
+      loadDataSourceCatalog() {
+        throw new Error('sync throw before Promise construction');
+      },
+    };
 
     const result = await fetchDataSourceCatalog(dataSource);
 

--- a/src/repositories/athenai-repository/__tests__/fetch-data-source-catalog.test.ts
+++ b/src/repositories/athenai-repository/__tests__/fetch-data-source-catalog.test.ts
@@ -1,0 +1,53 @@
+import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
+import { describe, expect, it } from 'vitest';
+import { fetchDataSourceCatalog } from '../fetch-data-source-catalog';
+import { createFixtureV2, TestDataSourceV2 } from './fixtures/test-data-source-v2';
+
+function makeCatalogFixture(): DataSourceCatalogBundle {
+  return {
+    bundle_version: 3,
+    kind: 'data-source-catalog',
+    metadata: { v: 1, data: { createdAt: '2026-05-15T00:00:00Z' } },
+    sources: { v: 1, data: {} },
+    globalInsights: {
+      v: 1,
+      data: { file: { sizeBytes: 0 }, counts: { stopGeo: 0 } },
+    },
+  };
+}
+
+describe('fetchDataSourceCatalog', () => {
+  it('returns the catalog and elapsed time on success', async () => {
+    const catalog = makeCatalogFixture();
+    const fixture = createFixtureV2();
+    const dataSource = new TestDataSourceV2({ test: fixture }, {}, {}, catalog);
+
+    const result = await fetchDataSourceCatalog(dataSource);
+
+    expect(result.catalog).toBe(catalog);
+    expect(result.ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns null catalog with elapsed time when the data source has no catalog', async () => {
+    const fixture = createFixtureV2();
+    const dataSource = new TestDataSourceV2({ test: fixture });
+
+    const result = await fetchDataSourceCatalog(dataSource);
+
+    expect(result.catalog).toBeNull();
+    expect(result.ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('normalizes thrown errors (e.g. envelope mismatch) to null catalog', async () => {
+    const envelopeError = new Error(
+      'global/data-source-catalog.json: invalid bundle_version (expected 3, got 2)',
+    );
+    const fixture = createFixtureV2();
+    const dataSource = new TestDataSourceV2({ test: fixture }, {}, {}, null, envelopeError);
+
+    const result = await fetchDataSourceCatalog(dataSource);
+
+    expect(result.catalog).toBeNull();
+    expect(result.ms).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/repositories/athenai-repository/__tests__/fetch-sources-v2.test.ts
+++ b/src/repositories/athenai-repository/__tests__/fetch-sources-v2.test.ts
@@ -49,6 +49,9 @@ describe('fetchSourcesV2', () => {
       loadGlobalInsights() {
         return Promise.resolve(null);
       },
+      loadDataSourceCatalog() {
+        return Promise.resolve(null);
+      },
     };
 
     const result = await fetchSourcesV2(['alpha', 'beta'], dataSource);

--- a/src/repositories/athenai-repository/__tests__/fetch-sources-v2.test.ts
+++ b/src/repositories/athenai-repository/__tests__/fetch-sources-v2.test.ts
@@ -60,4 +60,42 @@ describe('fetchSourcesV2', () => {
     expect(result.loadResult.failed[0].error).toBeInstanceOf(Error);
     expect(result.loadResult.failed[0].error.message).toBe('boom');
   });
+
+  it('reports synchronous throws from non-async loadData as per-prefix failures', async () => {
+    // A non-async impl that throws synchronously before constructing a
+    // Promise would bypass `Promise.allSettled` if the map callback did
+    // not wrap the call. fetchSourcesV2 must still classify the throw
+    // as a per-prefix failure rather than crashing the whole fetch.
+    const fixture = createFixtureV2();
+    const dataSource: TransitDataSourceV2 = {
+      loadData(prefix) {
+        if (prefix === 'alpha') {
+          return Promise.resolve({ ...fixture, prefix });
+        }
+        throw new Error('sync throw before Promise construction');
+      },
+      loadShapes() {
+        return Promise.resolve(null);
+      },
+      loadInsights() {
+        return Promise.resolve(null);
+      },
+      loadGlobalInsights() {
+        return Promise.resolve(null);
+      },
+      loadDataSourceCatalog() {
+        return Promise.resolve(null);
+      },
+    };
+
+    const result = await fetchSourcesV2(['alpha', 'beta'], dataSource);
+
+    expect(result.sources.map((s) => s.prefix)).toEqual(['alpha']);
+    expect(result.loadResult.loaded).toEqual(['alpha']);
+    expect(result.loadResult.failed).toHaveLength(1);
+    expect(result.loadResult.failed[0].prefix).toBe('beta');
+    expect(result.loadResult.failed[0].error.message).toBe(
+      'sync throw before Promise construction',
+    );
+  });
 });

--- a/src/repositories/athenai-repository/__tests__/fixtures/test-data-source-v2.ts
+++ b/src/repositories/athenai-repository/__tests__/fixtures/test-data-source-v2.ts
@@ -14,6 +14,7 @@
  * - Stop.agency_id is empty (v2 GTFS compliance)
  */
 
+import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
 import type {
   DataBundle,
   GlobalInsightsBundle,
@@ -37,15 +38,26 @@ export class TestDataSourceV2 implements TransitDataSourceV2 {
   private fixtures: Record<string, SourceDataV2>;
   private shapesFixtures: Record<string, ShapesBundle>;
   private insightsFixtures: Record<string, InsightsBundle>;
+  private dataSourceCatalog: DataSourceCatalogBundle | null;
+  /**
+   * When set, {@link loadDataSourceCatalog} rejects with this error.
+   * Used to verify that {@link AthenaiRepositoryV2.create} normalizes
+   * load failures (including bundle envelope mismatches) to `null`.
+   */
+  private dataSourceCatalogError: Error | null;
 
   constructor(
     fixtures: Record<string, SourceDataV2>,
     shapesFixtures: Record<string, ShapesBundle> = {},
     insightsFixtures: Record<string, InsightsBundle> = {},
+    dataSourceCatalog: DataSourceCatalogBundle | null = null,
+    dataSourceCatalogError: Error | null = null,
   ) {
     this.fixtures = fixtures;
     this.shapesFixtures = shapesFixtures;
     this.insightsFixtures = insightsFixtures;
+    this.dataSourceCatalog = dataSourceCatalog;
+    this.dataSourceCatalogError = dataSourceCatalogError;
   }
 
   loadData(prefix: string): Promise<SourceDataV2> {
@@ -66,6 +78,13 @@ export class TestDataSourceV2 implements TransitDataSourceV2 {
 
   loadGlobalInsights(): Promise<GlobalInsightsBundle | null> {
     return Promise.resolve(null);
+  }
+
+  loadDataSourceCatalog(): Promise<DataSourceCatalogBundle | null> {
+    if (this.dataSourceCatalogError) {
+      return Promise.reject(this.dataSourceCatalogError);
+    }
+    return Promise.resolve(this.dataSourceCatalog);
   }
 }
 

--- a/src/repositories/athenai-repository/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository/athenai-repository-v2.ts
@@ -17,6 +17,7 @@
  */
 
 import type { CalendarExceptionJson, CalendarServiceJson } from '@contracts/data/transit-json';
+import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
 import type { TimetableGroupV2Json } from '@contracts/data/transit-v2-json';
 
 import { FetchDataSourceV2 } from '../../datasources/fetch-data-source-v2';
@@ -62,6 +63,7 @@ import type {
 import type { TransitRepository } from '../transit-repository';
 import { normalizeOptionalResultLimit, normalizeStopQueryLimit } from '../transit-repository';
 import { enrichStopInsights } from './enrich-stop-insights';
+import { fetchDataSourceCatalog } from './fetch-data-source-catalog';
 import { fetchSourcesV2 } from './fetch-sources-v2';
 import { buildTranslatableText } from './lib/build-translatable-text';
 import { buildTripStopTimes } from './lib/build-trip-stop-times';
@@ -109,6 +111,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
   private readonly timetableByPattern: Map<string, PatternTimetableEntry[]>;
   private readonly headsignTranslations: HeadsignTranslationsByPrefix;
   private readonly sourceMetas: SourceMeta[];
+  private readonly dataSourceCatalog: DataSourceCatalogBundle | null;
 
   // Derived maps populated during initialization and lazy-load phases.
   private readonly stopInsightsMap = new Map<string, StopInsightsEntry>();
@@ -121,7 +124,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
   private shapesPromise: Promise<RouteShape[]> = Promise.resolve([]);
   private shapesCache: RouteShape[] | null = null;
 
-  private constructor(merged: MergedDataV2) {
+  private constructor(merged: MergedDataV2, dataSourceCatalog: DataSourceCatalogBundle | null) {
     this.stops = merged.stops;
     this.stopsMetaMap = merged.stopsMetaMap;
     this.routeMap = merged.routeMap;
@@ -134,6 +137,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     this.timetableByPattern = merged.timetableByPattern;
     this.headsignTranslations = merged.headsignTranslations;
     this.sourceMetas = merged.sourceMetas;
+    this.dataSourceCatalog = dataSourceCatalog;
   }
 
   private startShapesLoad(prefixes: string[], dataSource: TransitDataSourceV2): void {
@@ -158,11 +162,18 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     const t0 = performance.now();
     logger.info(`Loading sources: [${prefixes.join(', ')}]`);
 
-    const { sources, loadResult } = await fetchSourcesV2(prefixes, dataSource);
+    const [sourcesResult, catalogResult] = await Promise.all([
+      fetchSourcesV2(prefixes, dataSource),
+      fetchDataSourceCatalog(dataSource),
+    ]);
+    const { sources, loadResult, ms: sourcesMs } = sourcesResult;
+    const { catalog: dataSourceCatalog, ms: catalogMs } = catalogResult;
     const tFetch = performance.now();
     const fetchMs = Math.round(tFetch - t0);
     if (logger.isEnabled('info')) {
-      logger.info(`fetchSources: ${fetchMs}ms (${sources.length} sources)`);
+      logger.info(
+        `Fetched in ${fetchMs}ms (${sources.length} sources in ${Math.round(sourcesMs)}ms, catalog=${dataSourceCatalog ? 'loaded' : 'unavailable'} in ${Math.round(catalogMs)}ms)`,
+      );
     }
 
     if (logger.isEnabled('debug')) {
@@ -188,7 +199,7 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       );
     }
 
-    const repository = new AthenaiRepositoryV2(merged);
+    const repository = new AthenaiRepositoryV2(merged, dataSourceCatalog);
 
     const tEnrich = performance.now();
     await enrichStopInsights(
@@ -879,6 +890,11 @@ export class AthenaiRepositoryV2 implements TransitRepository {
   /** {@inheritDoc TransitRepository.getAllSourceMeta} */
   getAllSourceMeta(): Promise<CollectionResult<SourceMeta>> {
     return Promise.resolve({ success: true, data: this.sourceMetas, truncated: false });
+  }
+
+  /** {@inheritDoc TransitRepository.getDataSourceCatalog} */
+  getDataSourceCatalog(): DataSourceCatalogBundle | null {
+    return this.dataSourceCatalog;
   }
 
   /** {@inheritDoc TransitRepository.resolveStopStats} */

--- a/src/repositories/athenai-repository/enrich-stop-insights.ts
+++ b/src/repositories/athenai-repository/enrich-stop-insights.ts
@@ -1,4 +1,4 @@
-import type { GlobalInsightsBundle } from '@contracts/data/transit-v2-json';
+import type { GlobalInsightsBundle, InsightsBundle } from '@contracts/data/transit-v2-json';
 
 import type { StopWithMeta } from '../../types/app/transit-composed';
 import type { TransitDataSourceV2 } from '../../datasources/transit-data-source-v2';
@@ -29,6 +29,21 @@ async function loadGlobalInsightsSafe(
 }
 
 /**
+ * Call {@link TransitDataSourceV2.loadInsights} inside an `async`
+ * wrapper so that a synchronous throw from a non-`async` implementation
+ * is normalized to a rejected Promise. Without this guard, a sync throw
+ * inside `prefixes.map(...)` would escape the callback before
+ * `Promise.allSettled` could observe it, killing the whole enrichment
+ * phase.
+ */
+async function loadInsightsSafe(
+  dataSource: TransitDataSourceV2,
+  prefix: string,
+): Promise<InsightsBundle | null> {
+  return dataSource.loadInsights(prefix);
+}
+
+/**
  * Enrich stopsMetaMap with per-stop stats and geo data from insights bundles.
  *
  * - stopStats: from per-source InsightsBundle (all service groups stored
@@ -48,7 +63,7 @@ export async function enrichStopInsights(
   const t0 = performance.now();
 
   const [insightsResults, globalResult] = await Promise.all([
-    Promise.allSettled(prefixes.map((prefix) => dataSource.loadInsights(prefix))),
+    Promise.allSettled(prefixes.map((prefix) => loadInsightsSafe(dataSource, prefix))),
     loadGlobalInsightsSafe(dataSource),
   ]);
 

--- a/src/repositories/athenai-repository/enrich-stop-insights.ts
+++ b/src/repositories/athenai-repository/enrich-stop-insights.ts
@@ -1,9 +1,32 @@
+import type { GlobalInsightsBundle } from '@contracts/data/transit-v2-json';
+
 import type { StopWithMeta } from '../../types/app/transit-composed';
 import type { TransitDataSourceV2 } from '../../datasources/transit-data-source-v2';
 import { createLogger } from '../../lib/logger';
 import type { StopInsightsEntry } from './types';
 
 const logger = createLogger('AthenaiRepositoryV2');
+
+/**
+ * Fetch the global insights bundle, normalizing all failures (including
+ * a non-`async` implementation that throws synchronously) to `null`.
+ *
+ * Uses `try/catch` rather than `.catch(...)` because the
+ * {@link TransitDataSourceV2.loadGlobalInsights} contract returns a
+ * `Promise` but does not preclude implementations from throwing before
+ * the promise is constructed; `.catch(...)` would not absorb such a
+ * synchronous throw.
+ */
+async function loadGlobalInsightsSafe(
+  dataSource: TransitDataSourceV2,
+): Promise<GlobalInsightsBundle | null> {
+  try {
+    return await dataSource.loadGlobalInsights();
+  } catch (error) {
+    logger.warn('Failed to load global insights:', error);
+    return null;
+  }
+}
 
 /**
  * Enrich stopsMetaMap with per-stop stats and geo data from insights bundles.
@@ -26,10 +49,7 @@ export async function enrichStopInsights(
 
   const [insightsResults, globalResult] = await Promise.all([
     Promise.allSettled(prefixes.map((prefix) => dataSource.loadInsights(prefix))),
-    dataSource.loadGlobalInsights().catch((error) => {
-      logger.warn('Failed to load global insights:', error);
-      return null;
-    }),
+    loadGlobalInsightsSafe(dataSource),
   ]);
 
   let statsCount = 0;

--- a/src/repositories/athenai-repository/fetch-data-source-catalog.ts
+++ b/src/repositories/athenai-repository/fetch-data-source-catalog.ts
@@ -16,17 +16,25 @@ export interface FetchDataSourceCatalogResult {
  * Fetch the global data-source catalog bundle, normalizing all failures
  * (including bundle envelope mismatch) to `null`.
  *
- * Mirrors how `enrichStopInsights` handles `loadGlobalInsights`: catalog
- * absence degrades catalog UI only and does not affect transit query, so
- * any error is logged as a warning and converted to `null`.
+ * Catalog absence degrades catalog UI only and does not affect transit
+ * query, so any error is logged as a warning and converted to `null`.
+ *
+ * The `await` is wrapped in `try/catch` rather than chained with
+ * `.catch(...)` so that a synchronous throw from a non-`async`
+ * {@link TransitDataSourceV2.loadDataSourceCatalog} implementation is
+ * also normalized. The interface contract returns a `Promise` but does
+ * not preclude callers throwing before the promise is constructed.
  */
 export async function fetchDataSourceCatalog(
   dataSource: TransitDataSourceV2,
 ): Promise<FetchDataSourceCatalogResult> {
   const start = performance.now();
-  const catalog = await dataSource.loadDataSourceCatalog().catch((err: unknown) => {
+  let catalog: DataSourceCatalogBundle | null;
+  try {
+    catalog = await dataSource.loadDataSourceCatalog();
+  } catch (err: unknown) {
     logger.warn('Failed to load data source catalog:', err);
-    return null;
-  });
+    catalog = null;
+  }
   return { catalog, ms: performance.now() - start };
 }

--- a/src/repositories/athenai-repository/fetch-data-source-catalog.ts
+++ b/src/repositories/athenai-repository/fetch-data-source-catalog.ts
@@ -1,0 +1,32 @@
+import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
+
+import type { TransitDataSourceV2 } from '../../datasources/transit-data-source-v2';
+import { createLogger } from '../../lib/logger';
+
+const logger = createLogger('AthenaiRepositoryV2');
+
+export interface FetchDataSourceCatalogResult {
+  /** The fetched catalog bundle, or null when unavailable. */
+  catalog: DataSourceCatalogBundle | null;
+  /** Elapsed time in milliseconds, regardless of success or failure. */
+  ms: number;
+}
+
+/**
+ * Fetch the global data-source catalog bundle, normalizing all failures
+ * (including bundle envelope mismatch) to `null`.
+ *
+ * Mirrors how `enrichStopInsights` handles `loadGlobalInsights`: catalog
+ * absence degrades catalog UI only and does not affect transit query, so
+ * any error is logged as a warning and converted to `null`.
+ */
+export async function fetchDataSourceCatalog(
+  dataSource: TransitDataSourceV2,
+): Promise<FetchDataSourceCatalogResult> {
+  const start = performance.now();
+  const catalog = await dataSource.loadDataSourceCatalog().catch((err: unknown) => {
+    logger.warn('Failed to load data source catalog:', err);
+    return null;
+  });
+  return { catalog, ms: performance.now() - start };
+}

--- a/src/repositories/athenai-repository/fetch-sources-v2.ts
+++ b/src/repositories/athenai-repository/fetch-sources-v2.ts
@@ -4,11 +4,21 @@ import type { LoadResult } from './types';
 
 const logger = createLogger('AthenaiRepositoryV2');
 
+export interface FetchSourcesV2Result {
+  /** Successfully loaded source data, in input prefix order. */
+  sources: SourceDataV2[];
+  /** Per-prefix success/failure breakdown. */
+  loadResult: LoadResult;
+  /** Elapsed time in milliseconds for the parallel fetch. */
+  ms: number;
+}
+
 /** Fetch all v2 data bundles in parallel, tracking successes and failures. */
 export async function fetchSourcesV2(
   prefixes: string[],
   dataSource: TransitDataSourceV2,
-): Promise<{ sources: SourceDataV2[]; loadResult: LoadResult }> {
+): Promise<FetchSourcesV2Result> {
+  const start = performance.now();
   const results = await Promise.allSettled(prefixes.map((prefix) => dataSource.loadData(prefix)));
 
   const sources: SourceDataV2[] = [];
@@ -28,5 +38,5 @@ export async function fetchSourcesV2(
     }
   }
 
-  return { sources, loadResult: { loaded, failed } };
+  return { sources, loadResult: { loaded, failed }, ms: performance.now() - start };
 }

--- a/src/repositories/athenai-repository/fetch-sources-v2.ts
+++ b/src/repositories/athenai-repository/fetch-sources-v2.ts
@@ -13,13 +13,31 @@ export interface FetchSourcesV2Result {
   ms: number;
 }
 
+/**
+ * Call {@link TransitDataSourceV2.loadData} inside an `async` wrapper so
+ * that a synchronous throw from a non-`async` implementation is
+ * normalized to a rejected Promise. Without this guard, a sync throw
+ * inside `prefixes.map(...)` would escape the callback before
+ * `Promise.allSettled` could observe it, turning a per-source failure
+ * into a whole-batch failure that bypasses the `loadResult.failed`
+ * accounting below.
+ */
+async function loadDataSafe(
+  dataSource: TransitDataSourceV2,
+  prefix: string,
+): Promise<SourceDataV2> {
+  return dataSource.loadData(prefix);
+}
+
 /** Fetch all v2 data bundles in parallel, tracking successes and failures. */
 export async function fetchSourcesV2(
   prefixes: string[],
   dataSource: TransitDataSourceV2,
 ): Promise<FetchSourcesV2Result> {
   const start = performance.now();
-  const results = await Promise.allSettled(prefixes.map((prefix) => dataSource.loadData(prefix)));
+  const results = await Promise.allSettled(
+    prefixes.map((prefix) => loadDataSafe(dataSource, prefix)),
+  );
 
   const sources: SourceDataV2[] = [];
   const loaded: string[] = [];

--- a/src/repositories/mock-repository/mock-repository.ts
+++ b/src/repositories/mock-repository/mock-repository.ts
@@ -15,18 +15,15 @@
  * - `sta_south`: subway(1) + rail(2)
  */
 
+import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
+
+import { getServiceDay, getServiceDayMinutes } from '../../domain/transit/service-day';
+import {
+  sortTimetableEntriesByDepartureTime,
+  sortTimetableEntriesChronologically,
+} from '../../domain/transit/sort-timetable-entries';
+import { getTimetableEntriesState } from '../../domain/transit/timetable-utils';
 import type { Bounds, LatLng, RouteShape } from '../../types/app/map';
-import type { Agency, AppRouteTypeValue, Stop } from '../../types/app/transit';
-import type {
-  ContextualTimetableEntry,
-  SourceMeta,
-  StopWithMeta,
-  TimetableEntry,
-  TripInspectionGroupQuery,
-  TripLocator,
-  TripStopTime,
-  TripSnapshot,
-} from '../../types/app/transit-composed';
 import type {
   CollectionResult,
   Result,
@@ -36,29 +33,34 @@ import type {
   TripSnapshotResult,
   UpcomingTimetableResult,
 } from '../../types/app/repository';
-import { getTimetableEntriesState } from '../../domain/transit/timetable-utils';
-import { getServiceDay, getServiceDayMinutes } from '../../domain/transit/service-day';
-import {
-  sortTimetableEntriesByDepartureTime,
-  sortTimetableEntriesChronologically,
-} from '../../domain/transit/sort-timetable-entries';
-import { normalizeOptionalResultLimit, normalizeStopQueryLimit } from '../transit-repository';
+import type { Agency, AppRouteTypeValue, Stop } from '../../types/app/transit';
+import type {
+  ContextualTimetableEntry,
+  SourceMeta,
+  StopWithMeta,
+  TimetableEntry,
+  TripInspectionGroupQuery,
+  TripLocator,
+  TripSnapshot,
+  TripStopTime,
+} from '../../types/app/transit-composed';
 import type { TransitRepository } from '../transit-repository';
+import { normalizeOptionalResultLimit, normalizeStopQueryLimit } from '../transit-repository';
 import {
   AGENCY_MAP,
+  ROUTES,
   ROUTE_MAP,
   ROUTE_SHAPES,
-  ROUTES,
   ROUTE_STOP_SEQUENCES,
+  STOPS,
   STOP_AGENCIES,
   STOP_ROUTES,
   STOP_ROUTES_RESOLVED,
   STOP_ROUTE_TYPES,
-  STOPS,
   approxDistanceKm,
   computeArrivalMinutes,
-  computePatternTravelOffset,
   computeOccOffset,
+  computePatternTravelOffset,
   countStopOccurrences,
   createMockTranslatableText,
   createMockTripPatternId,
@@ -519,5 +521,10 @@ export class MockRepository implements TransitRepository {
       },
     };
     return Promise.resolve({ success: true, data: [meta], truncated: false });
+  }
+
+  /** {@inheritDoc TransitRepository.getDataSourceCatalog} */
+  getDataSourceCatalog(): DataSourceCatalogBundle | null {
+    return null;
   }
 }

--- a/src/repositories/transit-repository.ts
+++ b/src/repositories/transit-repository.ts
@@ -6,13 +6,9 @@
  * swappable by providing different {@link TransitRepository} implementations.
  */
 
+import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
+
 import type { Bounds, LatLng, RouteShape } from '../types/app/map';
-import type { Agency, AppRouteTypeValue, Stop } from '../types/app/transit';
-import type {
-  SourceMeta,
-  StopWithMeta,
-  TripInspectionGroupQuery,
-} from '../types/app/transit-composed';
 import type {
   CollectionResult,
   Result,
@@ -21,7 +17,13 @@ import type {
   TripSnapshotResult,
   UpcomingTimetableResult,
 } from '../types/app/repository';
-import type { TripLocator } from '../types/app/transit-composed';
+import type { Agency, AppRouteTypeValue, Stop } from '../types/app/transit';
+import type {
+  SourceMeta,
+  StopWithMeta,
+  TripInspectionGroupQuery,
+  TripLocator,
+} from '../types/app/transit-composed';
 
 /**
  * Maximum number of stops that a capped stop query can return.
@@ -538,4 +540,38 @@ export interface TransitRepository {
    * @returns Number of trips in the matched service day, or undefined.
    */
   resolveRouteFreq(routeId: string, serviceDate: Date): number | undefined;
+
+  /**
+   * Returns the data-source catalog bundle, or `null` when unavailable.
+   *
+   * The catalog is a pipeline-derived global artifact (built from the
+   * per-source v2 bundles) keyed by source prefix. It carries summary
+   * facts such as feed validity, agencies, route-type counts, stop
+   * location-type counts, max trips per day, and shape coverage.
+   *
+   * ### Scope vs `getAllSourceMeta()`
+   * The catalog's `sources.data` is keyed by source prefix as of the
+   * pipeline build time, and is independent of which sources are loaded
+   * into this repository instance. As a result, its key set may differ
+   * from {@link getAllSourceMeta} (which describes loaded sources only).
+   * Consumers that need to filter to loaded sources should intersect
+   * the catalog key set with their own context (e.g. `loadResult.loaded`).
+   *
+   * ### Future direction (Phase 2)
+   * {@link getAllSourceMeta} is expected to be deprecated and removed
+   * in a follow-up phase once consumers migrate to the catalog as the
+   * single source of per-source metadata.
+   *
+   * ### Error conditions
+   * `null` is returned when the catalog bundle is unavailable, including:
+   * - fetch error (404, network, timeout, non-JSON, parse error)
+   * - bundle envelope mismatch (wrong bundle_version or kind), caught at
+   *   the repository factory layer and normalized to `null`
+   *
+   * Catalog absence does not affect transit query — only catalog-related
+   * UI degrades.
+   *
+   * @returns The catalog bundle when available, otherwise `null`.
+   */
+  getDataSourceCatalog(): DataSourceCatalogBundle | null;
 }


### PR DESCRIPTION
## Summary
- Add `loadDataSourceCatalog()` to `TransitDataSourceV2` / `FetchDataSourceV2` to fetch `global/data-source-catalog.json` as an optional bundle.
- Expose catalog via `TransitRepository.getDataSourceCatalog(): DataSourceCatalogBundle | null`.
- Eager parallel fetch alongside per-source `data.json`; failures (network error, 404, envelope mismatch) are normalized to `null` so transit query is unaffected.
- Extract catalog fetcher into `fetch-data-source-catalog.ts`, mirroring `fetchSourcesV2`; both return self-timed `{ data, ms }` results.
- `repo-benchmark` (`?diag=repo-bench`) reports catalog status next to other getters.

Treats catalog as **derived metadata**, not primary data: scope-mismatch with `getAllSourceMeta()` (loaded subset vs. pipeline-built full set) is documented in the interface TSDoc. Primary Master Catalog promotion is intentionally deferred.

## Test plan
- [x] `npm run build` passes (tsc + vite build)
- [x] `npm run lint` / `npm run format:check` pass
- [x] `npx vitest run` — 3730 tests pass
- [x] Boot dev server → INFO log shows `Fetched in Xms (N sources in Xms, catalog=loaded in Xms)`
- [x] DevTools Network block `*data-source-catalog.json*` → log shows `catalog=unavailable`, app continues to work
- [x] `?diag=repo-bench` → bench output includes `getDataSourceCatalog: 0.00ms (N sources, createdAt=...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)