### PR TITLE
feat: add operating periods to data sources

### DIFF
--- a/contracts/data/transit-v2-catalog-json.ts
+++ b/contracts/data/transit-v2-catalog-json.ts
@@ -208,6 +208,21 @@ export interface DataSourceCatalogSourceSummary {
   /** Service-volume facts suitable for rough scale comparison. */
   service: {
     /**
+     * Trip-evidence-based operating service dates for this source.
+     *
+     * `first` / `last` use GTFS service-date format (`YYYYMMDD`), not
+     * ISO 8601 or agency-local calendar-date strings. Overnight times
+     * such as `25:00` remain attached to their original service date.
+     */
+    operatingDates?: {
+      /** First service date with at least one trip in the DataBundle (`YYYYMMDD`), or null. */
+      first: string | null;
+      /** Last service date with at least one trip in the DataBundle (`YYYYMMDD`), or null. */
+      last: string | null;
+      /** Number of service dates with at least one trip in the DataBundle. */
+      count: number;
+    };
+    /**
      * Highest one-day trip total represented by this source.
      *
      * Includes services introduced only through exception dates, not

--- a/pipeline/config/targets/build-data-source-catalog-test.ts
+++ b/pipeline/config/targets/build-data-source-catalog-test.ts
@@ -1,0 +1,47 @@
+/**
+ * Target list for DataSourceCatalogBundle build.
+ *
+ * Each entry is a prefix included in the generated
+ * `global/data-source-catalog.json` artifact.
+ *
+ * Kept separate from other target lists so the catalog build can evolve
+ * independently if its required source set diverges.
+ */
+export default [
+  // 'minkuru', // toei-bus
+  // 'toaran', // toei-train
+  // 'ktbus', // kanto-bus
+  // 'kobus', // keio-bus
+  // 'sggsm', // suginami-gsm
+  // 'kazag', // chiyoda-bus (community)
+  // 'edobus', // chuo-bus (community)
+  // 'sbbus', // seibu-bus
+  // 'iyt2', // iyotetsu-bus
+  // 'kbus', // kita-bus (community)
+  // 'kcbus', // kyoto-city-bus
+  // 'osmbus', // oshima-bus
+  // 'mykbus', // miyake-bus
+  // 'kseiw', // keisei-transit-bus
+  // 'mir', // mir-train (nippori-toneri liner)
+  // 'yurimo', // yurikamome
+  // 'nsrt', // nagoya-srt
+  'tmm', // tama-monorail
+  // 'twrr', // twr-rinkai
+  'vagfr', // vag-freiburg
+  // 'actvnav', // actv-nav
+  // 'tcship', // tokyo-cruise-ship
+  // 'tome', // tokyometro
+  // 'ntbus', // nishi-tokyo-bus
+  // 'snws', // sanwa-shosen
+  // 'tkksn', // tokai-kisen
+  // 'kcmb', // kagoshima-maritime-bureau
+  // 'oksrif', // okushiri-ferry
+  // 'orgfry', // orange-ferry
+  // 'uwjmfry', // uwajima-unyu
+  // 'mtfry', // meimon-taiyo-ferry
+  // 'itkfry', // itsukishima-kisen
+  // 'kytbus', // kyoto-bus
+  // 'od9bus', // odakyu-bus
+  // 'yht', // yokohama-municipal-subway
+  // 'yhb', // yokohama-municipal-bus
+];

--- a/pipeline/src/lib/pipeline/app-data-v2/__tests__/build-data-source-catalog.test.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/__tests__/build-data-source-catalog.test.ts
@@ -349,6 +349,11 @@ describe('buildDataSourceCatalogBundle', () => {
       start: '20260429',
       end: '20260503',
     });
+    expect(source.summary.service.operatingDates).toEqual({
+      first: '20260404',
+      last: '20260628',
+      count: 48,
+    });
     expect(source.summary.agencies).toEqual([
       { name: 'Test Agency', lang: 'ja', timezone: 'Asia/Tokyo' },
     ]);
@@ -368,6 +373,11 @@ describe('buildDataSourceCatalogBundle', () => {
       lonMax: 139.4,
     });
     expect(source.summary.service).toEqual({
+      operatingDates: {
+        first: '20260404',
+        last: '20260628',
+        count: 48,
+      },
       maxTripsPerDay: 2,
     });
     expect(source.summary.shapes).toEqual({
@@ -478,6 +488,11 @@ describe('buildDataSourceCatalogBundle', () => {
 
     expect(source.summary.periods.feedValidity).toEqual({ start: null, end: null });
     expect(source.summary.periods.exceptionRange).toEqual({ start: null, end: null });
+    expect(source.summary.service.operatingDates).toEqual({
+      first: '20260404',
+      last: '20260628',
+      count: 47,
+    });
     expect(source.summary.agencies).toEqual([{ name: 'Test Agency', timezone: 'Asia/Tokyo' }]);
     expect(source.summary.i18n.languages).toEqual(['de', 'en', 'ja']);
     expect(source.summary.stops.locationTypes).toEqual({});
@@ -504,7 +519,17 @@ describe('buildDataSourceCatalogBundle', () => {
       tripPatternGeo: 1,
       stopStats: 0,
     });
+    expect(bundle.sources.data.testpfx.summary.service.operatingDates).toEqual({
+      first: '20260404',
+      last: '20260628',
+      count: 48,
+    });
     expect(bundle.sources.data.testpfx.summary.service).toEqual({
+      operatingDates: {
+        first: '20260404',
+        last: '20260628',
+        count: 48,
+      },
       maxTripsPerDay: 2,
     });
   });
@@ -516,7 +541,17 @@ describe('buildDataSourceCatalogBundle', () => {
 
     const bundle = await buildDataSourceCatalogBundle(['testpfx']);
 
+    expect(bundle.sources.data.testpfx.summary.service.operatingDates).toEqual({
+      first: '20260404',
+      last: '20260628',
+      count: 48,
+    });
     expect(bundle.sources.data.testpfx.summary.service).toEqual({
+      operatingDates: {
+        first: '20260404',
+        last: '20260628',
+        count: 48,
+      },
       maxTripsPerDay: 5,
     });
   });

--- a/pipeline/src/lib/pipeline/app-data-v2/__tests__/compute-service-date-coverage.test.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/__tests__/compute-service-date-coverage.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for compute-service-date-coverage.ts.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { DataBundle } from '@contracts/data/transit-v2-json';
+
+import { computeServiceDateCoverage } from '../compute-service-date-coverage';
+
+function makeBundle(): DataBundle {
+  return {
+    bundle_version: 3,
+    kind: 'data',
+    stops: {
+      v: 2,
+      data: [{ v: 2, i: 'test:S1', n: 'Stop 1', a: 35.1, o: 139.1, l: 0 }],
+    },
+    routes: {
+      v: 2,
+      data: [
+        {
+          v: 2,
+          i: 'test:R1',
+          s: '1',
+          l: 'Route 1',
+          t: 3,
+          c: 'FFFFFF',
+          tc: '000000',
+          ai: 'test:A1',
+        },
+      ],
+    },
+    agency: {
+      v: 2,
+      data: [{ v: 2, i: 'test:A1', n: 'Agency', u: 'https://example.com', tz: 'Asia/Tokyo' }],
+    },
+    calendar: {
+      v: 1,
+      data: {
+        services: [{ i: 'svc:wd', s: '20260501', e: '20260507', d: [1, 1, 1, 1, 1, 0, 0] }],
+        exceptions: [],
+      },
+    },
+    feedInfo: {
+      v: 1,
+      data: { pn: '', pu: '', l: 'ja', s: '', e: '', v: '' },
+    },
+    timetable: {
+      v: 2,
+      data: {
+        'test:S1': [
+          {
+            v: 2,
+            tp: 'test:TP1',
+            si: 0,
+            d: { 'svc:wd': [480, 1500] },
+            a: { 'svc:wd': [480, 1500] },
+          },
+        ],
+      },
+    },
+    tripPatterns: {
+      v: 2,
+      data: {
+        'test:TP1': { v: 2, r: 'test:R1', h: 'Headsign', dir: 0, stops: [{ id: 'test:S1' }] },
+      },
+    },
+    translations: {
+      v: 1,
+      data: {
+        agency_names: {},
+        route_long_names: {},
+        route_short_names: {},
+        stop_names: {},
+        trip_headsigns: {},
+        stop_headsigns: {},
+      },
+    },
+    lookup: {
+      v: 2,
+      data: {},
+    },
+  };
+}
+
+describe('computeServiceDateCoverage', () => {
+  it('returns serviceDateCounts and operatingDates from active services', () => {
+    const bundle = makeBundle();
+
+    expect(computeServiceDateCoverage(bundle)).toEqual({
+      serviceDateCounts: [
+        { serviceDate: '20260501', tripCount: 2 },
+        { serviceDate: '20260504', tripCount: 2 },
+        { serviceDate: '20260505', tripCount: 2 },
+        { serviceDate: '20260506', tripCount: 2 },
+        { serviceDate: '20260507', tripCount: 2 },
+      ],
+      operatingDates: {
+        first: '20260501',
+        last: '20260507',
+        count: 5,
+      },
+    });
+  });
+
+  it('ignores non-origin timetable groups and supports exception-only services', () => {
+    const bundle = makeBundle();
+    bundle.calendar.data.services = [];
+    bundle.calendar.data.exceptions = [{ i: 'svc:x', d: '20260503', t: 1 }];
+    bundle.timetable.data['test:S1'] = [
+      {
+        v: 2,
+        tp: 'test:TP1',
+        si: 1,
+        d: { 'svc:x': [501, 601] },
+        a: { 'svc:x': [501, 601] },
+      },
+      {
+        v: 2,
+        tp: 'test:TP1',
+        si: 0,
+        d: { 'svc:x': [500] },
+        a: { 'svc:x': [500] },
+      },
+    ];
+
+    expect(computeServiceDateCoverage(bundle)).toEqual({
+      serviceDateCounts: [{ serviceDate: '20260503', tripCount: 1 }],
+      operatingDates: {
+        first: '20260503',
+        last: '20260503',
+        count: 1,
+      },
+    });
+  });
+
+  it('sums trip counts from multiple active services on the same service date', () => {
+    const bundle = makeBundle();
+    bundle.calendar.data.services = [
+      { i: 'svc:a', s: '20260504', e: '20260506', d: [1, 1, 1, 0, 0, 0, 0] },
+      { i: 'svc:b', s: '20260505', e: '20260507', d: [0, 1, 1, 1, 0, 0, 0] },
+    ];
+    bundle.timetable.data['test:S1'] = [
+      {
+        v: 2,
+        tp: 'test:TP1',
+        si: 0,
+        d: {
+          'svc:a': [480],
+          'svc:b': [600, 720],
+        },
+        a: {
+          'svc:a': [480],
+          'svc:b': [600, 720],
+        },
+      },
+    ];
+
+    expect(computeServiceDateCoverage(bundle)).toEqual({
+      serviceDateCounts: [
+        { serviceDate: '20260504', tripCount: 1 },
+        { serviceDate: '20260505', tripCount: 3 },
+        { serviceDate: '20260506', tripCount: 3 },
+        { serviceDate: '20260507', tripCount: 2 },
+      ],
+      operatingDates: {
+        first: '20260504',
+        last: '20260507',
+        count: 4,
+      },
+    });
+  });
+
+  it('excludes dates removed by calendar exceptions', () => {
+    const bundle = makeBundle();
+    bundle.calendar.data.services = [
+      { i: 'svc:wd', s: '20260504', e: '20260506', d: [1, 1, 1, 0, 0, 0, 0] },
+    ];
+    bundle.calendar.data.exceptions = [{ i: 'svc:wd', d: '20260505', t: 2 }];
+    bundle.timetable.data['test:S1'] = [
+      {
+        v: 2,
+        tp: 'test:TP1',
+        si: 0,
+        d: { 'svc:wd': [480, 540] },
+        a: { 'svc:wd': [480, 540] },
+      },
+    ];
+
+    expect(computeServiceDateCoverage(bundle)).toEqual({
+      serviceDateCounts: [
+        { serviceDate: '20260504', tripCount: 2 },
+        { serviceDate: '20260506', tripCount: 2 },
+      ],
+      operatingDates: {
+        first: '20260504',
+        last: '20260506',
+        count: 2,
+      },
+    });
+  });
+
+  it('returns empty output when no active date has trips', () => {
+    const bundle = makeBundle();
+    bundle.timetable.data['test:S1'] = [];
+
+    expect(computeServiceDateCoverage(bundle)).toEqual({
+      serviceDateCounts: [],
+      operatingDates: {
+        first: null,
+        last: null,
+        count: 0,
+      },
+    });
+  });
+});

--- a/pipeline/src/lib/pipeline/app-data-v2/build-data-source-catalog.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/build-data-source-catalog.ts
@@ -12,20 +12,14 @@ import type {
   InsightsBundle,
   ShapesBundle,
   StopV2Json,
-  TimetableGroupV2Json,
 } from '@contracts/data/transit-v2-json';
 
 import { getDistanceKmLight } from '../../geo-utils';
 import { V2_OUTPUT_DIR } from '../../paths';
-import { uniqueInOrder } from '../pipeline-utils';
 import { loadAllGtfsSources } from '../../resources/load-gtfs-sources';
 import { discoverOdptTrainSources } from '../../resources/load-odpt-train-sources';
-import {
-  addUtcDays,
-  buildExceptionMap,
-  computeActiveServiceIds,
-  getCalendarDateRange,
-} from './calendar-walk';
+import { uniqueInOrder } from '../pipeline-utils';
+import { computeServiceDateCoverage } from './compute-service-date-coverage';
 
 interface ResolvedCatalogTarget {
   prefix: string;
@@ -114,52 +108,6 @@ function buildRouteTypeCounts(bundle: DataBundle): Record<string, number> {
     counts[key] = (counts[key] ?? 0) + 1;
   }
   return counts;
-}
-
-function buildTripsByServiceId(
-  timetable: Record<string, TimetableGroupV2Json[]>,
-): Record<string, number> {
-  const tripsByServiceId: Record<string, number> = {};
-
-  for (const groups of Object.values(timetable)) {
-    for (const group of groups) {
-      if (group.si !== 0) {
-        continue;
-      }
-      for (const [serviceId, departures] of Object.entries(group.d)) {
-        tripsByServiceId[serviceId] = (tripsByServiceId[serviceId] ?? 0) + departures.length;
-      }
-    }
-  }
-
-  return tripsByServiceId;
-}
-
-function buildMaxTripsPerDay(bundle: DataBundle): number {
-  const { services, exceptions } = bundle.calendar.data;
-  const dateRange = getCalendarDateRange(services, exceptions);
-  if (!dateRange) {
-    return 0;
-  }
-
-  const exceptionsByServiceId = buildExceptionMap(exceptions);
-  const tripsByServiceId = buildTripsByServiceId(bundle.timetable.data);
-  let maxTripsPerDay = 0;
-
-  for (let date = dateRange.min; date <= dateRange.max; date = addUtcDays(date, 1)) {
-    const activeServiceIds = computeActiveServiceIds(date, services, exceptionsByServiceId);
-    let totalTrips = 0;
-
-    for (const serviceId of activeServiceIds) {
-      totalTrips += tripsByServiceId[serviceId] ?? 0;
-    }
-
-    if (totalTrips > maxTripsPerDay) {
-      maxTripsPerDay = totalTrips;
-    }
-  }
-
-  return maxTripsPerDay;
 }
 
 function buildStopLocationTypes(
@@ -286,7 +234,14 @@ function buildCatalogSource(
   shapesFilePath: string,
 ): DataSourceCatalogSource {
   const routeTypeCounts = buildRouteTypeCounts(dataBundle);
+
   const stopLocationTypes = buildStopLocationTypes(dataBundle.stops.data);
+
+  const { serviceDateCounts, operatingDates } = computeServiceDateCoverage(dataBundle);
+  const maxTripsPerDay = serviceDateCounts.reduce(
+    (maxTripsPerDay, serviceDateCount) => Math.max(maxTripsPerDay, serviceDateCount.tripCount),
+    0,
+  );
 
   return {
     summary: {
@@ -320,7 +275,8 @@ function buildCatalogSource(
         },
       },
       service: {
-        maxTripsPerDay: buildMaxTripsPerDay(dataBundle),
+        operatingDates,
+        maxTripsPerDay,
       },
       shapes: {
         available: shapesBundle !== null,

--- a/pipeline/src/lib/pipeline/app-data-v2/compute-service-date-coverage.ts
+++ b/pipeline/src/lib/pipeline/app-data-v2/compute-service-date-coverage.ts
@@ -1,0 +1,63 @@
+import type { DataBundle, TimetableGroupV2Json } from '@contracts/data/transit-v2-json';
+
+import { formatGtfsDateKey, walkCalendarDates } from './calendar-walk';
+
+export interface ServiceDateCount {
+  serviceDate: string;
+  tripCount: number;
+}
+
+export interface OperatingDatesSummary {
+  first: string | null;
+  last: string | null;
+  count: number;
+}
+
+function buildTripsPerService(
+  timetable: Record<string, TimetableGroupV2Json[]>,
+): Map<string, number> {
+  const tripsPerService = new Map<string, number>();
+
+  for (const groups of Object.values(timetable)) {
+    for (const group of groups) {
+      if (group.si !== 0) {
+        continue;
+      }
+      for (const [serviceId, departures] of Object.entries(group.d)) {
+        tripsPerService.set(serviceId, (tripsPerService.get(serviceId) ?? 0) + departures.length);
+      }
+    }
+  }
+
+  return tripsPerService;
+}
+
+export function computeServiceDateCoverage(bundle: DataBundle): {
+  serviceDateCounts: ServiceDateCount[];
+  operatingDates: OperatingDatesSummary;
+} {
+  const tripsPerService = buildTripsPerService(bundle.timetable.data);
+  const serviceDateCounts: ServiceDateCount[] = [];
+
+  walkCalendarDates(bundle.calendar.data, (date, activeServiceIds) => {
+    let tripCount = 0;
+    for (const serviceId of activeServiceIds) {
+      tripCount += tripsPerService.get(serviceId) ?? 0;
+    }
+    if (tripCount > 0) {
+      serviceDateCounts.push({
+        serviceDate: formatGtfsDateKey(date),
+        tripCount,
+      });
+    }
+  });
+
+  return {
+    serviceDateCounts,
+    operatingDates: {
+      first: serviceDateCounts[0]?.serviceDate ?? null,
+      last: serviceDateCounts.at(-1)?.serviceDate ?? null,
+      count: serviceDateCounts.length,
+    },
+  };
+}

--- a/src/components/datasource/data-source-group-item.stories.tsx
+++ b/src/components/datasource/data-source-group-item.stories.tsx
@@ -48,6 +48,7 @@ function buildGroupInfo(args: WrapperArgs): DataSourceGroupInfo | null {
         : new Set(LANGUAGE_POOL.slice(0, Math.max(0, args.languageCount))),
     boardingStopsCount: args.boardingStopsCount,
     maxTripsPerDay: args.maxTripsPerDay,
+    operatingDates: { first: '20260101', last: '20260131' },
     routeTypeCounts: null,
     routeShapesCount: null,
   };

--- a/src/components/datasource/data-source-group-summary-2.stories.tsx
+++ b/src/components/datasource/data-source-group-summary-2.stories.tsx
@@ -28,6 +28,7 @@ interface WrapperArgs {
   boardingStopsCount: number | null;
   maxTripsPerDay: number | null;
   routeShapesCount?: number | null;
+  showOperatingDates?: boolean;
 }
 
 function buildGroupInfo(args: WrapperArgs): DataSourceGroupInfo | null {
@@ -46,6 +47,8 @@ function buildGroupInfo(args: WrapperArgs): DataSourceGroupInfo | null {
       args.routeCount === undefined || args.routeCount === null ? null : { 3: args.routeCount },
     boardingStopsCount: args.boardingStopsCount,
     maxTripsPerDay: args.maxTripsPerDay,
+    operatingDates:
+      args.showOperatingDates === false ? null : { first: '20260101', last: '20260131' },
     routeShapesCount: args.routeShapesCount ?? null,
   };
 }
@@ -65,6 +68,7 @@ const meta = {
     boardingStopsCount: 1500,
     maxTripsPerDay: 8000,
     routeShapesCount: 48,
+    showOperatingDates: true,
   },
   argTypes: {
     groupInfoNull: { control: 'boolean' },
@@ -74,6 +78,7 @@ const meta = {
     boardingStopsCount: { control: 'number' },
     maxTripsPerDay: { control: 'number' },
     routeShapesCount: { control: 'number' },
+    showOperatingDates: { control: 'boolean' },
   },
   decorators: [
     (Story) => (

--- a/src/components/datasource/data-source-group-summary-2.tsx
+++ b/src/components/datasource/data-source-group-summary-2.tsx
@@ -1,4 +1,12 @@
-import { CalendarDays, Globe, HardDrive, Route, Signpost, Spline } from 'lucide-react';
+import {
+  CalendarDays,
+  CalendarRange,
+  Globe,
+  HardDrive,
+  Route,
+  Signpost,
+  Spline,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toTranslationCoverageLevel } from '../../domain/datasource/translation-coverage-level';
 import type { DataSourceGroupInfo } from '../../types/app/data-source-group-info';
@@ -67,11 +75,18 @@ export function DataSourceGroupSummary2({ groupInfo }: { groupInfo: DataSourceGr
   if (groupInfo === null) {
     return null;
   }
+  const operatingDatesText =
+    groupInfo.operatingDates === null ||
+    groupInfo.operatingDates.first === null ||
+    groupInfo.operatingDates.last === null
+      ? null
+      : `${groupInfo.operatingDates.first}-${groupInfo.operatingDates.last}`;
   const routesCount =
     groupInfo.routeTypeCounts === null || Object.keys(groupInfo.routeTypeCounts).length === 0
       ? null
       : Object.values(groupInfo.routeTypeCounts).reduce((sum, count) => sum + count, 0);
   const hasAnyMetric =
+    operatingDatesText !== null ||
     groupInfo.size !== null ||
     groupInfo.translationLanguages !== null ||
     routesCount !== null ||
@@ -150,6 +165,19 @@ export function DataSourceGroupSummary2({ groupInfo }: { groupInfo: DataSourceGr
           level={toMetricLevel(groupInfo.routeShapesCount, ROUTE_SHAPES_THRESHOLDS)}
           aria-label={t('dataSourceSettings.routeShapes.aria', {
             count: groupInfo.routeShapesCount.toLocaleString(i18n.language),
+          })}
+        />
+      )}
+
+      {/* Operating period */}
+      {operatingDatesText !== null && (
+        <MetricLevelBadge
+          size="xs"
+          icon={<CalendarRange />}
+          text={operatingDatesText}
+          level={0}
+          aria-label={t('dataSourceSettings.operatingDates.aria', {
+            range: operatingDatesText,
           })}
         />
       )}

--- a/src/components/datasource/data-source-group-summary.stories.tsx
+++ b/src/components/datasource/data-source-group-summary.stories.tsx
@@ -60,6 +60,7 @@ function Wrapper(args: WrapperArgs) {
           args.routeCount === undefined || args.routeCount === null ? null : { 3: args.routeCount },
         boardingStopsCount: args.boardingStopsCount,
         maxTripsPerDay: args.maxTripsPerDay,
+        operatingDates: { first: '20260101', last: '20260131' },
         routeShapesCount: args.routeShapesCount ?? null,
       };
   return <DataSourceGroupSummary groupInfo={groupInfo} />;

--- a/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
+++ b/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
@@ -9,6 +9,7 @@
  */
 
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DataSourceSettingsDialog } from '../data-source-settings-dialog';
 import settings from '../../../config/data-source-settings';
@@ -68,7 +69,7 @@ vi.mock('../../../hooks/use-user-data-source-settings', () => ({
 // source meta resolves to an empty collection — the dialog must remain
 // functional when no catalog is available, and per-group size captions
 // are simply hidden.
-const mockGetDataSourceCatalog = vi.fn<() => null>(() => null);
+const mockGetDataSourceCatalog = vi.fn<() => DataSourceCatalogBundle | null>(() => null);
 const mockGetAllSourceMeta = vi.fn(() =>
   Promise.resolve({ success: true as const, data: [], truncated: false }),
 );
@@ -153,6 +154,84 @@ function getAllSwitchesFor(groupName: string): HTMLElement[] {
 }
 
 describe('DataSourceSettingsDialog — normal mode', () => {
+  it('renders a group operatingDates summary when catalog data is available', async () => {
+    const customGroup: SourceGroup = {
+      id: 'demo-group',
+      prefixes: ['demo'],
+      routeTypes: [3],
+      systemEnabledByDefault: true,
+      userEnabledByDefault: true,
+      name: { name: 'Demo Group', names: { en: 'Demo Group' } },
+      countries: ['JP'],
+    };
+    const catalog: DataSourceCatalogBundle = {
+      bundle_version: 3,
+      kind: 'data-source-catalog',
+      metadata: { v: 1, data: { createdAt: '2026-05-19T00:00:00.000Z' } },
+      sources: {
+        v: 1,
+        data: {
+          demo: {
+            summary: {
+              periods: {
+                feedValidity: { start: null, end: null },
+                servicePeriod: { start: null, end: null },
+                exceptionRange: { start: null, end: null },
+              },
+              agencies: [{ name: 'Demo Agency', timezone: 'Asia/Tokyo' }],
+              i18n: { languages: [] },
+              routes: { typeCounts: { '3': 1 } },
+              stops: { locationTypes: {}, geo: { bbox: null } },
+              service: {
+                operatingDates: { first: '20260101', last: '20260131', count: 31 },
+                maxTripsPerDay: 10,
+              },
+              shapes: { available: false, routeCount: 0 },
+            },
+            bundles: {
+              dataBundle: {
+                file: { sizeBytes: 100 },
+                counts: {
+                  stops: 0,
+                  routes: 0,
+                  agency: 0,
+                  calendar: 0,
+                  feedInfo: 1,
+                  timetable: 0,
+                  tripPatterns: 0,
+                  translations: 0,
+                  lookup: 0,
+                },
+              },
+              insightsBundle: {
+                file: { sizeBytes: 20 },
+                counts: {
+                  serviceGroups: 0,
+                  tripPatternStats: 0,
+                  tripPatternGeo: 0,
+                  stopStats: 0,
+                },
+              },
+            },
+          },
+        },
+      },
+      globalInsights: { v: 1, data: { file: { sizeBytes: 1 }, counts: { stopGeo: 0 } } },
+    };
+    mockGetDataSourceCatalog.mockReturnValue(catalog);
+    mockComputeDialogDisplay.mockReturnValue({
+      visibleGroups: [customGroup],
+      effectiveEnabledIds: new Set(['demo-group']),
+    });
+
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+
+    const demoRow = findGroupRow('Demo Group');
+
+    expect(await within(demoRow).findByText('Jan 1, 2026 - Jan 31, 2026')).toBeInTheDocument();
+    expect(within(demoRow).queryByText('demo')).not.toBeInTheDocument();
+  });
+
   it('shows the development notice Alert, not the forced-mode Alert', () => {
     render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
     expect(screen.getByText('dataSourceSettings.developmentNotice.title')).toBeInTheDocument();
@@ -173,8 +252,11 @@ describe('DataSourceSettingsDialog — normal mode', () => {
       visibleGroups: [customGroup],
       effectiveEnabledIds: new Set(['other-test']),
     });
+
     render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+
     expect(screen.getByText('dataSourceSettings.section.other')).toBeInTheDocument();
+    expect(findGroupRow('Other Test')).toBeInTheDocument();
   });
 
   it('enables the Reset to defaults button', () => {

--- a/src/domain/datasource/__tests__/aggregate-source-counts.test.ts
+++ b/src/domain/datasource/__tests__/aggregate-source-counts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   aggregateBoardingStopsCount,
   aggregateMaxTripsPerDay,
+  aggregateOperatingDates,
   aggregateRouteTypeCounts,
   aggregateRouteShapesCount,
 } from '../aggregate-source-counts';
@@ -12,6 +13,7 @@ function makeInfo(
   prefix: string,
   fields: {
     maxTripsPerDay?: number | null;
+    operatingDates?: { first: string | null; last: string | null; count: number } | null;
     boardingStopsCount?: number | null;
     routeTypeCounts?: Partial<Record<AppRouteTypeValue, number>> | null;
     routeShapesCount?: number | null;
@@ -24,6 +26,7 @@ function makeInfo(
     servicePeriod: null,
     totalSizeBytes: null,
     maxTripsPerDay: fields.maxTripsPerDay ?? null,
+    operatingDates: fields.operatingDates ?? null,
     boardingStopsCount: fields.boardingStopsCount ?? null,
     routes:
       fields.routeTypeCounts === undefined || fields.routeTypeCounts === null
@@ -36,6 +39,47 @@ function makeInfo(
     translationLanguages: [],
   };
 }
+
+describe('aggregateOperatingDates', () => {
+  it('returns null for empty input', () => {
+    expect(aggregateOperatingDates([])).toBeNull();
+  });
+
+  it('returns null when every entry has a null value', () => {
+    expect(
+      aggregateOperatingDates([
+        makeInfo('a', { operatingDates: null }),
+        makeInfo('b', { operatingDates: null }),
+      ]),
+    ).toBeNull();
+  });
+
+  it('returns min first and max last across entries', () => {
+    expect(
+      aggregateOperatingDates([
+        makeInfo('a', { operatingDates: { first: '20260410', last: '20260420', count: 11 } }),
+        makeInfo('b', { operatingDates: { first: '20260401', last: '20260430', count: 30 } }),
+      ]),
+    ).toEqual({ first: '20260401', last: '20260430' });
+  });
+
+  it('skips null entries while keeping the others', () => {
+    expect(
+      aggregateOperatingDates([
+        makeInfo('a', { operatingDates: null }),
+        makeInfo('b', { operatingDates: { first: '20260501', last: '20260531', count: 31 } }),
+      ]),
+    ).toEqual({ first: '20260501', last: '20260531' });
+  });
+
+  it('preserves null boundaries when present in the only known entry', () => {
+    expect(
+      aggregateOperatingDates([
+        makeInfo('a', { operatingDates: { first: null, last: '20260531', count: 0 } }),
+      ]),
+    ).toEqual({ first: null, last: '20260531' });
+  });
+});
 
 describe('aggregateMaxTripsPerDay', () => {
   it('returns null for empty input', () => {

--- a/src/domain/datasource/__tests__/aggregate-source-size.test.ts
+++ b/src/domain/datasource/__tests__/aggregate-source-size.test.ts
@@ -10,6 +10,7 @@ function makeInfo(prefix: string, totalSizeBytes: number | null): DataSourceInfo
     servicePeriod: null,
     totalSizeBytes,
     maxTripsPerDay: null,
+    operatingDates: null,
     boardingStopsCount: null,
     routes: null,
     routeShapes: null,

--- a/src/domain/datasource/__tests__/aggregate-translation-languages.test.ts
+++ b/src/domain/datasource/__tests__/aggregate-translation-languages.test.ts
@@ -10,6 +10,7 @@ function makeInfo(prefix: string, translationLanguages: readonly string[] | null
     servicePeriod: null,
     totalSizeBytes: null,
     maxTripsPerDay: null,
+    operatingDates: null,
     boardingStopsCount: null,
     routes: null,
     routeShapes: null,

--- a/src/domain/datasource/__tests__/data-source-info.test.ts
+++ b/src/domain/datasource/__tests__/data-source-info.test.ts
@@ -43,7 +43,10 @@ function makeCatalogSource(
         },
         geo: { bbox: null },
       },
-      service: { maxTripsPerDay: 50 },
+      service: {
+        operatingDates: { first: '20260101', last: '20260930', count: 200 },
+        maxTripsPerDay: 50,
+      },
       shapes: { available: true, routeCount: 3 },
     },
   };
@@ -150,9 +153,35 @@ describe('composeDataSourceInfo', () => {
     expect(info.maxTripsPerDay).toBe(50);
   });
 
+  it('reads operatingDates from catalog summary', () => {
+    const info = composeDataSourceInfo('kobus', makeSourceMeta(), makeCatalogSource());
+    expect(info.operatingDates).toEqual({
+      first: '20260101',
+      last: '20260930',
+      count: 200,
+    });
+  });
+
   it('returns null maxTripsPerDay when catalog is missing', () => {
     const info = composeDataSourceInfo('kobus', makeSourceMeta(), undefined);
     expect(info.maxTripsPerDay).toBeNull();
+  });
+
+  it('returns null operatingDates when catalog is missing', () => {
+    const info = composeDataSourceInfo('kobus', makeSourceMeta(), undefined);
+    expect(info.operatingDates).toBeNull();
+  });
+
+  it('returns null operatingDates when catalog summary does not carry it', () => {
+    const catalogSource = makeCatalogSource({
+      summary: {
+        ...makeCatalogSource().summary,
+        service: { maxTripsPerDay: 50 },
+      },
+    });
+
+    const info = composeDataSourceInfo('kobus', makeSourceMeta(), catalogSource);
+    expect(info.operatingDates).toBeNull();
   });
 
   it('reads boardingStopsCount from locationTypes[0]', () => {

--- a/src/domain/datasource/aggregate-source-counts.ts
+++ b/src/domain/datasource/aggregate-source-counts.ts
@@ -29,6 +29,43 @@ export function aggregateMaxTripsPerDay(infos: readonly DataSourceInfo[]): numbe
 }
 
 /**
+ * Derive a boundary-only operating-date summary for a group.
+ *
+ * Uses `min(first)` and `max(last)` across per-prefix
+ * `DataSourceInfo.operatingDates`. The result intentionally omits a day
+ * count because overlapping source periods would require a true date-set
+ * union to count correctly.
+ *
+ * Returns `null` when **none** of the inputs has catalog-backed
+ * operating-date data.
+ */
+export function aggregateOperatingDates(
+  infos: readonly DataSourceInfo[],
+): { first: string | null; last: string | null } | null {
+  let first: string | null = null;
+  let last: string | null = null;
+  let found = false;
+
+  for (const info of infos) {
+    if (info.operatingDates === null) {
+      continue;
+    }
+    found = true;
+    if (
+      info.operatingDates.first !== null &&
+      (first === null || info.operatingDates.first < first)
+    ) {
+      first = info.operatingDates.first;
+    }
+    if (info.operatingDates.last !== null && (last === null || info.operatingDates.last > last)) {
+      last = info.operatingDates.last;
+    }
+  }
+
+  return found ? { first, last } : null;
+}
+
+/**
  * Sum the `boardingStopsCount` of every {@link DataSourceInfo} that
  * has a known catalog count.
  *

--- a/src/domain/datasource/data-source-info.ts
+++ b/src/domain/datasource/data-source-info.ts
@@ -121,6 +121,7 @@ export function composeDataSourceInfo(
     totalSizeBytes: sumBundleSizes(catalogSource),
     translationLanguages: catalogSource?.summary.i18n.languages ?? null,
     maxTripsPerDay: catalogSource?.summary.service.maxTripsPerDay ?? null,
+    operatingDates: catalogSource?.summary.service.operatingDates ?? null,
     boardingStopsCount: countBoardingStops(catalogSource),
     routes: normalizeRouteTypeCounts(catalogSource),
     routeShapes: composeRouteShapes(catalogSource),

--- a/src/hooks/use-data-source-group-info.ts
+++ b/src/hooks/use-data-source-group-info.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import {
   aggregateBoardingStopsCount,
   aggregateMaxTripsPerDay,
+  aggregateOperatingDates,
   aggregateRouteTypeCounts,
   aggregateRouteShapesCount,
 } from '../domain/datasource/aggregate-source-counts';
@@ -91,6 +92,7 @@ export function useDataSourceGroupInfo(
         translationLanguages: aggregateTranslationLanguages(infos),
         boardingStopsCount: aggregateBoardingStopsCount(infos),
         maxTripsPerDay: aggregateMaxTripsPerDay(infos),
+        operatingDates: aggregateOperatingDates(infos),
         routeTypeCounts: aggregateRouteTypeCounts(infos),
         routeShapesCount: aggregateRouteShapesCount(infos),
       });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -205,6 +205,9 @@
     "maxTripsPerDay": {
       "aria": "estimated max daily trips: {{count}}"
     },
+    "operatingDates": {
+      "aria": "Operating period {{range}}"
+    },
     "toggle": {
       "aria": "Enable {{group}}"
     },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -205,6 +205,9 @@
     "maxTripsPerDay": {
       "aria": "最大便数の目安 {{count}} 便"
     },
+    "operatingDates": {
+      "aria": "運行期間 {{range}}"
+    },
     "toggle": {
       "aria": "{{group}} を有効化"
     },

--- a/src/types/app/data-source-group-info.ts
+++ b/src/types/app/data-source-group-info.ts
@@ -65,6 +65,19 @@ export interface DataSourceGroupInfo {
    */
   maxTripsPerDay: number | null;
   /**
+   * Earliest and latest service dates observed across the group's
+   * prefixes.
+   *
+   * Derived as `min(first)` / `max(last)` over per-prefix
+   * `DataSourceInfo.operatingDates`, so this is a boundary summary, not
+   * a guarantee of continuous service through the whole span.
+   * `null` when no prefix has catalog-backed operating-date data.
+   */
+  operatingDates: {
+    first: string | null;
+    last: string | null;
+  } | null;
+  /**
    * Sum of per-prefix route counts keyed by normalized app route type.
    * `null` when no prefix has catalog-backed route metadata.
    */

--- a/src/types/app/data-source-info.ts
+++ b/src/types/app/data-source-info.ts
@@ -73,6 +73,19 @@ export interface DataSourceInfo {
   maxTripsPerDay: number | null;
 
   /**
+   * Trip-evidence-based operating service-date summary from catalog
+   * `summary.service.operatingDates`.
+   *
+   * `null` when catalog is unavailable or when the source does not
+   * carry this summary in the catalog.
+   */
+  operatingDates: {
+    first: string | null;
+    last: string | null;
+    count: number;
+  } | null;
+
+  /**
    * Count of physical boarding stops (`location_type == 0`) from
    * catalog. `null` when catalog is unavailable.
    */


### PR DESCRIPTION
## Summary
- compute trip-evidence-based operating date coverage in the v2 data source catalog pipeline
- expose operating date summaries through app data source info and group aggregations
- show operating periods in the data source settings UI and align related i18n, stories, and tests

## Validation
- npm run format
- npm run lint
- npm run build