### PR TITLE
Report repository load progress and app init logs

### DIFF
--- a/src/datasources/__tests__/fetch-data-source-v2.test.ts
+++ b/src/datasources/__tests__/fetch-data-source-v2.test.ts
@@ -563,7 +563,7 @@ describe('formatTransferSummary', () => {
       transferSize: 0,
       encodedBodySize: 512,
       decodedBodySize: 2048,
-      fromCache: true,
+      noNetworkTransfer: true,
     };
     expect(formatTransferSummary(metrics, 0)).toBe('no network transfer, 2.0KB decoded');
   });
@@ -573,7 +573,7 @@ describe('formatTransferSummary', () => {
       transferSize: 1500,
       encodedBodySize: 1024,
       decodedBodySize: 10240,
-      fromCache: false,
+      noNetworkTransfer: false,
     };
     expect(formatTransferSummary(metrics, 0)).toBe('1.0KB over the wire, 10.0KB decoded');
   });

--- a/src/datasources/__tests__/fetch-data-source-v2.test.ts
+++ b/src/datasources/__tests__/fetch-data-source-v2.test.ts
@@ -176,6 +176,19 @@ describe('FetchDataSourceV2', () => {
       await expect(ds.loadData('tobus')).rejects.toThrow('invalid bundle_version');
     });
 
+    it('emits failed instead of succeeded when envelope validation fails', async () => {
+      const bad = { ...makeDataBundle(), bundle_version: 1 };
+      const events: string[] = [];
+      fetchMock.mockResolvedValueOnce(jsonResponse(bad));
+      const ds = new FetchDataSourceV2();
+      ds.setLoadEventReporter((event) => {
+        events.push(event.type);
+      });
+
+      await expect(ds.loadData('tobus')).rejects.toThrow('invalid bundle_version');
+      expect(events).toEqual(['started', 'failed']);
+    });
+
     it('throws on wrong bundle kind', async () => {
       const bad = { ...makeDataBundle(), kind: 'shapes' };
       fetchMock.mockResolvedValueOnce(jsonResponse(bad));

--- a/src/datasources/__tests__/fetch-data-source-v2.test.ts
+++ b/src/datasources/__tests__/fetch-data-source-v2.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { FetchDataSourceV2, validateBasePath } from '../fetch-data-source-v2';
+import {
+  FetchDataSourceV2,
+  formatTransferSummary,
+  selectResourceTimingEntry,
+  validateBasePath,
+} from '../fetch-data-source-v2';
+import { configureLogger, getLoggerConfig } from '../../lib/logger';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -195,6 +201,94 @@ describe('FetchDataSourceV2', () => {
       const ds = new FetchDataSourceV2('/data-v2', 100);
       await expect(ds.loadData('tobus')).rejects.toThrow('timeout');
     });
+
+    it('does not fail a successful fetch when debug logging is enabled without location', async () => {
+      const loggerConfig = getLoggerConfig();
+      const originalLocation = globalThis.location;
+      const consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+      configureLogger({
+        level: 'debug',
+        enabledTags: ['FetchDataSourceV2'],
+        tagLevels: { ...loggerConfig.tagLevels },
+      });
+      vi.stubGlobal('location', undefined);
+      fetchMock.mockResolvedValueOnce(jsonResponse(makeDataBundle()));
+
+      try {
+        const ds = new FetchDataSourceV2();
+        await expect(ds.loadData('tobus')).resolves.toMatchObject({ prefix: 'tobus' });
+        expect(consoleDebugSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[FetchDataSourceV2]'),
+          expect.stringContaining(
+            'fetch metrics: tobus/data.json: estimated 0.6KB decoded (transfer size unavailable)',
+          ),
+        );
+      } finally {
+        configureLogger({
+          level: loggerConfig.level,
+          enabledTags: [...loggerConfig.enabledTags],
+          tagLevels: { ...loggerConfig.tagLevels },
+        });
+        vi.stubGlobal('location', originalLocation);
+      }
+    });
+
+    it('uses PerformanceObserver metrics in the debug log when available', async () => {
+      const loggerConfig = getLoggerConfig();
+      const consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+      const performanceNowSpy = vi
+        .spyOn(performance, 'now')
+        .mockReturnValueOnce(10)
+        .mockReturnValueOnce(22)
+        .mockReturnValueOnce(27);
+      const resolvedUrl = new URL('/data-v2/tobus/data.json', globalThis.location.href).href;
+      const entry = {
+        entryType: 'resource',
+        name: resolvedUrl,
+        startTime: 15,
+        transferSize: 1536,
+        encodedBodySize: 1024,
+        decodedBodySize: 2048,
+      } as PerformanceResourceTiming;
+
+      class MockPerformanceObserver {
+        observe = vi.fn();
+        disconnect = vi.fn();
+        takeRecords = vi.fn(() => [entry as unknown as PerformanceEntry]);
+
+        constructor(_callback: PerformanceObserverCallback) {}
+      }
+
+      configureLogger({
+        level: 'debug',
+        enabledTags: ['FetchDataSourceV2'],
+        tagLevels: { ...loggerConfig.tagLevels },
+      });
+      vi.stubGlobal(
+        'PerformanceObserver',
+        MockPerformanceObserver as unknown as typeof PerformanceObserver,
+      );
+      fetchMock.mockResolvedValueOnce(jsonResponse(makeDataBundle()));
+
+      try {
+        const ds = new FetchDataSourceV2();
+        await expect(ds.loadData('tobus')).resolves.toMatchObject({ prefix: 'tobus' });
+        expect(consoleDebugSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[FetchDataSourceV2]'),
+          expect.stringContaining(
+            'fetch metrics: tobus/data.json: 1.0KB over the wire, 2.0KB decoded',
+          ),
+        );
+      } finally {
+        configureLogger({
+          level: loggerConfig.level,
+          enabledTags: [...loggerConfig.enabledTags],
+          tagLevels: { ...loggerConfig.tagLevels },
+        });
+        performanceNowSpy.mockRestore();
+      }
+    });
   });
 
   // --- loadShapes (optional) ---
@@ -383,5 +477,76 @@ describe('validateBasePath', () => {
 
   it('throws on empty string', () => {
     expect(() => validateBasePath('/')).toThrow('Invalid VITE_TRANSIT_DATA_PATH');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectResourceTimingEntry
+// ---------------------------------------------------------------------------
+
+describe('selectResourceTimingEntry', () => {
+  /** Build a minimal Resource Timing entry carrying only `startTime`. */
+  function entryAt(startTime: number): PerformanceResourceTiming {
+    return { startTime } as unknown as PerformanceResourceTiming;
+  }
+
+  it('returns undefined for an empty entry list', () => {
+    expect(selectResourceTimingEntry([], 100)).toBeUndefined();
+  });
+
+  it('returns undefined when every entry started before sinceTime', () => {
+    const entries = [entryAt(10), entryAt(50), entryAt(99)];
+    expect(selectResourceTimingEntry(entries, 100)).toBeUndefined();
+  });
+
+  it('returns the only entry started at or after sinceTime', () => {
+    const target = entryAt(150);
+    expect(selectResourceTimingEntry([entryAt(10), target], 100)).toBe(target);
+  });
+
+  it('includes an entry whose startTime equals sinceTime exactly', () => {
+    const target = entryAt(100);
+    expect(selectResourceTimingEntry([target], 100)).toBe(target);
+  });
+
+  it('returns the earliest entry when several started after sinceTime', () => {
+    // The current fetch produced the earliest qualifying entry; later ones
+    // belong to subsequent loads of the same URL.
+    const earliest = entryAt(120);
+    const entries = [entryAt(50), earliest, entryAt(300), entryAt(180)];
+    expect(selectResourceTimingEntry(entries, 100)).toBe(earliest);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatTransferSummary
+// ---------------------------------------------------------------------------
+
+describe('formatTransferSummary', () => {
+  it('falls back to the decoded text length when metrics are unavailable', () => {
+    // 4096 UTF-16 code units / 1024 = 4.0 KB
+    expect(formatTransferSummary(null, 4096)).toBe(
+      'estimated 4.0KB decoded (transfer size unavailable)',
+    );
+  });
+
+  it('reports when the response required no network transfer', () => {
+    const metrics = {
+      transferSize: 0,
+      encodedBodySize: 512,
+      decodedBodySize: 2048,
+      fromCache: true,
+    };
+    expect(formatTransferSummary(metrics, 0)).toBe('no network transfer, 2.0KB decoded');
+  });
+
+  it('reports wire and decoded sizes for a network fetch', () => {
+    const metrics = {
+      transferSize: 1500,
+      encodedBodySize: 1024,
+      decodedBodySize: 10240,
+      fromCache: false,
+    };
+    expect(formatTransferSummary(metrics, 0)).toBe('1.0KB over the wire, 10.0KB decoded');
   });
 });

--- a/src/datasources/__tests__/fetch-data-source-v2.test.ts
+++ b/src/datasources/__tests__/fetch-data-source-v2.test.ts
@@ -302,6 +302,45 @@ describe('FetchDataSourceV2', () => {
         performanceNowSpy.mockRestore();
       }
     });
+
+    it('disconnects PerformanceObserver even when fetch returns null early', async () => {
+      const loggerConfig = getLoggerConfig();
+      const observerInstances: MockPerformanceObserver[] = [];
+
+      class MockPerformanceObserver {
+        observe = vi.fn();
+        disconnect = vi.fn();
+        takeRecords = vi.fn(() => []);
+
+        constructor(_callback: PerformanceObserverCallback) {
+          observerInstances.push(this);
+        }
+      }
+
+      configureLogger({
+        level: 'debug',
+        enabledTags: ['FetchDataSourceV2'],
+        tagLevels: { ...loggerConfig.tagLevels },
+      });
+      vi.stubGlobal(
+        'PerformanceObserver',
+        MockPerformanceObserver as unknown as typeof PerformanceObserver,
+      );
+      fetchMock.mockResolvedValueOnce(notFoundResponse());
+
+      try {
+        const ds = new FetchDataSourceV2();
+        await expect(ds.loadShapes('tobus')).resolves.toBeNull();
+        expect(observerInstances).toHaveLength(1);
+        expect(observerInstances[0].disconnect).toHaveBeenCalledTimes(1);
+      } finally {
+        configureLogger({
+          level: loggerConfig.level,
+          enabledTags: [...loggerConfig.enabledTags],
+          tagLevels: { ...loggerConfig.tagLevels },
+        });
+      }
+    });
   });
 
   // --- loadShapes (optional) ---

--- a/src/datasources/__tests__/fetch-data-source-v2.test.ts
+++ b/src/datasources/__tests__/fetch-data-source-v2.test.ts
@@ -327,6 +327,34 @@ describe('FetchDataSourceV2', () => {
       expect(await ds.loadShapes('tobus')).toBeNull();
     });
 
+    it('warns on JSON parse error before skipping an optional bundle', async () => {
+      const loggerConfig = getLoggerConfig();
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      configureLogger({
+        level: 'debug',
+        enabledTags: ['FetchDataSourceV2'],
+        tagLevels: { ...loggerConfig.tagLevels },
+      });
+      fetchMock.mockResolvedValueOnce(brokenJsonResponse());
+
+      try {
+        const ds = new FetchDataSourceV2();
+        await expect(ds.loadShapes('tobus')).resolves.toBeNull();
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[FetchDataSourceV2]'),
+          expect.stringContaining('tobus/shapes.json: JSON parse error (optional, skipping)'),
+          expect.any(SyntaxError),
+        );
+      } finally {
+        configureLogger({
+          level: loggerConfig.level,
+          enabledTags: [...loggerConfig.enabledTags],
+          tagLevels: { ...loggerConfig.tagLevels },
+        });
+      }
+    });
+
     it('returns null on timeout', async () => {
       fetchMock.mockRejectedValueOnce(new DOMException('The operation was aborted.', 'AbortError'));
       const ds = new FetchDataSourceV2('/data-v2', 100);

--- a/src/datasources/fetch-data-source-v2.ts
+++ b/src/datasources/fetch-data-source-v2.ts
@@ -118,6 +118,8 @@ interface FetchBundleOptions {
   timeoutMs?: number;
 }
 
+type LogLevel = 'debug' | 'warn' | 'error';
+
 /**
  * Network transfer metrics for a fetched bundle, read from the Resource
  * Timing API after the response body is fully downloaded.
@@ -130,15 +132,15 @@ interface FetchBundleOptions {
 export interface ResourceTransferMetrics {
   /**
    * Bytes transferred over the network, including response headers.
-   * `0` when the response was served from the HTTP cache.
+   * `0` when the browser reports that no network transfer was required.
    */
   transferSize: number;
   /** Compressed body size — the bytes actually downloaded. */
   encodedBodySize: number;
   /** Uncompressed body size. Matches the file size on disk. */
   decodedBodySize: number;
-  /** `true` when served from the HTTP cache (`transferSize === 0`). */
-  fromCache: boolean;
+  /** `true` when no network transfer was reported (`transferSize === 0`). */
+  noNetworkTransfer: boolean;
 }
 
 /**
@@ -176,7 +178,7 @@ function buildResourceTransferMetrics(entry: PerformanceResourceTiming): Resourc
     transferSize: entry.transferSize,
     encodedBodySize: entry.encodedBodySize,
     decodedBodySize: entry.decodedBodySize,
-    fromCache: entry.transferSize === 0,
+    noNetworkTransfer: entry.transferSize === 0,
   };
 }
 
@@ -203,6 +205,11 @@ interface FetchBundleTextResult {
   sizeApprox: number;
   networkMs: number;
   transferMetrics: ResourceTransferMetrics | null;
+}
+
+interface TimedFetchResult {
+  response: Response;
+  timeoutId: ReturnType<typeof setTimeout>;
 }
 
 /**
@@ -268,7 +275,7 @@ export function formatTransferSummary(
     )}KB decoded (transfer size unavailable)`;
   }
   const decodedKB = (metrics.decodedBodySize / 1024).toFixed(1);
-  if (metrics.fromCache) {
+  if (metrics.noNetworkTransfer) {
     return `no network transfer, ${decodedKB}KB decoded`;
   }
   const wireKB = (metrics.encodedBodySize / 1024).toFixed(1);
@@ -314,60 +321,61 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     validatePrefix(prefix);
 
     const path = `${prefix}/data.json`;
-    const result = await this.loadRequiredBundle(path);
-
-    assertBundleEnvelope(result.json, 'data', path);
-    return { prefix, data: result.json as DataBundle };
+    const data = await this.loadRequiredTypedBundle<DataBundle>(path, 'data');
+    return { prefix, data };
   }
 
   /** {@inheritDoc TransitDataSourceV2.loadShapes} */
   async loadShapes(prefix: string): Promise<ShapesBundle | null> {
     validatePrefix(prefix);
-
-    const result = await this.loadOptionalBundle(`${prefix}/shapes.json`);
-    if (!result) {
-      return null;
-    }
-
-    assertBundleEnvelope(result.json, 'shapes', `${prefix}/shapes.json`);
-    return result.json as ShapesBundle;
+    return this.loadOptionalTypedBundle<ShapesBundle>(`${prefix}/shapes.json`, 'shapes');
   }
 
   /** {@inheritDoc TransitDataSourceV2.loadInsights} */
   async loadInsights(prefix: string): Promise<InsightsBundle | null> {
     validatePrefix(prefix);
-
-    const result = await this.loadOptionalBundle(`${prefix}/insights.json`);
-    if (!result) {
-      return null;
-    }
-
-    assertBundleEnvelope(result.json, 'insights', `${prefix}/insights.json`);
-    return result.json as InsightsBundle;
+    return this.loadOptionalTypedBundle<InsightsBundle>(`${prefix}/insights.json`, 'insights');
   }
 
   /** {@inheritDoc TransitDataSourceV2.loadGlobalInsights} */
   async loadGlobalInsights(): Promise<GlobalInsightsBundle | null> {
-    const path = 'global/insights.json';
-    const result = await this.loadOptionalBundle(path);
-    if (!result) {
-      return null;
-    }
-
-    assertBundleEnvelope(result.json, 'global-insights', path);
-    return result.json as GlobalInsightsBundle;
+    return this.loadOptionalTypedBundle<GlobalInsightsBundle>(
+      'global/insights.json',
+      'global-insights',
+    );
   }
 
   /** {@inheritDoc TransitDataSourceV2.loadDataSourceCatalog} */
   async loadDataSourceCatalog(): Promise<DataSourceCatalogBundle | null> {
-    const path = 'global/data-source-catalog.json';
-    const result = await this.loadOptionalBundle(path, { timeoutMs: CATALOG_TIMEOUT_MS });
+    return this.loadOptionalTypedBundle<DataSourceCatalogBundle>(
+      'global/data-source-catalog.json',
+      'data-source-catalog',
+      { timeoutMs: CATALOG_TIMEOUT_MS },
+    );
+  }
+
+  private async loadRequiredTypedBundle<T>(
+    path: string,
+    expectedKind: string,
+    options: FetchBundleOptions = {},
+  ): Promise<T> {
+    const result = await this.loadRequiredBundle(path, options);
+    assertBundleEnvelope(result.json, expectedKind, path);
+    return result.json as T;
+  }
+
+  private async loadOptionalTypedBundle<T>(
+    path: string,
+    expectedKind: string,
+    options: FetchBundleOptions = {},
+  ): Promise<T | null> {
+    const result = await this.loadOptionalBundle(path, options);
     if (!result) {
       return null;
     }
 
-    assertBundleEnvelope(result.json, 'data-source-catalog', path);
-    return result.json as DataSourceCatalogBundle;
+    assertBundleEnvelope(result.json, expectedKind, path);
+    return result.json as T;
   }
 
   /**
@@ -420,91 +428,22 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     const debugLoggingEnabled = logger.isEnabled('debug');
     const transferCapture = debugLoggingEnabled ? startResourceTransferCapture(url, t0) : null;
 
-    // --- Network request with timeout ---
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      controller.abort();
-    }, timeoutMs);
-
-    let response: Response;
-    try {
-      response = await fetch(url, { signal: controller.signal });
-    } catch (e) {
-      clearTimeout(timeoutId);
-      const isTimeout = e instanceof DOMException && e.name === 'AbortError';
-      if (isTimeout) {
-        logger.error(`${path}: timeout after ${timeoutMs}ms`);
-        if (optional) {
-          return null;
-        }
-        throw new Error(`${path}: timeout after ${timeoutMs}ms`);
-      }
-      if (optional) {
-        logger.debug(`${path}: network error (optional, skipping)`);
-        return null;
-      }
-      logger.warn(`${path}: network error`, e);
-      throw new Error(`${path}: network error`, { cause: e });
+    const fetched = await this.fetchResponseWithTimeout(path, url, timeoutMs, optional);
+    if (fetched === null) {
+      return null;
     }
 
-    // --- HTTP status check ---
-    // clearTimeout is deferred until after response.text() so that the
-    // timeout covers the entire transfer, not just the headers.
-    if (response.status === 404) {
-      clearTimeout(timeoutId);
-      if (optional) {
-        logger.debug(`${path}: 404 (optional, skipping)`);
-        return null;
-      }
-      logger.warn(`${path}: HTTP 404`);
-      throw new Error(`${path}: HTTP 404`);
-    }
-    if (!response.ok) {
-      clearTimeout(timeoutId);
-      if (optional) {
-        logger.debug(`${path}: HTTP ${response.status} (optional, skipping)`);
-        return null;
-      }
-      logger.warn(`${path}: HTTP ${response.status}`);
-      throw new Error(`${path}: HTTP ${response.status}`);
+    const { response, timeoutId } = fetched;
+    const validatedResponse = this.validateJsonResponse(path, response, timeoutId, optional);
+    if (validatedResponse === null) {
+      return null;
     }
 
-    // --- Content-type validation ---
-    const contentType = response.headers.get('content-type') ?? '';
-    if (!contentType.includes('application/json')) {
-      clearTimeout(timeoutId);
-      if (optional) {
-        logger.debug(`${path}: non-JSON content-type (optional, skipping)`);
-        return null;
-      }
-      logger.warn(
-        `${path}: expected application/json but got "${contentType}" (possible SPA fallback)`,
-      );
-      throw new Error(
-        `${path}: expected application/json but got "${contentType}" (possible SPA fallback)`,
-      );
+    const text = await this.readBundleText(path, validatedResponse, timeoutId, timeoutMs, optional);
+    if (text === null) {
+      return null;
     }
 
-    let text: string;
-    try {
-      text = await response.text();
-    } catch (e) {
-      clearTimeout(timeoutId);
-      const isTimeout = e instanceof DOMException && e.name === 'AbortError';
-      if (isTimeout) {
-        logger.error(`${path}: timeout after ${timeoutMs}ms (during body download)`);
-        if (optional) {
-          return null;
-        }
-        throw new Error(`${path}: timeout after ${timeoutMs}ms (during body download)`);
-      }
-      if (optional) {
-        logger.debug(`${path}: body read error (optional, skipping)`);
-        return null;
-      }
-      logger.warn(`${path}: body read error`, e);
-      throw new Error(`${path}: body read error`, { cause: e });
-    }
     clearTimeout(timeoutId);
     const tNetwork = performance.now();
 
@@ -516,6 +455,108 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     };
   }
 
+  private async fetchResponseWithTimeout(
+    path: string,
+    url: string,
+    timeoutMs: number,
+    optional: boolean,
+  ): Promise<TimedFetchResult | null> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, timeoutMs);
+
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+      return { response, timeoutId };
+    } catch (e) {
+      clearTimeout(timeoutId);
+      const isTimeout = e instanceof DOMException && e.name === 'AbortError';
+      if (isTimeout) {
+        return this.handleBundleFailure(path, optional, `timeout after ${timeoutMs}ms`, {
+          requiredLevel: 'error',
+          optionalLevel: 'error',
+        });
+      }
+      return this.handleBundleFailure(path, optional, 'network error', {
+        requiredLevel: 'warn',
+        optionalLevel: 'debug',
+        cause: e,
+      });
+    }
+  }
+
+  private validateJsonResponse(
+    path: string,
+    response: Response,
+    timeoutId: ReturnType<typeof setTimeout>,
+    optional: boolean,
+  ): Response | null {
+    // clearTimeout is deferred until after response.text() so that the
+    // timeout covers the entire transfer, not just the headers.
+    if (response.status === 404) {
+      clearTimeout(timeoutId);
+      return this.handleBundleFailure(path, optional, 'HTTP 404', {
+        requiredLevel: 'warn',
+        optionalLevel: 'debug',
+      });
+    }
+    if (!response.ok) {
+      clearTimeout(timeoutId);
+      return this.handleBundleFailure(path, optional, `HTTP ${response.status}`, {
+        requiredLevel: 'warn',
+        optionalLevel: 'debug',
+      });
+    }
+
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      clearTimeout(timeoutId);
+      return this.handleBundleFailure(
+        path,
+        optional,
+        `expected application/json but got "${contentType}" (possible SPA fallback)`,
+        {
+          requiredLevel: 'warn',
+          optionalLevel: 'debug',
+        },
+      );
+    }
+
+    return response;
+  }
+
+  private async readBundleText(
+    path: string,
+    response: Response,
+    timeoutId: ReturnType<typeof setTimeout>,
+    timeoutMs: number,
+    optional: boolean,
+  ): Promise<string | null> {
+    try {
+      return await response.text();
+    } catch (e) {
+      clearTimeout(timeoutId);
+      const isTimeout = e instanceof DOMException && e.name === 'AbortError';
+      if (isTimeout) {
+        return this.handleBundleFailure(
+          path,
+          optional,
+          `timeout after ${timeoutMs}ms (during body download)`,
+          {
+            requiredLevel: 'error',
+            optionalLevel: 'error',
+          },
+        );
+      }
+      return this.handleBundleFailure(path, optional, 'body read error', {
+        requiredLevel: 'warn',
+        optionalLevel: 'debug',
+        cause: e,
+      });
+    }
+  }
+
   private parseBundleJsonWithPolicy(
     path: string,
     text: string,
@@ -524,13 +565,48 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     try {
       return parseBundleJsonText(text);
     } catch (e) {
-      if (optional) {
-        logger.warn(`${path}: JSON parse error (optional, skipping)`, e);
-        return null;
-      }
-      logger.warn(`${path}: JSON parse error`, e);
-      throw new Error(`${path}: JSON parse error`, { cause: e });
+      return this.handleBundleFailure(path, optional, 'JSON parse error', {
+        requiredLevel: 'warn',
+        optionalLevel: 'warn',
+        cause: e,
+      });
     }
+  }
+
+  private handleBundleFailure(
+    path: string,
+    optional: boolean,
+    message: string,
+    options: {
+      requiredLevel: LogLevel;
+      optionalLevel: LogLevel;
+      cause?: unknown;
+    },
+  ): null {
+    if (optional) {
+      this.logBundleFailure(options.optionalLevel, `${path}: ${message} (optional, skipping)`, {
+        cause: options.cause,
+      });
+      return null;
+    }
+
+    this.logBundleFailure(options.requiredLevel, `${path}: ${message}`, { cause: options.cause });
+    if (options.cause === undefined) {
+      throw new Error(`${path}: ${message}`);
+    }
+    throw new Error(`${path}: ${message}`, { cause: options.cause });
+  }
+
+  private logBundleFailure(
+    level: LogLevel,
+    message: string,
+    options: { cause?: unknown } = {},
+  ): void {
+    if (options.cause === undefined) {
+      logger[level](message);
+      return;
+    }
+    logger[level](message, options.cause);
   }
 
   /**

--- a/src/datasources/fetch-data-source-v2.ts
+++ b/src/datasources/fetch-data-source-v2.ts
@@ -710,9 +710,9 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     }
 
     const metrics: BundleLoadMetrics = {
-      transferBytes: fetched.transferMetrics?.encodedBodySize,
+      encodedBytes: fetched.transferMetrics?.encodedBodySize,
       decodedBytes: fetched.transferMetrics?.decodedBodySize,
-      estimatedDecodedBytes: fetched.sizeApprox,
+      fallbackDecodedBytes: fetched.sizeApprox,
       networkMs: fetched.networkMs,
       parseMs: parsed.parseMs,
     };

--- a/src/datasources/fetch-data-source-v2.ts
+++ b/src/datasources/fetch-data-source-v2.ts
@@ -207,6 +207,7 @@ function collectMatchingResourceEntries(
 
 interface ResourceTransferCapture {
   readMetrics(): ResourceTransferMetrics | null;
+  dispose(): void;
 }
 
 interface FetchBundleTextResult {
@@ -235,14 +236,15 @@ interface TimedFetchResult {
  */
 function startResourceTransferCapture(url: string, sinceTime: number): ResourceTransferCapture {
   if (typeof performance === 'undefined' || typeof PerformanceObserver === 'undefined') {
-    return { readMetrics: () => null };
+    return { readMetrics: () => null, dispose: () => {} };
   }
   if (typeof globalThis.location?.href !== 'string') {
-    return { readMetrics: () => null };
+    return { readMetrics: () => null, dispose: () => {} };
   }
 
   const resolvedUrl = new URL(url, globalThis.location.href).href;
   const observedEntries: PerformanceResourceTiming[] = [];
+  let disconnected = false;
   const observer = new PerformanceObserver((list) => {
     observedEntries.push(...collectMatchingResourceEntries(list.getEntries(), resolvedUrl));
   });
@@ -251,15 +253,26 @@ function startResourceTransferCapture(url: string, sinceTime: number): ResourceT
     observer.observe({ type: 'resource', buffered: true });
   } catch {
     observer.disconnect();
-    return { readMetrics: () => null };
+    return { readMetrics: () => null, dispose: () => {} };
   }
+
+  const disconnect = () => {
+    if (disconnected) {
+      return;
+    }
+    disconnected = true;
+    observer.disconnect();
+  };
 
   return {
     readMetrics() {
       const pendingEntries = collectMatchingResourceEntries(observer.takeRecords(), resolvedUrl);
-      observer.disconnect();
+      disconnect();
       const entry = selectResourceTimingEntry([...observedEntries, ...pendingEntries], sinceTime);
       return entry ? buildResourceTransferMetrics(entry) : null;
+    },
+    dispose() {
+      disconnect();
     },
   };
 }
@@ -444,31 +457,41 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     const debugLoggingEnabled = logger.isEnabled('debug');
     const transferCapture = debugLoggingEnabled ? startResourceTransferCapture(url, t0) : null;
 
-    const fetched = await this.fetchResponseWithTimeout(path, url, timeoutMs, optional);
-    if (fetched === null) {
-      return null;
+    try {
+      const fetched = await this.fetchResponseWithTimeout(path, url, timeoutMs, optional);
+      if (fetched === null) {
+        return null;
+      }
+
+      const { response, timeoutId } = fetched;
+      const validatedResponse = this.validateJsonResponse(path, response, timeoutId, optional);
+      if (validatedResponse === null) {
+        return null;
+      }
+
+      const text = await this.readBundleText(
+        path,
+        validatedResponse,
+        timeoutId,
+        timeoutMs,
+        optional,
+      );
+      if (text === null) {
+        return null;
+      }
+
+      clearTimeout(timeoutId);
+      const tNetwork = performance.now();
+
+      return {
+        text,
+        sizeApprox: text.length,
+        networkMs: Math.round(tNetwork - t0),
+        transferMetrics: transferCapture?.readMetrics() ?? null,
+      };
+    } finally {
+      transferCapture?.dispose();
     }
-
-    const { response, timeoutId } = fetched;
-    const validatedResponse = this.validateJsonResponse(path, response, timeoutId, optional);
-    if (validatedResponse === null) {
-      return null;
-    }
-
-    const text = await this.readBundleText(path, validatedResponse, timeoutId, timeoutMs, optional);
-    if (text === null) {
-      return null;
-    }
-
-    clearTimeout(timeoutId);
-    const tNetwork = performance.now();
-
-    return {
-      text,
-      sizeApprox: text.length,
-      networkMs: Math.round(tNetwork - t0),
-      transferMetrics: transferCapture?.readMetrics() ?? null,
-    };
   }
 
   private async fetchResponseWithTimeout(

--- a/src/datasources/fetch-data-source-v2.ts
+++ b/src/datasources/fetch-data-source-v2.ts
@@ -25,6 +25,13 @@ import type {
   ShapesBundle,
 } from '@contracts/data/transit-v2-json';
 
+import type {
+  BundleLoadEvent,
+  BundleLoadFailureReason,
+  BundleLoadKind,
+  BundleLoadMetrics,
+  BundleLoadReporter,
+} from './load-events';
 import {
   parseBundleJson as parseBundleJsonText,
   type ParseBundleJsonResult,
@@ -302,6 +309,7 @@ function logParseMetrics(path: string, parseMs: number): void {
 export class FetchDataSourceV2 implements TransitDataSourceV2 {
   private readonly basePath: string;
   private readonly timeoutMs: number;
+  private loadEventReporter: BundleLoadReporter | undefined;
 
   /**
    * @param basePath - Base URL path for v2 data files.
@@ -314,6 +322,10 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     // Normalize trailing slash to prevent double-slash in URLs
     this.basePath = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
     this.timeoutMs = timeoutMs;
+  }
+
+  setLoadEventReporter(reporter: BundleLoadReporter | undefined): void {
+    this.loadEventReporter = reporter;
   }
 
   /** {@inheritDoc TransitDataSourceV2.loadData} */
@@ -473,12 +485,12 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       clearTimeout(timeoutId);
       const isTimeout = e instanceof DOMException && e.name === 'AbortError';
       if (isTimeout) {
-        return this.handleBundleFailure(path, optional, `timeout after ${timeoutMs}ms`, {
+        return this.handleBundleFailure(path, optional, 'timeout', `timeout after ${timeoutMs}ms`, {
           requiredLevel: 'error',
           optionalLevel: 'error',
         });
       }
-      return this.handleBundleFailure(path, optional, 'network error', {
+      return this.handleBundleFailure(path, optional, 'network-error', 'network error', {
         requiredLevel: 'warn',
         optionalLevel: 'debug',
         cause: e,
@@ -496,14 +508,14 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     // timeout covers the entire transfer, not just the headers.
     if (response.status === 404) {
       clearTimeout(timeoutId);
-      return this.handleBundleFailure(path, optional, 'HTTP 404', {
+      return this.handleBundleFailure(path, optional, 'http-error', 'HTTP 404', {
         requiredLevel: 'warn',
         optionalLevel: 'debug',
       });
     }
     if (!response.ok) {
       clearTimeout(timeoutId);
-      return this.handleBundleFailure(path, optional, `HTTP ${response.status}`, {
+      return this.handleBundleFailure(path, optional, 'http-error', `HTTP ${response.status}`, {
         requiredLevel: 'warn',
         optionalLevel: 'debug',
       });
@@ -515,6 +527,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       return this.handleBundleFailure(
         path,
         optional,
+        'non-json',
         `expected application/json but got "${contentType}" (possible SPA fallback)`,
         {
           requiredLevel: 'warn',
@@ -542,6 +555,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
         return this.handleBundleFailure(
           path,
           optional,
+          'timeout',
           `timeout after ${timeoutMs}ms (during body download)`,
           {
             requiredLevel: 'error',
@@ -549,7 +563,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
           },
         );
       }
-      return this.handleBundleFailure(path, optional, 'body read error', {
+      return this.handleBundleFailure(path, optional, 'body-read-error', 'body read error', {
         requiredLevel: 'warn',
         optionalLevel: 'debug',
         cause: e,
@@ -565,7 +579,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     try {
       return parseBundleJsonText(text);
     } catch (e) {
-      return this.handleBundleFailure(path, optional, 'JSON parse error', {
+      return this.handleBundleFailure(path, optional, 'json-parse-error', 'JSON parse error', {
         requiredLevel: 'warn',
         optionalLevel: 'warn',
         cause: e,
@@ -576,6 +590,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
   private handleBundleFailure(
     path: string,
     optional: boolean,
+    reason: BundleLoadFailureReason,
     message: string,
     options: {
       requiredLevel: LogLevel;
@@ -584,12 +599,24 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     },
   ): null {
     if (optional) {
+      this.emitBundleLoadEvent({
+        ...describeBundleLoadTarget(path, optional),
+        type: 'skipped',
+        reason,
+        message,
+      });
       this.logBundleFailure(options.optionalLevel, `${path}: ${message} (optional, skipping)`, {
         cause: options.cause,
       });
       return null;
     }
 
+    this.emitBundleLoadEvent({
+      ...describeBundleLoadTarget(path, optional),
+      type: 'failed',
+      reason,
+      message,
+    });
     this.logBundleFailure(options.requiredLevel, `${path}: ${message}`, { cause: options.cause });
     if (options.cause === undefined) {
       throw new Error(`${path}: ${message}`);
@@ -609,6 +636,10 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     logger[level](message, options.cause);
   }
 
+  private emitBundleLoadEvent(event: BundleLoadEvent): void {
+    this.loadEventReporter?.(event);
+  }
+
   /**
    * Load, validate content-type, and parse a JSON bundle file.
    *
@@ -623,6 +654,8 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     optional: boolean,
     options: FetchBundleOptions,
   ): Promise<FetchBundleResult | null> {
+    const target = describeBundleLoadTarget(path, optional);
+    this.emitBundleLoadEvent({ ...target, type: 'started' });
     const debugLoggingEnabled = logger.isEnabled('debug');
     const fetched = await this.fetchBundleText(path, optional, options);
     if (fetched === null) {
@@ -640,11 +673,63 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       logParseMetrics(path, parsed.parseMs);
     }
 
+    const metrics: BundleLoadMetrics = {
+      transferBytes: fetched.transferMetrics?.encodedBodySize,
+      decodedBytes: fetched.transferMetrics?.decodedBodySize,
+      estimatedDecodedBytes: fetched.sizeApprox,
+      networkMs: fetched.networkMs,
+      parseMs: parsed.parseMs,
+    };
+    this.emitBundleLoadEvent({
+      ...target,
+      type: 'succeeded',
+      metrics,
+    });
+
     return {
       json: parsed.json,
       sizeApprox: fetched.sizeApprox,
       networkMs: fetched.networkMs,
       parseMs: parsed.parseMs,
     };
+  }
+}
+
+function describeBundleLoadTarget(
+  path: string,
+  optional: boolean,
+): {
+  path: string;
+  prefix: string | null;
+  kind: BundleLoadKind;
+  optional: boolean;
+} {
+  if (path === 'global/insights.json') {
+    return { path, prefix: null, kind: 'global-insights', optional };
+  }
+  if (path === 'global/data-source-catalog.json') {
+    return { path, prefix: null, kind: 'data-source-catalog', optional };
+  }
+
+  const slashIndex = path.indexOf('/');
+  if (slashIndex === -1) {
+    return { path, prefix: null, kind: 'unknown', optional };
+  }
+  const prefix = path.slice(0, slashIndex);
+  const fileName = path.slice(slashIndex + 1);
+  const kind = fileNameToBundleKind(fileName);
+  return { path, prefix, kind, optional };
+}
+
+function fileNameToBundleKind(fileName: string): BundleLoadKind {
+  switch (fileName) {
+    case 'data.json':
+      return 'data';
+    case 'shapes.json':
+      return 'shapes';
+    case 'insights.json':
+      return 'insights';
+    default:
+      return 'unknown';
   }
 }

--- a/src/datasources/fetch-data-source-v2.ts
+++ b/src/datasources/fetch-data-source-v2.ts
@@ -114,6 +114,8 @@ interface FetchBundleResult {
   networkMs: number;
   /** Time spent on JSON.parse (ms). */
   parseMs: number;
+  /** Transport and decoded size metrics captured for the successful load. */
+  metrics: BundleLoadMetrics;
 }
 
 /** Per-call options for bundle fetch helpers. */
@@ -372,7 +374,8 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     options: FetchBundleOptions = {},
   ): Promise<T> {
     const result = await this.loadRequiredBundle(path, options);
-    assertBundleEnvelope(result.json, expectedKind, path);
+    this.assertBundleEnvelopeWithEvent(path, false, result.json, expectedKind);
+    this.emitBundleLoadSucceeded(path, false, result.metrics);
     return result.json as T;
   }
 
@@ -386,7 +389,8 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       return null;
     }
 
-    assertBundleEnvelope(result.json, expectedKind, path);
+    this.assertBundleEnvelopeWithEvent(path, true, result.json, expectedKind);
+    this.emitBundleLoadSucceeded(path, true, result.metrics);
     return result.json as T;
   }
 
@@ -587,6 +591,38 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     }
   }
 
+  private assertBundleEnvelopeWithEvent(
+    path: string,
+    optional: boolean,
+    json: unknown,
+    expectedKind: string,
+  ): void {
+    try {
+      assertBundleEnvelope(json, expectedKind, path);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.emitBundleLoadEvent({
+        ...describeBundleLoadTarget(path, optional),
+        type: 'failed',
+        reason: 'bundle-envelope-error',
+        message,
+      });
+      throw error;
+    }
+  }
+
+  private emitBundleLoadSucceeded(
+    path: string,
+    optional: boolean,
+    metrics: BundleLoadMetrics,
+  ): void {
+    this.emitBundleLoadEvent({
+      ...describeBundleLoadTarget(path, optional),
+      type: 'succeeded',
+      metrics,
+    });
+  }
+
   private handleBundleFailure(
     path: string,
     optional: boolean,
@@ -680,17 +716,13 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       networkMs: fetched.networkMs,
       parseMs: parsed.parseMs,
     };
-    this.emitBundleLoadEvent({
-      ...target,
-      type: 'succeeded',
-      metrics,
-    });
 
     return {
       json: parsed.json,
       sizeApprox: fetched.sizeApprox,
       networkMs: fetched.networkMs,
       parseMs: parsed.parseMs,
+      metrics,
     };
   }
 }

--- a/src/datasources/fetch-data-source-v2.ts
+++ b/src/datasources/fetch-data-source-v2.ts
@@ -124,7 +124,7 @@ function validatePrefix(prefix: string): void {
 /**
  * Result of fetching a bundle file.
  *
- * For optional bundles, {@link FetchDataSourceV2.fetchOptionalBundle}
+ * For optional bundles, {@link FetchDataSourceV2.loadOptionalBundle}
  * returns `null` when the data is unavailable (404, HTTP error, timeout,
  * network error, non-JSON content-type, or JSON parse error).
  */
@@ -150,6 +150,178 @@ interface FetchBundleOptions {
    * When omitted, the instance's {@link FetchDataSourceV2.timeoutMs} is used.
    */
   timeoutMs?: number;
+}
+
+/**
+ * Network transfer metrics for a fetched bundle, read from the Resource
+ * Timing API after the response body is fully downloaded.
+ *
+ * Sizes are in bytes. `transferSize` / `encodedBodySize` / `decodedBodySize`
+ * are all `0` when the browser refuses to expose them (a cross-origin
+ * response without `Timing-Allow-Origin`); the v2 data files are served
+ * same-origin, so this normally does not happen.
+ */
+export interface ResourceTransferMetrics {
+  /**
+   * Bytes transferred over the network, including response headers.
+   * `0` when the response was served from the HTTP cache.
+   */
+  transferSize: number;
+  /** Compressed body size — the bytes actually downloaded. */
+  encodedBodySize: number;
+  /** Uncompressed body size. Matches the file size on disk. */
+  decodedBodySize: number;
+  /** `true` when served from the HTTP cache (`transferSize === 0`). */
+  fromCache: boolean;
+}
+
+/**
+ * Select the Resource Timing entry produced by a fetch started at or
+ * after `sinceTime`.
+ *
+ * `performance.getEntriesByName(url)` returns an entry for every past
+ * load of the same URL — the app fetches some bundles (e.g. `insights.json`)
+ * more than once. The entry for the current fetch is the earliest one
+ * whose `startTime` is at or after the moment that fetch began.
+ *
+ * @param entries - Resource Timing entries for a single URL.
+ * @param sinceTime - `performance.now()` value captured before the fetch.
+ * @returns The matching entry, or `undefined` when none qualifies.
+ * @internal Exported for testing.
+ */
+export function selectResourceTimingEntry(
+  entries: readonly PerformanceResourceTiming[],
+  sinceTime: number,
+): PerformanceResourceTiming | undefined {
+  let selected: PerformanceResourceTiming | undefined;
+  for (const entry of entries) {
+    if (entry.startTime < sinceTime) {
+      continue;
+    }
+    if (selected === undefined || entry.startTime < selected.startTime) {
+      selected = entry;
+    }
+  }
+  return selected;
+}
+
+function buildResourceTransferMetrics(entry: PerformanceResourceTiming): ResourceTransferMetrics {
+  return {
+    transferSize: entry.transferSize,
+    encodedBodySize: entry.encodedBodySize,
+    decodedBodySize: entry.decodedBodySize,
+    fromCache: entry.transferSize === 0,
+  };
+}
+
+function collectMatchingResourceEntries(
+  entries: readonly PerformanceEntry[],
+  resolvedUrl: string,
+): PerformanceResourceTiming[] {
+  const matched: PerformanceResourceTiming[] = [];
+  for (const entry of entries) {
+    if (entry.entryType !== 'resource' || entry.name !== resolvedUrl) {
+      continue;
+    }
+    matched.push(entry as PerformanceResourceTiming);
+  }
+  return matched;
+}
+
+interface ResourceTransferCapture {
+  readMetrics(): ResourceTransferMetrics | null;
+}
+
+interface FetchBundleTextResult {
+  text: string;
+  sizeApprox: number;
+  networkMs: number;
+  transferMetrics: ResourceTransferMetrics | null;
+}
+
+interface ParseBundleJsonResult {
+  json: unknown;
+  parseMs: number;
+}
+
+/**
+ * Start observing Resource Timing entries for a fetch.
+ *
+ * The observer is started before the fetch so repeated requests to the same
+ * URL can be disambiguated using `sinceTime` without relying on a later
+ * name-based scan of the whole buffer.
+ *
+ * @param url - The URL passed to `fetch` (origin-relative).
+ * @param sinceTime - `performance.now()` captured before the fetch.
+ * @returns Capture handle. `readMetrics()` returns transfer metrics, or
+ *          `null` when Resource Timing data is unavailable.
+ */
+function startResourceTransferCapture(url: string, sinceTime: number): ResourceTransferCapture {
+  if (typeof performance === 'undefined' || typeof PerformanceObserver === 'undefined') {
+    return { readMetrics: () => null };
+  }
+  if (typeof globalThis.location?.href !== 'string') {
+    return { readMetrics: () => null };
+  }
+
+  const resolvedUrl = new URL(url, globalThis.location.href).href;
+  const observedEntries: PerformanceResourceTiming[] = [];
+  const observer = new PerformanceObserver((list) => {
+    observedEntries.push(...collectMatchingResourceEntries(list.getEntries(), resolvedUrl));
+  });
+
+  try {
+    observer.observe({ type: 'resource', buffered: true });
+  } catch {
+    observer.disconnect();
+    return { readMetrics: () => null };
+  }
+
+  return {
+    readMetrics() {
+      const pendingEntries = collectMatchingResourceEntries(observer.takeRecords(), resolvedUrl);
+      observer.disconnect();
+      const entry = selectResourceTimingEntry([...observedEntries, ...pendingEntries], sinceTime);
+      return entry ? buildResourceTransferMetrics(entry) : null;
+    },
+  };
+}
+
+/**
+ * Format the size segment of a fetch debug-log line.
+ *
+ * @param metrics - Transfer metrics, or `null` when Resource Timing data
+ *                  was unavailable.
+ * @param decodedTextLength - Length of the decoded response text (UTF-16
+ *                  code units), used as a fallback when `metrics` is `null`.
+ * @returns A human-readable size description for logging.
+ * @internal Exported for testing.
+ */
+export function formatTransferSummary(
+  metrics: ResourceTransferMetrics | null,
+  decodedTextLength: number,
+): string {
+  if (metrics === null) {
+    return `estimated ${(decodedTextLength / 1024).toFixed(
+      1,
+    )}KB decoded (transfer size unavailable)`;
+  }
+  const decodedKB = (metrics.decodedBodySize / 1024).toFixed(1);
+  if (metrics.fromCache) {
+    return `no network transfer, ${decodedKB}KB decoded`;
+  }
+  const wireKB = (metrics.encodedBodySize / 1024).toFixed(1);
+  return `${wireKB}KB over the wire, ${decodedKB}KB decoded`;
+}
+
+function logFetchMetrics(path: string, fetched: FetchBundleTextResult): void {
+  logger.debug(
+    `fetch metrics: ${path}: ${formatTransferSummary(fetched.transferMetrics, fetched.sizeApprox)} (fetch=${fetched.networkMs}ms)`,
+  );
+}
+
+function logParseMetrics(path: string, parseMs: number): void {
+  logger.debug(`parse metrics: ${path}: parse=${parseMs}ms`);
 }
 
 /**
@@ -181,7 +353,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     validatePrefix(prefix);
 
     const path = `${prefix}/data.json`;
-    const result = await this.fetchRequiredBundle(path);
+    const result = await this.loadRequiredBundle(path);
 
     validateBundleEnvelope(result.json, 'data', path);
     return { prefix, data: result.json as DataBundle };
@@ -191,7 +363,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
   async loadShapes(prefix: string): Promise<ShapesBundle | null> {
     validatePrefix(prefix);
 
-    const result = await this.fetchOptionalBundle(`${prefix}/shapes.json`);
+    const result = await this.loadOptionalBundle(`${prefix}/shapes.json`);
     if (!result) {
       return null;
     }
@@ -204,7 +376,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
   async loadInsights(prefix: string): Promise<InsightsBundle | null> {
     validatePrefix(prefix);
 
-    const result = await this.fetchOptionalBundle(`${prefix}/insights.json`);
+    const result = await this.loadOptionalBundle(`${prefix}/insights.json`);
     if (!result) {
       return null;
     }
@@ -216,7 +388,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
   /** {@inheritDoc TransitDataSourceV2.loadGlobalInsights} */
   async loadGlobalInsights(): Promise<GlobalInsightsBundle | null> {
     const path = 'global/insights.json';
-    const result = await this.fetchOptionalBundle(path);
+    const result = await this.loadOptionalBundle(path);
     if (!result) {
       return null;
     }
@@ -228,7 +400,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
   /** {@inheritDoc TransitDataSourceV2.loadDataSourceCatalog} */
   async loadDataSourceCatalog(): Promise<DataSourceCatalogBundle | null> {
     const path = 'global/data-source-catalog.json';
-    const result = await this.fetchOptionalBundle(path, { timeoutMs: CATALOG_TIMEOUT_MS });
+    const result = await this.loadOptionalBundle(path, { timeoutMs: CATALOG_TIMEOUT_MS });
     if (!result) {
       return null;
     }
@@ -238,7 +410,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
   }
 
   /**
-   * Fetch a required bundle.
+   * Load a required bundle.
    *
    * @param path - Relative path under base (e.g. "tobus/data.json").
    * @param options - Per-call options. `timeoutMs` overrides the instance default.
@@ -246,21 +418,21 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
    * @throws On network error, timeout, HTTP error, non-JSON content-type
    *         (possible SPA fallback), or JSON parse error.
    */
-  private async fetchRequiredBundle(
+  private async loadRequiredBundle(
     path: string,
     options: FetchBundleOptions = {},
   ): Promise<FetchBundleResult> {
-    const result = await this.doFetch(path, false, options);
+    const result = await this.doLoadBundle(path, false, options);
     if (result === null) {
-      // Required fetch never returns null from doFetch — either succeeds or
+      // Required load never returns null from doLoadBundle — either succeeds or
       // throws. Guard kept as a defensive invariant assertion.
-      throw new Error(`${path}: unexpected null from required fetch`);
+      throw new Error(`${path}: unexpected null from required load`);
     }
     return result;
   }
 
   /**
-   * Fetch an optional bundle.
+   * Load an optional bundle.
    *
    * @param path - Relative path under base (e.g. "tobus/shapes.json").
    * @param options - Per-call options. `timeoutMs` overrides the instance default.
@@ -269,29 +441,23 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
    *          or JSON parse error). Bundle envelope validation is the caller's
    *          responsibility and still throws on mismatch.
    */
-  private async fetchOptionalBundle(
+  private async loadOptionalBundle(
     path: string,
     options: FetchBundleOptions = {},
   ): Promise<FetchBundleResult | null> {
-    return this.doFetch(path, true, options);
+    return this.doLoadBundle(path, true, options);
   }
 
-  /**
-   * Fetch, validate content-type, and parse a JSON bundle file.
-   *
-   * All outcomes are logged at the appropriate level:
-   * - Success: debug (path, size, network/parse timing)
-   * - Timeout: error (always, regardless of optional flag)
-   * - Other failures: warn for required, debug for optional
-   */
-  private async doFetch(
+  private async fetchBundleText(
     path: string,
     optional: boolean,
     options: FetchBundleOptions,
-  ): Promise<FetchBundleResult | null> {
+  ): Promise<FetchBundleTextResult | null> {
     const url = `${this.basePath}/${path}`;
     const timeoutMs = options.timeoutMs ?? this.timeoutMs;
     const t0 = performance.now();
+    const debugLoggingEnabled = logger.isEnabled('debug');
+    const transferCapture = debugLoggingEnabled ? startResourceTransferCapture(url, t0) : null;
 
     // --- Network request with timeout ---
     const controller = new AbortController();
@@ -306,7 +472,6 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       clearTimeout(timeoutId);
       const isTimeout = e instanceof DOMException && e.name === 'AbortError';
       if (isTimeout) {
-        // Timeout is always logged as error regardless of optional flag
         logger.error(`${path}: timeout after ${timeoutMs}ms`);
         if (optional) {
           return null;
@@ -344,10 +509,6 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     }
 
     // --- Content-type validation ---
-    // SPA fallback rewrites (e.g. Vercel) return 200 + HTML for missing
-    // files instead of 404. Detect this for both required and optional
-    // files — for required files, a clear error is better than a
-    // cryptic JSON.parse failure on HTML content.
     const contentType = response.headers.get('content-type') ?? '';
     if (!contentType.includes('application/json')) {
       clearTimeout(timeoutId);
@@ -363,9 +524,6 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       );
     }
 
-    // --- Response body + parse ---
-    // The abort signal remains active during body download. If the
-    // timeout fires here, response.text() rejects with AbortError.
     let text: string;
     try {
       text = await response.text();
@@ -389,6 +547,21 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     clearTimeout(timeoutId);
     const tNetwork = performance.now();
 
+    return {
+      text,
+      sizeApprox: text.length,
+      networkMs: Math.round(tNetwork - t0),
+      transferMetrics: transferCapture?.readMetrics() ?? null,
+    };
+  }
+
+  private parseBundleJson(
+    path: string,
+    text: string,
+    optional: boolean,
+  ): ParseBundleJsonResult | null {
+    const tParseStart = performance.now();
+
     let json: unknown;
     try {
       json = JSON.parse(text) as unknown;
@@ -400,13 +573,48 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       logger.warn(`${path}: JSON parse error`, e);
       throw new Error(`${path}: JSON parse error`, { cause: e });
     }
-    const tParse = performance.now();
 
-    const networkMs = Math.round(tNetwork - t0);
-    const parseMs = Math.round(tParse - tNetwork);
-    const sizeKB = (text.length / 1024).toFixed(1);
-    logger.debug(`${path}: ${sizeKB}KB (network=${networkMs}ms, parse=${parseMs}ms)`);
+    return {
+      json,
+      parseMs: Math.round(performance.now() - tParseStart),
+    };
+  }
 
-    return { json, sizeApprox: text.length, networkMs, parseMs };
+  /**
+   * Load, validate content-type, and parse a JSON bundle file.
+   *
+   * All outcomes are logged at the appropriate level:
+   * - Success: debug (path, transfer/decoded size, network/parse timing)
+   * - Timeout: error (always, regardless of optional flag)
+   * - Other failures: warn for required, debug for optional
+   */
+  private async doLoadBundle(
+    path: string,
+    optional: boolean,
+    options: FetchBundleOptions,
+  ): Promise<FetchBundleResult | null> {
+    const debugLoggingEnabled = logger.isEnabled('debug');
+    const fetched = await this.fetchBundleText(path, optional, options);
+    if (fetched === null) {
+      return null;
+    }
+    if (debugLoggingEnabled) {
+      logFetchMetrics(path, fetched);
+    }
+
+    const parsed = this.parseBundleJson(path, fetched.text, optional);
+    if (parsed === null) {
+      return null;
+    }
+    if (debugLoggingEnabled) {
+      logParseMetrics(path, parsed.parseMs);
+    }
+
+    return {
+      json: parsed.json,
+      sizeApprox: fetched.sizeApprox,
+      networkMs: fetched.networkMs,
+      parseMs: parsed.parseMs,
+    };
   }
 }

--- a/src/datasources/fetch-data-source-v2.ts
+++ b/src/datasources/fetch-data-source-v2.ts
@@ -25,6 +25,11 @@ import type {
   ShapesBundle,
 } from '@contracts/data/transit-v2-json';
 
+import {
+  parseBundleJson as parseBundleJsonText,
+  type ParseBundleJsonResult,
+} from './lib/parse-bundle-json';
+import { validateBundleEnvelope as assertBundleEnvelope } from './lib/validate-bundle-envelope';
 import { createLogger } from '../lib/logger';
 import { sanitizeDirName } from '../utils/sanitize-dir-name';
 import type { SourceDataV2, TransitDataSourceV2 } from './transit-data-source-v2';
@@ -45,9 +50,6 @@ export function validateBasePath(value: string): string {
   sanitizeDirName(dir, 'VITE_TRANSIT_DATA_PATH');
   return value.startsWith('/') ? value : `/${value}`;
 }
-
-/** Expected bundle_version for all v2 bundles. */
-const EXPECTED_BUNDLE_VERSION = 3;
 
 /**
  * Default per-request timeout in milliseconds.
@@ -73,42 +75,6 @@ const CATALOG_TIMEOUT_MS = 5_000;
 
 /** Pattern for valid source prefixes. */
 const PREFIX_PATTERN = /^[a-z0-9_-]+$/;
-
-/**
- * Validate that a parsed JSON object has the expected bundle_version and kind.
- *
- * This is a structural check on the top-level discriminant fields.
- * It does NOT validate individual sections within the bundle — that
- * is the repository's responsibility when consuming the data.
- *
- * @throws When bundle_version or kind does not match expectations.
- */
-function validateBundleEnvelope<K extends string>(
-  json: unknown,
-  expectedKind: K,
-  path: string,
-): asserts json is { bundle_version: 3; kind: K } {
-  if (json === null) {
-    throw new Error(`${path}: expected JSON object, got null`);
-  }
-  if (Array.isArray(json)) {
-    throw new Error(`${path}: expected JSON object, got array`);
-  }
-  if (typeof json !== 'object') {
-    throw new Error(`${path}: expected JSON object, got ${typeof json}`);
-  }
-  const obj = json as Record<string, unknown>;
-  if (obj.bundle_version !== EXPECTED_BUNDLE_VERSION) {
-    throw new Error(
-      `${path}: invalid bundle_version (expected ${EXPECTED_BUNDLE_VERSION}, got ${String(obj.bundle_version)})`,
-    );
-  }
-  if (obj.kind !== expectedKind) {
-    throw new Error(
-      `${path}: invalid bundle kind (expected "${expectedKind}", got "${String(obj.kind)}")`,
-    );
-  }
-}
 
 /**
  * Validate that the prefix is a safe, expected format.
@@ -239,11 +205,6 @@ interface FetchBundleTextResult {
   transferMetrics: ResourceTransferMetrics | null;
 }
 
-interface ParseBundleJsonResult {
-  json: unknown;
-  parseMs: number;
-}
-
 /**
  * Start observing Resource Timing entries for a fetch.
  *
@@ -355,7 +316,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     const path = `${prefix}/data.json`;
     const result = await this.loadRequiredBundle(path);
 
-    validateBundleEnvelope(result.json, 'data', path);
+    assertBundleEnvelope(result.json, 'data', path);
     return { prefix, data: result.json as DataBundle };
   }
 
@@ -368,7 +329,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       return null;
     }
 
-    validateBundleEnvelope(result.json, 'shapes', `${prefix}/shapes.json`);
+    assertBundleEnvelope(result.json, 'shapes', `${prefix}/shapes.json`);
     return result.json as ShapesBundle;
   }
 
@@ -381,7 +342,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       return null;
     }
 
-    validateBundleEnvelope(result.json, 'insights', `${prefix}/insights.json`);
+    assertBundleEnvelope(result.json, 'insights', `${prefix}/insights.json`);
     return result.json as InsightsBundle;
   }
 
@@ -393,7 +354,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       return null;
     }
 
-    validateBundleEnvelope(result.json, 'global-insights', path);
+    assertBundleEnvelope(result.json, 'global-insights', path);
     return result.json as GlobalInsightsBundle;
   }
 
@@ -405,7 +366,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       return null;
     }
 
-    validateBundleEnvelope(result.json, 'data-source-catalog', path);
+    assertBundleEnvelope(result.json, 'data-source-catalog', path);
     return result.json as DataSourceCatalogBundle;
   }
 
@@ -555,29 +516,21 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
     };
   }
 
-  private parseBundleJson(
+  private parseBundleJsonWithPolicy(
     path: string,
     text: string,
     optional: boolean,
   ): ParseBundleJsonResult | null {
-    const tParseStart = performance.now();
-
-    let json: unknown;
     try {
-      json = JSON.parse(text) as unknown;
+      return parseBundleJsonText(text);
     } catch (e) {
       if (optional) {
-        logger.debug(`${path}: JSON parse error (optional, skipping)`);
+        logger.warn(`${path}: JSON parse error (optional, skipping)`, e);
         return null;
       }
       logger.warn(`${path}: JSON parse error`, e);
       throw new Error(`${path}: JSON parse error`, { cause: e });
     }
-
-    return {
-      json,
-      parseMs: Math.round(performance.now() - tParseStart),
-    };
   }
 
   /**
@@ -586,7 +539,8 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
    * All outcomes are logged at the appropriate level:
    * - Success: debug (path, transfer/decoded size, network/parse timing)
    * - Timeout: error (always, regardless of optional flag)
-   * - Other failures: warn for required, debug for optional
+   * - Other failures: warn for required, debug for optional except parse
+   *   errors, which are warned even for optional bundles
    */
   private async doLoadBundle(
     path: string,
@@ -602,7 +556,7 @@ export class FetchDataSourceV2 implements TransitDataSourceV2 {
       logFetchMetrics(path, fetched);
     }
 
-    const parsed = this.parseBundleJson(path, fetched.text, optional);
+    const parsed = this.parseBundleJsonWithPolicy(path, fetched.text, optional);
     if (parsed === null) {
       return null;
     }

--- a/src/datasources/lib/__tests__/bundle-json-helpers.test.ts
+++ b/src/datasources/lib/__tests__/bundle-json-helpers.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { parseBundleJson } from '../parse-bundle-json';
+import { validateBundleEnvelope } from '../validate-bundle-envelope';
+
+describe('parseBundleJson', () => {
+  it('returns parsed JSON and parse duration', () => {
+    const performanceNowSpy = vi
+      .spyOn(performance, 'now')
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(14);
+
+    try {
+      expect(parseBundleJson('{"kind":"data","bundle_version":3}')).toEqual({
+        json: { kind: 'data', bundle_version: 3 },
+        parseMs: 4,
+      });
+    } finally {
+      performanceNowSpy.mockRestore();
+    }
+  });
+
+  it('throws the JSON.parse error for invalid JSON', () => {
+    expect(() => parseBundleJson('{"broken json')).toThrow();
+  });
+});
+
+describe('validateBundleEnvelope', () => {
+  it('accepts a valid bundle envelope', () => {
+    expect(() =>
+      validateBundleEnvelope({ bundle_version: 3, kind: 'data' }, 'data', 'tobus/data.json'),
+    ).not.toThrow();
+  });
+
+  it('throws for a null payload', () => {
+    expect(() => validateBundleEnvelope(null, 'data', 'tobus/data.json')).toThrow(
+      'expected JSON object, got null',
+    );
+  });
+
+  it('throws for an invalid bundle version', () => {
+    expect(() =>
+      validateBundleEnvelope({ bundle_version: 2, kind: 'data' }, 'data', 'tobus/data.json'),
+    ).toThrow('invalid bundle_version');
+  });
+
+  it('throws for an invalid bundle kind', () => {
+    expect(() =>
+      validateBundleEnvelope({ bundle_version: 3, kind: 'shapes' }, 'data', 'tobus/data.json'),
+    ).toThrow('invalid bundle kind');
+  });
+});

--- a/src/datasources/lib/parse-bundle-json.ts
+++ b/src/datasources/lib/parse-bundle-json.ts
@@ -1,0 +1,14 @@
+export interface ParseBundleJsonResult {
+  json: unknown;
+  parseMs: number;
+}
+
+export function parseBundleJson(text: string): ParseBundleJsonResult {
+  const startedAt = performance.now();
+  const json = JSON.parse(text) as unknown;
+
+  return {
+    json,
+    parseMs: Math.round(performance.now() - startedAt),
+  };
+}

--- a/src/datasources/lib/validate-bundle-envelope.ts
+++ b/src/datasources/lib/validate-bundle-envelope.ts
@@ -1,0 +1,28 @@
+const EXPECTED_BUNDLE_VERSION = 3;
+
+export function validateBundleEnvelope<K extends string>(
+  json: unknown,
+  expectedKind: K,
+  path: string,
+): asserts json is { bundle_version: 3; kind: K } {
+  if (json === null) {
+    throw new Error(`${path}: expected JSON object, got null`);
+  }
+  if (Array.isArray(json)) {
+    throw new Error(`${path}: expected JSON object, got array`);
+  }
+  if (typeof json !== 'object') {
+    throw new Error(`${path}: expected JSON object, got ${typeof json}`);
+  }
+  const obj = json as Record<string, unknown>;
+  if (obj.bundle_version !== EXPECTED_BUNDLE_VERSION) {
+    throw new Error(
+      `${path}: invalid bundle_version (expected ${EXPECTED_BUNDLE_VERSION}, got ${String(obj.bundle_version)})`,
+    );
+  }
+  if (obj.kind !== expectedKind) {
+    throw new Error(
+      `${path}: invalid bundle kind (expected "${expectedKind}", got "${String(obj.kind)}")`,
+    );
+  }
+}

--- a/src/datasources/load-events.ts
+++ b/src/datasources/load-events.ts
@@ -15,11 +15,19 @@ export type BundleLoadFailureReason =
   | 'json-parse-error'
   | 'bundle-envelope-error';
 
+/**
+ * Optional transport and parsing metrics captured for a successful bundle load.
+ */
 export interface BundleLoadMetrics {
-  transferBytes?: number;
+  /** Encoded response body size reported by Resource Timing, when available. */
+  encodedBytes?: number;
+  /** Decoded response body size reported by Resource Timing, when available. */
   decodedBytes?: number;
-  estimatedDecodedBytes?: number;
+  /** Fallback decoded-size approximation used when decoded bytes are unavailable. */
+  fallbackDecodedBytes?: number;
+  /** Time spent on network transfer and body read, in milliseconds. */
   networkMs?: number;
+  /** Time spent parsing JSON, in milliseconds. */
   parseMs?: number;
 }
 

--- a/src/datasources/load-events.ts
+++ b/src/datasources/load-events.ts
@@ -12,7 +12,8 @@ export type BundleLoadFailureReason =
   | 'http-error'
   | 'non-json'
   | 'body-read-error'
-  | 'json-parse-error';
+  | 'json-parse-error'
+  | 'bundle-envelope-error';
 
 export interface BundleLoadMetrics {
   transferBytes?: number;

--- a/src/datasources/load-events.ts
+++ b/src/datasources/load-events.ts
@@ -1,0 +1,59 @@
+export type BundleLoadKind =
+  | 'data'
+  | 'shapes'
+  | 'insights'
+  | 'global-insights'
+  | 'data-source-catalog'
+  | 'unknown';
+
+export type BundleLoadFailureReason =
+  | 'timeout'
+  | 'network-error'
+  | 'http-error'
+  | 'non-json'
+  | 'body-read-error'
+  | 'json-parse-error';
+
+export interface BundleLoadMetrics {
+  transferBytes?: number;
+  decodedBytes?: number;
+  estimatedDecodedBytes?: number;
+  networkMs?: number;
+  parseMs?: number;
+}
+
+interface BundleLoadEventBase {
+  path: string;
+  prefix: string | null;
+  kind: BundleLoadKind;
+  optional: boolean;
+}
+
+export interface BundleLoadStartedEvent extends BundleLoadEventBase {
+  type: 'started';
+}
+
+export interface BundleLoadSucceededEvent extends BundleLoadEventBase {
+  type: 'succeeded';
+  metrics: BundleLoadMetrics;
+}
+
+export interface BundleLoadSkippedEvent extends BundleLoadEventBase {
+  type: 'skipped';
+  reason: BundleLoadFailureReason;
+  message: string;
+}
+
+export interface BundleLoadFailedEvent extends BundleLoadEventBase {
+  type: 'failed';
+  reason: BundleLoadFailureReason;
+  message: string;
+}
+
+export type BundleLoadEvent =
+  | BundleLoadStartedEvent
+  | BundleLoadSucceededEvent
+  | BundleLoadSkippedEvent
+  | BundleLoadFailedEvent;
+
+export type BundleLoadReporter = (event: BundleLoadEvent) => void;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,13 @@ import { DataSourceManager } from './config/data-source-manager';
 import { resolveFetchDataSources } from './domain/datasource/resolve-fetch-data-sources';
 import { loadEnabledGroupIdsFromStorage } from './domain/datasource/data-source-selection-storage';
 import type { TransitRepository } from './repositories/transit-repository';
-import { AthenaiRepositoryV2, type LoadResult } from './repositories/athenai-repository';
+import {
+  AthenaiRepositoryV2,
+  formatBootLoadProgressSummary,
+  formatLoadActivitySummary,
+  type LoadResult,
+  type RepositoryLoadProgressSummary,
+} from './repositories/athenai-repository';
 import {
   cleanupInvalidQueryParams,
   getDiagParam,
@@ -25,13 +31,33 @@ const logger = createLogger('App');
 async function createRepository(): Promise<{
   repository: TransitRepository;
   loadResult: LoadResult;
+  loadProgress: RepositoryLoadProgressSummary;
 }> {
   const repo = getRepoParam();
 
   if (repo === 'mock') {
     logger.info('Using MockRepository (?repo=mock)');
     const { MockRepository } = await import('./repositories/mock-repository');
-    return { repository: new MockRepository(), loadResult: { loaded: [], failed: [] } };
+    return {
+      repository: new MockRepository(),
+      loadResult: { loaded: [], failed: [] },
+      loadProgress: {
+        boot: {
+          totalSources: 0,
+          startedSources: 0,
+          completedSources: 0,
+          failedSources: 0,
+          progressRatio: 1,
+          lastRequiredEvent: null,
+        },
+        activity: {
+          requestCounts: { started: 0, succeeded: 0, skipped: 0, failed: 0 },
+          totalEncodedBytes: 0,
+          totalDecodedBytes: 0,
+          lastEvent: null,
+        },
+      },
+    };
   }
 
   const dsm = new DataSourceManager(loadEnabledGroupIdsFromStorage());
@@ -42,13 +68,32 @@ async function createRepository(): Promise<{
   );
 
   logger.info(`Using AthenaiRepositoryV2: [${prefixes.join(', ')}]`);
-  const { repository, loadResult } = await AthenaiRepositoryV2.create(prefixes);
+  const bootStartTime = performance.now();
+  let hasLoggedBootComplete = false;
+  const onLoadProgress = logger.isEnabled('debug')
+    ? (summary: RepositoryLoadProgressSummary) => {
+        logger.debug(formatBootLoadProgressSummary(summary.boot));
+        logger.debug(formatLoadActivitySummary(summary.activity));
+        if (!hasLoggedBootComplete && summary.boot.progressRatio === 1) {
+          hasLoggedBootComplete = true;
+          const bootMs = Math.round(performance.now() - bootStartTime);
+          logger.info(
+            `Required data load complete in ${bootMs}ms: ${formatBootLoadProgressSummary(summary.boot, { mode: 'complete' })} | ${formatLoadActivitySummary(summary.activity, { mode: 'snapshot' })}`,
+          );
+        }
+      }
+    : undefined;
+  const { repository, loadResult, loadProgress } = await AthenaiRepositoryV2.create(
+    prefixes,
+    undefined,
+    onLoadProgress,
+  );
   if (loadResult.failed.length > 0) {
     logger.warn(
       `Failed to load ${loadResult.failed.length} source(s): [${loadResult.failed.map((f) => f.prefix).join(', ')}]`,
     );
   }
-  return { repository, loadResult };
+  return { repository, loadResult, loadProgress };
 }
 
 async function init() {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -70,19 +70,21 @@ async function createRepository(): Promise<{
   logger.info(`Using AthenaiRepositoryV2: [${prefixes.join(', ')}]`);
   const bootStartTime = performance.now();
   let hasLoggedBootComplete = false;
-  const onLoadProgress = logger.isEnabled('debug')
-    ? (summary: RepositoryLoadProgressSummary) => {
-        logger.debug(formatBootLoadProgressSummary(summary.boot));
-        logger.debug(formatLoadActivitySummary(summary.activity));
-        if (!hasLoggedBootComplete && summary.boot.progressRatio === 1) {
-          hasLoggedBootComplete = true;
-          const bootMs = Math.round(performance.now() - bootStartTime);
-          logger.info(
-            `Required data load complete in ${bootMs}ms: ${formatBootLoadProgressSummary(summary.boot, { mode: 'complete' })} | ${formatLoadActivitySummary(summary.activity, { mode: 'snapshot' })}`,
-          );
-        }
-      }
-    : undefined;
+  const onLoadProgress = (summary: RepositoryLoadProgressSummary) => {
+    if (logger.isEnabled('debug')) {
+      logger.debug(formatBootLoadProgressSummary(summary.boot));
+      logger.debug(formatLoadActivitySummary(summary.activity));
+    }
+
+    if (!hasLoggedBootComplete && summary.boot.progressRatio === 1) {
+      hasLoggedBootComplete = true;
+      const bootMs = Math.round(performance.now() - bootStartTime);
+      logger.info(
+        `Required data load complete in ${bootMs}ms: ${formatBootLoadProgressSummary(summary.boot, { mode: 'complete' })} | ${formatLoadActivitySummary(summary.activity, { mode: 'snapshot' })}`,
+      );
+    }
+  };
+
   const { repository, loadResult, loadProgress } = await AthenaiRepositoryV2.create(
     prefixes,
     undefined,

--- a/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
@@ -62,6 +62,23 @@ describe('AthenaiRepositoryV2.create', () => {
     assertSuccess(stops);
     expect(stops.data.length).toBeGreaterThan(0);
   });
+
+  it('returns aggregated load progress and emits progress updates', async () => {
+    const fixture = createFixtureV2();
+    const ds = new TestDataSourceV2({ test: fixture });
+    const progressUpdates: number[] = [];
+
+    const { loadProgress } = await AthenaiRepositoryV2.create(['test'], ds, (summary) => {
+      progressUpdates.push(summary.boot.completedSources + summary.boot.failedSources);
+    });
+
+    expect(loadProgress.boot.totalSources).toBe(1);
+    expect(loadProgress.boot.completedSources).toBe(1);
+    expect(loadProgress.boot.failedSources).toBe(0);
+    expect(loadProgress.activity.requestCounts.started).toBeGreaterThan(0);
+    expect(progressUpdates[0]).toBe(0);
+    expect(progressUpdates).toContain(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
+++ b/src/repositories/athenai-repository/__tests__/athenai-repository-v2.test.ts
@@ -79,6 +79,20 @@ describe('AthenaiRepositoryV2.create', () => {
     expect(progressUpdates[0]).toBe(0);
     expect(progressUpdates).toContain(1);
   });
+
+  it('counts catalog rejection as failed activity without failing repository creation', async () => {
+    const fixture = createFixtureV2();
+    const envelopeError = new Error(
+      'global/data-source-catalog.json: invalid bundle_version (expected 3, got 2)',
+    );
+    const ds = new TestDataSourceV2({ test: fixture }, {}, {}, null, envelopeError);
+
+    const { repository, loadProgress } = await AthenaiRepositoryV2.create(['test'], ds);
+
+    expect(repository.getDataSourceCatalog()).toBeNull();
+    expect(loadProgress.boot.completedSources).toBe(1);
+    expect(loadProgress.activity.requestCounts.failed).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/repositories/athenai-repository/__tests__/fixtures/test-data-source-v2.ts
+++ b/src/repositories/athenai-repository/__tests__/fixtures/test-data-source-v2.ts
@@ -23,6 +23,7 @@ import type {
   TimetableGroupV2Json,
 } from '@contracts/data/transit-v2-json';
 
+import type { BundleLoadReporter } from '../../../../datasources/load-events';
 import type {
   SourceDataV2,
   TransitDataSourceV2,
@@ -45,6 +46,7 @@ export class TestDataSourceV2 implements TransitDataSourceV2 {
    * load failures (including bundle envelope mismatches) to `null`.
    */
   private dataSourceCatalogError: Error | null;
+  private loadEventReporter: BundleLoadReporter | undefined;
 
   constructor(
     fixtures: Record<string, SourceDataV2>,
@@ -60,31 +62,147 @@ export class TestDataSourceV2 implements TransitDataSourceV2 {
     this.dataSourceCatalogError = dataSourceCatalogError;
   }
 
+  setLoadEventReporter(reporter: BundleLoadReporter | undefined): void {
+    this.loadEventReporter = reporter;
+  }
+
   loadData(prefix: string): Promise<SourceDataV2> {
+    this.loadEventReporter?.({
+      type: 'started',
+      path: `${prefix}/data.json`,
+      prefix,
+      kind: 'data',
+      optional: false,
+    });
     const data = this.fixtures[prefix];
     if (!data) {
+      this.loadEventReporter?.({
+        type: 'failed',
+        path: `${prefix}/data.json`,
+        prefix,
+        kind: 'data',
+        optional: false,
+        reason: 'network-error',
+        message: `Unknown prefix: ${prefix}`,
+      });
       return Promise.reject(new Error(`Unknown prefix: ${prefix}`));
     }
+    this.loadEventReporter?.({
+      type: 'succeeded',
+      path: `${prefix}/data.json`,
+      prefix,
+      kind: 'data',
+      optional: false,
+      metrics: {},
+    });
     return Promise.resolve(data);
   }
 
   loadShapes(prefix: string): Promise<ShapesBundle | null> {
-    return Promise.resolve(this.shapesFixtures[prefix] ?? null);
+    return Promise.resolve(
+      this.emitOptionalFixtureResult(
+        `${prefix}/shapes.json`,
+        prefix,
+        'shapes',
+        this.shapesFixtures[prefix],
+      ),
+    );
   }
 
   loadInsights(prefix: string): Promise<InsightsBundle | null> {
-    return Promise.resolve(this.insightsFixtures[prefix] ?? null);
+    return Promise.resolve(
+      this.emitOptionalFixtureResult(
+        `${prefix}/insights.json`,
+        prefix,
+        'insights',
+        this.insightsFixtures[prefix],
+      ),
+    );
   }
 
   loadGlobalInsights(): Promise<GlobalInsightsBundle | null> {
-    return Promise.resolve(null);
+    return Promise.resolve(
+      this.emitOptionalFixtureResult('global/insights.json', null, 'global-insights', null),
+    );
   }
 
   loadDataSourceCatalog(): Promise<DataSourceCatalogBundle | null> {
+    this.loadEventReporter?.({
+      type: 'started',
+      path: 'global/data-source-catalog.json',
+      prefix: null,
+      kind: 'data-source-catalog',
+      optional: true,
+    });
     if (this.dataSourceCatalogError) {
+      this.loadEventReporter?.({
+        type: 'skipped',
+        path: 'global/data-source-catalog.json',
+        prefix: null,
+        kind: 'data-source-catalog',
+        optional: true,
+        reason: 'network-error',
+        message: this.dataSourceCatalogError.message,
+      });
       return Promise.reject(this.dataSourceCatalogError);
     }
+    if (this.dataSourceCatalog === null) {
+      this.loadEventReporter?.({
+        type: 'skipped',
+        path: 'global/data-source-catalog.json',
+        prefix: null,
+        kind: 'data-source-catalog',
+        optional: true,
+        reason: 'http-error',
+        message: 'fixture missing',
+      });
+      return Promise.resolve(null);
+    }
+    this.loadEventReporter?.({
+      type: 'succeeded',
+      path: 'global/data-source-catalog.json',
+      prefix: null,
+      kind: 'data-source-catalog',
+      optional: true,
+      metrics: {},
+    });
     return Promise.resolve(this.dataSourceCatalog);
+  }
+
+  private emitOptionalFixtureResult<T>(
+    path: string,
+    prefix: string | null,
+    kind: 'shapes' | 'insights' | 'global-insights',
+    value: T | null | undefined,
+  ): T | null {
+    this.loadEventReporter?.({
+      type: 'started',
+      path,
+      prefix,
+      kind,
+      optional: true,
+    });
+    if (value == null) {
+      this.loadEventReporter?.({
+        type: 'skipped',
+        path,
+        prefix,
+        kind,
+        optional: true,
+        reason: 'http-error',
+        message: 'fixture missing',
+      });
+      return null;
+    }
+    this.loadEventReporter?.({
+      type: 'succeeded',
+      path,
+      prefix,
+      kind,
+      optional: true,
+      metrics: {},
+    });
+    return value;
   }
 }
 

--- a/src/repositories/athenai-repository/__tests__/fixtures/test-data-source-v2.ts
+++ b/src/repositories/athenai-repository/__tests__/fixtures/test-data-source-v2.ts
@@ -136,12 +136,12 @@ export class TestDataSourceV2 implements TransitDataSourceV2 {
     });
     if (this.dataSourceCatalogError) {
       this.loadEventReporter?.({
-        type: 'skipped',
+        type: 'failed',
         path: 'global/data-source-catalog.json',
         prefix: null,
         kind: 'data-source-catalog',
         optional: true,
-        reason: 'network-error',
+        reason: 'bundle-envelope-error',
         message: this.dataSourceCatalogError.message,
       });
       return Promise.reject(this.dataSourceCatalogError);

--- a/src/repositories/athenai-repository/__tests__/load-progress.test.ts
+++ b/src/repositories/athenai-repository/__tests__/load-progress.test.ts
@@ -80,4 +80,76 @@ describe('load progress reducer', () => {
       'data size: encoded=0B decoded=0B',
     );
   });
+
+  it('preserves the last required event after non-required activity', () => {
+    let state = createInitialRepositoryLoadProgressState(['alpha']);
+    state = reduceRepositoryLoadProgressState(state, {
+      type: 'succeeded',
+      path: 'alpha/data.json',
+      prefix: 'alpha',
+      kind: 'data',
+      optional: false,
+      metrics: {},
+    });
+    state = reduceRepositoryLoadProgressState(state, {
+      type: 'started',
+      path: 'alpha/shapes.json',
+      prefix: 'alpha',
+      kind: 'shapes',
+      optional: true,
+    });
+
+    const summary = summarizeRepositoryLoadProgress(state);
+    expect(summary.boot.lastRequiredEvent).toMatchObject({
+      type: 'succeeded',
+      path: 'alpha/data.json',
+    });
+    expect(formatBootLoadProgressSummary(summary.boot)).toContain('last=succeeded:alpha/data.json');
+  });
+
+  it('returns a defensive copy of request counts', () => {
+    let state = createInitialRepositoryLoadProgressState(['alpha']);
+    state = reduceRepositoryLoadProgressState(state, {
+      type: 'started',
+      path: 'alpha/data.json',
+      prefix: 'alpha',
+      kind: 'data',
+      optional: false,
+    });
+
+    const summaryA = summarizeRepositoryLoadProgress(state);
+    summaryA.activity.requestCounts.started = 99;
+    const summaryB = summarizeRepositoryLoadProgress(state);
+
+    expect(summaryB.activity.requestCounts.started).toBe(1);
+  });
+
+  it('moves a failed required source back to loading when restarted', () => {
+    let state = createInitialRepositoryLoadProgressState(['alpha']);
+    state = reduceRepositoryLoadProgressState(state, {
+      type: 'failed',
+      path: 'alpha/data.json',
+      prefix: 'alpha',
+      kind: 'data',
+      optional: false,
+      reason: 'network-error',
+      message: 'boom',
+    });
+    state = reduceRepositoryLoadProgressState(state, {
+      type: 'started',
+      path: 'alpha/data.json',
+      prefix: 'alpha',
+      kind: 'data',
+      optional: false,
+    });
+
+    const summary = summarizeRepositoryLoadProgress(state);
+    expect(summary.boot.failedSources).toBe(0);
+    expect(summary.boot.startedSources).toBe(1);
+    expect(summary.boot.progressRatio).toBe(0);
+    expect(summary.boot.lastRequiredEvent).toMatchObject({
+      type: 'started',
+      path: 'alpha/data.json',
+    });
+  });
 });

--- a/src/repositories/athenai-repository/__tests__/load-progress.test.ts
+++ b/src/repositories/athenai-repository/__tests__/load-progress.test.ts
@@ -20,7 +20,7 @@ describe('load progress reducer', () => {
         prefix: 'alpha',
         kind: 'data',
         optional: false,
-        metrics: { transferBytes: 100, decodedBytes: 200, networkMs: 3, parseMs: 1 },
+        metrics: { encodedBytes: 100, decodedBytes: 200, networkMs: 3, parseMs: 1 },
       },
       { type: 'started', path: 'beta/data.json', prefix: 'beta', kind: 'data', optional: false },
       {

--- a/src/repositories/athenai-repository/__tests__/load-progress.test.ts
+++ b/src/repositories/athenai-repository/__tests__/load-progress.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BundleLoadEvent } from '../../../datasources/load-events';
+import {
+  createInitialRepositoryLoadProgressState,
+  formatBootLoadProgressSummary,
+  formatLoadActivitySizeSummary,
+  formatLoadActivitySummary,
+  reduceRepositoryLoadProgressState,
+  summarizeRepositoryLoadProgress,
+} from '../load-progress';
+
+describe('load progress reducer', () => {
+  it('tracks required source progress from data bundle events', () => {
+    const events: BundleLoadEvent[] = [
+      { type: 'started', path: 'alpha/data.json', prefix: 'alpha', kind: 'data', optional: false },
+      {
+        type: 'succeeded',
+        path: 'alpha/data.json',
+        prefix: 'alpha',
+        kind: 'data',
+        optional: false,
+        metrics: { transferBytes: 100, decodedBytes: 200, networkMs: 3, parseMs: 1 },
+      },
+      { type: 'started', path: 'beta/data.json', prefix: 'beta', kind: 'data', optional: false },
+      {
+        type: 'failed',
+        path: 'beta/data.json',
+        prefix: 'beta',
+        kind: 'data',
+        optional: false,
+        reason: 'json-parse-error',
+        message: 'bad json',
+      },
+    ];
+
+    let state = createInitialRepositoryLoadProgressState(['alpha', 'beta']);
+    for (const event of events) {
+      state = reduceRepositoryLoadProgressState(state, event);
+    }
+
+    const summary = summarizeRepositoryLoadProgress(state);
+    expect(summary.boot.startedSources).toBe(2);
+    expect(summary.boot.completedSources).toBe(1);
+    expect(summary.boot.failedSources).toBe(1);
+    expect(summary.boot.progressRatio).toBe(1);
+    expect(summary.activity.requestCounts).toEqual({
+      started: 2,
+      succeeded: 1,
+      skipped: 0,
+      failed: 1,
+    });
+    expect(summary.activity.totalEncodedBytes).toBe(100);
+    expect(summary.activity.totalDecodedBytes).toBe(200);
+  });
+
+  it('formats separate boot and activity summary lines', () => {
+    let state = createInitialRepositoryLoadProgressState(['alpha']);
+    state = reduceRepositoryLoadProgressState(state, {
+      type: 'started',
+      path: 'alpha/data.json',
+      prefix: 'alpha',
+      kind: 'data',
+      optional: false,
+    });
+    const summary = summarizeRepositoryLoadProgress(state);
+
+    expect(formatBootLoadProgressSummary(summary.boot)).toContain('boot progress: required=0/1');
+    expect(formatBootLoadProgressSummary(summary.boot, { mode: 'complete' })).toContain(
+      'required data load complete: required=0/1',
+    );
+    expect(formatBootLoadProgressSummary(summary.boot)).toContain('last=started:alpha/data.json');
+    expect(formatLoadActivitySummary(summary.activity)).toContain(
+      'load activity: requests=1/0/0/0',
+    );
+    expect(formatLoadActivitySummary(summary.activity, { mode: 'snapshot' })).toContain(
+      'load activity snapshot: requests=1/0/0/0',
+    );
+    expect(formatLoadActivitySizeSummary(summary.activity)).toBe(
+      'data size: encoded=0B decoded=0B',
+    );
+  });
+});

--- a/src/repositories/athenai-repository/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository/athenai-repository-v2.ts
@@ -21,6 +21,7 @@ import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog
 import type { TimetableGroupV2Json } from '@contracts/data/transit-v2-json';
 
 import { FetchDataSourceV2 } from '../../datasources/fetch-data-source-v2';
+import type { BundleLoadReporter } from '../../datasources/load-events';
 import type { TransitDataSourceV2 } from '../../datasources/transit-data-source-v2';
 import {
   binarySearchFirstGte,
@@ -67,6 +68,13 @@ import { fetchDataSourceCatalog } from './fetch-data-source-catalog';
 import { fetchSourcesV2 } from './fetch-sources-v2';
 import { buildTranslatableText } from './lib/build-translatable-text';
 import { buildTripStopTimes } from './lib/build-trip-stop-times';
+import {
+  createInitialRepositoryLoadProgressState,
+  formatBootLoadProgressSummary,
+  formatLoadActivitySummary,
+  reduceRepositoryLoadProgressState,
+  summarizeRepositoryLoadProgress,
+} from './load-progress';
 import { sortTripStopTimesByStopIndex } from './lib/sort-trip-stop-times';
 import { mergeSourcesV2 } from './merge-sources-v2';
 import type {
@@ -75,6 +83,7 @@ import type {
   MergedDataV2,
   PatternStatsEntry,
   PatternTimetableEntry,
+  RepositoryLoadProgressSummary,
   RouteFreqEntry,
   StopInsightsEntry,
 } from './types';
@@ -87,6 +96,8 @@ export interface CreateResult {
   repository: TransitRepository;
   /** Details about which sources succeeded/failed. */
   loadResult: LoadResult;
+  /** Aggregated load progress summary collected during startup. */
+  loadProgress: RepositoryLoadProgressSummary;
 }
 
 /**
@@ -158,10 +169,17 @@ export class AthenaiRepositoryV2 implements TransitRepository {
   static async create(
     prefixes: string[],
     dataSource: TransitDataSourceV2 = new FetchDataSourceV2(),
+    onLoadProgress: ((summary: RepositoryLoadProgressSummary) => void) | undefined = undefined,
   ): Promise<CreateResult> {
     const t0 = performance.now();
     logger.info(`Loading sources: [${prefixes.join(', ')}]`);
 
+    const progressCollector = createRepositoryLoadProgressCollector(prefixes, onLoadProgress);
+    attachLoadReporterIfSupported(dataSource, progressCollector.report);
+
+    if (logger.isEnabled('debug')) {
+      logger.debug(`boot phase: fetch start (sources=${prefixes.length}, catalog=true)`);
+    }
     const [sourcesResult, catalogResult] = await Promise.all([
       fetchSourcesV2(prefixes, dataSource),
       fetchDataSourceCatalog(dataSource),
@@ -177,17 +195,18 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     }
 
     if (logger.isEnabled('debug')) {
-      for (const source of sources) {
-        logger.debug(
-          `[${source.prefix}] stops=${source.data.stops.data.length} routes=${source.data.routes.data.length} tripPatterns=${Object.keys(source.data.tripPatterns.data).length}`,
-        );
-      }
+      logger.debug(`boot phase: merge start (sources=${sources.length})`);
     }
 
     const merged = mergeSourcesV2(sources);
     const tMerge = performance.now();
     const mergeMs = Math.round(tMerge - tFetch);
     if (logger.isEnabled('debug')) {
+      for (const source of sources) {
+        logger.debug(
+          `[${source.prefix}] stops=${source.data.stops.data.length} routes=${source.data.routes.data.length} tripPatterns=${Object.keys(source.data.tripPatterns.data).length}`,
+        );
+      }
       logger.debug(
         `mergeSources: ${mergeMs}ms (stops=${merged.stops.length} routes=${merged.routeMap.size} stopsMetaMap=${merged.stopsMetaMap.size})`,
       );
@@ -201,6 +220,9 @@ export class AthenaiRepositoryV2 implements TransitRepository {
 
     const repository = new AthenaiRepositoryV2(merged, dataSourceCatalog);
 
+    if (logger.isEnabled('debug')) {
+      logger.debug(`boot phase: enrich start (sources=${loadResult.loaded.length})`);
+    }
     const tEnrich = performance.now();
     await enrichStopInsights(
       merged.stopsMetaMap,
@@ -213,8 +235,11 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     logger.info(
       `Initialized in ${Math.round(performance.now() - t0)}ms (fetch=${fetchMs}ms, merge=${mergeMs}ms, enrich=${enrichMs}ms): stops=${merged.stops.length} routes=${merged.routeMap.size} timetable_stops=${Object.keys(merged.timetable).length}`,
     );
+    if (logger.isEnabled('debug')) {
+      logger.debug(`boot phase: shapes start (sources=${loadResult.loaded.length})`);
+    }
     repository.startShapesLoad(loadResult.loaded, dataSource);
-    return { repository, loadResult };
+    return { repository, loadResult, loadProgress: progressCollector.snapshot() };
   }
 
   private async loadAllShapesWithInsights(
@@ -1010,4 +1035,74 @@ export class AthenaiRepositoryV2 implements TransitRepository {
     this.activeServiceCache.set(key, ids);
     return ids;
   }
+}
+
+type LoadEventReportableDataSource = TransitDataSourceV2 & {
+  setLoadEventReporter(reporter: BundleLoadReporter | undefined): void;
+};
+
+function attachLoadReporterIfSupported(
+  dataSource: TransitDataSourceV2,
+  reporter: BundleLoadReporter,
+): void {
+  if (
+    'setLoadEventReporter' in dataSource &&
+    typeof dataSource.setLoadEventReporter === 'function'
+  ) {
+    (dataSource as LoadEventReportableDataSource).setLoadEventReporter(reporter);
+  }
+}
+
+function createRepositoryLoadProgressCollector(
+  prefixes: string[],
+  onLoadProgress: ((summary: RepositoryLoadProgressSummary) => void) | undefined,
+): {
+  report: BundleLoadReporter;
+  snapshot: () => RepositoryLoadProgressSummary;
+} {
+  let state = createInitialRepositoryLoadProgressState(prefixes);
+
+  const notify = (eventLabel: string) => {
+    const summary = summarizeRepositoryLoadProgress(state);
+    if (logger.isEnabled('debug')) {
+      const lastEvent = summary.activity.lastEvent;
+      if (lastEvent === null || isRequiredBootEvent(lastEvent)) {
+        logger.debug(
+          `${formatBootEventLabel(eventLabel)} | ${formatBootLoadProgressSummary(summary.boot)} | ${formatLoadActivitySummary(summary.activity)}`,
+        );
+      } else {
+        logger.debug(
+          `${formatActivityEventLabel(eventLabel)} | ${formatLoadActivitySummary(summary.activity)}`,
+        );
+      }
+    }
+    onLoadProgress?.(summary);
+  };
+
+  notify('load event: init');
+
+  return {
+    report(event) {
+      state = reduceRepositoryLoadProgressState(state, event);
+      notify(`load event: ${event.type}:${event.path}`);
+    },
+    snapshot() {
+      return summarizeRepositoryLoadProgress(state);
+    },
+  };
+}
+
+function isRequiredBootEvent(event: Parameters<BundleLoadReporter>[0]): boolean {
+  return event.kind === 'data' && !event.optional && event.prefix !== null;
+}
+
+function formatBootEventLabel(eventLabel: string): string {
+  if (eventLabel === 'load event: init') {
+    return 'boot event: init';
+  }
+  return eventLabel.replace('load event:', 'boot event:');
+}
+
+function formatActivityEventLabel(eventLabel: string): string {
+  return eventLabel.replace('load event:', 'activity event:');
 }

--- a/src/repositories/athenai-repository/index.ts
+++ b/src/repositories/athenai-repository/index.ts
@@ -3,11 +3,19 @@ export type { CreateResult } from './athenai-repository-v2';
 export { mergeSourcesV2 } from './merge-sources-v2';
 export { fetchSourcesV2 } from './fetch-sources-v2';
 export { enrichStopInsights } from './enrich-stop-insights';
+export {
+  formatBootLoadProgressSummary,
+  formatLoadActivitySizeSummary,
+  formatLoadActivitySummary,
+} from './load-progress';
 export type {
+  BootLoadProgressSummary,
   HeadsignTranslationsByPrefix,
+  LoadActivitySummary,
   LoadResult,
   MergedDataV2,
   PatternStatsEntry,
+  RepositoryLoadProgressSummary,
   RouteFreqEntry,
   StopInsightsEntry,
 } from './types';

--- a/src/repositories/athenai-repository/load-progress.ts
+++ b/src/repositories/athenai-repository/load-progress.ts
@@ -1,0 +1,208 @@
+import type { BundleLoadEvent } from '../../datasources/load-events';
+
+type RequiredSourceStatus = 'idle' | 'loading' | 'loaded' | 'failed';
+
+export interface BootLoadProgressSummary {
+  totalSources: number;
+  startedSources: number;
+  completedSources: number;
+  failedSources: number;
+  progressRatio: number;
+  lastRequiredEvent: BundleLoadEvent | null;
+}
+
+export interface LoadActivitySummary {
+  requestCounts: {
+    started: number;
+    succeeded: number;
+    skipped: number;
+    failed: number;
+  };
+  totalEncodedBytes: number;
+  totalDecodedBytes: number;
+  lastEvent: BundleLoadEvent | null;
+}
+
+export interface RepositoryLoadProgressSummary {
+  boot: BootLoadProgressSummary;
+  activity: LoadActivitySummary;
+}
+
+interface FormatBootLoadProgressSummaryOptions {
+  mode?: 'progress' | 'complete';
+}
+
+interface FormatLoadActivitySummaryOptions {
+  mode?: 'progress' | 'snapshot';
+}
+
+interface RepositoryLoadProgressState {
+  totalSources: number;
+  requiredSourceStatusByPrefix: Record<string, RequiredSourceStatus>;
+  requestCounts: {
+    started: number;
+    succeeded: number;
+    skipped: number;
+    failed: number;
+  };
+  totalEncodedBytes: number;
+  totalDecodedBytes: number;
+  lastEvent: BundleLoadEvent | null;
+}
+
+export function createInitialRepositoryLoadProgressState(
+  prefixes: string[],
+): RepositoryLoadProgressState {
+  const requiredSourceStatusByPrefix: Record<string, RequiredSourceStatus> = {};
+  for (const prefix of prefixes) {
+    requiredSourceStatusByPrefix[prefix] = 'idle';
+  }
+
+  return {
+    totalSources: prefixes.length,
+    requiredSourceStatusByPrefix,
+    requestCounts: {
+      started: 0,
+      succeeded: 0,
+      skipped: 0,
+      failed: 0,
+    },
+    totalEncodedBytes: 0,
+    totalDecodedBytes: 0,
+    lastEvent: null,
+  };
+}
+
+export function reduceRepositoryLoadProgressState(
+  state: RepositoryLoadProgressState,
+  event: BundleLoadEvent,
+): RepositoryLoadProgressState {
+  const next: RepositoryLoadProgressState = {
+    ...state,
+    requiredSourceStatusByPrefix: { ...state.requiredSourceStatusByPrefix },
+    requestCounts: { ...state.requestCounts },
+    lastEvent: event,
+  };
+
+  switch (event.type) {
+    case 'started': {
+      next.requestCounts.started += 1;
+      if (event.kind === 'data' && event.prefix !== null) {
+        const current = next.requiredSourceStatusByPrefix[event.prefix];
+        if (current === 'idle') {
+          next.requiredSourceStatusByPrefix[event.prefix] = 'loading';
+        }
+      }
+      return next;
+    }
+    case 'succeeded': {
+      next.requestCounts.succeeded += 1;
+      next.totalEncodedBytes += event.metrics.transferBytes ?? 0;
+      next.totalDecodedBytes +=
+        event.metrics.decodedBytes ?? event.metrics.estimatedDecodedBytes ?? 0;
+      if (event.kind === 'data' && event.prefix !== null) {
+        const current = next.requiredSourceStatusByPrefix[event.prefix];
+        if (current !== 'loaded') {
+          next.requiredSourceStatusByPrefix[event.prefix] = 'loaded';
+        }
+      }
+      return next;
+    }
+    case 'skipped': {
+      next.requestCounts.skipped += 1;
+      return next;
+    }
+    case 'failed': {
+      next.requestCounts.failed += 1;
+      if (event.kind === 'data' && event.prefix !== null) {
+        const current = next.requiredSourceStatusByPrefix[event.prefix];
+        if (current !== 'loaded' && current !== 'failed') {
+          next.requiredSourceStatusByPrefix[event.prefix] = 'failed';
+        }
+      }
+      return next;
+    }
+  }
+}
+
+export function summarizeRepositoryLoadProgress(
+  state: RepositoryLoadProgressState,
+): RepositoryLoadProgressSummary {
+  let startedSources = 0;
+  let completedSources = 0;
+  let failedSources = 0;
+
+  for (const status of Object.values(state.requiredSourceStatusByPrefix)) {
+    if (status !== 'idle') {
+      startedSources += 1;
+    }
+    if (status === 'loaded') {
+      completedSources += 1;
+    }
+    if (status === 'failed') {
+      failedSources += 1;
+    }
+  }
+
+  const processedSources = completedSources + failedSources;
+  return {
+    boot: {
+      totalSources: state.totalSources,
+      startedSources,
+      completedSources,
+      failedSources,
+      progressRatio: state.totalSources === 0 ? 1 : processedSources / state.totalSources,
+      lastRequiredEvent: isRequiredDataEvent(state.lastEvent) ? state.lastEvent : null,
+    },
+    activity: {
+      requestCounts: state.requestCounts,
+      totalEncodedBytes: state.totalEncodedBytes,
+      totalDecodedBytes: state.totalDecodedBytes,
+      lastEvent: state.lastEvent,
+    },
+  };
+}
+
+export function formatBootLoadProgressSummary(
+  summary: BootLoadProgressSummary,
+  options?: FormatBootLoadProgressSummaryOptions,
+): string {
+  const processedSources = summary.completedSources + summary.failedSources;
+  const progressPercent = Math.round(summary.progressRatio * 100);
+  const lastEvent =
+    summary.lastRequiredEvent === null
+      ? 'idle'
+      : `${summary.lastRequiredEvent.type}:${summary.lastRequiredEvent.path}`;
+  const label = options?.mode === 'complete' ? 'required data load complete' : 'boot progress';
+
+  return `${label}: required=${processedSources}/${summary.totalSources} (${progressPercent}%) loaded=${summary.completedSources} failed=${summary.failedSources} last=${lastEvent}`;
+}
+
+export function formatLoadActivitySummary(
+  summary: LoadActivitySummary,
+  options?: FormatLoadActivitySummaryOptions,
+): string {
+  const lastEvent =
+    summary.lastEvent === null ? 'idle' : `${summary.lastEvent.type}:${summary.lastEvent.path}`;
+  const label = options?.mode === 'snapshot' ? 'load activity snapshot' : 'load activity';
+
+  return `${label}: requests=${summary.requestCounts.started}/${summary.requestCounts.succeeded}/${summary.requestCounts.skipped}/${summary.requestCounts.failed} encoded=${formatBytes(summary.totalEncodedBytes)} decoded=${formatBytes(summary.totalDecodedBytes)} last=${lastEvent}`;
+}
+
+export function formatLoadActivitySizeSummary(summary: LoadActivitySummary): string {
+  return `data size: encoded=${formatBytes(summary.totalEncodedBytes)} decoded=${formatBytes(summary.totalDecodedBytes)}`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function isRequiredDataEvent(event: BundleLoadEvent | null): event is BundleLoadEvent {
+  return event !== null && event.kind === 'data' && !event.optional;
+}

--- a/src/repositories/athenai-repository/load-progress.ts
+++ b/src/repositories/athenai-repository/load-progress.ts
@@ -2,27 +2,49 @@ import type { BundleLoadEvent } from '../../datasources/load-events';
 
 type RequiredSourceStatus = 'idle' | 'loading' | 'loaded' | 'failed';
 
+/**
+ * Summary of required `data` bundle progress used for repository boot completion.
+ */
 export interface BootLoadProgressSummary {
+  /** Total number of required data sources tracked for boot. */
   totalSources: number;
+  /** Number of required data sources that have left the idle state. */
   startedSources: number;
+  /** Number of required data sources that completed successfully. */
   completedSources: number;
+  /** Number of required data sources that finished with failure. */
   failedSources: number;
+  /** Processed required sources as a ratio of total required sources. */
   progressRatio: number;
+  /** Most recent required `data` load event observed for boot progress. */
   lastRequiredEvent: BundleLoadEvent | null;
 }
 
+/**
+ * Snapshot of all load activity observed so far, including non-boot requests.
+ */
 export interface LoadActivitySummary {
   requestCounts: {
+    /** Total number of load requests that started. */
     started: number;
+    /** Total number of load requests that succeeded. */
     succeeded: number;
+    /** Total number of load requests that were skipped. */
     skipped: number;
+    /** Total number of load requests that failed. */
     failed: number;
   };
+  /** Sum of encoded response body sizes observed across successful loads. */
   totalEncodedBytes: number;
+  /** Sum of decoded body sizes or estimated decoded sizes across successful loads. */
   totalDecodedBytes: number;
+  /** Most recent load event observed across all activity. */
   lastEvent: BundleLoadEvent | null;
 }
 
+/**
+ * Combined repository load progress view exposed to app and repository observers.
+ */
 export interface RepositoryLoadProgressSummary {
   boot: BootLoadProgressSummary;
   activity: LoadActivitySummary;
@@ -36,17 +58,29 @@ interface FormatLoadActivitySummaryOptions {
   mode?: 'progress' | 'snapshot';
 }
 
+/**
+ * Internal accumulator state used to reduce raw datasource events into summaries.
+ */
 interface RepositoryLoadProgressState {
+  /** Total number of required data sources tracked by this reducer. */
   totalSources: number;
+  /** Per-prefix boot status for required data source loading. */
   requiredSourceStatusByPrefix: Record<string, RequiredSourceStatus>;
   requestCounts: {
+    /** Total number of load requests that started. */
     started: number;
+    /** Total number of load requests that succeeded. */
     succeeded: number;
+    /** Total number of load requests that were skipped. */
     skipped: number;
+    /** Total number of load requests that failed. */
     failed: number;
   };
+  /** Sum of encoded response body sizes observed across successful loads. */
   totalEncodedBytes: number;
+  /** Sum of decoded body sizes or estimated decoded sizes across successful loads. */
   totalDecodedBytes: number;
+  /** Most recent raw load event reduced into this state. */
   lastEvent: BundleLoadEvent | null;
 }
 

--- a/src/repositories/athenai-repository/load-progress.ts
+++ b/src/repositories/athenai-repository/load-progress.ts
@@ -80,6 +80,8 @@ interface RepositoryLoadProgressState {
   totalEncodedBytes: number;
   /** Sum of decoded body sizes or estimated decoded sizes across successful loads. */
   totalDecodedBytes: number;
+  /** Most recent required `data` load event observed by this reducer. */
+  lastRequiredEvent: BundleLoadEvent | null;
   /** Most recent raw load event reduced into this state. */
   lastEvent: BundleLoadEvent | null;
 }
@@ -103,6 +105,7 @@ export function createInitialRepositoryLoadProgressState(
     },
     totalEncodedBytes: 0,
     totalDecodedBytes: 0,
+    lastRequiredEvent: null,
     lastEvent: null,
   };
 }
@@ -123,9 +126,10 @@ export function reduceRepositoryLoadProgressState(
       next.requestCounts.started += 1;
       if (event.kind === 'data' && event.prefix !== null) {
         const current = next.requiredSourceStatusByPrefix[event.prefix];
-        if (current === 'idle') {
+        if (current !== 'loaded' && current !== 'loading') {
           next.requiredSourceStatusByPrefix[event.prefix] = 'loading';
         }
+        next.lastRequiredEvent = event;
       }
       return next;
     }
@@ -139,6 +143,7 @@ export function reduceRepositoryLoadProgressState(
         if (current !== 'loaded') {
           next.requiredSourceStatusByPrefix[event.prefix] = 'loaded';
         }
+        next.lastRequiredEvent = event;
       }
       return next;
     }
@@ -153,6 +158,7 @@ export function reduceRepositoryLoadProgressState(
         if (current !== 'loaded' && current !== 'failed') {
           next.requiredSourceStatusByPrefix[event.prefix] = 'failed';
         }
+        next.lastRequiredEvent = event;
       }
       return next;
     }
@@ -186,10 +192,10 @@ export function summarizeRepositoryLoadProgress(
       completedSources,
       failedSources,
       progressRatio: state.totalSources === 0 ? 1 : processedSources / state.totalSources,
-      lastRequiredEvent: isRequiredDataEvent(state.lastEvent) ? state.lastEvent : null,
+      lastRequiredEvent: state.lastRequiredEvent,
     },
     activity: {
-      requestCounts: state.requestCounts,
+      requestCounts: { ...state.requestCounts },
       totalEncodedBytes: state.totalEncodedBytes,
       totalDecodedBytes: state.totalDecodedBytes,
       lastEvent: state.lastEvent,
@@ -235,8 +241,4 @@ function formatBytes(bytes: number): string {
     return `${(bytes / 1024).toFixed(1)}KB`;
   }
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
-}
-
-function isRequiredDataEvent(event: BundleLoadEvent | null): event is BundleLoadEvent {
-  return event !== null && event.kind === 'data' && !event.optional;
 }

--- a/src/repositories/athenai-repository/load-progress.ts
+++ b/src/repositories/athenai-repository/load-progress.ts
@@ -131,9 +131,9 @@ export function reduceRepositoryLoadProgressState(
     }
     case 'succeeded': {
       next.requestCounts.succeeded += 1;
-      next.totalEncodedBytes += event.metrics.transferBytes ?? 0;
+      next.totalEncodedBytes += event.metrics.encodedBytes ?? 0;
       next.totalDecodedBytes +=
-        event.metrics.decodedBytes ?? event.metrics.estimatedDecodedBytes ?? 0;
+        event.metrics.decodedBytes ?? event.metrics.fallbackDecodedBytes ?? 0;
       if (event.kind === 'data' && event.prefix !== null) {
         const current = next.requiredSourceStatusByPrefix[event.prefix];
         if (current !== 'loaded') {

--- a/src/repositories/athenai-repository/types.ts
+++ b/src/repositories/athenai-repository/types.ts
@@ -68,3 +68,9 @@ export interface PatternStatsEntry {
   rds: Partial<Record<string, number[]>>;
   freqs: Partial<Record<string, number>>;
 }
+
+export type {
+  BootLoadProgressSummary,
+  LoadActivitySummary,
+  RepositoryLoadProgressSummary,
+} from './load-progress';


### PR DESCRIPTION
## Summary
- add datasource load events and repository-side progress aggregation for boot and activity
- add app and repository info/debug logs for required data load, activity snapshots, and initialization timing
- add focused tests covering datasource event reporting and repository load progress summaries

## Validation
- npm run format
- npm run lint
- npm run build
- repository progress tests: 75 passed

## Notes
- UI progress representation is intentionally deferred to a follow-up after this PR is merged