### PR TITLE
feat: add bootstrap progress shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - App boot: React mount と repository boot を分離し、repository 準備中にも最小限の bootstrap shell を表示するようにした。既存の repository 選択 (`?repo=` / `?sources=`) と boot-time diagnostics の挙動は維持しつつ、loading / error 表示を i18n 対応し、今後の progress UI 追加に備えた。
 - App boot: bootstrap shell に required data bundle の per-prefix 進捗を示す progress bar、最新状態の `ProgressStatus`、scrollable な `ProgressLogs` を追加し、repository boot 完了後は短い fade transition で App に切り替えるようにした。
+- App boot: bootstrap shell の progress / notice 表示を調整。progress bar は `info` 系トークンを使うようにし、完了数・失敗数は数値だけを強調表示した。notice は required `data.json` failure を `Errors`、optional bundle failure を `Warnings` に分離し、`?bootstrap=hold` のときだけ scrollable な progress log viewer を表示するようにした。
 - Data source catalog / settings: trip 実績ベースの運行期間 summary `summary.service.operatingDates` (`first` / `last` / `count`) を catalog に追加し、Data Source Settings dialog では group summary に `YYYYMMDD-YYYYMMDD` 形式の運行期間 badge として表示するようにした。group 集約は `min(first)` / `max(last)` の boundary-only summary とし、per-group の `count` は持たない。
 - Data: kyoto-bus の GTFS resource を 20260516 版へ更新。
 - Data: kyoto-city-bus の GTFS resource を 20260518 版へ更新。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [CalVer](https://calver.org/).
 ### Changed
 
 - App boot: React mount と repository boot を分離し、repository 準備中にも最小限の bootstrap shell を表示するようにした。既存の repository 選択 (`?repo=` / `?sources=`) と boot-time diagnostics の挙動は維持しつつ、loading / error 表示を i18n 対応し、今後の progress UI 追加に備えた。
+- App boot: bootstrap shell に required data bundle の per-prefix 進捗を示す progress bar、最新状態の `ProgressStatus`、scrollable な `ProgressLogs` を追加し、repository boot 完了後は短い fade transition で App に切り替えるようにした。
 - Data source catalog / settings: trip 実績ベースの運行期間 summary `summary.service.operatingDates` (`first` / `last` / `count`) を catalog に追加し、Data Source Settings dialog では group summary に `YYYYMMDD-YYYYMMDD` 形式の運行期間 badge として表示するようにした。group 集約は `min(first)` / `max(last)` の boundary-only summary とし、per-group の `count` は持たない。
 - Data: kyoto-bus の GTFS resource を 20260516 版へ更新。
 - Data: kyoto-city-bus の GTFS resource を 20260518 版へ更新。

--- a/PRD.md
+++ b/PRD.md
@@ -124,6 +124,7 @@ URL パラメータでアプリの動作を制御できる。パラメータは�
 | `?stop=<stop_id>`     | 初期選択 stop の指定                   | `/?stop=minkuru:0442-01`       |
 | `?tileIdx=<number>`   | タイルソースの初期選択 (0-based index) | `/?tileIdx=3`                  |
 | `?lang=<code>`        | 表示言語の初期選択 (BCP 47)            | `/?lang=en`                    |
+| `?bootstrap=hold`     | 起動完了後も Bootstrap 表示を保持      | `/?bootstrap=hold`             |
 
 - `?repo=mock` 指定時は `?sources` は無視される
 - `?sources` 指定時は localStorage の設定を上書きするが、localStorage 自体は更新しない (一時的な override)
@@ -132,6 +133,7 @@ URL パラメータでアプリの動作を制御できる。パラメータは�
 - `?zm` は単独指定可能 (座標はランダム/env、zoom だけ上書き)
 - `?tileIdx` は localStorage の `tileIndex` より優先されるが、localStorage 自体は更新しない (一時的な override)
 - `?lang` は localStorage の `lang` より優先されるが、localStorage 自体は更新しない (一時的な override)。`normalizeLang` で正規化される (例: `zh-TW` → `zh-Hant`)。サポート外の値はデフォルト言語にフォールバック
+- `?bootstrap=hold` は Bootstrap UI 確認用。repository boot 完了後も Bootstrap 表示を保持し、明示操作で App 表示へ進む
 - 無効な値 (非数値、範囲外、Infinity) は無視してフォールバック
 - 優先順位: query params > env variables > ランダム選択
 - 全パラメータのパースは `src/lib/query-params.ts` で一元管理

--- a/src/__tests__/bootstrap-app.test.tsx
+++ b/src/__tests__/bootstrap-app.test.tsx
@@ -2,12 +2,14 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import BootstrapApp from '../bootstrap-app';
-import type { AppBootstrapState } from '../hooks/use-app-bootstrap';
+import type { AppBootstrapState, BootstrapProgressLogEntry } from '../hooks/use-app-bootstrap';
+import type { RepositoryLoadProgressSummary } from '../repositories/athenai-repository';
 import type { TransitRepository } from '../repositories/transit-repository';
 
 const mockUseAppBootstrap = vi.hoisted(() => vi.fn<() => AppBootstrapState>());
 const mockTransitRepositoryProvider = vi.hoisted(() => vi.fn());
 const mockSourceLoadStateProvider = vi.hoisted(() => vi.fn());
+const mockGetBootstrapParam = vi.hoisted(() => vi.fn<() => 'hold' | null>(() => null));
 
 vi.mock('../hooks/use-app-bootstrap', () => ({
   useAppBootstrap: () => mockUseAppBootstrap(),
@@ -46,6 +48,7 @@ vi.mock('../contexts/source-load-state-provider', () => ({
 }));
 
 vi.mock('../lib/query-params', () => ({
+  getBootstrapParam: () => mockGetBootstrapParam(),
   getSourcesParam: () => 'alpha,beta',
 }));
 
@@ -54,21 +57,154 @@ vi.mock('react-i18next', () => ({
     t: (key: string) => {
       const labels: Record<string, string> = {
         'bootstrap.loading.title': 'Preparing app',
-        'bootstrap.loading.detail': 'This will only take a moment.',
+        'bootstrap.loading.message': 'This will only take a moment.',
+        'bootstrap.loading.progressLabel': 'Loading data',
+        'bootstrap.loading.progressFailed': 'failed',
+        'bootstrap.ready.title': 'Ready',
+        'bootstrap.ready.message': 'Ready',
+        'bootstrap.action.showApp': 'Show app',
+        'bootstrap.action.reload': 'Reload',
+        'bootstrap.logViewer.title': 'Load log',
+        'bootstrap.notice.loadFailuresTitle': 'Data load issues',
         'bootstrap.error.title': 'Could not start Athenai',
-        'bootstrap.error.detail': 'Please reload the app and try again.',
-        'bootstrap.error.reload': 'Reload',
+        'bootstrap.error.message': 'Please reload the app and try again.',
       };
       return labels[key] ?? key;
     },
   }),
 }));
 
+function createProgressSummary(): RepositoryLoadProgressSummary {
+  const event = {
+    type: 'succeeded',
+    kind: 'data',
+    path: 'alpha/data.json',
+    prefix: 'alpha',
+    optional: false,
+    metrics: {},
+  } as const;
+
+  return {
+    boot: {
+      totalSources: 2,
+      startedSources: 2,
+      completedSources: 1,
+      failedSources: 0,
+      progressRatio: 0.5,
+      lastRequiredEvent: event,
+    },
+    activity: {
+      requestCounts: { started: 2, succeeded: 1, skipped: 0, failed: 0 },
+      totalEncodedBytes: 0,
+      totalDecodedBytes: 0,
+      lastEvent: event,
+    },
+  };
+}
+
+function createFailedProgressSummary(): RepositoryLoadProgressSummary {
+  const event = {
+    type: 'failed',
+    kind: 'data',
+    path: 'x13103b/data.json',
+    prefix: 'x13103b',
+    optional: false,
+    reason: 'http-error',
+    message: 'Not Found',
+  } as const;
+
+  return {
+    boot: {
+      totalSources: 2,
+      startedSources: 2,
+      completedSources: 1,
+      failedSources: 1,
+      progressRatio: 1,
+      lastRequiredEvent: event,
+    },
+    activity: {
+      requestCounts: { started: 2, succeeded: 1, skipped: 0, failed: 1 },
+      totalEncodedBytes: 0,
+      totalDecodedBytes: 0,
+      lastEvent: event,
+    },
+  };
+}
+
+function createCompletedProgressSummaryWithOptionalLastEvent(): RepositoryLoadProgressSummary {
+  const requiredEvent = {
+    type: 'failed',
+    kind: 'data',
+    path: 'x13103b/data.json',
+    prefix: 'x13103b',
+    optional: false,
+    reason: 'http-error',
+    message: 'Not Found',
+  } as const;
+  const optionalEvent = {
+    type: 'succeeded',
+    kind: 'global-insights',
+    path: 'global/insights.json',
+    prefix: null,
+    optional: true,
+    metrics: {},
+  } as const;
+
+  return {
+    boot: {
+      totalSources: 2,
+      startedSources: 2,
+      completedSources: 0,
+      failedSources: 2,
+      progressRatio: 1,
+      lastRequiredEvent: requiredEvent,
+    },
+    activity: {
+      requestCounts: { started: 4, succeeded: 2, skipped: 0, failed: 2 },
+      totalEncodedBytes: 0,
+      totalDecodedBytes: 0,
+      lastEvent: optionalEvent,
+    },
+  };
+}
+
+function createProgressLog(summary: RepositoryLoadProgressSummary): BootstrapProgressLogEntry {
+  return {
+    id: 1,
+    createdAt: 100,
+    event: summary.activity.lastEvent,
+    summary,
+  };
+}
+
+function createLoadingState(
+  progress: RepositoryLoadProgressSummary | null = null,
+): Extract<AppBootstrapState, { status: 'loading' }> {
+  return {
+    status: 'loading',
+    progress,
+    logs: progress === null ? [] : [createProgressLog(progress)],
+  };
+}
+
+function stubReducedMotion(): void {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+}
+
 describe('BootstrapApp', () => {
   beforeEach(() => {
     mockUseAppBootstrap.mockReset();
     mockTransitRepositoryProvider.mockReset();
     mockSourceLoadStateProvider.mockReset();
+    mockGetBootstrapParam.mockReset();
+    mockGetBootstrapParam.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -76,21 +212,55 @@ describe('BootstrapApp', () => {
   });
 
   it('renders the boot shell while the repository is loading', () => {
-    mockUseAppBootstrap.mockReturnValue({ status: 'loading' });
+    mockUseAppBootstrap.mockReturnValue(createLoadingState());
 
     render(<BootstrapApp />);
 
-    expect(screen.getByText('Preparing app')).toBeInTheDocument();
+    expect(screen.getByText('This will only take a moment.')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Loading data' })).toHaveAttribute(
+      'aria-valuenow',
+      '0',
+    );
     expect(screen.queryByText('app-mounted')).not.toBeInTheDocument();
   });
 
-  it('mounts the app once bootstrap completes', () => {
+  it('renders bootstrap progress status and logs', () => {
+    const progress = createProgressSummary();
+    mockUseAppBootstrap.mockReturnValue(createLoadingState(progress));
+
+    render(<BootstrapApp />);
+
+    expect(screen.getByRole('progressbar', { name: 'Loading data' })).toHaveAttribute(
+      'aria-valuenow',
+      '50',
+    );
+    expect(screen.getByText('✅ 1')).toBeInTheDocument();
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Load log')).not.toBeInTheDocument();
+  });
+
+  it('lists loading failures in the notice area before ready', () => {
+    const progress = createFailedProgressSummary();
+    mockUseAppBootstrap.mockReturnValue(createLoadingState(progress));
+
+    render(<BootstrapApp />);
+
+    expect(screen.getByLabelText('Data load issues')).toBeInTheDocument();
+    expect(screen.getByText('✅ 1 ⚠️ 1')).toBeInTheDocument();
+    expect(screen.getAllByText('x13103b')).toHaveLength(2);
+    expect(screen.getByText('http-error: Not Found')).toBeInTheDocument();
+  });
+
+  it('mounts the app automatically when ready and reduced motion is enabled', () => {
+    stubReducedMotion();
     const repository = {} as TransitRepository;
     const loadResult = { loaded: ['alpha'], failed: [] };
     mockUseAppBootstrap.mockReturnValue({
       status: 'ready',
       repository,
       loadResult,
+      progress: null,
+      logs: [],
     });
 
     render(<BootstrapApp />);
@@ -101,6 +271,84 @@ describe('BootstrapApp', () => {
       sourcesParam: 'alpha,beta',
     });
     expect(screen.getByText('app-mounted')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Show app' })).not.toBeInTheDocument();
+  });
+
+  it('lists startup load failures in the notice area before showing the app', () => {
+    const repository = {} as TransitRepository;
+    mockUseAppBootstrap.mockReturnValue({
+      status: 'ready',
+      repository,
+      loadResult: {
+        loaded: ['alpha'],
+        failed: [{ prefix: 'x13103b', error: new Error('Not Found') }],
+      },
+      progress: null,
+      logs: [],
+    });
+
+    render(<BootstrapApp />);
+
+    expect(screen.getByLabelText('Data load issues')).toBeInTheDocument();
+    expect(screen.getByText('x13103b')).toBeInTheDocument();
+    expect(screen.getByText('Not Found')).toBeInTheDocument();
+    expect(screen.queryByText('app-mounted')).not.toBeInTheDocument();
+  });
+
+  it('keeps the ready boot shell visible when bootstrap hold mode is enabled', () => {
+    stubReducedMotion();
+    mockGetBootstrapParam.mockReturnValue('hold');
+    const repository = {} as TransitRepository;
+    const loadResult = { loaded: ['alpha'], failed: [] };
+    mockUseAppBootstrap.mockReturnValue({
+      status: 'ready',
+      repository,
+      loadResult,
+      progress: null,
+      logs: [],
+    });
+
+    render(<BootstrapApp />);
+
+    expect(screen.getByText('Ready')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show app' })).toBeInTheDocument();
+    expect(screen.queryByText('app-mounted')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show app' }));
+
+    expect(mockTransitRepositoryProvider).toHaveBeenCalledWith(repository);
+    expect(mockSourceLoadStateProvider).toHaveBeenCalledWith({
+      initialLoadResult: loadResult,
+      sourcesParam: 'alpha,beta',
+    });
+    expect(screen.getByText('app-mounted')).toBeInTheDocument();
+  });
+
+  it('shows only completed counts in progress status after bootstrap is ready', () => {
+    const repository = {} as TransitRepository;
+    const progress = createCompletedProgressSummaryWithOptionalLastEvent();
+    mockUseAppBootstrap.mockReturnValue({
+      status: 'ready',
+      repository,
+      loadResult: {
+        loaded: [],
+        failed: [
+          { prefix: 'x85b', error: new Error('Not Found') },
+          { prefix: 'x13103b', error: new Error('Not Found') },
+        ],
+      },
+      progress,
+      logs: [createProgressLog(progress)],
+    });
+
+    render(<BootstrapApp />);
+
+    expect(screen.getByText('✅ 0 ⚠️ 2')).toBeInTheDocument();
+    expect(screen.queryByText('✅ 0 ⚠️ 2 - global insights')).not.toBeInTheDocument();
+    expect(screen.queryByText('global insights')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/succeeded global-insights global\/insights\.json/),
+    ).not.toBeInTheDocument();
   });
 
   it('shows a reload action when bootstrap fails', () => {
@@ -109,14 +357,39 @@ describe('BootstrapApp', () => {
     mockUseAppBootstrap.mockReturnValue({
       status: 'error',
       error: new Error('boot failed'),
+      progress: null,
+      logs: [],
     });
 
     render(<BootstrapApp />);
 
-    expect(screen.getByText('Could not start Athenai')).toBeInTheDocument();
     expect(screen.getByText('Please reload the app and try again.')).toBeInTheDocument();
     expect(screen.queryByText('boot failed')).not.toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Reload' }));
     expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows collected progress content when bootstrap fails after progress events', () => {
+    const reload = vi.fn();
+    const progress = createFailedProgressSummary();
+    vi.stubGlobal('location', { ...window.location, reload });
+    mockUseAppBootstrap.mockReturnValue({
+      status: 'error',
+      error: new Error('boot failed'),
+      progress,
+      logs: [createProgressLog(progress)],
+    });
+
+    render(<BootstrapApp />);
+
+    expect(screen.getByText('Please reload the app and try again.')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Loading data' })).toHaveAttribute(
+      'aria-valuenow',
+      '100',
+    );
+    expect(screen.getByLabelText('Data load issues')).toBeInTheDocument();
+    expect(screen.getByText('http-error: Not Found')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Load log')).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/bootstrap-app.test.tsx
+++ b/src/__tests__/bootstrap-app.test.tsx
@@ -66,6 +66,9 @@ vi.mock('react-i18next', () => ({
         'bootstrap.action.reload': 'Reload',
         'bootstrap.logViewer.title': 'Load log',
         'bootstrap.notice.loadFailuresTitle': 'Data load issues',
+        'bootstrap.tips.dataSources': 'You can change data in settings.',
+        'bootstrap.tips.selection': 'Choose the data you need or are interested in.',
+        'bootstrap.tips.performance': 'Large data can affect app performance.',
         'bootstrap.error.title': 'Could not start Athenai',
         'bootstrap.error.message': 'Please reload the app and try again.',
       };
@@ -177,6 +180,23 @@ function createProgressLog(summary: RepositoryLoadProgressSummary): BootstrapPro
   };
 }
 
+function createProgressLogWithEvent({
+  event,
+  id,
+  summary,
+}: {
+  event: BootstrapProgressLogEntry['event'];
+  id: number;
+  summary: RepositoryLoadProgressSummary;
+}): BootstrapProgressLogEntry {
+  return {
+    id,
+    createdAt: 100 + id,
+    event,
+    summary,
+  };
+}
+
 function createLoadingState(
   progress: RepositoryLoadProgressSummary | null = null,
 ): Extract<AppBootstrapState, { status: 'loading' }> {
@@ -217,6 +237,10 @@ describe('BootstrapApp', () => {
     render(<BootstrapApp />);
 
     expect(screen.getByText('This will only take a moment.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Tips')).toBeInTheDocument();
+    expect(screen.getByText('You can change data in settings.')).toBeInTheDocument();
+    expect(screen.getByText('Choose the data you need or are interested in.')).toBeInTheDocument();
+    expect(screen.getByText('Large data can affect app performance.')).toBeInTheDocument();
     expect(screen.getByRole('progressbar', { name: 'Loading data' })).toHaveAttribute(
       'aria-valuenow',
       '0',
@@ -237,6 +261,19 @@ describe('BootstrapApp', () => {
     expect(screen.getByText('✅ 1')).toBeInTheDocument();
     expect(screen.getByText('alpha')).toBeInTheDocument();
     expect(screen.queryByLabelText('Load log')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bootstrap-progress-log-viewer')).not.toBeInTheDocument();
+  });
+
+  it('renders the progress log viewer while bootstrap hold mode is enabled', () => {
+    mockGetBootstrapParam.mockReturnValue('hold');
+    const progress = createProgressSummary();
+    mockUseAppBootstrap.mockReturnValue(createLoadingState(progress));
+
+    render(<BootstrapApp />);
+
+    expect(screen.getByTestId('bootstrap-progress-log-viewer')).toBeInTheDocument();
+    expect(screen.getByLabelText('Load log')).toBeInTheDocument();
+    expect(screen.getByText(/succeeded data alpha\/data\.json/)).toBeInTheDocument();
   });
 
   it('lists loading failures in the notice area before ready', () => {
@@ -295,6 +332,51 @@ describe('BootstrapApp', () => {
     expect(screen.queryByText('app-mounted')).not.toBeInTheDocument();
   });
 
+  it('keeps optional load notices visible after bootstrap is ready', () => {
+    const repository = {} as TransitRepository;
+    const progress = createFailedProgressSummary();
+    const dataFailureEvent = {
+      type: 'failed',
+      kind: 'data',
+      path: 'x13103b/data.json',
+      prefix: 'x13103b',
+      optional: false,
+      reason: 'http-error',
+      message: 'Data Not Found',
+    } as const;
+    const insightsFailureEvent = {
+      type: 'failed',
+      kind: 'insights',
+      path: 'x13103b/insights.json',
+      prefix: 'x13103b',
+      optional: true,
+      reason: 'network-error',
+      message: 'Insights unavailable',
+    } as const;
+
+    mockUseAppBootstrap.mockReturnValue({
+      status: 'ready',
+      repository,
+      loadResult: {
+        loaded: ['alpha'],
+        failed: [{ prefix: 'x13103b', error: new Error('Not Found') }],
+      },
+      progress,
+      logs: [
+        createProgressLogWithEvent({ event: dataFailureEvent, id: 1, summary: progress }),
+        createProgressLogWithEvent({ event: insightsFailureEvent, id: 2, summary: progress }),
+      ],
+    });
+
+    render(<BootstrapApp />);
+
+    expect(screen.getByLabelText('Data load issues')).toBeInTheDocument();
+    expect(screen.getAllByText('x13103b')).toHaveLength(2);
+    expect(screen.getByText('Not Found')).toBeInTheDocument();
+    expect(screen.queryByText('http-error: Data Not Found')).not.toBeInTheDocument();
+    expect(screen.getByText('network-error: Insights unavailable')).toBeInTheDocument();
+  });
+
   it('keeps the ready boot shell visible when bootstrap hold mode is enabled', () => {
     stubReducedMotion();
     mockGetBootstrapParam.mockReturnValue('hold');
@@ -311,7 +393,9 @@ describe('BootstrapApp', () => {
     render(<BootstrapApp />);
 
     expect(screen.getByText('Ready')).toBeInTheDocument();
+    expect(screen.getByLabelText('Tips')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Show app' })).toBeInTheDocument();
+    expect(screen.getByTestId('bootstrap-progress-log-viewer')).toBeInTheDocument();
     expect(screen.queryByText('app-mounted')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Show app' }));
@@ -364,6 +448,7 @@ describe('BootstrapApp', () => {
     render(<BootstrapApp />);
 
     expect(screen.getByText('Please reload the app and try again.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Tips')).toBeInTheDocument();
     expect(screen.queryByText('boot failed')).not.toBeInTheDocument();
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Reload' }));

--- a/src/__tests__/bootstrap-app.test.tsx
+++ b/src/__tests__/bootstrap-app.test.tsx
@@ -65,7 +65,8 @@ vi.mock('react-i18next', () => ({
         'bootstrap.action.showApp': 'Show app',
         'bootstrap.action.reload': 'Reload',
         'bootstrap.logViewer.title': 'Load log',
-        'bootstrap.notice.loadFailuresTitle': 'Data load issues',
+        'bootstrap.notice.loadErrorsTitle': 'Data load errors',
+        'bootstrap.notice.loadWarningsTitle': 'Data load warnings',
         'bootstrap.tips.dataSources': 'You can change data in settings.',
         'bootstrap.tips.selection': 'Choose the data you need or are interested in.',
         'bootstrap.tips.performance': 'Large data can affect app performance.',
@@ -76,6 +77,16 @@ vi.mock('react-i18next', () => ({
     },
   }),
 }));
+
+function hasExactTextContent(text: string): (_content: string, element: Element | null) => boolean {
+  return (_content, element) => {
+    return (
+      element?.tagName.toLowerCase() === 'p' &&
+      element.getAttribute('aria-live') === 'polite' &&
+      element.textContent === text
+    );
+  };
+}
 
 function createProgressSummary(): RepositoryLoadProgressSummary {
   const event = {
@@ -258,7 +269,7 @@ describe('BootstrapApp', () => {
       'aria-valuenow',
       '50',
     );
-    expect(screen.getByText('✅ 1')).toBeInTheDocument();
+    expect(screen.getByText(hasExactTextContent('✅ 1'))).toBeInTheDocument();
     expect(screen.getByText('alpha')).toBeInTheDocument();
     expect(screen.queryByLabelText('Load log')).not.toBeInTheDocument();
     expect(screen.queryByTestId('bootstrap-progress-log-viewer')).not.toBeInTheDocument();
@@ -282,9 +293,9 @@ describe('BootstrapApp', () => {
 
     render(<BootstrapApp />);
 
-    expect(screen.getByLabelText('Data load issues')).toBeInTheDocument();
-    expect(screen.getByText('✅ 1 ⚠️ 1')).toBeInTheDocument();
-    expect(screen.getAllByText('x13103b')).toHaveLength(2);
+    expect(screen.getByLabelText('Data load errors')).toBeInTheDocument();
+    expect(screen.getByText(hasExactTextContent('✅ 1 ⚠️ 1'))).toBeInTheDocument();
+    expect(screen.getByText('x13103b/data.json')).toBeInTheDocument();
     expect(screen.getByText('http-error: Not Found')).toBeInTheDocument();
   });
 
@@ -326,8 +337,8 @@ describe('BootstrapApp', () => {
 
     render(<BootstrapApp />);
 
-    expect(screen.getByLabelText('Data load issues')).toBeInTheDocument();
-    expect(screen.getByText('x13103b')).toBeInTheDocument();
+    expect(screen.getByLabelText('Data load errors')).toBeInTheDocument();
+    expect(screen.getByText('x13103b/data.json')).toBeInTheDocument();
     expect(screen.getByText('Not Found')).toBeInTheDocument();
     expect(screen.queryByText('app-mounted')).not.toBeInTheDocument();
   });
@@ -370,8 +381,10 @@ describe('BootstrapApp', () => {
 
     render(<BootstrapApp />);
 
-    expect(screen.getByLabelText('Data load issues')).toBeInTheDocument();
-    expect(screen.getAllByText('x13103b')).toHaveLength(2);
+    expect(screen.getByLabelText('Data load errors')).toBeInTheDocument();
+    expect(screen.getByLabelText('Data load warnings')).toBeInTheDocument();
+    expect(screen.getByText('x13103b/data.json')).toBeInTheDocument();
+    expect(screen.getByText('x13103b/insights.json')).toBeInTheDocument();
     expect(screen.getByText('Not Found')).toBeInTheDocument();
     expect(screen.queryByText('http-error: Data Not Found')).not.toBeInTheDocument();
     expect(screen.getByText('network-error: Insights unavailable')).toBeInTheDocument();
@@ -427,8 +440,10 @@ describe('BootstrapApp', () => {
 
     render(<BootstrapApp />);
 
-    expect(screen.getByText('✅ 0 ⚠️ 2')).toBeInTheDocument();
-    expect(screen.queryByText('✅ 0 ⚠️ 2 - global insights')).not.toBeInTheDocument();
+    expect(screen.getByText(hasExactTextContent('✅ 0 ⚠️ 2'))).toBeInTheDocument();
+    expect(
+      screen.queryByText(hasExactTextContent('✅ 0 ⚠️ 2 - global insights')),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText('global insights')).not.toBeInTheDocument();
     expect(
       screen.queryByText(/succeeded global-insights global\/insights\.json/),
@@ -473,7 +488,7 @@ describe('BootstrapApp', () => {
       'aria-valuenow',
       '100',
     );
-    expect(screen.getByLabelText('Data load issues')).toBeInTheDocument();
+    expect(screen.getByLabelText('Data load errors')).toBeInTheDocument();
     expect(screen.getByText('http-error: Not Found')).toBeInTheDocument();
     expect(screen.queryByLabelText('Load log')).not.toBeInTheDocument();
   });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -39,6 +39,7 @@ import { useTransitRepository } from './hooks/use-transit-repository';
 import { useTripInspection } from './hooks/use-trip-inspection';
 import { useUserSettings } from './hooks/use-user-settings';
 import i18n from './i18n';
+import { applyAppTheme } from './lib/app-theme';
 import { createLogger } from './lib/logger';
 import { getStopParam } from './lib/query-params';
 import { LocalStorageUserDataRepository } from './repositories/local-storage-user-data-repository';
@@ -955,7 +956,7 @@ export default function App() {
 
   // Sync dark class on <html> element
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', settings.theme === 'dark');
+    applyAppTheme(settings.theme);
   }, [settings.theme]);
 
   return (

--- a/src/bootstrap-app.tsx
+++ b/src/bootstrap-app.tsx
@@ -1,11 +1,249 @@
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode, type TransitionEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import App from './app';
 import { Button } from './components/ui/button';
+import { Progress } from './components/ui/progress';
 import { SourceLoadStateProvider } from './contexts/source-load-state-provider';
 import { TransitRepositoryProvider } from './contexts/transit-repository-provider';
-import { useAppBootstrap } from './hooks/use-app-bootstrap';
-import { getSourcesParam } from './lib/query-params';
+import {
+  useAppBootstrap,
+  type AppBootstrapState,
+  type BootstrapProgressLogEntry,
+} from './hooks/use-app-bootstrap';
+import { getBootstrapParam, getSourcesParam } from './lib/query-params';
+import { cn } from './lib/utils';
+
+type AppBootstrapLoadingState = Extract<AppBootstrapState, { status: 'loading' }>;
+type AppBootstrapReadyState = Extract<AppBootstrapState, { status: 'ready' }>;
+type AppBootShellState = 'loading' | 'ready' | 'error';
+type NoticeItem = {
+  id: string;
+  label: string;
+  message: string;
+};
+
+const APP_TITLE = 'Athenai Transit';
+
+function shouldReduceMotion(): boolean {
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+}
+
+function getProgressValue(progress: AppBootstrapLoadingState['progress']): number {
+  return Math.round((progress?.boot.progressRatio ?? 0) * 100);
+}
+
+function formatProgressEvent(event: BootstrapProgressLogEntry['event']): string | null {
+  if (event === null) {
+    return null;
+  }
+  return `${event.type} ${event.kind} ${event.path}`;
+}
+
+function formatProgressTask(event: BootstrapProgressLogEntry['event']): string | null {
+  if (event === null) {
+    return null;
+  }
+
+  switch (event.kind) {
+    case 'data':
+      return event.prefix ?? event.path;
+    case 'data-source-catalog':
+      return 'data source catalog';
+    case 'global-insights':
+      return 'global insights';
+    case 'insights':
+      return event.prefix === null ? 'insights' : `${event.prefix} insights`;
+    case 'shapes':
+      return event.prefix === null ? 'shapes' : `${event.prefix} shapes`;
+    case 'unknown':
+      return event.path;
+  }
+}
+
+function ProgressCounts({ progress }: { progress: AppBootstrapLoadingState['progress'] }) {
+  if (progress === null) {
+    return null;
+  }
+
+  const failedText = progress.boot.failedSources > 0 ? ` ⚠️ ${progress.boot.failedSources}` : '';
+
+  return (
+    <p
+      aria-live="polite"
+      className="text-muted-foreground text-center text-sm font-medium tabular-nums"
+    >
+      ✅ {progress.boot.completedSources}
+      {failedText}
+    </p>
+  );
+}
+
+function CurrentProgressTask({
+  progress,
+  showCurrentTask,
+}: {
+  progress: AppBootstrapLoadingState['progress'];
+  showCurrentTask: boolean;
+}) {
+  if (!showCurrentTask || progress === null) {
+    return null;
+  }
+
+  const taskLabel = formatProgressTask(
+    progress.activity.lastEvent ?? progress.boot.lastRequiredEvent,
+  );
+
+  if (taskLabel === null) {
+    return null;
+  }
+
+  return <p className="text-muted-foreground truncate text-center text-xs">{taskLabel}</p>;
+}
+
+type ProgressLogViewerProps = {
+  logs: BootstrapProgressLogEntry[];
+  title: string;
+};
+
+function ProgressLogViewer({ logs, title }: ProgressLogViewerProps) {
+  return (
+    <div className="border-border/70 bg-muted/30 flex min-h-0 flex-1 flex-col rounded-md border text-xs">
+      <div className="text-muted-foreground border-border/70 border-b px-3 py-2 font-medium">
+        {title}
+      </div>
+      <div aria-label={title} className="min-h-0 overflow-y-auto px-3 py-2">
+        <ol className="flex flex-col gap-1">
+          {logs.map((log) => {
+            const processedSources =
+              log.summary.boot.completedSources + log.summary.boot.failedSources;
+            const eventLabel = formatProgressEvent(log.event) ?? 'progress updated';
+            return (
+              <li className="text-muted-foreground font-mono text-[11px] leading-4" key={log.id}>
+                {eventLabel} · {processedSources}/{log.summary.boot.totalSources}
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </div>
+  );
+}
+
+void ProgressLogViewer;
+
+type NoticeAreaProps = {
+  items: NoticeItem[];
+  title: string;
+};
+
+function NoticeArea({ items, title }: NoticeAreaProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-label={title}
+      className="border-destructive/40 bg-destructive/5 text-destructive rounded-md border text-xs"
+    >
+      <div className="border-destructive/30 border-b px-3 py-2 font-medium">{title}</div>
+      <ol className="max-h-32 overflow-y-auto px-3 py-2">
+        {items.map((item) => (
+          <li className="flex gap-2 py-1" key={item.id}>
+            <span className="font-mono">{item.label}</span>
+            <span className="min-w-0 flex-1 wrap-break-word text-current/80">{item.message}</span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function createNoticeItemsFromLogs(logs: BootstrapProgressLogEntry[]): NoticeItem[] {
+  return logs.flatMap((log) => {
+    const event = log.event;
+    if (event === null || (event.type !== 'failed' && event.type !== 'skipped')) {
+      return [];
+    }
+
+    return [
+      {
+        id: `log-${log.id}`,
+        label: event.prefix ?? event.path,
+        message: `${event.reason}: ${event.message}`,
+      },
+    ];
+  });
+}
+
+function createNoticeItemsFromFailures(
+  failures: AppBootstrapReadyState['loadResult']['failed'],
+): NoticeItem[] {
+  return failures.map((failure) => ({
+    id: `source-${failure.prefix}`,
+    label: failure.prefix,
+    message: failure.error.message,
+  }));
+}
+
+type BootstrapProgressContentProps = {
+  progress: AppBootstrapLoadingState['progress'];
+  logs: BootstrapProgressLogEntry[];
+  loadFailures?: AppBootstrapReadyState['loadResult']['failed'];
+  showCurrentTask: boolean;
+};
+
+function BootstrapProgressContent({
+  progress,
+  logs,
+  loadFailures,
+  showCurrentTask,
+}: BootstrapProgressContentProps) {
+  const { t } = useTranslation();
+  const noticeItems =
+    loadFailures === undefined
+      ? createNoticeItemsFromLogs(logs)
+      : createNoticeItemsFromFailures(loadFailures);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3 pt-2">
+      <div className="flex flex-col gap-4">
+        <Progress
+          aria-label={t('bootstrap.loading.progressLabel')}
+          value={getProgressValue(progress)}
+          className="h-2"
+        />
+        <ProgressCounts progress={progress} />
+        <CurrentProgressTask progress={progress} showCurrentTask={showCurrentTask} />
+      </div>
+      <NoticeArea items={noticeItems} title={t('bootstrap.notice.loadFailuresTitle')} />
+      {/* Temporary disabled */}
+      {/* <ProgressLogViewer logs={logs} title={t('bootstrap.logViewer.title')} /> */}
+    </div>
+  );
+}
+
+type AppBootShellProps = {
+  title: string;
+  state: AppBootShellState;
+  message?: string;
+  action?: ReactNode;
+  exiting?: boolean;
+  onTransitionEnd?: (event: TransitionEvent<HTMLDivElement>) => void;
+  progressContent?: ReactNode;
+};
+
+type BootstrapShellViewProps = {
+  bootstrap: AppBootstrapState;
+  exiting?: boolean;
+  holdReady?: boolean;
+  onShowApp?: () => void;
+  onExited?: () => void;
+};
+
+type RepositoryBackedAppProps = {
+  readyState: AppBootstrapReadyState;
+};
 
 /**
  * Minimal boot-time shell shown before the transit repository is available.
@@ -15,32 +253,136 @@ import { getSourcesParam } from './lib/query-params';
  */
 function AppBootShell({
   title,
-  detail,
+  state: _state,
+  message,
   action,
-}: {
-  title: string;
-  detail: string;
-  action?: ReactNode;
-}) {
+  exiting = false,
+  onTransitionEnd,
+  progressContent,
+}: AppBootShellProps) {
   return (
-    <div className="bg-background text-foreground flex h-full flex-col">
-      <div className="bg-border/70 h-1 w-full">
-        <div className="bg-primary/80 h-full w-1/3 animate-pulse" />
-      </div>
-      <div className="flex min-h-0 flex-1 flex-col justify-between px-5 py-6 sm:px-6 sm:py-7">
-        <div className="space-y-1">
+    <div
+      className={cn(
+        'bg-background text-foreground flex h-full flex-col transition-opacity duration-200 ease-out motion-reduce:transition-none',
+        exiting ? 'opacity-0' : 'opacity-100',
+      )}
+      onTransitionEnd={onTransitionEnd}
+    >
+      <div className="mx-auto flex h-full w-full max-w-md flex-col px-5 pt-16 pb-8">
+        <div className="flex shrink-0 flex-col items-center gap-4 pb-5 text-center">
           <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-            Athenai Transit
+            {title}
           </p>
-          <h1 className="text-lg font-semibold">{title}</h1>
+          <p className="text-muted-foreground text-sm leading-6">{message}</p>
         </div>
 
-        <div className="space-y-3">
-          <p className="text-muted-foreground max-w-sm text-sm leading-6">{detail}</p>
-          {action}
-        </div>
+        <div className="flex min-h-0 flex-1 flex-col gap-4">{progressContent}</div>
+
+        {action === undefined ? null : (
+          <div className="flex shrink-0 justify-center pt-5">{action}</div>
+        )}
       </div>
     </div>
+  );
+}
+
+function hasProgressContent(
+  progress: AppBootstrapLoadingState['progress'],
+  logs: BootstrapProgressLogEntry[],
+): boolean {
+  return progress !== null || logs.length > 0;
+}
+
+function BootstrapShellView({
+  bootstrap,
+  exiting = false,
+  holdReady = false,
+  onExited,
+  onShowApp,
+}: BootstrapShellViewProps) {
+  const { t } = useTranslation();
+
+  if (bootstrap.status === 'loading') {
+    return (
+      <AppBootShell
+        title={APP_TITLE}
+        state="loading"
+        message={t('bootstrap.loading.message')}
+        progressContent={
+          <BootstrapProgressContent
+            progress={bootstrap.progress}
+            logs={bootstrap.logs}
+            showCurrentTask
+          />
+        }
+      />
+    );
+  }
+
+  if (bootstrap.status === 'error') {
+    const progressContent = hasProgressContent(bootstrap.progress, bootstrap.logs) ? (
+      <BootstrapProgressContent
+        progress={bootstrap.progress}
+        logs={bootstrap.logs}
+        showCurrentTask={false}
+      />
+    ) : undefined;
+
+    return (
+      <AppBootShell
+        title={APP_TITLE}
+        state="error"
+        message={t('bootstrap.error.message')}
+        progressContent={progressContent}
+        action={
+          <Button onClick={() => window.location.reload()} size="sm">
+            {t('bootstrap.action.reload')}
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <AppBootShell
+      title={APP_TITLE}
+      state="ready"
+      message={t('bootstrap.ready.message')}
+      action={
+        holdReady ? (
+          <Button onClick={onShowApp} size="sm">
+            {t('bootstrap.action.showApp')}
+          </Button>
+        ) : undefined
+      }
+      exiting={exiting}
+      onTransitionEnd={(event) => {
+        if (event.currentTarget === event.target) {
+          onExited?.();
+        }
+      }}
+      progressContent={
+        <BootstrapProgressContent
+          progress={bootstrap.progress}
+          logs={bootstrap.logs}
+          loadFailures={bootstrap.loadResult.failed}
+          showCurrentTask={false}
+        />
+      }
+    />
+  );
+}
+
+function RepositoryBackedApp({ readyState }: RepositoryBackedAppProps) {
+  return (
+    <TransitRepositoryProvider repository={readyState.repository}>
+      <SourceLoadStateProvider
+        initialLoadResult={readyState.loadResult}
+        sourcesParam={getSourcesParam()}
+      >
+        <App />
+      </SourceLoadStateProvider>
+    </TransitRepositoryProvider>
   );
 }
 
@@ -52,37 +394,41 @@ function AppBootShell({
  * repository and startup load result are ready.
  */
 export default function BootstrapApp() {
-  const { t } = useTranslation();
   const bootstrap = useAppBootstrap();
+  const shouldHoldReadyShell = getBootstrapParam() === 'hold';
+  const [hasRequestedAppDisplay, setHasRequestedAppDisplay] = useState(false);
+  const [isBootShellExiting, setIsBootShellExiting] = useState(false);
+  const [hasBootShellExited, setHasBootShellExited] = useState(false);
+  const canStartReadyTransition =
+    bootstrap.status === 'ready' && (!shouldHoldReadyShell || hasRequestedAppDisplay);
 
-  if (bootstrap.status === 'loading') {
-    return (
-      <AppBootShell title={t('bootstrap.loading.title')} detail={t('bootstrap.loading.detail')} />
-    );
-  }
+  useEffect(() => {
+    if (!canStartReadyTransition || shouldReduceMotion()) {
+      return;
+    }
 
-  if (bootstrap.status === 'error') {
-    return (
-      <AppBootShell
-        title={t('bootstrap.error.title')}
-        detail={t('bootstrap.error.detail')}
-        action={
-          <Button onClick={() => window.location.reload()} size="sm">
-            {t('bootstrap.error.reload')}
-          </Button>
-        }
-      />
-    );
+    const frameId = window.requestAnimationFrame(() => {
+      setIsBootShellExiting(true);
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [canStartReadyTransition]);
+
+  if (
+    canStartReadyTransition &&
+    bootstrap.status === 'ready' &&
+    (hasBootShellExited || shouldReduceMotion())
+  ) {
+    return <RepositoryBackedApp readyState={bootstrap} />;
   }
 
   return (
-    <TransitRepositoryProvider repository={bootstrap.repository}>
-      <SourceLoadStateProvider
-        initialLoadResult={bootstrap.loadResult}
-        sourcesParam={getSourcesParam()}
-      >
-        <App />
-      </SourceLoadStateProvider>
-    </TransitRepositoryProvider>
+    <BootstrapShellView
+      bootstrap={bootstrap}
+      exiting={bootstrap.status === 'ready' && isBootShellExiting}
+      holdReady={bootstrap.status === 'ready' && shouldHoldReadyShell}
+      onExited={() => setHasBootShellExited(true)}
+      onShowApp={() => setHasRequestedAppDisplay(true)}
+    />
   );
 }

--- a/src/bootstrap-app.tsx
+++ b/src/bootstrap-app.tsx
@@ -21,6 +21,10 @@ type NoticeItem = {
   label: string;
   message: string;
 };
+type NoticeItemsBySeverity = {
+  errors: NoticeItem[];
+  warnings: NoticeItem[];
+};
 
 const APP_TITLE = 'Athenai Transit';
 
@@ -65,15 +69,21 @@ function ProgressCounts({ progress }: { progress: AppBootstrapLoadingState['prog
     return null;
   }
 
-  const failedText = progress.boot.failedSources > 0 ? ` ⚠️ ${progress.boot.failedSources}` : '';
+  const hasFailedSources = progress.boot.failedSources > 0;
 
   return (
     <p
       aria-live="polite"
       className="text-muted-foreground text-center text-sm font-medium tabular-nums"
     >
-      ✅ {progress.boot.completedSources}
-      {failedText}
+      <span>✅ </span>
+      <span className="text-lg">{progress.boot.completedSources}</span>
+      {hasFailedSources ? (
+        <>
+          <span> ⚠️ </span>
+          <span className="text-lg">{progress.boot.failedSources}</span>
+        </>
+      ) : null}
     </p>
   );
 }
@@ -168,20 +178,24 @@ function BootstrapUserTips() {
 
 type NoticeAreaProps = {
   items: NoticeItem[];
+  severity: 'error' | 'warning';
   title: string;
 };
 
-function NoticeArea({ items, title }: NoticeAreaProps) {
+function NoticeArea({ items, severity, title }: NoticeAreaProps) {
   if (items.length === 0) {
     return null;
   }
 
+  const className =
+    severity === 'error'
+      ? 'border-destructive/40 bg-destructive/5 text-destructive'
+      : 'border-amber-500/30 bg-amber-500/8 text-amber-700 dark:text-amber-300';
+  const headerClassName = severity === 'error' ? 'border-destructive/30' : 'border-amber-500/20';
+
   return (
-    <section
-      aria-label={title}
-      className="border-destructive/40 bg-destructive/5 text-destructive rounded-md border text-xs"
-    >
-      <div className="border-destructive/30 border-b px-3 py-2 font-medium">{title}</div>
+    <section aria-label={title} className={cn('rounded-md border text-xs', className)}>
+      <div className={cn('border-b px-3 py-2 font-medium', headerClassName)}>{title}</div>
       <ol className="max-h-32 overflow-y-auto px-3 py-2">
         {items.map((item) => (
           <li className="flex gap-2 py-1" key={item.id}>
@@ -205,22 +219,23 @@ function getNoticeKeyForLogEntry(log: BootstrapProgressLogEntry): string | null 
   return `log:${event.path}`;
 }
 
-function createNoticeItems({
+function createNoticeItemsBySeverity({
   failures,
   logs,
 }: {
   failures?: AppBootstrapReadyState['loadResult']['failed'];
   logs: BootstrapProgressLogEntry[];
-}): NoticeItem[] {
-  const items: NoticeItem[] = [];
+}): NoticeItemsBySeverity {
+  const errors: NoticeItem[] = [];
+  const warnings: NoticeItem[] = [];
   const seenKeys = new Set<string>();
 
   if (failures !== undefined) {
     for (const failure of failures) {
       seenKeys.add(`source-data:${failure.prefix}`);
-      items.push({
+      errors.push({
         id: `source-${failure.prefix}`,
-        label: failure.prefix,
+        label: `${failure.prefix}/data.json`,
         message: failure.error.message,
       });
     }
@@ -238,14 +253,20 @@ function createNoticeItems({
     }
 
     seenKeys.add(key);
-    items.push({
+    const item = {
       id: `log-${log.id}`,
-      label: event.prefix ?? event.path,
+      label: event.path,
       message: `${event.reason}: ${event.message}`,
-    });
+    };
+
+    if (event.kind === 'data' && event.optional === false) {
+      errors.push(item);
+    } else {
+      warnings.push(item);
+    }
   }
 
-  return items;
+  return { errors, warnings };
 }
 
 type BootstrapProgressContentProps = {
@@ -264,7 +285,7 @@ function BootstrapProgressContent({
   showProgressLogViewer,
 }: BootstrapProgressContentProps) {
   const { t } = useTranslation();
-  const noticeItems = createNoticeItems({ failures: loadFailures, logs });
+  const noticeItems = createNoticeItemsBySeverity({ failures: loadFailures, logs });
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3 pt-2">
@@ -272,12 +293,21 @@ function BootstrapProgressContent({
         <Progress
           aria-label={t('bootstrap.loading.progressLabel')}
           value={getProgressValue(progress)}
-          className="h-2"
+          className="bg-info/20 *:data-[slot=progress-indicator]:bg-info h-2"
         />
         <ProgressCounts progress={progress} />
         <CurrentProgressTask progress={progress} showCurrentTask={showCurrentTask} />
       </div>
-      <NoticeArea items={noticeItems} title={t('bootstrap.notice.loadFailuresTitle')} />
+      <NoticeArea
+        items={noticeItems.errors}
+        severity="error"
+        title={t('bootstrap.notice.loadErrorsTitle')}
+      />
+      <NoticeArea
+        items={noticeItems.warnings}
+        severity="warning"
+        title={t('bootstrap.notice.loadWarningsTitle')}
+      />
       {showProgressLogViewer ? (
         <ProgressLogViewer logs={logs} title={t('bootstrap.logViewer.title')} />
       ) : null}

--- a/src/bootstrap-app.tsx
+++ b/src/bootstrap-app.tsx
@@ -365,10 +365,10 @@ function AppBootShell({
     >
       <div className="mx-auto flex h-full w-full max-w-md flex-col px-5 pt-16 pb-8">
         <div className="flex shrink-0 flex-col items-center gap-4 pb-5 text-center">
-          <p className="text-muted-foreground text-base font-medium tracking-wide uppercase">
+          <p className="font-press-start text-muted-foreground text-xl font-medium tracking-wide uppercase">
             {title}
           </p>
-          <p className="text-muted-foreground text-sm leading-6">{message}</p>
+          <p className="font-press-start text-muted-foreground text-sm leading-6">{message}</p>
           {tips}
         </div>
 

--- a/src/bootstrap-app.tsx
+++ b/src/bootstrap-app.tsx
@@ -107,7 +107,10 @@ type ProgressLogViewerProps = {
 
 function ProgressLogViewer({ logs, title }: ProgressLogViewerProps) {
   return (
-    <div className="border-border/70 bg-muted/30 flex min-h-0 flex-1 flex-col rounded-md border text-xs">
+    <div
+      className="border-border/70 bg-muted/30 flex min-h-0 flex-1 flex-col rounded-md border text-xs"
+      data-testid="bootstrap-progress-log-viewer"
+    >
       <div className="text-muted-foreground border-border/70 border-b px-3 py-2 font-medium">
         {title}
       </div>
@@ -129,7 +132,39 @@ function ProgressLogViewer({ logs, title }: ProgressLogViewerProps) {
   );
 }
 
-void ProgressLogViewer;
+function BootstrapUserTips() {
+  const { t } = useTranslation();
+  const title = 'Tips';
+  const items = [
+    { icon: '⚙️', text: t('bootstrap.tips.dataSources') },
+    { icon: '📍', text: t('bootstrap.tips.selection') },
+    { icon: '📱', text: t('bootstrap.tips.performance') },
+  ];
+
+  return (
+    <section
+      aria-label={title}
+      className="border-border/70 bg-muted/80 text-muted-foreground w-full rounded-md border px-2.5 py-2 text-left text-[11px] leading-4"
+    >
+      <p className="text-foreground/80 flex items-center gap-1 text-xs leading-4 font-medium">
+        <span aria-hidden="true" className="text-xs leading-none">
+          💡
+        </span>
+        <span>{title}</span>
+      </p>
+      <ul className="mt-1 flex flex-col gap-0.5">
+        {items.map((item) => (
+          <li className="grid grid-cols-[1rem_1fr] gap-1.5" key={item.icon}>
+            <span aria-hidden="true" className="text-center leading-4">
+              {item.icon}
+            </span>
+            <span className="min-w-0">{item.text}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
 
 type NoticeAreaProps = {
   items: NoticeItem[];
@@ -159,31 +194,58 @@ function NoticeArea({ items, title }: NoticeAreaProps) {
   );
 }
 
-function createNoticeItemsFromLogs(logs: BootstrapProgressLogEntry[]): NoticeItem[] {
-  return logs.flatMap((log) => {
-    const event = log.event;
-    if (event === null || (event.type !== 'failed' && event.type !== 'skipped')) {
-      return [];
-    }
-
-    return [
-      {
-        id: `log-${log.id}`,
-        label: event.prefix ?? event.path,
-        message: `${event.reason}: ${event.message}`,
-      },
-    ];
-  });
+function getNoticeKeyForLogEntry(log: BootstrapProgressLogEntry): string | null {
+  const event = log.event;
+  if (event === null || (event.type !== 'failed' && event.type !== 'skipped')) {
+    return null;
+  }
+  if (event.kind === 'data' && event.prefix !== null) {
+    return `source-data:${event.prefix}`;
+  }
+  return `log:${event.path}`;
 }
 
-function createNoticeItemsFromFailures(
-  failures: AppBootstrapReadyState['loadResult']['failed'],
-): NoticeItem[] {
-  return failures.map((failure) => ({
-    id: `source-${failure.prefix}`,
-    label: failure.prefix,
-    message: failure.error.message,
-  }));
+function createNoticeItems({
+  failures,
+  logs,
+}: {
+  failures?: AppBootstrapReadyState['loadResult']['failed'];
+  logs: BootstrapProgressLogEntry[];
+}): NoticeItem[] {
+  const items: NoticeItem[] = [];
+  const seenKeys = new Set<string>();
+
+  if (failures !== undefined) {
+    for (const failure of failures) {
+      seenKeys.add(`source-data:${failure.prefix}`);
+      items.push({
+        id: `source-${failure.prefix}`,
+        label: failure.prefix,
+        message: failure.error.message,
+      });
+    }
+  }
+
+  for (const log of logs) {
+    const key = getNoticeKeyForLogEntry(log);
+    if (key === null || seenKeys.has(key)) {
+      continue;
+    }
+
+    const event = log.event;
+    if (event === null || (event.type !== 'failed' && event.type !== 'skipped')) {
+      continue;
+    }
+
+    seenKeys.add(key);
+    items.push({
+      id: `log-${log.id}`,
+      label: event.prefix ?? event.path,
+      message: `${event.reason}: ${event.message}`,
+    });
+  }
+
+  return items;
 }
 
 type BootstrapProgressContentProps = {
@@ -191,6 +253,7 @@ type BootstrapProgressContentProps = {
   logs: BootstrapProgressLogEntry[];
   loadFailures?: AppBootstrapReadyState['loadResult']['failed'];
   showCurrentTask: boolean;
+  showProgressLogViewer: boolean;
 };
 
 function BootstrapProgressContent({
@@ -198,12 +261,10 @@ function BootstrapProgressContent({
   logs,
   loadFailures,
   showCurrentTask,
+  showProgressLogViewer,
 }: BootstrapProgressContentProps) {
   const { t } = useTranslation();
-  const noticeItems =
-    loadFailures === undefined
-      ? createNoticeItemsFromLogs(logs)
-      : createNoticeItemsFromFailures(loadFailures);
+  const noticeItems = createNoticeItems({ failures: loadFailures, logs });
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3 pt-2">
@@ -217,8 +278,9 @@ function BootstrapProgressContent({
         <CurrentProgressTask progress={progress} showCurrentTask={showCurrentTask} />
       </div>
       <NoticeArea items={noticeItems} title={t('bootstrap.notice.loadFailuresTitle')} />
-      {/* Temporary disabled */}
-      {/* <ProgressLogViewer logs={logs} title={t('bootstrap.logViewer.title')} /> */}
+      {showProgressLogViewer ? (
+        <ProgressLogViewer logs={logs} title={t('bootstrap.logViewer.title')} />
+      ) : null}
     </div>
   );
 }
@@ -227,6 +289,7 @@ type AppBootShellProps = {
   title: string;
   state: AppBootShellState;
   message?: string;
+  tips?: ReactNode;
   action?: ReactNode;
   exiting?: boolean;
   onTransitionEnd?: (event: TransitionEvent<HTMLDivElement>) => void;
@@ -237,6 +300,7 @@ type BootstrapShellViewProps = {
   bootstrap: AppBootstrapState;
   exiting?: boolean;
   holdReady?: boolean;
+  showProgressLogViewer?: boolean;
   onShowApp?: () => void;
   onExited?: () => void;
 };
@@ -255,6 +319,7 @@ function AppBootShell({
   title,
   state: _state,
   message,
+  tips,
   action,
   exiting = false,
   onTransitionEnd,
@@ -270,10 +335,11 @@ function AppBootShell({
     >
       <div className="mx-auto flex h-full w-full max-w-md flex-col px-5 pt-16 pb-8">
         <div className="flex shrink-0 flex-col items-center gap-4 pb-5 text-center">
-          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          <p className="text-muted-foreground text-base font-medium tracking-wide uppercase">
             {title}
           </p>
           <p className="text-muted-foreground text-sm leading-6">{message}</p>
+          {tips}
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col gap-4">{progressContent}</div>
@@ -297,10 +363,12 @@ function BootstrapShellView({
   bootstrap,
   exiting = false,
   holdReady = false,
+  showProgressLogViewer = false,
   onExited,
   onShowApp,
 }: BootstrapShellViewProps) {
   const { t } = useTranslation();
+  const tips = <BootstrapUserTips />;
 
   if (bootstrap.status === 'loading') {
     return (
@@ -308,11 +376,13 @@ function BootstrapShellView({
         title={APP_TITLE}
         state="loading"
         message={t('bootstrap.loading.message')}
+        tips={tips}
         progressContent={
           <BootstrapProgressContent
             progress={bootstrap.progress}
             logs={bootstrap.logs}
             showCurrentTask
+            showProgressLogViewer={showProgressLogViewer}
           />
         }
       />
@@ -325,6 +395,7 @@ function BootstrapShellView({
         progress={bootstrap.progress}
         logs={bootstrap.logs}
         showCurrentTask={false}
+        showProgressLogViewer={showProgressLogViewer}
       />
     ) : undefined;
 
@@ -333,6 +404,7 @@ function BootstrapShellView({
         title={APP_TITLE}
         state="error"
         message={t('bootstrap.error.message')}
+        tips={tips}
         progressContent={progressContent}
         action={
           <Button onClick={() => window.location.reload()} size="sm">
@@ -348,6 +420,7 @@ function BootstrapShellView({
       title={APP_TITLE}
       state="ready"
       message={t('bootstrap.ready.message')}
+      tips={tips}
       action={
         holdReady ? (
           <Button onClick={onShowApp} size="sm">
@@ -367,6 +440,7 @@ function BootstrapShellView({
           logs={bootstrap.logs}
           loadFailures={bootstrap.loadResult.failed}
           showCurrentTask={false}
+          showProgressLogViewer={showProgressLogViewer}
         />
       }
     />
@@ -427,6 +501,7 @@ export default function BootstrapApp() {
       bootstrap={bootstrap}
       exiting={bootstrap.status === 'ready' && isBootShellExiting}
       holdReady={bootstrap.status === 'ready' && shouldHoldReadyShell}
+      showProgressLogViewer={shouldHoldReadyShell}
       onExited={() => setHasBootShellExited(true)}
       onShowApp={() => setHasRequestedAppDisplay(true)}
     />

--- a/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
+++ b/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
@@ -228,7 +228,7 @@ describe('DataSourceSettingsDialog — normal mode', () => {
 
     const demoRow = findGroupRow('Demo Group');
 
-    expect(await within(demoRow).findByText('Jan 1, 2026 - Jan 31, 2026')).toBeInTheDocument();
+    expect(await within(demoRow).findByText('20260101-20260131')).toBeInTheDocument();
     expect(within(demoRow).queryByText('demo')).not.toBeInTheDocument();
   });
 

--- a/src/hooks/__tests__/use-app-bootstrap.test.tsx
+++ b/src/hooks/__tests__/use-app-bootstrap.test.tsx
@@ -1,6 +1,9 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { LoadResult } from '../../repositories/athenai-repository';
+import type {
+  LoadResult,
+  RepositoryLoadProgressSummary,
+} from '../../repositories/athenai-repository';
 import type { TransitRepository } from '../../repositories/transit-repository';
 
 type SetupOptions = {
@@ -10,15 +13,36 @@ type SetupOptions = {
   prefixes?: string[];
   createResult?: { repository: TransitRepository; loadResult: LoadResult };
   createError?: Error;
+  deferCreate?: boolean;
   diagnosticsError?: Error;
 };
+
+type RepositoryCreateMock = (
+  prefixes: string[],
+  dataSource: unknown,
+  onLoadProgress?: (summary: RepositoryLoadProgressSummary) => void,
+) => Promise<{ repository: TransitRepository; loadResult: LoadResult }>;
 
 async function setupUseAppBootstrap(options: SetupOptions = {}) {
   const repository = options.createResult?.repository ?? ({} as TransitRepository);
   const loadResult = options.createResult?.loadResult ?? { loaded: ['alpha'], failed: [] };
   const mockRepository = { mock: true } as unknown as TransitRepository;
+  let resolveCreatePromise: (() => void) | null = null;
 
-  const create = vi.fn(() => {
+  const create = vi.fn<RepositoryCreateMock>((_prefixes, _dataSource, _onLoadProgress) => {
+    if (options.deferCreate) {
+      return new Promise<{ repository: TransitRepository; loadResult: LoadResult }>(
+        (resolve, reject) => {
+          resolveCreatePromise = () => {
+            if (options.createError) {
+              reject(options.createError);
+              return;
+            }
+            resolve({ repository, loadResult });
+          };
+        },
+      );
+    }
     if (options.createError) {
       return Promise.reject(options.createError);
     }
@@ -71,8 +95,37 @@ async function setupUseAppBootstrap(options: SetupOptions = {}) {
     MockRepository,
     mockRepository,
     repository,
+    resolveCreate: () => resolveCreatePromise?.(),
     runDiagnostics,
     useAppBootstrap,
+  };
+}
+
+function createProgressSummary(): RepositoryLoadProgressSummary {
+  const event = {
+    type: 'succeeded',
+    kind: 'data',
+    path: 'alpha/data.json',
+    prefix: 'alpha',
+    optional: false,
+    metrics: {},
+  } as const;
+
+  return {
+    boot: {
+      totalSources: 2,
+      startedSources: 2,
+      completedSources: 1,
+      failedSources: 0,
+      progressRatio: 0.5,
+      lastRequiredEvent: event,
+    },
+    activity: {
+      requestCounts: { started: 2, succeeded: 1, skipped: 0, failed: 0 },
+      totalEncodedBytes: 0,
+      totalDecodedBytes: 0,
+      lastEvent: event,
+    },
   };
 }
 
@@ -101,8 +154,51 @@ describe('useAppBootstrap', () => {
 
     expect(create).toHaveBeenCalledTimes(1);
     expect(create).toHaveBeenCalledWith(['alpha', 'beta'], undefined, expect.any(Function));
-    expect(first.result.current).toEqual({ status: 'ready', repository, loadResult });
-    expect(second.result.current).toEqual({ status: 'ready', repository, loadResult });
+    expect(first.result.current).toEqual({
+      status: 'ready',
+      repository,
+      loadResult,
+      progress: null,
+      logs: [],
+    });
+    expect(second.result.current).toEqual({
+      status: 'ready',
+      repository,
+      loadResult,
+      progress: null,
+      logs: [],
+    });
+  });
+
+  it('updates loading state from repository progress events', async () => {
+    const { create, resolveCreate, useAppBootstrap } = await setupUseAppBootstrap({
+      deferCreate: true,
+    });
+    const progress = createProgressSummary();
+
+    const { result } = renderHook(() => useAppBootstrap());
+
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    const onLoadProgress = create.mock.calls[0]?.[2];
+    expect(onLoadProgress).toEqual(expect.any(Function));
+    act(() => {
+      onLoadProgress?.(progress);
+    });
+
+    await waitFor(() => expect(result.current.progress).toBe(progress));
+    expect(result.current).toMatchObject({
+      status: 'loading',
+      progress,
+      logs: [
+        {
+          event: progress.activity.lastEvent,
+          summary: progress,
+        },
+      ],
+    });
+
+    resolveCreate();
+    await waitFor(() => expect(result.current.status).toBe('ready'));
   });
 
   it('uses MockRepository when ?repo=mock is selected', async () => {
@@ -120,6 +216,8 @@ describe('useAppBootstrap', () => {
       status: 'ready',
       repository: mockRepository,
       loadResult: { loaded: [], failed: [] },
+      progress: null,
+      logs: [],
     });
   });
 
@@ -144,6 +242,45 @@ describe('useAppBootstrap', () => {
     const { result } = renderHook(() => useAppBootstrap());
 
     await waitFor(() => expect(result.current.status).toBe('error'));
-    expect(result.current).toEqual({ status: 'error', error: createError });
+    expect(result.current).toEqual({
+      status: 'error',
+      error: createError,
+      progress: null,
+      logs: [],
+    });
+  });
+
+  it('keeps the last progress snapshot when repository boot fails', async () => {
+    const createError = new Error('repository failed');
+    const { create, resolveCreate, useAppBootstrap } = await setupUseAppBootstrap({
+      createError,
+      deferCreate: true,
+    });
+    const progress = createProgressSummary();
+
+    const { result } = renderHook(() => useAppBootstrap());
+
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    const onLoadProgress = create.mock.calls[0]?.[2];
+    expect(onLoadProgress).toEqual(expect.any(Function));
+    act(() => {
+      onLoadProgress?.(progress);
+    });
+
+    await waitFor(() => expect(result.current.progress).toBe(progress));
+    resolveCreate();
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current).toMatchObject({
+      status: 'error',
+      error: createError,
+      progress,
+      logs: [
+        {
+          event: progress.activity.lastEvent,
+          summary: progress,
+        },
+      ],
+    });
   });
 });

--- a/src/hooks/use-app-bootstrap.ts
+++ b/src/hooks/use-app-bootstrap.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { DataSourceManager } from '../config/data-source-manager';
+import type { BundleLoadEvent } from '../datasources/load-events';
 import { resolveFetchDataSources } from '../domain/datasource/resolve-fetch-data-sources';
 import { loadEnabledGroupIdsFromStorage } from '../domain/datasource/data-source-selection-storage';
 import { getDiagParam, getRepoParam, getSourcesParam } from '../lib/query-params';
@@ -14,20 +15,34 @@ import {
 import type { TransitRepository } from '../repositories/transit-repository';
 
 const logger = createLogger('AppBootstrap');
+const MAX_BOOTSTRAP_PROGRESS_LOGS = 500;
+
+export type BootstrapProgressLogEntry = {
+  id: number;
+  createdAt: number;
+  event: BundleLoadEvent | null;
+  summary: RepositoryLoadProgressSummary;
+};
 
 type AppBootstrapReadyState = {
   status: 'ready';
   repository: TransitRepository;
   loadResult: LoadResult;
+  progress: RepositoryLoadProgressSummary | null;
+  logs: BootstrapProgressLogEntry[];
 };
 
 type AppBootstrapLoadingState = {
   status: 'loading';
+  progress: RepositoryLoadProgressSummary | null;
+  logs: BootstrapProgressLogEntry[];
 };
 
 type AppBootstrapErrorState = {
   status: 'error';
   error: Error;
+  progress: RepositoryLoadProgressSummary | null;
+  logs: BootstrapProgressLogEntry[];
 };
 
 export type AppBootstrapState =
@@ -36,7 +51,35 @@ export type AppBootstrapState =
   | AppBootstrapErrorState;
 
 let bootstrapPromise: Promise<AppBootstrapReadyState> | null = null;
+let bootstrapProgress: RepositoryLoadProgressSummary | null = null;
+let bootstrapProgressLogs: BootstrapProgressLogEntry[] = [];
+let nextBootstrapProgressLogId = 1;
 let hasLoggedBootstrapMount = false;
+const progressListeners = new Set<(state: AppBootstrapLoadingState) => void>();
+
+function createLoadingState(): AppBootstrapLoadingState {
+  return {
+    status: 'loading',
+    progress: bootstrapProgress,
+    logs: bootstrapProgressLogs,
+  };
+}
+
+function publishBootstrapProgress(summary: RepositoryLoadProgressSummary): void {
+  bootstrapProgress = summary;
+  const entry: BootstrapProgressLogEntry = {
+    id: nextBootstrapProgressLogId,
+    createdAt: performance.now(),
+    event: summary.activity.lastEvent ?? summary.boot.lastRequiredEvent,
+    summary,
+  };
+  nextBootstrapProgressLogId += 1;
+  bootstrapProgressLogs = [...bootstrapProgressLogs, entry].slice(-MAX_BOOTSTRAP_PROGRESS_LOGS);
+  const loadingState = createLoadingState();
+  for (const listener of progressListeners) {
+    listener(loadingState);
+  }
+}
 
 async function createRepository(): Promise<{
   repository: TransitRepository;
@@ -64,6 +107,8 @@ async function createRepository(): Promise<{
   const bootStartTime = performance.now();
   let hasLoggedBootComplete = false;
   const onLoadProgress = (summary: RepositoryLoadProgressSummary) => {
+    publishBootstrapProgress(summary);
+
     if (logger.isEnabled('debug')) {
       logger.debug(formatBootLoadProgressSummary(summary.boot));
       logger.debug(formatLoadActivitySummary(summary.activity));
@@ -117,6 +162,8 @@ async function bootstrapApplication(): Promise<AppBootstrapReadyState> {
     status: 'ready',
     repository,
     loadResult,
+    progress: bootstrapProgress,
+    logs: bootstrapProgressLogs,
   };
 }
 
@@ -131,10 +178,16 @@ function getBootstrapPromise(): Promise<AppBootstrapReadyState> {
 }
 
 export function useAppBootstrap(): AppBootstrapState {
-  const [state, setState] = useState<AppBootstrapState>({ status: 'loading' });
+  const [state, setState] = useState<AppBootstrapState>(() => createLoadingState());
 
   useEffect(() => {
     let cancelled = false;
+    const onProgress = (loadingState: AppBootstrapLoadingState) => {
+      if (!cancelled) {
+        setState((current) => (current.status === 'loading' ? loadingState : current));
+      }
+    };
+    progressListeners.add(onProgress);
 
     if (!hasLoggedBootstrapMount && logger.isEnabled('debug')) {
       hasLoggedBootstrapMount = true;
@@ -154,12 +207,18 @@ export function useAppBootstrap(): AppBootstrapState {
         const resolvedError = error instanceof Error ? error : new Error(String(error));
         logger.error('App bootstrap failed:', resolvedError);
         if (!cancelled) {
-          setState({ status: 'error', error: resolvedError });
+          setState({
+            status: 'error',
+            error: resolvedError,
+            progress: bootstrapProgress,
+            logs: bootstrapProgressLogs,
+          });
         }
       });
 
     return () => {
       cancelled = true;
+      progressListeners.delete(onProgress);
     };
   }, []);
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -11,7 +11,8 @@
       "title": "Logs"
     },
     "notice": {
-      "loadFailuresTitle": "Errors"
+      "loadErrorsTitle": "Errors",
+      "loadWarningsTitle": "Warnings"
     },
     "tips": {
       "dataSources": "You can change data in settings.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -21,7 +21,7 @@
     },
     "loading": {
       "title": "Preparing app",
-      "message": "This will only take a moment.",
+      "message": "Now Loading...",
       "progressLabel": "Loading data",
       "progressFailed": "failed"
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3,14 +3,29 @@
     "loading": "Loading..."
   },
   "bootstrap": {
+    "action": {
+      "reload": "Reload",
+      "showApp": "Show app"
+    },
+    "logViewer": {
+      "title": "Logs"
+    },
+    "notice": {
+      "loadFailuresTitle": "Errors"
+    },
     "loading": {
       "title": "Preparing app",
-      "detail": "This will only take a moment."
+      "message": "This will only take a moment.",
+      "progressLabel": "Loading data",
+      "progressFailed": "failed"
+    },
+    "ready": {
+      "title": "Ready",
+      "message": "Ready"
     },
     "error": {
       "title": "Could not start Athenai",
-      "detail": "Please reload the app and try again.",
-      "reload": "Reload"
+      "message": "Please reload the app and try again."
     }
   },
   "view": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -13,6 +13,11 @@
     "notice": {
       "loadFailuresTitle": "Errors"
     },
+    "tips": {
+      "dataSources": "You can change data in settings.",
+      "selection": "Choose the data you need or are interested in.",
+      "performance": "Large data can affect app performance."
+    },
     "loading": {
       "title": "Preparing app",
       "message": "This will only take a moment.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -21,13 +21,13 @@
     },
     "loading": {
       "title": "準備中",
-      "message": "しばらくお待ちください",
+      "message": "Now Loading...",
       "progressLabel": "データを読み込み中",
       "progressFailed": "失敗"
     },
     "ready": {
-      "title": "準備完了",
-      "message": "準備完了"
+      "title": "Ready",
+      "message": "Ready"
     },
     "error": {
       "title": "あてのない乗換案内を起動できませんでした",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3,14 +3,29 @@
     "loading": "読み込み中..."
   },
   "bootstrap": {
+    "action": {
+      "reload": "再読み込み",
+      "showApp": "アプリを表示"
+    },
+    "logViewer": {
+      "title": "ログ"
+    },
+    "notice": {
+      "loadFailuresTitle": "エラー"
+    },
     "loading": {
       "title": "準備中",
-      "detail": "しばらくお待ちください"
+      "message": "しばらくお待ちください",
+      "progressLabel": "データを読み込み中",
+      "progressFailed": "失敗"
+    },
+    "ready": {
+      "title": "準備完了",
+      "message": "準備完了"
     },
     "error": {
       "title": "あてのない乗換案内を起動できませんでした",
-      "detail": "再読み込みしてもう一度お試しください",
-      "reload": "再読み込み"
+      "message": "再読み込みしてもう一度お試しください"
     }
   },
   "view": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -11,7 +11,8 @@
       "title": "ログ"
     },
     "notice": {
-      "loadFailuresTitle": "エラー"
+      "loadErrorsTitle": "エラー",
+      "loadWarningsTitle": "注意"
     },
     "tips": {
       "dataSources": "データは設定画面から変更できます",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -13,6 +13,11 @@
     "notice": {
       "loadFailuresTitle": "エラー"
     },
+    "tips": {
+      "dataSources": "データは設定画面から変更できます",
+      "selection": "必要なデータや興味のあるデータを選択して下さい",
+      "performance": "サイズの大きなデータはアプリの動作性能に影響します"
+    },
     "loading": {
       "title": "準備中",
       "message": "しばらくお待ちください",

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
@@ -10,6 +12,14 @@
   &::-webkit-scrollbar {
     display: none;
   }
+}
+
+@utility font-vt323 {
+  font-family: 'VT323', monospace;
+}
+
+@utility font-press-start {
+  font-family: 'Press Start 2P', monospace;
 }
 
 @utility border-app-neutral {

--- a/src/lib/__tests__/app-theme.test.ts
+++ b/src/lib/__tests__/app-theme.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { applyAppTheme, applyStoredAppTheme, loadStoredAppTheme } from '../app-theme';
+
+const SETTINGS_STORAGE_KEY = 'athenai-settings';
+
+describe('app-theme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('applies the dark class for dark theme', () => {
+    applyAppTheme('dark');
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('removes the dark class for light theme', () => {
+    document.documentElement.classList.add('dark');
+
+    applyAppTheme('light');
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('loads the stored dark theme', () => {
+    localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify({ theme: 'dark' }));
+
+    expect(loadStoredAppTheme()).toBe('dark');
+  });
+
+  it('falls back to light when stored settings are missing or invalid', () => {
+    expect(loadStoredAppTheme()).toBe('light');
+
+    localStorage.setItem(SETTINGS_STORAGE_KEY, 'not-json');
+
+    expect(loadStoredAppTheme()).toBe('light');
+  });
+
+  it('applies the stored theme', () => {
+    localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify({ theme: 'dark' }));
+
+    applyStoredAppTheme();
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/src/lib/__tests__/query-params.test.ts
+++ b/src/lib/__tests__/query-params.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TILE_SOURCES } from '../../config/tile-sources';
 import {
   cleanupInvalidQueryParams,
+  getBootstrapParam,
   getDiagParam,
   getLangParam,
   getRepoParam,
@@ -297,6 +298,25 @@ describe('getDiagParam', () => {
   });
 });
 
+describe('getBootstrapParam', () => {
+  afterEach(restoreLocation);
+
+  it('returns null when no param', () => {
+    setSearch('');
+    expect(getBootstrapParam()).toBeNull();
+  });
+
+  it('returns "hold" when ?bootstrap=hold', () => {
+    setSearch('?bootstrap=hold');
+    expect(getBootstrapParam()).toBe('hold');
+  });
+
+  it('returns null for unrecognized values', () => {
+    setSearch('?bootstrap=auto');
+    expect(getBootstrapParam()).toBeNull();
+  });
+});
+
 describe('getStopParam', () => {
   afterEach(restoreLocation);
 
@@ -336,9 +356,9 @@ describe('cleanupInvalidQueryParams', () => {
     restoreLocation();
   });
 
-  it('removes invalid repo/time/lat/lng/zm/stop/tileIdx params and preserves valid free-form params', () => {
+  it('removes invalid repo/bootstrap/time/lat/lng/zm/stop/tileIdx params and preserves valid free-form params', () => {
     setSearch(
-      '?repo=v1&time=bad&lat=999&lng=abc&zm=99&stop=%20%20&tileIdx=abc&sources=minkuru&diag=v2-load',
+      '?repo=v1&bootstrap=auto&time=bad&lat=999&lng=abc&zm=99&stop=%20%20&tileIdx=abc&sources=minkuru&diag=v2-load',
     );
 
     cleanupInvalidQueryParams(TILE_SOURCE_COUNT);
@@ -353,7 +373,7 @@ describe('cleanupInvalidQueryParams', () => {
 
   it('does nothing when all params are valid', () => {
     setSearch(
-      '?repo=mock&time=2026-03-25T20:55:00+09:00&lat=35.68&lng=139.77&zm=14&stop=keio_S0123&tileIdx=3',
+      '?repo=mock&bootstrap=hold&time=2026-03-25T20:55:00+09:00&lat=35.68&lng=139.77&zm=14&stop=keio_S0123&tileIdx=3',
     );
 
     cleanupInvalidQueryParams(TILE_SOURCE_COUNT);

--- a/src/lib/app-theme.ts
+++ b/src/lib/app-theme.ts
@@ -1,0 +1,29 @@
+import type { Theme } from '../types/app/settings';
+
+const SETTINGS_STORAGE_KEY = 'athenai-settings';
+
+type StoredSettings = {
+  theme?: unknown;
+};
+
+export function applyAppTheme(theme: Theme): void {
+  document.documentElement.classList.toggle('dark', theme === 'dark');
+}
+
+export function loadStoredAppTheme(): Theme {
+  try {
+    const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    if (raw === null) {
+      return 'light';
+    }
+
+    const settings = JSON.parse(raw) as StoredSettings;
+    return settings.theme === 'dark' ? 'dark' : 'light';
+  } catch {
+    return 'light';
+  }
+}
+
+export function applyStoredAppTheme(): void {
+  applyAppTheme(loadStoredAppTheme());
+}

--- a/src/lib/query-params.ts
+++ b/src/lib/query-params.ts
@@ -16,6 +16,7 @@
  * - `?tileIdx=0` — initial tile source index (0-based, overrides localStorage)
  * - `?lang=en` — initial display language (BCP 47 code, overrides localStorage)
  * - `?diag=v2-load` — run diagnostics (see DEVELOPMENT.md)
+ * - `?bootstrap=hold` — keep the bootstrap shell visible after ready for UI checks
  */
 
 import { DEFAULT_MAX_ZOOM } from '../config/map-constants';
@@ -45,8 +46,14 @@ function getParams(): URLSearchParams {
 /** Valid values for the `?repo=` query parameter. */
 export type RepoParam = 'v2' | 'mock';
 
+/** Valid values for the `?bootstrap=` query parameter. */
+export type BootstrapParam = 'hold';
+
 /** Set of recognized `?repo=` values. */
 const VALID_REPO_VALUES = new Set<string>(['v2', 'mock']);
+
+/** Set of recognized `?bootstrap=` values. */
+const VALID_BOOTSTRAP_VALUES = new Set<string>(['hold']);
 
 /**
  * Returns the `?repo=` param value, defaulting to 'v2'.
@@ -107,6 +114,11 @@ export function cleanupInvalidQueryParams(tileSourceCount: number): void {
   const repo = params.get('repo');
   if (repo !== null && !VALID_REPO_VALUES.has(repo)) {
     keysToRemove.push('repo');
+  }
+
+  const bootstrap = params.get('bootstrap');
+  if (bootstrap !== null && !VALID_BOOTSTRAP_VALUES.has(bootstrap)) {
+    keysToRemove.push('bootstrap');
   }
 
   // Use raw query extraction here so timezone offsets like `+09:00`
@@ -205,6 +217,23 @@ export function getStopParam(): string | null {
  */
 export function getDiagParam(): string | null {
   return getParams().get('diag');
+}
+
+/**
+ * Returns the `?bootstrap=` param value, or null if absent or unrecognized.
+ *
+ * `hold` keeps the bootstrap shell visible after repository boot finishes,
+ * allowing developers to inspect the ready-state bootstrap UI before mounting
+ * the repository-backed app.
+ *
+ * @returns The bootstrap mode, or null for the default automatic transition.
+ */
+export function getBootstrapParam(): BootstrapParam | null {
+  const value = getParams().get('bootstrap');
+  if (value === 'hold') {
+    return value;
+  }
+  return null;
 }
 
 /**

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,8 +4,12 @@ import 'leaflet/dist/leaflet.css';
 import './index.css';
 import './i18n';
 import BootstrapApp from './bootstrap-app';
+import { applyStoredAppTheme } from './lib/app-theme';
 import { cleanupInvalidQueryParams } from './lib/query-params';
 import { TILE_SOURCES } from './config/tile-sources';
+
+// Apply the persisted theme before the bootstrap shell is rendered.
+applyStoredAppTheme();
 
 // Remove invalid query params (e.g., legacy ?repo=v1, malformed ?time=) from the URL.
 cleanupInvalidQueryParams(TILE_SOURCES.length);


### PR DESCRIPTION
## Summary
- add a bootstrap shell that shows repository boot progress before the main app mounts
- separate required load errors from optional warnings, add hold-mode log viewing, and refine progress/tips presentation
- update CHANGELOG for the bootstrap progress and notice refinements

## Validation
- npm run format
- npm run lint
- npm run build
- BootstrapApp test file via Vitest
