### PR TITLE
Add error boundary and global error handler

### DIFF
--- a/src/__tests__/bootstrap-app.test.tsx
+++ b/src/__tests__/bootstrap-app.test.tsx
@@ -10,13 +10,14 @@ const mockUseAppBootstrap = vi.hoisted(() => vi.fn<() => AppBootstrapState>());
 const mockTransitRepositoryProvider = vi.hoisted(() => vi.fn());
 const mockSourceLoadStateProvider = vi.hoisted(() => vi.fn());
 const mockGetBootstrapParam = vi.hoisted(() => vi.fn<() => 'hold' | null>(() => null));
+const mockAppRender = vi.hoisted(() => vi.fn<() => ReactNode>());
 
 vi.mock('../hooks/use-app-bootstrap', () => ({
   useAppBootstrap: () => mockUseAppBootstrap(),
 }));
 
 vi.mock('../app', () => ({
-  default: () => <div>app-mounted</div>,
+  default: () => mockAppRender(),
 }));
 
 vi.mock('../contexts/transit-repository-provider', () => ({
@@ -72,6 +73,12 @@ vi.mock('react-i18next', () => ({
         'bootstrap.tips.performance': 'Large data can affect app performance.',
         'bootstrap.error.title': 'Could not start Athenai',
         'bootstrap.error.message': 'Please reload the app and try again.',
+        'errorBoundary.title': 'Something went wrong',
+        'errorBoundary.message':
+          'An error occurred while displaying the app. If reloading does not help, try clearing the cache.',
+        'errorBoundary.detailLabel': 'Error details',
+        'errorBoundary.action.clearCacheAndReload': 'Clear cache and reload',
+        'errorBoundary.action.reload': 'Reload',
       };
       return labels[key] ?? key;
     },
@@ -236,6 +243,8 @@ describe('BootstrapApp', () => {
     mockSourceLoadStateProvider.mockReset();
     mockGetBootstrapParam.mockReset();
     mockGetBootstrapParam.mockReturnValue(null);
+    mockAppRender.mockReset();
+    mockAppRender.mockReturnValue(<div>app-mounted</div>);
   });
 
   afterEach(() => {
@@ -491,5 +500,47 @@ describe('BootstrapApp', () => {
     expect(screen.getByLabelText('Data load errors')).toBeInTheDocument();
     expect(screen.getByText('http-error: Not Found')).toBeInTheDocument();
     expect(screen.queryByLabelText('Load log')).not.toBeInTheDocument();
+  });
+
+  it('renders the error boundary fallback when the app throws during render', () => {
+    stubReducedMotion();
+    mockAppRender.mockImplementation(() => {
+      throw new Error('render boom');
+    });
+    mockUseAppBootstrap.mockReturnValue({
+      status: 'ready',
+      repository: {} as TransitRepository,
+      loadResult: { loaded: ['alpha'], failed: [] },
+      progress: null,
+      logs: [],
+    });
+
+    render(<BootstrapApp />);
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('render boom')).toBeInTheDocument();
+    expect(screen.queryByText('app-mounted')).not.toBeInTheDocument();
+  });
+
+  it('renders the error boundary fallback when a provider throws during render', () => {
+    // A provider throwing is only caught when the boundary sits outside the
+    // provider tree — this pins the insertion position against regressions.
+    stubReducedMotion();
+    mockTransitRepositoryProvider.mockImplementation(() => {
+      throw new Error('provider boom');
+    });
+    mockUseAppBootstrap.mockReturnValue({
+      status: 'ready',
+      repository: {} as TransitRepository,
+      loadResult: { loaded: ['alpha'], failed: [] },
+      progress: null,
+      logs: [],
+    });
+
+    render(<BootstrapApp />);
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('provider boom')).toBeInTheDocument();
+    expect(screen.queryByText('app-mounted')).not.toBeInTheDocument();
   });
 });

--- a/src/bootstrap-app.tsx
+++ b/src/bootstrap-app.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState, type ReactNode, type TransitionEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import App from './app';
+import { RootErrorBoundary } from './components/error-boundary';
 import { Button } from './components/ui/button';
 import { Progress } from './components/ui/progress';
+import { APP_TITLE } from './config/app-meta';
 import { SourceLoadStateProvider } from './contexts/source-load-state-provider';
 import { TransitRepositoryProvider } from './contexts/transit-repository-provider';
 import {
@@ -25,8 +27,6 @@ type NoticeItemsBySeverity = {
   errors: NoticeItem[];
   warnings: NoticeItem[];
 };
-
-const APP_TITLE = 'Athenai Transit';
 
 function shouldReduceMotion(): boolean {
   return window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches === true;
@@ -363,6 +363,7 @@ function AppBootShell({
       )}
       onTransitionEnd={onTransitionEnd}
     >
+      {/* pt-24 clears the iOS black-translucent status bar, under which the PWA content extends. */}
       <div className="mx-auto flex h-full w-full max-w-md flex-col px-8 pt-24 pb-8">
         <div className="flex shrink-0 flex-col items-center gap-8 pb-4 text-center">
           <p className="font-press-start text-muted-foreground text-xl font-medium tracking-wide uppercase">
@@ -479,14 +480,16 @@ function BootstrapShellView({
 
 function RepositoryBackedApp({ readyState }: RepositoryBackedAppProps) {
   return (
-    <TransitRepositoryProvider repository={readyState.repository}>
-      <SourceLoadStateProvider
-        initialLoadResult={readyState.loadResult}
-        sourcesParam={getSourcesParam()}
-      >
-        <App />
-      </SourceLoadStateProvider>
-    </TransitRepositoryProvider>
+    <RootErrorBoundary>
+      <TransitRepositoryProvider repository={readyState.repository}>
+        <SourceLoadStateProvider
+          initialLoadResult={readyState.loadResult}
+          sourcesParam={getSourcesParam()}
+        >
+          <App />
+        </SourceLoadStateProvider>
+      </TransitRepositoryProvider>
+    </RootErrorBoundary>
   );
 }
 

--- a/src/components/error-boundary.stories.tsx
+++ b/src/components/error-boundary.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ErrorBoundaryFallbackView } from './error-boundary';
+
+const meta = {
+  title: 'ErrorBoundary/Fallback',
+  component: ErrorBoundaryFallbackView,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '100dvh' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    appTitle: 'Athenai Transit',
+    title: '問題が発生しました',
+    message:
+      'アプリの表示中にエラーが発生しました。再読み込みで回復しない場合は、キャッシュを消去してお試しください。',
+    detailLabel: 'エラー詳細',
+    errorText: "Cannot read properties of undefined (reading 'headsign')",
+    clearCacheLabel: 'キャッシュを消去して再読み込み',
+    reloadLabel: '再読み込み',
+    isRecovering: false,
+    onClearCache: () => {},
+    onReload: () => {},
+  },
+} satisfies Meta<typeof ErrorBoundaryFallbackView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Japanese: Story = {};
+
+export const English: Story = {
+  args: {
+    title: 'Something went wrong',
+    message:
+      'An error occurred while displaying the app. If reloading does not help, try clearing the cache.',
+    detailLabel: 'Error details',
+    errorText: "Cannot read properties of undefined (reading 'headsign')",
+    clearCacheLabel: 'Clear cache and reload',
+    reloadLabel: 'Reload',
+  },
+};
+
+export const LongErrorText: Story = {
+  args: {
+    errorText:
+      "TypeError: Cannot read properties of undefined (reading 'departures') at StopTimetable (stop-timetable.tsx:142:18) at renderWithHooks (react-dom.js:11121:18)",
+  },
+};
+
+export const Recovering: Story = {
+  args: {
+    isRecovering: true,
+  },
+};

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,0 +1,155 @@
+import { Component, useState, type ErrorInfo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { APP_TITLE } from '../config/app-meta';
+import { recoverFromCacheCorruption } from '../lib/cache-recovery';
+import { formatErrorMessage } from '../lib/format-error-message';
+import { createLogger } from '../lib/logger';
+import { Alert, AlertDescription, AlertTitle } from './ui/alert';
+import { Button } from './ui/button';
+
+const logger = createLogger('ErrorBoundary');
+
+type ErrorBoundaryFallbackViewProps = {
+  appTitle: string;
+  title: string;
+  message: string;
+  detailLabel: string;
+  errorText: string;
+  clearCacheLabel: string;
+  reloadLabel: string;
+  isRecovering: boolean;
+  onClearCache: () => void;
+  onReload: () => void;
+};
+
+/**
+ * Presentational error screen. Holds no i18n or state so it can be rendered
+ * directly in Storybook with explicit text for each language.
+ */
+function ErrorBoundaryFallbackView({
+  appTitle,
+  title,
+  message,
+  detailLabel,
+  errorText,
+  clearCacheLabel,
+  reloadLabel,
+  isRecovering,
+  onClearCache,
+  onReload,
+}: ErrorBoundaryFallbackViewProps) {
+  return (
+    <div className="bg-background text-foreground flex h-full flex-col">
+      {/* pt-24 clears the iOS black-translucent status bar, under which the PWA content extends. */}
+      <div className="mx-auto flex h-full w-full max-w-md flex-col px-4 pt-24 pb-8">
+        {/* appTitle stays fixed; the heading, message and error detail scroll
+            so the actions below stay visible on small screens. */}
+        <p className="font-press-start text-muted-foreground shrink-0 pb-6 text-center text-xl font-medium tracking-wide uppercase">
+          {appTitle}
+        </p>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto">
+          <div className="flex shrink-0 flex-col items-center gap-6 text-center">
+            <p className="text-foreground text-base font-medium">{title}</p>
+            <p className="text-muted-foreground text-sm leading-6">{message}</p>
+          </div>
+
+          <Alert variant="destructive">
+            <AlertTitle>{detailLabel}</AlertTitle>
+            <AlertDescription>
+              <p className="font-mono text-xs wrap-break-word whitespace-pre-wrap">{errorText}</p>
+            </AlertDescription>
+          </Alert>
+        </div>
+
+        <div className="flex shrink-0 flex-col gap-2 pt-5 sm:flex-row sm:justify-center">
+          <Button
+            variant="destructive"
+            size="sm"
+            className="w-full sm:w-auto"
+            disabled={isRecovering}
+            onClick={onClearCache}
+          >
+            {clearCacheLabel}
+          </Button>
+          <Button variant="outline" size="sm" className="w-full sm:w-auto" onClick={onReload}>
+            {reloadLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Smart wrapper around {@link ErrorBoundaryFallbackView}: resolves localized
+ * text, owns the "recovering" state, and wires the recovery / reload actions.
+ */
+function ErrorBoundaryFallback({ error }: { error: unknown }) {
+  const { t } = useTranslation();
+  const [isRecovering, setIsRecovering] = useState(false);
+
+  const handleClearCache = (): void => {
+    setIsRecovering(true);
+    void recoverFromCacheCorruption();
+  };
+
+  const handleReload = (): void => {
+    window.location.reload();
+  };
+
+  return (
+    <ErrorBoundaryFallbackView
+      appTitle={APP_TITLE}
+      title={t('errorBoundary.title')}
+      message={t('errorBoundary.message')}
+      detailLabel={t('errorBoundary.detailLabel')}
+      errorText={formatErrorMessage(error)}
+      clearCacheLabel={t('errorBoundary.action.clearCacheAndReload')}
+      reloadLabel={t('errorBoundary.action.reload')}
+      isRecovering={isRecovering}
+      onClearCache={handleClearCache}
+      onReload={handleReload}
+    />
+  );
+}
+
+type RootErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type RootErrorBoundaryState = {
+  hasError: boolean;
+  error: unknown;
+};
+
+/**
+ * Top-level error boundary around the repository-backed app tree.
+ *
+ * Catches errors thrown while rendering the app (e.g. a `TypeError` from
+ * reading a field that a stale cached data bundle lacks) and shows a readable
+ * recovery screen instead of a blank page.
+ *
+ * `hasError` is tracked independently of `error` so a falsy thrown value
+ * (`throw null`, `throw ''`) still triggers the fallback.
+ */
+class RootErrorBoundary extends Component<RootErrorBoundaryProps, RootErrorBoundaryState> {
+  state: RootErrorBoundaryState = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: unknown): RootErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: ErrorInfo): void {
+    logger.error('render error caught', error, errorInfo.componentStack);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return <ErrorBoundaryFallback error={this.state.error} />;
+    }
+    return this.props.children;
+  }
+}
+
+export { RootErrorBoundary, ErrorBoundaryFallbackView };

--- a/src/config/app-meta.ts
+++ b/src/config/app-meta.ts
@@ -1,0 +1,13 @@
+/**
+ * Application identity constants.
+ */
+
+/**
+ * The app's brand title, shown as the in-app heading on the boot shell and
+ * the error boundary fallback.
+ *
+ * This is the Latin brand form, rendered in the `font-press-start` pixel
+ * font. The localized and HTML-metadata forms ("あてのない乗換案内" /
+ * "アテナイ") live in `index.html` and the PWA manifest in `vite.config.ts`.
+ */
+export const APP_TITLE = 'Athenai Transit';

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -209,6 +209,24 @@
   "dataLoad": {
     "failed": "Failed to load data"
   },
+  "errorBoundary": {
+    "title": "Something went wrong",
+    "message": "An error occurred while displaying the app. If reloading does not help, try clearing the cache.",
+    "detailLabel": "Error details",
+    "action": {
+      "clearCacheAndReload": "Clear cache and reload",
+      "reload": "Reload"
+    }
+  },
+  "globalError": {
+    "title": "Unexpected error",
+    "message": "An error occurred while the app was running. Reload the app if the screen does not behave correctly.",
+    "detailLabel": "Error details",
+    "action": {
+      "reload": "Reload",
+      "dismiss": "Dismiss"
+    }
+  },
   "dataSourceSettings": {
     "title": "Data source settings",
     "description": "Data sources in use and their state",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -209,6 +209,24 @@
   "dataLoad": {
     "failed": "データの取得に失敗しました"
   },
+  "errorBoundary": {
+    "title": "問題が発生しました",
+    "message": "アプリの表示中にエラーが発生しました。再読み込みで回復しない場合は、キャッシュを消去してお試しください。",
+    "detailLabel": "エラー詳細",
+    "action": {
+      "clearCacheAndReload": "キャッシュを消去して再読み込み",
+      "reload": "再読み込み"
+    }
+  },
+  "globalError": {
+    "title": "予期しないエラーが発生しました",
+    "message": "アプリの処理中にエラーが発生しました。画面が正しく動かない場合は再読み込みしてください。",
+    "detailLabel": "エラー詳細",
+    "action": {
+      "reload": "再読み込み",
+      "dismiss": "閉じる"
+    }
+  },
   "dataSourceSettings": {
     "title": "データソース設定",
     "description": "利用するデータソースと状態",

--- a/src/lib/__tests__/cache-recovery.test.ts
+++ b/src/lib/__tests__/cache-recovery.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearAllCaches,
+  recoverFromCacheCorruption,
+  unregisterAllServiceWorkers,
+} from '../cache-recovery';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('clearAllCaches', () => {
+  it('returns unsupported when the Cache Storage API is unavailable', async () => {
+    // jsdom does not implement Cache Storage, so `caches` is absent here.
+    expect(await clearAllCaches()).toEqual({ kind: 'unsupported' });
+  });
+
+  it('deletes every cache and reports ok', async () => {
+    const deleteFn = vi.fn().mockResolvedValue(true);
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockResolvedValue(['gtfs-data-v2', 'map-tiles', 'workbox-precache-v1']),
+      delete: deleteFn,
+    });
+
+    const result = await clearAllCaches();
+
+    expect(deleteFn).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({ kind: 'ok', cleared: 3 });
+  });
+
+  it('reports ok with zero cleared when there are no caches', async () => {
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockResolvedValue([]),
+      delete: vi.fn(),
+    });
+
+    expect(await clearAllCaches()).toEqual({ kind: 'ok', cleared: 0 });
+  });
+
+  it('attempts every cache and reports partial when some deletions fail', async () => {
+    const failure = new Error('delete failed');
+    const deleteFn = vi
+      .fn()
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce(true);
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockResolvedValue(['a', 'b', 'c']),
+      delete: deleteFn,
+    });
+
+    const result = await clearAllCaches();
+
+    expect(deleteFn).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({ kind: 'partial', cleared: 2, failed: 1, errors: [failure] });
+  });
+
+  it('reports partial when a cache deletion resolves false', async () => {
+    const deleteFn = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockResolvedValue(['a', 'b']),
+      delete: deleteFn,
+    });
+
+    const result = await clearAllCaches();
+
+    expect(deleteFn).toHaveBeenCalledTimes(2);
+    expect(result.kind).toBe('partial');
+    if (result.kind === 'partial') {
+      expect(result.cleared).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toBeInstanceOf(Error);
+      expect((result.errors[0] as Error).message).toBe('Operation resolved false');
+    }
+  });
+
+  it('reports failed when cache enumeration itself throws', async () => {
+    const failure = new Error('keys failed');
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockRejectedValue(failure),
+      delete: vi.fn(),
+    });
+
+    expect(await clearAllCaches()).toEqual({ kind: 'failed', error: failure });
+  });
+});
+
+describe('unregisterAllServiceWorkers', () => {
+  it('returns unsupported when the Service Worker API is unavailable', async () => {
+    vi.stubGlobal('navigator', {});
+    expect(await unregisterAllServiceWorkers()).toEqual({ kind: 'unsupported' });
+  });
+
+  it('unregisters every registration and reports ok', async () => {
+    const unregisterA = vi.fn().mockResolvedValue(true);
+    const unregisterB = vi.fn().mockResolvedValue(true);
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        getRegistrations: vi
+          .fn()
+          .mockResolvedValue([{ unregister: unregisterA }, { unregister: unregisterB }]),
+      },
+    });
+
+    const result = await unregisterAllServiceWorkers();
+
+    expect(unregisterA).toHaveBeenCalledTimes(1);
+    expect(unregisterB).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ kind: 'ok', cleared: 2 });
+  });
+
+  it('attempts every registration and reports partial when some fail', async () => {
+    const failure = new Error('unregister failed');
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        getRegistrations: vi
+          .fn()
+          .mockResolvedValue([
+            { unregister: vi.fn().mockResolvedValue(true) },
+            { unregister: vi.fn().mockRejectedValue(failure) },
+          ]),
+      },
+    });
+
+    expect(await unregisterAllServiceWorkers()).toEqual({
+      kind: 'partial',
+      cleared: 1,
+      failed: 1,
+      errors: [failure],
+    });
+  });
+
+  it('reports partial when a service worker unregister resolves false', async () => {
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        getRegistrations: vi
+          .fn()
+          .mockResolvedValue([
+            { unregister: vi.fn().mockResolvedValue(true) },
+            { unregister: vi.fn().mockResolvedValue(false) },
+          ]),
+      },
+    });
+
+    const result = await unregisterAllServiceWorkers();
+
+    expect(result.kind).toBe('partial');
+    if (result.kind === 'partial') {
+      expect(result.cleared).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toBeInstanceOf(Error);
+      expect((result.errors[0] as Error).message).toBe('Operation resolved false');
+    }
+  });
+
+  it('reports failed when getRegistrations itself throws', async () => {
+    const failure = new Error('getRegistrations failed');
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        getRegistrations: vi.fn().mockRejectedValue(failure),
+      },
+    });
+
+    expect(await unregisterAllServiceWorkers()).toEqual({ kind: 'failed', error: failure });
+  });
+});
+
+describe('recoverFromCacheCorruption', () => {
+  it('reloads the page after clearing caches and service workers', async () => {
+    const reload = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload });
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockResolvedValue(['gtfs-data-v2']),
+      delete: vi.fn().mockResolvedValue(true),
+    });
+    vi.stubGlobal('navigator', {
+      serviceWorker: { getRegistrations: vi.fn().mockResolvedValue([]) },
+    });
+
+    await recoverFromCacheCorruption();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reloads when cache clearing fails and service workers are unsupported', async () => {
+    const reload = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload });
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockRejectedValue(new Error('keys failed')),
+      delete: vi.fn(),
+    });
+    vi.stubGlobal('navigator', {});
+
+    await recoverFromCacheCorruption();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/__tests__/cache-recovery.test.ts
+++ b/src/lib/__tests__/cache-recovery.test.ts
@@ -197,4 +197,20 @@ describe('recoverFromCacheCorruption', () => {
 
     expect(reload).toHaveBeenCalledTimes(1);
   });
+
+  it('still reloads when a recovery step throws unexpectedly', async () => {
+    const reload = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload });
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockResolvedValue(null),
+      delete: vi.fn(),
+    });
+    vi.stubGlobal('navigator', {
+      serviceWorker: { getRegistrations: vi.fn().mockResolvedValue([]) },
+    });
+
+    await recoverFromCacheCorruption();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/lib/__tests__/format-error-message.test.ts
+++ b/src/lib/__tests__/format-error-message.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { formatErrorMessage } from '../format-error-message';
+
+describe('formatErrorMessage', () => {
+  it('returns the message of a standard Error', () => {
+    expect(formatErrorMessage(new Error('something broke'))).toBe('something broke');
+  });
+
+  it('returns the message of an Error subclass', () => {
+    expect(formatErrorMessage(new TypeError('not a function'))).toBe('not a function');
+  });
+
+  it('falls back to the error name when the message is empty', () => {
+    expect(formatErrorMessage(new TypeError(''))).toBe('TypeError');
+  });
+
+  it('returns a string value as-is', () => {
+    expect(formatErrorMessage('plain string error')).toBe('plain string error');
+  });
+
+  it('handles null', () => {
+    expect(formatErrorMessage(null)).toBe('null');
+  });
+
+  it('handles undefined', () => {
+    expect(formatErrorMessage(undefined)).toBe('undefined');
+  });
+
+  it('handles a number', () => {
+    expect(formatErrorMessage(42)).toBe('42');
+  });
+
+  it('handles a plain object', () => {
+    expect(formatErrorMessage({ code: 1 })).toBe('[object Object]');
+  });
+
+  it('falls back when an object cannot be converted to a string', () => {
+    expect(formatErrorMessage(Object.create(null))).toBe('Unknown error');
+  });
+});

--- a/src/lib/__tests__/global-error-handler.test.ts
+++ b/src/lib/__tests__/global-error-handler.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../../i18n';
+import { installGlobalErrorHandlers } from '../global-error-handler';
+
+const OVERLAY_ID = 'athenai-global-error-overlay';
+
+function createUnhandledRejectionEvent(reason: unknown): PromiseRejectionEvent {
+  const event = new Event('unhandledrejection') as PromiseRejectionEvent;
+  Object.defineProperty(event, 'reason', { value: reason });
+  return event;
+}
+
+describe('installGlobalErrorHandlers', () => {
+  let uninstall: () => void;
+
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    document.body.innerHTML = '';
+    uninstall = installGlobalErrorHandlers();
+  });
+
+  afterEach(() => {
+    uninstall();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('shows a DOM overlay for uncaught window errors', () => {
+    window.dispatchEvent(new ErrorEvent('error', { error: new Error('render failed') }));
+
+    const overlay = document.getElementById(OVERLAY_ID);
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveAttribute('role', 'alertdialog');
+    expect(overlay).toHaveTextContent('Unexpected error');
+    expect(overlay).toHaveTextContent('render failed');
+  });
+
+  it('shows a DOM overlay for unhandled promise rejections', () => {
+    window.dispatchEvent(createUnhandledRejectionEvent('async failed'));
+
+    const overlay = document.getElementById(OVERLAY_ID);
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveTextContent('Unexpected error');
+    expect(overlay).toHaveTextContent('async failed');
+  });
+
+  it('replaces the existing overlay with the latest error', () => {
+    window.dispatchEvent(new ErrorEvent('error', { error: new Error('first') }));
+    window.dispatchEvent(new ErrorEvent('error', { error: new Error('second') }));
+
+    const overlays = document.querySelectorAll(`#${OVERLAY_ID}`);
+    expect(overlays).toHaveLength(1);
+    expect(overlays[0]).toHaveTextContent('second');
+    expect(overlays[0]).not.toHaveTextContent('first');
+  });
+
+  it('wires reload and dismiss actions', () => {
+    const reload = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload });
+    window.dispatchEvent(new ErrorEvent('error', { error: new Error('action failed') }));
+
+    document.querySelector<HTMLButtonElement>('#athenai-global-error-overlay button')?.click();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new ErrorEvent('error', { error: new Error('dismiss failed') }));
+    const buttons = document.querySelectorAll<HTMLButtonElement>(
+      '#athenai-global-error-overlay button',
+    );
+    buttons[1]?.click();
+
+    expect(document.getElementById(OVERLAY_ID)).not.toBeInTheDocument();
+  });
+
+  it('does not register duplicate handlers', () => {
+    const sameUninstall = installGlobalErrorHandlers();
+    expect(sameUninstall).toBe(uninstall);
+
+    window.dispatchEvent(new ErrorEvent('error', { error: new Error('single') }));
+
+    expect(console.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to fixed English labels when translation lookup fails', () => {
+    vi.spyOn(i18n, 't').mockImplementation(() => {
+      throw new Error('i18n failed');
+    });
+
+    window.dispatchEvent(new ErrorEvent('error', { error: new Error('fallback failed') }));
+
+    const overlay = document.getElementById(OVERLAY_ID);
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveTextContent('Unexpected error');
+    expect(overlay).toHaveTextContent('Reload');
+    expect(overlay).toHaveTextContent('Dismiss');
+    expect(overlay).toHaveTextContent('fallback failed');
+  });
+
+  it.each([
+    'ResizeObserver loop completed with undelivered notifications.',
+    'ResizeObserver loop limit exceeded',
+    'Script error.',
+    '   ',
+  ])('ignores known noisy window errors: %s', (message) => {
+    window.dispatchEvent(new ErrorEvent('error', { message }));
+
+    expect(document.getElementById(OVERLAY_ID)).not.toBeInTheDocument();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('ignores known noisy unhandled rejections', () => {
+    window.dispatchEvent(
+      createUnhandledRejectionEvent(new Error('ResizeObserver loop limit exceeded.')),
+    );
+
+    expect(document.getElementById(OVERLAY_ID)).not.toBeInTheDocument();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/global-error-handler.test.ts
+++ b/src/lib/__tests__/global-error-handler.test.ts
@@ -73,6 +73,26 @@ describe('installGlobalErrorHandlers', () => {
     expect(document.getElementById(OVERLAY_ID)).not.toBeInTheDocument();
   });
 
+  it('moves focus into the overlay and restores the previous focus when dismissed', () => {
+    const previousButton = document.createElement('button');
+    previousButton.textContent = 'Previous action';
+    document.body.append(previousButton);
+    previousButton.focus();
+
+    window.dispatchEvent(new ErrorEvent('error', { error: new Error('focus failed') }));
+
+    expect(document.activeElement).toBe(
+      document.querySelector<HTMLButtonElement>('#athenai-global-error-overlay button'),
+    );
+
+    const buttons = document.querySelectorAll<HTMLButtonElement>(
+      '#athenai-global-error-overlay button',
+    );
+    buttons[1]?.click();
+
+    expect(document.activeElement).toBe(previousButton);
+  });
+
   it('does not register duplicate handlers', () => {
     const sameUninstall = installGlobalErrorHandlers();
     expect(sameUninstall).toBe(uninstall);

--- a/src/lib/cache-recovery.ts
+++ b/src/lib/cache-recovery.ts
@@ -1,0 +1,115 @@
+import { createLogger } from './logger';
+
+const logger = createLogger('CacheRecovery');
+
+/**
+ * Outcome of a single cache-recovery step (cache deletion or service worker
+ * unregistration).
+ *
+ * - `ok` — the step ran and every entry succeeded. `cleared` is the count
+ *   of processed entries (`0` when there were none).
+ * - `partial` — the step tried every entry but some failed. `cleared` /
+ *   `failed` count each, and `errors` collects the failure reasons.
+ * - `unsupported` — the underlying browser API is unavailable.
+ * - `failed` — the step could not even enumerate its entries (the listing
+ *   call itself rejected); nothing was processed. `error` is the cause.
+ */
+export type CacheRecoveryStepResult =
+  | { kind: 'ok'; cleared: number }
+  | { kind: 'partial'; cleared: number; failed: number; errors: unknown[] }
+  | { kind: 'unsupported' }
+  | { kind: 'failed'; error: unknown };
+
+/**
+ * Reduce settled per-entry results into a {@link CacheRecoveryStepResult}.
+ * Every entry has already been attempted; this only classifies the outcome.
+ */
+function summarizeSettledResults(
+  results: PromiseSettledResult<boolean>[],
+): CacheRecoveryStepResult {
+  const errors: unknown[] = [];
+  let cleared = 0;
+  for (const result of results) {
+    if (result.status === 'fulfilled' && result.value) {
+      cleared += 1;
+    } else if (result.status === 'fulfilled') {
+      errors.push(new Error('Operation resolved false'));
+    } else {
+      errors.push(result.reason);
+    }
+  }
+  if (errors.length === 0) {
+    return { kind: 'ok', cleared };
+  }
+  return { kind: 'partial', cleared, failed: errors.length, errors };
+}
+
+/**
+ * Delete every entry in the Cache Storage API.
+ *
+ * This removes the workbox precache as well as the runtime caches
+ * (`gtfs-data-v2`, `map-tiles`), so stale cached data that no longer matches
+ * the running app code is discarded. `localStorage` is intentionally left
+ * untouched. Every cache is attempted even if some deletions fail.
+ *
+ * @returns The step outcome. See {@link CacheRecoveryStepResult}.
+ */
+export async function clearAllCaches(): Promise<CacheRecoveryStepResult> {
+  if (typeof window === 'undefined' || !('caches' in window)) {
+    return { kind: 'unsupported' };
+  }
+  let keys: string[];
+  try {
+    keys = await window.caches.keys();
+  } catch (error) {
+    return { kind: 'failed', error };
+  }
+  const results = await Promise.allSettled(keys.map((key) => window.caches.delete(key)));
+  return summarizeSettledResults(results);
+}
+
+/**
+ * Unregister every Service Worker registration for this origin.
+ *
+ * Every registration is attempted even if some unregistrations fail.
+ *
+ * @returns The step outcome. See {@link CacheRecoveryStepResult}.
+ */
+export async function unregisterAllServiceWorkers(): Promise<CacheRecoveryStepResult> {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+    return { kind: 'unsupported' };
+  }
+  let registrations: readonly ServiceWorkerRegistration[];
+  try {
+    registrations = await navigator.serviceWorker.getRegistrations();
+  } catch (error) {
+    return { kind: 'failed', error };
+  }
+  const results = await Promise.allSettled(
+    registrations.map((registration) => registration.unregister()),
+  );
+  return summarizeSettledResults(results);
+}
+
+/** Log a step outcome, escalating to `warn` when it did not fully succeed. */
+function logStep(label: string, result: CacheRecoveryStepResult): void {
+  if (result.kind === 'failed' || result.kind === 'partial') {
+    logger.warn(label, result);
+  } else {
+    logger.info(label, result);
+  }
+}
+
+/**
+ * Recover from a corrupted / stale cache state by clearing all caches and
+ * Service Worker registrations, then reloading the page.
+ *
+ * The two steps are independent: a failure or unsupported result in one does
+ * not prevent the other, and the page is always reloaded at the end so the
+ * app re-fetches a consistent set of code and data.
+ */
+export async function recoverFromCacheCorruption(): Promise<void> {
+  logStep('cleared caches', await clearAllCaches());
+  logStep('unregistered service workers', await unregisterAllServiceWorkers());
+  window.location.reload();
+}

--- a/src/lib/cache-recovery.ts
+++ b/src/lib/cache-recovery.ts
@@ -100,6 +100,17 @@ function logStep(label: string, result: CacheRecoveryStepResult): void {
   }
 }
 
+async function runRecoveryStep(
+  label: string,
+  step: () => Promise<CacheRecoveryStepResult>,
+): Promise<void> {
+  try {
+    logStep(label, await step());
+  } catch (error) {
+    logger.warn(`${label} failed unexpectedly`, error);
+  }
+}
+
 /**
  * Recover from a corrupted / stale cache state by clearing all caches and
  * Service Worker registrations, then reloading the page.
@@ -109,7 +120,14 @@ function logStep(label: string, result: CacheRecoveryStepResult): void {
  * app re-fetches a consistent set of code and data.
  */
 export async function recoverFromCacheCorruption(): Promise<void> {
-  logStep('cleared caches', await clearAllCaches());
-  logStep('unregistered service workers', await unregisterAllServiceWorkers());
-  window.location.reload();
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    await runRecoveryStep('cleared caches', clearAllCaches);
+    await runRecoveryStep('unregistered service workers', unregisterAllServiceWorkers);
+  } finally {
+    window.location.reload();
+  }
 }

--- a/src/lib/format-error-message.ts
+++ b/src/lib/format-error-message.ts
@@ -1,0 +1,23 @@
+/**
+ * Format an unknown thrown value into a human-readable string for display.
+ *
+ * A React error boundary (and any `catch` block) receives whatever was
+ * thrown, which is not guaranteed to be an `Error` — `throw "text"`,
+ * `throw null`, and `throw { code: 1 }` are all valid. This normalizes any
+ * such value into a displayable string.
+ *
+ * @param error - The value caught by an error boundary or `catch` block.
+ * @returns For an `Error`, its `message` (falling back to `name` when the
+ *   message is an empty string, so the result is never blank). For any
+ *   other value, a best-effort string conversion.
+ */
+export function formatErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message.length > 0 ? error.message : error.name;
+  }
+  try {
+    return String(error);
+  } catch {
+    return 'Unknown error';
+  }
+}

--- a/src/lib/global-error-handler.ts
+++ b/src/lib/global-error-handler.ts
@@ -1,0 +1,222 @@
+import i18n from '../i18n';
+import { formatErrorMessage } from './format-error-message';
+import { createLogger } from './logger';
+
+const logger = createLogger('GlobalErrorHandler');
+const OVERLAY_ID = 'athenai-global-error-overlay';
+const LABEL_FALLBACKS = {
+  title: 'Unexpected error',
+  message:
+    'An error occurred while the app was running. Reload the app if the screen does not behave correctly.',
+  detailLabel: 'Error details',
+  reload: 'Reload',
+  dismiss: 'Dismiss',
+} as const;
+const IGNORED_ERROR_PATTERNS = [
+  /^ResizeObserver loop completed with undelivered notifications\.?$/,
+  /^ResizeObserver loop limit exceeded\.?$/,
+  /^Script error\.?$/,
+] as const;
+
+let uninstallCurrentHandlers: (() => void) | null = null;
+
+function getLabel(key: string, fallback: string): string {
+  try {
+    const label = i18n.t(key);
+    return label !== key ? label : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function shouldIgnoreGlobalError(error: unknown): boolean {
+  const message = formatErrorMessage(error).trim();
+  if (message.length === 0) {
+    return true;
+  }
+  return IGNORED_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+function createTextElement(documentRef: Document, tagName: string, text: string): HTMLElement {
+  const element = documentRef.createElement(tagName);
+  element.textContent = text;
+  return element;
+}
+
+function applyOverlayStyles(overlay: HTMLElement): void {
+  overlay.style.position = 'fixed';
+  overlay.style.inset = '0';
+  overlay.style.zIndex = '2147483647';
+  overlay.style.display = 'flex';
+  overlay.style.alignItems = 'center';
+  overlay.style.justifyContent = 'center';
+  overlay.style.padding = '24px';
+  overlay.style.background = 'rgba(15, 23, 42, 0.72)';
+  overlay.style.color = '#0f172a';
+}
+
+function applyPanelStyles(panel: HTMLElement): void {
+  panel.style.width = 'min(100%, 28rem)';
+  panel.style.maxHeight = 'min(80vh, 40rem)';
+  panel.style.overflowY = 'auto';
+  panel.style.borderRadius = '8px';
+  panel.style.border = '1px solid rgba(220, 38, 38, 0.28)';
+  panel.style.background = '#ffffff';
+  panel.style.padding = '20px';
+  panel.style.boxShadow = '0 24px 80px rgba(15, 23, 42, 0.36)';
+  panel.style.fontFamily =
+    'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+}
+
+function applyDetailStyles(detail: HTMLElement): void {
+  detail.style.margin = '12px 0 0';
+  detail.style.padding = '12px';
+  detail.style.borderRadius = '6px';
+  detail.style.background = '#fef2f2';
+  detail.style.color = '#991b1b';
+  detail.style.whiteSpace = 'pre-wrap';
+  detail.style.overflowWrap = 'anywhere';
+  detail.style.fontFamily = 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
+  detail.style.fontSize = '12px';
+  detail.style.lineHeight = '1.5';
+}
+
+function applyButtonStyles(button: HTMLButtonElement, variant: 'primary' | 'secondary'): void {
+  button.style.width = '100%';
+  button.style.minHeight = '36px';
+  button.style.borderRadius = '6px';
+  button.style.padding = '8px 12px';
+  button.style.fontSize = '14px';
+  button.style.fontWeight = '600';
+  button.style.cursor = 'pointer';
+  if (variant === 'primary') {
+    button.style.border = '1px solid #dc2626';
+    button.style.background = '#dc2626';
+    button.style.color = '#ffffff';
+  } else {
+    button.style.border = '1px solid #cbd5e1';
+    button.style.background = '#ffffff';
+    button.style.color = '#0f172a';
+  }
+}
+
+function showGlobalErrorOverlay(error: unknown): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const host = document.body ?? document.documentElement;
+  if (host === null) {
+    return;
+  }
+
+  document.getElementById(OVERLAY_ID)?.remove();
+
+  const overlay = document.createElement('div');
+  overlay.id = OVERLAY_ID;
+  overlay.setAttribute('role', 'alertdialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.setAttribute('aria-labelledby', `${OVERLAY_ID}-title`);
+  overlay.setAttribute('aria-describedby', `${OVERLAY_ID}-message`);
+  applyOverlayStyles(overlay);
+
+  const panel = document.createElement('section');
+  applyPanelStyles(panel);
+
+  const title = createTextElement(
+    document,
+    'h1',
+    getLabel('globalError.title', LABEL_FALLBACKS.title),
+  );
+  title.id = `${OVERLAY_ID}-title`;
+  title.style.margin = '0';
+  title.style.fontSize = '18px';
+  title.style.lineHeight = '1.4';
+  title.style.fontWeight = '700';
+
+  const message = createTextElement(
+    document,
+    'p',
+    getLabel('globalError.message', LABEL_FALLBACKS.message),
+  );
+  message.id = `${OVERLAY_ID}-message`;
+  message.style.margin = '8px 0 0';
+  message.style.color = '#475569';
+  message.style.fontSize = '14px';
+  message.style.lineHeight = '1.7';
+
+  const detailLabel = createTextElement(
+    document,
+    'p',
+    getLabel('globalError.detailLabel', LABEL_FALLBACKS.detailLabel),
+  );
+  detailLabel.style.margin = '16px 0 0';
+  detailLabel.style.fontSize = '13px';
+  detailLabel.style.fontWeight = '700';
+
+  const detail = createTextElement(document, 'pre', formatErrorMessage(error));
+  applyDetailStyles(detail);
+
+  const actions = document.createElement('div');
+  actions.style.display = 'flex';
+  actions.style.flexDirection = 'column';
+  actions.style.gap = '8px';
+  actions.style.marginTop = '16px';
+
+  const reloadButton = document.createElement('button');
+  reloadButton.type = 'button';
+  reloadButton.textContent = getLabel('globalError.action.reload', LABEL_FALLBACKS.reload);
+  applyButtonStyles(reloadButton, 'primary');
+  reloadButton.addEventListener('click', () => window.location.reload());
+
+  const dismissButton = document.createElement('button');
+  dismissButton.type = 'button';
+  dismissButton.textContent = getLabel('globalError.action.dismiss', LABEL_FALLBACKS.dismiss);
+  applyButtonStyles(dismissButton, 'secondary');
+  dismissButton.addEventListener('click', () => overlay.remove());
+
+  actions.append(reloadButton, dismissButton);
+  panel.append(title, message, detailLabel, detail, actions);
+  overlay.append(panel);
+  host.append(overlay);
+}
+
+function handleErrorEvent(event: ErrorEvent): void {
+  const error: unknown = event.error ?? event.message;
+  if (shouldIgnoreGlobalError(error)) {
+    logger.debug('ignored uncaught error', error);
+    return;
+  }
+  logger.error('uncaught error', error);
+  showGlobalErrorOverlay(error);
+}
+
+function handleUnhandledRejection(event: PromiseRejectionEvent): void {
+  const reason: unknown = event.reason;
+  if (shouldIgnoreGlobalError(reason)) {
+    logger.debug('ignored unhandled rejection', reason);
+    return;
+  }
+  logger.error('unhandled rejection', reason);
+  showGlobalErrorOverlay(reason);
+}
+
+export function installGlobalErrorHandlers(): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+  if (uninstallCurrentHandlers !== null) {
+    return uninstallCurrentHandlers;
+  }
+
+  window.addEventListener('error', handleErrorEvent);
+  window.addEventListener('unhandledrejection', handleUnhandledRejection);
+
+  uninstallCurrentHandlers = () => {
+    window.removeEventListener('error', handleErrorEvent);
+    window.removeEventListener('unhandledrejection', handleUnhandledRejection);
+    uninstallCurrentHandlers = null;
+  };
+
+  return uninstallCurrentHandlers;
+}

--- a/src/lib/global-error-handler.ts
+++ b/src/lib/global-error-handler.ts
@@ -111,6 +111,14 @@ function showGlobalErrorOverlay(error: unknown): void {
   }
 
   document.getElementById(OVERLAY_ID)?.remove();
+  const previousActiveElement = document.activeElement;
+
+  function removeOverlay(): void {
+    overlay.remove();
+    if (previousActiveElement instanceof HTMLElement && previousActiveElement.isConnected) {
+      previousActiveElement.focus();
+    }
+  }
 
   const overlay = document.createElement('div');
   overlay.id = OVERLAY_ID;
@@ -173,12 +181,13 @@ function showGlobalErrorOverlay(error: unknown): void {
   dismissButton.type = 'button';
   dismissButton.textContent = getLabel('globalError.action.dismiss', LABEL_FALLBACKS.dismiss);
   applyButtonStyles(dismissButton, 'secondary');
-  dismissButton.addEventListener('click', () => overlay.remove());
+  dismissButton.addEventListener('click', removeOverlay);
 
   actions.append(reloadButton, dismissButton);
   panel.append(title, message, detailLabel, detail, actions);
   overlay.append(panel);
   host.append(overlay);
+  reloadButton.focus();
 }
 
 function handleErrorEvent(event: ErrorEvent): void {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,8 +5,11 @@ import './index.css';
 import './i18n';
 import BootstrapApp from './bootstrap-app';
 import { applyStoredAppTheme } from './lib/app-theme';
+import { installGlobalErrorHandlers } from './lib/global-error-handler';
 import { cleanupInvalidQueryParams } from './lib/query-params';
 import { TILE_SOURCES } from './config/tile-sources';
+
+installGlobalErrorHandlers();
 
 // Apply the persisted theme before the bootstrap shell is rendered.
 applyStoredAppTheme();


### PR DESCRIPTION
## Summary

An uncaught render error previously left users on a blank white screen with no way to recover or diagnose — especially on iOS Chrome, where the console is not accessible. The root cause traced to the service worker serving a stale `data-v2` JSON bundle whose schema no longer matched the running app code, throwing a `TypeError` during render.

This adds a defensive error-handling layer so failures surface as a readable recovery screen instead of a blank page.

## Changes

- **`RootErrorBoundary`** wraps the repository-backed app tree. Catches errors thrown during render and shows a fallback with the error detail and a "clear cache and reload" recovery action.
- **`global-error-handler`** installs `error` / `unhandledrejection` listeners and shows a React-independent DOM overlay for uncaught window errors and unhandled promise rejections. Known browser noise (`ResizeObserver loop …`, cross-origin `Script error.`, empty messages) is filtered out.
- **`cache-recovery`** clears Cache Storage and unregisters service workers, then reloads.
- **`formatErrorMessage`** normalizes unknown thrown values (non-`Error` throws) into a displayable string.
- `APP_TITLE` extracted to `config/app-meta` and shared.

## Out of scope

Versioning the `data-v2` fetch URL (the root-cause fix that prevents the stale-bundle schema mismatch entirely) is tracked separately.

## Test plan

- `npm run lint` — clean
- `npm test` — 3407 unit tests pass, incl. new `cache-recovery`, `format-error-message`, `global-error-handler`, and error-boundary integration tests
- `npm run build` — succeeds
- Storybook: error-boundary fallback verified at mobile viewport (buttons stay visible with long error text)
- Manual global error handler check:
  - Start the dev server with `npm run dev`
  - Open the app in a browser
  - In DevTools Console, run:
    ```js
    setTimeout(() => {
      throw new Error('global error handler test')
    }, 0)
    ```
  - Confirm the emergency overlay appears with the error detail, and Reload / Dismiss work
  - In DevTools Console, run:
    ```js
    Promise.reject(new Error('global rejection handler test'))
    ```
  - Confirm the same overlay appears for the unhandled rejection
  - Optional noise-filter check: run `setTimeout(() => { throw new Error('ResizeObserver loop limit exceeded') }, 0)` and confirm no overlay appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)