### PR TITLE
refactor(map): extract MapOverlay from MapView

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -280,7 +280,7 @@ App root (relative h-dvh w-dvw)
 └── MapSlotProvider                                                ← slot DOM 要素を context で共有
     ├── MapViewContainer                                            ← MapView 専用の position wrapper
     │   ├── MapView                                                ← 常駐、 transition で unmount しない
-    │   └── TimeControls                                            ← map と co-locate する chrome
+    │   └── MapOverlay                                              ← map に被さる chrome 全般 (panel 群 / locate / TimeControls / StopHistory / Portals)
     └── AppLayout                                                   ← overlay 選択
         ├── 'simple' → MapBottomSheetLayout
         │              ├── <div ref={setMapSlot} h-[60dvh]/>        ← slot div (透明)
@@ -336,6 +336,7 @@ multi-pane の `ResizablePanelGroup` は **layout shell でしかなく**、 map
 | `src/contexts/map-slot-context.tsx`          | `MapSlotContext` 定義                                                                                                                                     |
 | `src/contexts/map-slot-provider.tsx`         | `MapSlotProvider`: slot 共有 state holder                                                                                                                 |
 | `src/components/map/map-view-container.tsx`  | `MapViewContainer`: hoist された MapView の position 制御                                                                                                 |
+| `src/components/map/map-overlay.tsx`         | `MapOverlay`: map に被さる chrome 全般 (corner panels / locate button / `TimeControls` / `StopHistory` / `Portals`)。 MapView と sibling                  |
 | `src/components/app-layout.tsx`              | `AppLayout`: `useLayoutMode()` で overlay 選択                                                                                                            |
 | `src/components/map-bottom-sheet-layout.tsx` | simple mode overlay (slot div + BottomSheet)                                                                                                              |
 | `src/components/multi-pane-layout.tsx`       | multi-pane mode overlay (ResizablePanelGroup + slot)                                                                                                      |
@@ -392,7 +393,7 @@ MapView 内でも component local な layering には `z-0` や `z-10` を使っ
 
 App root container、 hoist された `MapView` wrapper、 `MultiPaneLayout` の `ResizablePanelGroup` のように **app 全体の layout 構造だけを担う wrapper** には `z-index` を明示しない。
 
-- 上記の wrapper に `z-index` を指定する(例: `relative z-0`、 `fixed inset-0 z-0`)と、 新しい stacking context が生成され、 中の chrome (`TimeControls` の z-1000、 `MapOverlayPanels` の z-1000/1001/1002、 `ZoomDisplay` の z-1000 等) が **root context から見えなくなる**。 結果として doc の予約レンジが意図どおり composing しなくなり、 BottomSheet (z-1000) や StopPanel (z-1000) が常に chrome を覆ってしまう等の重なり崩れが発生する
+- 上記の wrapper に `z-index` を指定する(例: `relative z-0`、 `fixed inset-0 z-0`)と、 新しい stacking context が生成され、 中の chrome (`MapOverlay` 配下の `TimeControls` の z-1000、 corner panel 群の z-1000/1001/1002、 `ZoomDisplay` の z-1000 等) が **root context から見えなくなる**。 結果として doc の予約レンジが意図どおり composing しなくなり、 BottomSheet (z-1000) や StopPanel (z-1000) が常に chrome を覆ってしまう等の重なり崩れが発生する
 - `position: relative` / `absolute` だけ与えて positioning context のみ提供する。 `z-index` は `auto` のまま明示しない
     - `fixed` は z-index 値に関わらず stacking context を作る仕様なので、 hoist された `MapView` の wrapper には `fixed inset-0` ではなく **「App root が `relative h-dvh w-dvw` で viewport を確定 + 中の wrapper が `absolute inset-0`」** という構造を採用する(`src/app.tsx`)
 - 例: `src/app.tsx` の `<div className="relative h-dvh w-dvw overflow-hidden">` (App root) と内側の `<div className="absolute inset-0">` (MapView wrapper)、 `src/components/multi-pane-layout.tsx` の `<ResizablePanelGroup className="absolute inset-0">`

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -32,6 +32,7 @@ const {
   mockFocusStop,
   mockAppLayout,
   mockMapView,
+  mockMapOverlay,
   mockUseTimetable,
   mockOpenStopTimetable,
   mockOpenRouteHeadsignTimetable,
@@ -50,6 +51,7 @@ const {
   mockFocusStop: vi.fn(),
   mockAppLayout: vi.fn(),
   mockMapView: vi.fn(),
+  mockMapOverlay: vi.fn(),
   mockUseTimetable: vi.fn<() => UseTimetableReturn>(),
   mockOpenStopTimetable: vi.fn(),
   mockOpenRouteHeadsignTimetable: vi.fn(),
@@ -147,6 +149,21 @@ vi.mock('../lib/query-params', () => ({
 vi.mock('../components/map/map-view', () => ({
   MapView: (props: unknown) => {
     mockMapView(props);
+    return null;
+  },
+}));
+
+// `MapOverlay` is hoisted next to `MapView` in `app.tsx` (Phase 1
+// refactor). Mock it so the test doesn't pull in the real overlay
+// subtree — that subtree's transitive imports (the locate button →
+// `use-map-navigation-actions` → `map-defaults`) reach
+// `query-params.ts` exports beyond `getStopParam`, which the mock
+// above does not provide. Also captures the props so tests that need
+// to drive history/portal handlers (now passed to `MapOverlay`
+// rather than MapView) can fetch them from this mock.
+vi.mock('../components/map/map-overlay', () => ({
+  MapOverlay: (props: unknown) => {
+    mockMapOverlay(props);
     return null;
   },
 }));
@@ -271,6 +288,7 @@ describe('App anchor error toast', () => {
     mockFocusStop.mockReset();
     mockAppLayout.mockReset();
     mockMapView.mockReset();
+    mockMapOverlay.mockReset();
     mockUseTimetable.mockReset();
     mockOpenStopTimetable.mockReset();
     mockOpenRouteHeadsignTimetable.mockReset();
@@ -579,16 +597,17 @@ describe('App anchor error toast', () => {
       expect(mockAppLayout).toHaveBeenCalled();
     });
 
-    // onHistorySelect is now passed directly to the hoisted MapView at
-    // App root (not via AppLayout.mapViewProps). Grab it from MapView's
-    // captured props.
-    const lastMapViewCall = mockMapView.mock.lastCall;
-    const mapViewProps = lastMapViewCall?.[0] as {
+    // onHistorySelect lives on MapOverlay (Phase 1 refactor: chrome
+    // extracted out of MapView; previously this prop flowed
+    // App → MapView → MapOverlay, now App → MapOverlay directly).
+    // Capture from its mock.
+    const lastOverlayCall = mockMapOverlay.mock.lastCall;
+    const overlayProps = lastOverlayCall?.[0] as {
       onHistorySelect: (entry: StopHistoryEntry) => void;
     };
 
     act(() => {
-      mapViewProps.onHistorySelect(entry);
+      overlayProps.onHistorySelect(entry);
     });
 
     await waitFor(() => {
@@ -637,13 +656,15 @@ describe('App anchor error toast', () => {
       expect(mockAppLayout).toHaveBeenCalled();
     });
 
-    const lastMapViewCall = mockMapView.mock.lastCall;
-    const mapViewProps = lastMapViewCall?.[0] as {
+    // onHistorySelect now lives on MapOverlay (Phase 1 refactor:
+    // chrome extracted out of MapView). Capture from there.
+    const lastOverlayCall = mockMapOverlay.mock.lastCall;
+    const overlayProps = lastOverlayCall?.[0] as {
       onHistorySelect: (entry: StopHistoryEntry) => void;
     };
 
     act(() => {
-      mapViewProps.onHistorySelect(entry);
+      overlayProps.onHistorySelect(entry);
     });
 
     await waitFor(() => {
@@ -684,13 +705,15 @@ describe('App anchor error toast', () => {
       expect(mockAppLayout).toHaveBeenCalled();
     });
 
-    const lastMapViewCall = mockMapView.mock.lastCall;
-    const mapViewProps = lastMapViewCall?.[0] as {
+    // onHistorySelect now lives on MapOverlay (Phase 1 refactor:
+    // chrome extracted out of MapView). Capture from there.
+    const lastOverlayCall = mockMapOverlay.mock.lastCall;
+    const overlayProps = lastOverlayCall?.[0] as {
       onHistorySelect: (entry: StopHistoryEntry) => void;
     };
 
     act(() => {
-      mapViewProps.onHistorySelect(entry);
+      overlayProps.onHistorySelect(entry);
     });
 
     await waitFor(() => {

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -602,7 +602,8 @@ describe('App anchor error toast', () => {
     // App → MapView → MapOverlay, now App → MapOverlay directly).
     // Capture from its mock.
     const lastOverlayCall = mockMapOverlay.mock.lastCall;
-    const overlayProps = lastOverlayCall?.[0] as {
+    expect(lastOverlayCall).toBeDefined();
+    const overlayProps = lastOverlayCall![0] as {
       onHistorySelect: (entry: StopHistoryEntry) => void;
     };
 
@@ -659,7 +660,8 @@ describe('App anchor error toast', () => {
     // onHistorySelect now lives on MapOverlay (Phase 1 refactor:
     // chrome extracted out of MapView). Capture from there.
     const lastOverlayCall = mockMapOverlay.mock.lastCall;
-    const overlayProps = lastOverlayCall?.[0] as {
+    expect(lastOverlayCall).toBeDefined();
+    const overlayProps = lastOverlayCall![0] as {
       onHistorySelect: (entry: StopHistoryEntry) => void;
     };
 
@@ -708,7 +710,8 @@ describe('App anchor error toast', () => {
     // onHistorySelect now lives on MapOverlay (Phase 1 refactor:
     // chrome extracted out of MapView). Capture from there.
     const lastOverlayCall = mockMapOverlay.mock.lastCall;
-    const overlayProps = lastOverlayCall?.[0] as {
+    expect(lastOverlayCall).toBeDefined();
+    const overlayProps = lastOverlayCall![0] as {
       onHistorySelect: (entry: StopHistoryEntry) => void;
     };
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import type L from 'leaflet';
 
 import { toast } from 'sonner';
 
 // types
 import type { AutoLocateOffReason } from './types/app/auto-locate';
-import type { Bounds, LatLng, RouteShape } from './types/app/map';
+import type { Bounds, LatLng, RouteShape, UserLocation } from './types/app/map';
 import type { StopsCounts } from './types/app/stop';
 import type { AppRouteTypeValue, Stop, TimetableEntriesState } from './types/app/transit';
 import type {
@@ -90,9 +91,9 @@ import { StopSearchDialog } from './components/dialog/stop-search-dialog';
 import { TimetableModal } from './components/dialog/timetable-modal';
 import { TripInspectionDialog } from './components/dialog/trip-inspection-dialog';
 import { AppLayout } from './components/app-layout';
+import { MapOverlay } from './components/map/map-overlay';
 import { MapView } from './components/map/map-view';
 import { MapViewContainer } from './components/map/map-view-container';
-import { TimeControls } from './components/time-controls';
 import { Toaster } from './components/ui/sonner';
 import { MapSlotProvider } from './contexts/map-slot-provider';
 
@@ -186,6 +187,32 @@ export default function App() {
       return false;
     });
   }, []);
+
+  // Last known user geolocation. Lifted from MapView so both the
+  // user-location marker (rendered inside MapView) and the locate
+  // button (rendered inside MapOverlay) read from the same
+  // source. `useMapLocateWatch` inside MapView publishes each fix via
+  // the `onLocated` prop; the manual locate flow inside the locate
+  // button publishes via the same callback.
+  const [userLocation, setUserLocation] = useState<UserLocation | null>(null);
+  // Counter that increments every time a fresh geolocation fix
+  // arrives (manual locate or auto-tracking watchPosition update).
+  // Forwarded to the locate button as `locatePulseKey` so the button
+  // replays a brief ripple animation to acknowledge the event without
+  // altering its persistent state.
+  const [locateUpdateCount, setLocateUpdateCount] = useState(0);
+  const handleLocated = useCallback((location: UserLocation) => {
+    setUserLocation(location);
+    setLocateUpdateCount((n) => n + 1);
+  }, []);
+
+  // Leaflet `L.Map` instance captured from MapView via `onMapInstance`.
+  // Forwarded to chrome that needs to drive the map directly (e.g.
+  // `MapOverlay`'s MapControlPanel / MapNavigationPanel /
+  // locate-button manual-locate flow). Stays `null` until MapView
+  // mounts; consumers must tolerate the initial `null`.
+  const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+
   const [searchModalOpen, setSearchModalOpen] = useState(false);
   const [infoDialogOpen, setInfoDialogOpen] = useState(false);
   const [dataSourceSettingsDialogOpen, setDataSourceSettingsDialogOpen] = useState(false);
@@ -1119,49 +1146,70 @@ export default function App() {
             visibleRouteShapes={visibleRouteShapes}
             tileIndex={settings.tileIndex}
             renderMode={settings.renderMode}
-            perfMode={settings.perfMode}
             infoLevel={settings.infoLevel}
             dataLang={langChain}
             time={dateTime}
             onBoundsChanged={handleBoundsChanged}
             onStopSelected={handleSelectStop}
             onFetchStopTimes={handleFetchStopTimes}
-            onToggleStopType={handleToggleStopType}
-            onToggleBusShapes={handleToggleBusShapes}
-            onToggleNonBusShapes={handleToggleNonBusShapes}
-            onCycleTile={handleCycleTile}
-            onToggleRenderMode={handleToggleRenderMode}
-            onTogglePerfMode={handleTogglePerfMode}
-            onCycleInfoLevel={handleCycleInfoLevel}
             onDeselectStop={deselectStop}
             onRouteShapeSelected={selectRouteShape}
             resolveRouteFreq={resolveRouteFreq}
             theme={settings.theme}
             doubleTapDrag={settings.doubleTapDrag}
+            autoLocateEnabled={autoLocateEnabled}
+            onDisableAutoLocate={disableAutoLocate}
+            userLocation={userLocation}
+            onLocated={handleLocated}
+            onMapInstance={setMapInstance}
+            heightClassName="h-full"
+          />
+          {/* All chrome that overlays the map: corner panels, locate
+           * button, top-centre StopHistory / Portals dropdowns, and
+           * the TimeControls time-pinning bar. Sibling of MapView so
+           * the Leaflet subtree owns only Leaflet content. Rendered
+           * inside MapViewContainer so its `absolute` children resolve
+           * against the same slot bbox as MapView — keeping all
+           * map-area chrome (TimeControls' `left-1/2`, the StopHistory
+           * / Portals dropdowns, etc.) consistently anchored to the
+           * visible map area rather than the full viewport. */}
+          <MapOverlay
+            map={mapInstance}
+            tileIndex={settings.tileIndex}
+            visibleRouteShapes={visibleRouteShapes}
+            visibleStopTypes={enabledRouteTypes}
+            renderMode={settings.renderMode}
+            perfMode={settings.perfMode}
+            infoLevel={settings.infoLevel}
+            theme={settings.theme}
+            selectedStopId={selectedStopId}
+            stopHistory={history}
+            anchors={anchors}
+            onCycleTile={handleCycleTile}
+            onToggleBusShapes={handleToggleBusShapes}
+            onToggleNonBusShapes={handleToggleNonBusShapes}
+            onToggleRenderMode={handleToggleRenderMode}
+            onTogglePerfMode={handleTogglePerfMode}
+            onCycleInfoLevel={handleCycleInfoLevel}
             onToggleDarkMode={handleToggleDarkMode}
             onCycleLang={handleCycleLang}
+            dataLang={langChain}
+            onToggleStopType={handleToggleStopType}
             onSearchClick={() => setSearchModalOpen(true)}
             onInfoClick={() => setInfoDialogOpen(true)}
-            stopHistory={history}
-            onHistorySelect={handleHistorySelect}
-            anchors={anchors}
-            onPortalSelect={handlePortalSelect}
-            onPortalRemove={(entry) => handleToggleAnchorByStopId(entry.snapshot.stopId)}
-            lookupAnchorStopMeta={lookupAnchorStopMeta}
-            lookupHistoryStopMeta={lookupHistoryStopMeta}
+            onLocated={handleLocated}
             autoLocateEnabled={autoLocateEnabled}
             onEnableAutoLocate={enableAutoLocate}
             onDisableAutoLocate={disableAutoLocate}
-            heightClassName="h-full"
-          />
-          {/* TimeControls lives inside MapViewContainer so its
-           * `absolute left-1/2 -translate-x-1/2` is centred on the
-           * **visible map area** (the slot bbox that MapViewContainer
-           * positions itself to), not on the full viewport. The
-           * StopHistory / Portals dropdowns rendered inside MapView
-           * are positioned the same way; this keeps all map-area
-           * chrome consistently anchored to the map. */}
-          <TimeControls
+            locatePulseKey={locateUpdateCount}
+            onDeselectStop={deselectStop}
+            onHistorySelect={handleHistorySelect}
+            onPortalSelect={handlePortalSelect}
+            onPortalRemove={(entry: AnchorEntry) =>
+              handleToggleAnchorByStopId(entry.snapshot.stopId)
+            }
+            lookupAnchorStopMeta={lookupAnchorStopMeta}
+            lookupHistoryStopMeta={lookupHistoryStopMeta}
             time={dateTime}
             isCustomTime={isCustomTime}
             onResetToNow={resetToNow}

--- a/src/components/map/__tests__/map-view-container.test.tsx
+++ b/src/components/map/__tests__/map-view-container.test.tsx
@@ -122,8 +122,8 @@ describe('MapViewContainer', () => {
 
   it('does not set a `z-index` on the wrapper (must not create a stacking context)', () => {
     // Guards DEVELOPMENT.md "App shell wrapper" rule: a z-index here
-    // would trap descendant z-1000+ chrome (TimeControls,
-    // MapOverlayPanels) inside a local stacking context.
+    // would trap descendant z-1000+ chrome (MapOverlay's TimeControls,
+    // corner panels, dropdowns) inside a local stacking context.
     const { container } = render(
       <MapSlotProvider>
         <MapViewContainer>

--- a/src/components/map/map-overlay.tsx
+++ b/src/components/map/map-overlay.tsx
@@ -14,8 +14,25 @@ import { StopControlPanel } from '../panel/stop-control-panel';
 import { StopTypeFilterPanel } from '../panel/stop-type-filter-panel';
 import { Portals } from '../portals';
 import { StopHistory } from '../stop-history';
+import { TimeControls } from '../time-controls';
 
-interface MapOverlayPanelsProps {
+/**
+ * Props for {@link MapOverlay} — every chrome element that visually
+ * overlays the map (corner panels, locate button, top-centre
+ * dropdowns, time picker).
+ *
+ * `MapOverlay` is the sibling of `MapView` inside `MapViewContainer`:
+ * MapView owns the Leaflet subtree, MapOverlay owns the surrounding
+ * UI. Anything that should appear above the map but is *not* part of
+ * the Leaflet rendering belongs here.
+ */
+interface MapOverlayProps {
+  /**
+   * The Leaflet `L.Map` instance published by MapView (via
+   * `onMapInstance`). `null` until MapView has mounted Leaflet; the
+   * map-aware children (`MapControlPanel`, `MapNavigationPanel`)
+   * render only once it is non-null.
+   */
   map: L.Map | null;
   infoLevel: InfoLevel;
   visibleRouteShapes: Set<number>;
@@ -64,9 +81,28 @@ interface MapOverlayPanelsProps {
   lookupAnchorStopMeta: (stopId: string) => StopWithMeta | null;
   lookupHistoryStopMeta: (stopId: string) => StopWithMeta | null;
   tileIndex: number | null;
+  /** Currently displayed time (from `useDateTime`). */
+  time: Date;
+  /** True when the displayed time is user-pinned (not "now"). */
+  isCustomTime: boolean;
+  /** Reset the displayed time back to the live "now" clock. */
+  onResetToNow: () => void;
+  /** Pin the displayed time to the user-selected value. */
+  onCustomTimeSet: (date: Date) => void;
 }
 
-export function MapOverlayPanels({
+/**
+ * All chrome that overlays the map: corner panels, the locate
+ * button, top-centre `StopHistory` / `Portals` dropdowns, and the
+ * `TimeControls` time-pinning bar. Rendered as a sibling of
+ * `MapView` inside `MapViewContainer` so each `absolute`-positioned
+ * child resolves against the visible map area.
+ *
+ * This component is purely presentational and stateless — it forwards
+ * props to its sub-components. Lifted state (`map` instance,
+ * `userLocation` via `onLocated`, etc.) is owned by `app.tsx`.
+ */
+export function MapOverlay({
   map,
   infoLevel,
   visibleRouteShapes,
@@ -101,7 +137,11 @@ export function MapOverlayPanels({
   lookupAnchorStopMeta,
   lookupHistoryStopMeta,
   tileIndex,
-}: MapOverlayPanelsProps) {
+  time,
+  isCustomTime,
+  onResetToNow,
+  onCustomTimeSet,
+}: MapOverlayProps) {
   return (
     <>
       {map && <MapControlPanel map={map} infoLevel={infoLevel} />}
@@ -144,6 +184,12 @@ export function MapOverlayPanels({
       />
       <StopControlPanel infoLevel={infoLevel} onSearchClick={onSearchClick} />
       <InfoPanel infoLevel={infoLevel} onInfoClick={onInfoClick} />
+      <TimeControls
+        time={time}
+        isCustomTime={isCustomTime}
+        onResetToNow={onResetToNow}
+        onCustomTimeSet={onCustomTimeSet}
+      />
       <div className="pointer-events-none absolute top-[calc(4rem+env(safe-area-inset-top))] left-1/2 z-1001 flex -translate-x-1/2 gap-2 *:pointer-events-auto">
         <StopHistory
           history={stopHistory}

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -5,7 +5,7 @@ import L from 'leaflet';
 import { toast } from 'sonner';
 import type { AutoLocateOffReason } from '../../types/app/auto-locate';
 import type { Bounds, LatLng, RouteShape } from '../../types/app/map';
-import type { InfoLevel, PerfMode, RenderMode, Theme } from '../../types/app/settings';
+import type { InfoLevel, RenderMode, Theme } from '../../types/app/settings';
 import type { Agency, AppRouteTypeValue, Stop } from '../../types/app/transit';
 import type { StopWithContext, StopWithMeta } from '../../types/app/transit-composed';
 import { DEFAULT_MAX_ZOOM } from '../../config/map-constants';
@@ -15,7 +15,6 @@ import { resolveLocateAction } from '../../lib/map-locate';
 import { smoothMoveTo, toBounds, toCenter } from '../../lib/leaflet-helpers';
 import { StopMarkers } from '../marker/stop-markers';
 import type { UserLocation } from '../../types/app/map';
-import { MapOverlayPanels } from './map-overlay-panels';
 
 import {
   CLICK_SUPPRESSION_MS,
@@ -23,8 +22,6 @@ import {
 } from '../../domain/map/map-click-suppression';
 import { resolveMapMaxZoom } from '../../domain/map/map-max-zoom';
 import { createLogger } from '../../lib/logger';
-import type { StopHistoryEntry } from '../../domain/transit/stop-history';
-import type { AnchorEntry } from '../../domain/portal/anchor';
 import type { SelectionInfo } from '../../domain/map/selection';
 import { buildTimetableEntriesMap } from '../../domain/map/selection';
 import { resolveRenderModes } from '../../domain/map/render-mode';
@@ -235,7 +232,6 @@ export interface MapViewProps {
   visibleRouteShapes: Set<number>;
   tileIndex: number | null;
   renderMode: RenderMode;
-  perfMode: PerfMode;
   infoLevel: InfoLevel;
   /** Display language chain for translated GTFS/ODPT data names. */
   dataLang: readonly string[];
@@ -243,42 +239,12 @@ export interface MapViewProps {
   onBoundsChanged: (bounds: Bounds, center: LatLng) => void;
   onStopSelected: (stop: Stop) => void;
   onFetchStopTimes: (stopId: string) => Promise<StopWithContext | null>;
-  onToggleStopType: (rt: number) => void;
-  onToggleBusShapes: () => void;
-  onToggleNonBusShapes: () => void;
-  onCycleTile: () => void;
-  onToggleRenderMode: () => void;
-  onTogglePerfMode: () => void;
-  onCycleInfoLevel: () => void;
   theme: Theme;
   doubleTapDrag: 'zoom-in' | 'zoom-out';
-  onToggleDarkMode: () => void;
-  onCycleLang: () => void;
   onDeselectStop: () => void;
   onRouteShapeSelected: (routeId: string) => void;
   /** Resolves the number of trips on a route in the current service day. */
   resolveRouteFreq: (routeId: string) => number | undefined;
-  onSearchClick: () => void;
-  onInfoClick: () => void;
-  /** Stop selection history entries, most recent first. */
-  stopHistory: StopHistoryEntry[];
-  /** Called when a history entry is chosen. */
-  onHistorySelect: (entry: StopHistoryEntry) => void;
-  /** Anchor (bookmarked stop) entries, most recently added first. */
-  anchors: AnchorEntry[];
-  /** Called when an anchor is chosen from the Portal dropdown. */
-  onPortalSelect: (entry: AnchorEntry) => void;
-  /** Removes the anchor for a Portal entry whose stop_id is no longer
-   *  resolvable in the current GTFS dataset. */
-  onPortalRemove: (entry: AnchorEntry) => void;
-  /**
-   * Looks up an anchored stop's current `StopWithMeta` from the
-   * repository's full dataset. Forwarded to the Portal dropdown so
-   * anchor display names can be resolved against the latest GTFS
-   * data at render time, regardless of viewport position.
-   */
-  lookupAnchorStopMeta: (stopId: string) => StopWithMeta | null;
-  lookupHistoryStopMeta: (stopId: string) => StopWithMeta | null;
   /** Height class applied to the outer map container. */
   heightClassName?: string;
   /**
@@ -289,12 +255,36 @@ export interface MapViewProps {
    * each disable trigger) reads from the same source of truth.
    */
   autoLocateEnabled: boolean;
-  /** Turn auto-locate on (= called from the locate button's near-center
-   *  branch). */
-  onEnableAutoLocate: () => void;
-  /** Turn auto-locate off, tagging the call site with a typed reason
-   *  for diagnostics. */
+  /**
+   * Turn auto-locate off, tagging the call site with a typed reason
+   * for diagnostics. Called from within MapView for `'manual-drag'`,
+   * `'pinch-zoom-shift'`, and `'permission-denied'` (geolocation watch
+   * error).
+   */
   onDisableAutoLocate: (reason: AutoLocateOffReason) => void;
+  /**
+   * Last known user geolocation; owned by `app.tsx` so it is also
+   * available to chrome rendered outside MapView (e.g. the locate
+   * button in `MapOverlay`). MapView reads this for the
+   * user-location marker, the auto-pan effect, and the pinch-zoom
+   * yield logic.
+   */
+  userLocation: UserLocation | null;
+  /**
+   * Called with every fresh geolocation fix from MapView's
+   * `useMapLocateWatch` (the continuous-tracking watchPosition tick).
+   * `app.tsx` updates the lifted `userLocation` state and bumps the
+   * `locatePulseKey` counter forwarded to `MapOverlay`'s locate
+   * button.
+   */
+  onLocated: (location: UserLocation) => void;
+  /**
+   * Published when the underlying Leaflet `L.Map` is created (and on
+   * subsequent re-creations). `app.tsx` captures the instance so
+   * chrome extracted out of MapView (`MapOverlay`, eventually
+   * `EdgeMarkersSwitch`) can interact with the same map.
+   */
+  onMapInstance?: (map: L.Map) => void;
 }
 
 export function MapView({
@@ -311,52 +301,40 @@ export function MapView({
   visibleRouteShapes,
   tileIndex,
   renderMode,
-  perfMode,
   infoLevel,
   dataLang,
   time: now,
   onBoundsChanged,
   onStopSelected,
   onFetchStopTimes,
-  onToggleStopType,
-  onToggleBusShapes,
-  onToggleNonBusShapes,
-  onCycleTile,
-  onToggleRenderMode,
-  onTogglePerfMode,
-  onCycleInfoLevel,
   theme,
   doubleTapDrag,
-  onToggleDarkMode,
-  onCycleLang,
   onDeselectStop,
   onRouteShapeSelected,
   resolveRouteFreq,
-  onSearchClick,
-  onInfoClick,
-  stopHistory,
-  lookupAnchorStopMeta,
-  lookupHistoryStopMeta,
-  onHistorySelect,
-  anchors,
-  onPortalSelect,
-  onPortalRemove,
   heightClassName,
   autoLocateEnabled,
-  onEnableAutoLocate,
   onDisableAutoLocate,
+  userLocation,
+  onLocated,
+  onMapInstance,
 }: MapViewProps) {
   const { t } = useTranslation();
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
-  const [userLocation, setUserLocation] = useState<UserLocation | null>(null);
   const [zoom, setZoom] = useState(INITIAL_ZOOM);
-  // Counter that increments every time a fresh geolocation fix arrives
-  // (manual locate or auto-tracking watchPosition update). Forwarded
-  // to the locate button as `pulseKey` so the button replays a brief
-  // ripple animation to acknowledge the event without altering its
-  // persistent state.
-  const [locateUpdateCount, setLocateUpdateCount] = useState(0);
   const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Bridge MapRef -> both the local `mapInstance` state (consumed by
+  // effects in this component) and the parent-supplied `onMapInstance`
+  // callback (consumed by `MapOverlay` / `EdgeMarkersSwitch`
+  // hosted in `app.tsx`).
+  const handleMapInstance = useCallback(
+    (map: L.Map) => {
+      setMapInstance(map);
+      onMapInstance?.(map);
+    },
+    [onMapInstance],
+  );
 
   const { nearby: nearbyRenderMode, far: farRenderMode } = resolveRenderModes(renderMode, zoom);
 
@@ -392,15 +370,6 @@ export function MapView({
     visibleRouteShapes,
     selectionInfo,
   });
-
-  const handleLocated = useCallback((location: UserLocation) => {
-    setUserLocation(location);
-    // Bump the counter so the locate button replays its ripple
-    // animation. Both manual (`useMapLocate`) and auto (`useMapLocateWatch`)
-    // paths end up here, so the button reacts uniformly to any
-    // successful position fix.
-    setLocateUpdateCount((n) => n + 1);
-  }, []);
 
   // A user-initiated map drag implies the user wants to look at a
   // different area, so auto-tracking should yield. `dragstart` is a
@@ -445,7 +414,7 @@ export function MapView({
   );
   useMapLocateWatch({
     enabled: autoLocateEnabled,
-    onLocated: handleLocated,
+    onLocated,
     onError: handleTrackingError,
   });
 
@@ -590,7 +559,7 @@ export function MapView({
         <DistanceRings />
         {infoLevel === 'verbose' && <ZoomDisplay />}
         <PanToFocus position={focusPosition} />
-        <MapRef onMap={setMapInstance} />
+        <MapRef onMap={handleMapInstance} />
         {userLocation && (
           <>
             <Circle
@@ -680,42 +649,6 @@ export function MapView({
         )}
       </MapContainer>
 
-      <MapOverlayPanels
-        map={mapInstance}
-        tileIndex={tileIndex}
-        visibleRouteShapes={visibleRouteShapes}
-        visibleStopTypes={visibleStopTypes}
-        renderMode={renderMode}
-        perfMode={perfMode}
-        infoLevel={infoLevel}
-        theme={theme}
-        selectedStopId={selectedStopId}
-        stopHistory={stopHistory}
-        anchors={anchors}
-        onCycleTile={onCycleTile}
-        onToggleBusShapes={onToggleBusShapes}
-        onToggleNonBusShapes={onToggleNonBusShapes}
-        onToggleRenderMode={onToggleRenderMode}
-        onTogglePerfMode={onTogglePerfMode}
-        onCycleInfoLevel={onCycleInfoLevel}
-        onToggleDarkMode={onToggleDarkMode}
-        onCycleLang={onCycleLang}
-        dataLang={dataLang}
-        onToggleStopType={onToggleStopType}
-        onSearchClick={onSearchClick}
-        onInfoClick={onInfoClick}
-        onLocated={handleLocated}
-        autoLocateEnabled={autoLocateEnabled}
-        onEnableAutoLocate={onEnableAutoLocate}
-        onDisableAutoLocate={onDisableAutoLocate}
-        locatePulseKey={locateUpdateCount}
-        onDeselectStop={onDeselectStop}
-        onHistorySelect={onHistorySelect}
-        onPortalSelect={onPortalSelect}
-        onPortalRemove={onPortalRemove}
-        lookupAnchorStopMeta={lookupAnchorStopMeta}
-        lookupHistoryStopMeta={lookupHistoryStopMeta}
-      />
       {mapInstance && (
         <EdgeMarkersSwitch
           map={mapInstance}


### PR DESCRIPTION
## Summary

Hoist all map-overlay chrome — corner panels, locate button, top-centre `StopHistory` / `Portals` dropdowns, and `TimeControls` — into a single `MapOverlay` component that sits as a sibling of `MapView` inside `MapViewContainer`. `MapView` now owns only the Leaflet subtree.

## What changed

### `MapOverlayPanels` → `MapOverlay` (rename + scope expansion)

- Renamed `MapOverlayPanels` → `MapOverlay` (file: `map-overlay.tsx`). The previous name implied "panels only" but the component already held the `StopHistory` / `Portals` dropdowns; merging `TimeControls` in makes the generic name a better fit and keeps a clear `MapView` / `MapOverlay` pair under `MapViewContainer`.
- `TimeControls` is now rendered inside `MapOverlay` (was a sibling of `MapView` in `app.tsx`). It still resolves `left-1/2` against the visible map area because `MapOverlay` is a sibling of `MapView` under the same `MapViewContainer` (which owns the slot bbox).

### State lift: locate ownership moves to `app.tsx`

- `userLocation`, `locateUpdateCount`, and the captured Leaflet `L.Map` instance now live in `app.tsx`.
- `MapView` publishes the map via `onMapInstance` and forwards each geolocation fix via `onLocated` (single sink: `useMapLocate` manual flow + `useMapLocateWatch` watchPosition tick).
- This means chrome rendered outside the Leaflet subtree (the locate button, etc.) reads from the same source as the user-location marker.

### `MapView` props: 47 → 26 (−21)

Dropped props (all were pure pass-through to `MapOverlayPanels`):

| Category | Props |
|---|---|
| Chrome callbacks (18) | `onToggleStopType`, `onToggleBusShapes`, `onToggleNonBusShapes`, `onCycleTile`, `onToggleRenderMode`, `onTogglePerfMode`, `onCycleInfoLevel`, `onToggleDarkMode`, `onCycleLang`, `onSearchClick`, `onInfoClick`, `onHistorySelect`, `onPortalSelect`, `onPortalRemove`, `lookupAnchorStopMeta`, `lookupHistoryStopMeta`, `stopHistory`, `anchors` |
| State props (3) | `perfMode`, `onEnableAutoLocate` (also pass-through), and removed via lift: internal `userLocation` / `locateUpdateCount` / `handleLocated` |

Added: `userLocation`, `onLocated`, `onMapInstance`.

## Test changes

`src/__tests__/app.test.tsx` adds a `MapOverlay` mock — without it the real subtree's transitive imports (`use-map-navigation-actions` → `map-defaults` → `query-params`) would resolve `parseQueryLat` / `parseQueryLng` / `parseQueryZoom`, which the existing `query-params` mock does not provide. The three history-handler tests now capture props from the new `mockMapOverlay` instead of `mockMapView`.

## Docs

`DEVELOPMENT.md`:
- DOM-hierarchy diagram under "MapView の常駐 (case 1A hoist)" now shows `MapOverlay` as the child of `MapViewContainer` (replacing the former `TimeControls` sibling entry).
- "関連 file マップ" gains a row for `src/components/map/map-overlay.tsx`.
- "App shell wrapper は stacking context を作らない" note's chrome list now reads `MapOverlay` 配下の `TimeControls` + corner panels.

PRD.md — no changes (no component-level references).

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit -p tsconfig.app.json` | ✅ |
| `npm run lint` | ✅ |
| `npm run format:check` | ✅ |
| `npx vitest run` | ✅ 4059 / 4059 |
| `npm run build` | ✅ |
| Browser-verify | ✅ (local) |

## Out of scope (separate PR)

- **Phase 1.5**: extract `EdgeMarkersSwitch` and lift `useMapSelectionLayers` (derived `filteredNearbyStops` / `routeStopMarkers`). Different scope — touches Leaflet-pane–level rendering rather than overlay chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)