### PR TITLE
refactor(app): narrow MapSlotProvider scope

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1240,63 +1240,69 @@ export default function App() {
           nearbyStopsCounts={nearbyStopsCounts}
           filteredNearbyStopsCounts={filteredNearbyStopsCounts}
         />
-        <StopSearchDialog
-          repo={repo}
-          infoLevel={settings.infoLevel}
-          dataLang={langChain}
-          mapCenter={mapCenter}
-          isStopAnchor={isStopAnchor}
-          onSelectStop={handleSearchSelect}
-          onToggleAnchor={handleToggleAnchorByStopId}
-          onShowStopTimetable={handleShowStopTimetable}
-          onOpenTripInspectionByStopId={handleOpenTripInspectionByStopId}
-          open={searchModalOpen}
-          onOpenChange={setSearchModalOpen}
-        />
-        <InfoDialog
-          open={infoDialogOpen}
-          onOpenChange={setInfoDialogOpen}
-          onOpenDataSourceSettings={() => setDataSourceSettingsDialogOpen(true)}
-        />
-        <DataSourceSettingsDialog
-          open={dataSourceSettingsDialogOpen}
-          onOpenChange={setDataSourceSettingsDialogOpen}
-        />
-        <ShortcutHelpDialog open={shortcutHelpOpen} onOpenChange={setShortcutHelpOpen} />
-        <TripInspectionDialog
-          open={tripInspectionSnapshot !== null}
-          snapshot={tripInspectionSnapshot}
-          tripInspectionTargets={tripInspectionTargets}
-          currentTripInspectionTargetIndex={currentTripInspectionTargetIndex}
-          showNoticeNonce={showNoticeNonce}
-          now={dateTime}
-          infoLevel={settings.infoLevel}
-          dataLangs={langChain}
-          onOpenPreviousTrip={openPreviousTripInspection}
-          onOpenNextTrip={openNextTripInspection}
-          onInspectTrip={handleInspectTripFromDialog}
-          onSelectStopById={handleSelectStopFromTripInspection}
-          onOpenChange={handleTripInspectionOpenChange}
-        />
-        <TimetableModal
-          key={timetableData?.stop.stop_id ?? 'closed'}
-          data={timetableData}
-          time={dateTime}
-          infoLevel={settings.infoLevel}
-          dataLangs={langChain}
-          globalFilter={globalFilter}
-          onInspectTrip={handleInspectTrip}
-          onClose={closeTimetable}
-        />
-        <Toaster
-          theme={settings.theme}
-          position="bottom-center"
-          closeButton={true}
-          richColors
-          expand={true}
-          visibleToasts={10}
-        />
       </MapSlotProvider>
+      {/* Dialogs / Toaster do not consume `MapSlotContext`, so they
+       * live as siblings of `MapSlotProvider` rather than children.
+       * Keeping the provider's scope narrow (`MapViewContainer` +
+       * `AppLayout` only) makes "which subtree depends on the map
+       * slot" obvious at a glance and lets these overlays be tested
+       * without a `MapSlotProvider` fixture. */}
+      <StopSearchDialog
+        repo={repo}
+        infoLevel={settings.infoLevel}
+        dataLang={langChain}
+        mapCenter={mapCenter}
+        isStopAnchor={isStopAnchor}
+        onSelectStop={handleSearchSelect}
+        onToggleAnchor={handleToggleAnchorByStopId}
+        onShowStopTimetable={handleShowStopTimetable}
+        onOpenTripInspectionByStopId={handleOpenTripInspectionByStopId}
+        open={searchModalOpen}
+        onOpenChange={setSearchModalOpen}
+      />
+      <InfoDialog
+        open={infoDialogOpen}
+        onOpenChange={setInfoDialogOpen}
+        onOpenDataSourceSettings={() => setDataSourceSettingsDialogOpen(true)}
+      />
+      <DataSourceSettingsDialog
+        open={dataSourceSettingsDialogOpen}
+        onOpenChange={setDataSourceSettingsDialogOpen}
+      />
+      <ShortcutHelpDialog open={shortcutHelpOpen} onOpenChange={setShortcutHelpOpen} />
+      <TripInspectionDialog
+        open={tripInspectionSnapshot !== null}
+        snapshot={tripInspectionSnapshot}
+        tripInspectionTargets={tripInspectionTargets}
+        currentTripInspectionTargetIndex={currentTripInspectionTargetIndex}
+        showNoticeNonce={showNoticeNonce}
+        now={dateTime}
+        infoLevel={settings.infoLevel}
+        dataLangs={langChain}
+        onOpenPreviousTrip={openPreviousTripInspection}
+        onOpenNextTrip={openNextTripInspection}
+        onInspectTrip={handleInspectTripFromDialog}
+        onSelectStopById={handleSelectStopFromTripInspection}
+        onOpenChange={handleTripInspectionOpenChange}
+      />
+      <TimetableModal
+        key={timetableData?.stop.stop_id ?? 'closed'}
+        data={timetableData}
+        time={dateTime}
+        infoLevel={settings.infoLevel}
+        dataLangs={langChain}
+        globalFilter={globalFilter}
+        onInspectTrip={handleInspectTrip}
+        onClose={closeTimetable}
+      />
+      <Toaster
+        theme={settings.theme}
+        position="bottom-center"
+        closeButton={true}
+        richColors
+        expand={true}
+        visibleToasts={10}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Narrow `MapSlotProvider`'s scope in `app.tsx` so it wraps only the two subtrees that actually consume `MapSlotContext`: `MapViewContainer` (reader via `useMapSlotElement`) and `AppLayout` (its layout children — `MapBottomSheetLayout` / `MultiPaneLayout` — write the slot via `useSetMapSlotElement`).

The six dialogs and the `Toaster` previously rendered inside the provider become siblings of it. They never call `useMapSlotElement` / `useSetMapSlotElement`, so moving them out is a no-op for runtime context resolution.

## Why

| Observation | Implication |
|---|---|
| `MapSlotProvider` only renders a plain `Context.Provider` (no DOM wrapper) | Moving children out → in-React-tree position changes, rendered DOM tree unchanged |
| Only 3 components anywhere in the app call MapSlot hooks (`MapViewContainer`, `MapBottomSheetLayout`, `MultiPaneLayout`) | The 7 unrelated overlays do not need to be inside the provider |
| Provider name (`MapSlotProvider`) implies map-slot scope | Wrapping unrelated dialogs widens the scope past what the name suggests |

Result: the provider's name now matches its scope, and dialog-only tests can be written without a `MapSlotProvider` fixture.

## What changed

`src/app.tsx` only — pure JSX restructuring. No logic, prop, or component changes.

```tsx
// Before
<MapSlotProvider>
  <MapViewContainer>...</MapViewContainer>
  <AppLayout ... />
  <StopSearchDialog ... />
  <InfoDialog ... />
  <DataSourceSettingsDialog ... />
  <ShortcutHelpDialog ... />
  <TripInspectionDialog ... />
  <TimetableModal ... />
  <Toaster ... />
</MapSlotProvider>

// After
<MapSlotProvider>
  <MapViewContainer>...</MapViewContainer>
  <AppLayout ... />
</MapSlotProvider>
<StopSearchDialog ... />
<InfoDialog ... />
<DataSourceSettingsDialog ... />
<ShortcutHelpDialog ... />
<TripInspectionDialog ... />
<TimetableModal ... />
<Toaster ... />
```

The diff is `+62 / -56`, but the actual semantic change is one closing tag moved plus 7 children re-indented one level shallower.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit -p tsconfig.app.json` | ✅ |
| `npm run lint` | ✅ |
| `npm run format:check` | ✅ |
| `npx vitest run` | ✅ 4059 / 4059 |
| `npm run build` | ✅ |
| Browser-verify | ✅ (local) |

## Out of scope

- No follow-up refactor planned. The provider name now matches its consumer set; this is purely cleanup, not a stepping stone to a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)