### PR TITLE
fix(app): derive routeTypeMap synchronously to remove gray-flash

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -45,6 +45,7 @@ import { type StopHistoryEntry } from './domain/transit/stop-history';
 import { findVisibleStopMetaById } from './domain/transit/stop-meta-lookup';
 import { buildHistoryNavigationPayload } from './domain/transit/stop-navigation';
 import { createStopReferenceSnapshot } from './domain/transit/stop-reference-snapshot';
+import { buildStopRouteTypeMap } from './domain/transit/stop-route-type-map';
 import {
   applyStopEventAttributeTogglesToStops,
   omitStopsWithoutStopTimes,
@@ -262,28 +263,14 @@ export default function App() {
     repo,
   );
 
-  // Build routeTypes lookup covering all visible stops (in-bound + nearby)
-  const [routeTypeMap, setRouteTypeMap] = useState<Map<string, AppRouteTypeValue[]>>(
-    () => new Map(),
+  // routeTypes lookup for all visible stops (in-bound + nearby).
+  // Sync derivation keeps it in the same commit as the stops, so
+  // new markers never flash gray before colour resolves. See
+  // `buildStopRouteTypeMap` for the data-equivalence rationale.
+  const routeTypeMap = useMemo(
+    () => buildStopRouteTypeMap([...inBoundStops, ...radiusStops]),
+    [inBoundStops, radiusStops],
   );
-
-  useEffect(() => {
-    const allStops = [
-      ...inBoundStops.map((s) => s.stop.stop_id),
-      ...radiusStops.map((s) => s.stop.stop_id),
-    ];
-    const uniqueIds = [...new Set(allStops)];
-
-    void Promise.all(
-      uniqueIds.map(async (stopId) => {
-        const result = await repo.getRouteTypesForStop(stopId);
-        const routeTypes = result.success ? result.data : [-1 as const];
-        return [stopId, routeTypes] as const;
-      }),
-    ).then((entries) => {
-      setRouteTypeMap(new Map(entries));
-    });
-  }, [inBoundStops, radiusStops, repo]);
 
   const {
     selectedStopId,

--- a/src/domain/map/map-selection-layers.ts
+++ b/src/domain/map/map-selection-layers.ts
@@ -2,6 +2,7 @@ import type { RouteShape } from '../../types/app/map';
 import type { AppRouteTypeValue, Stop } from '../../types/app/transit';
 import type { StopWithMeta } from '../../types/app/transit-composed';
 import type { SelectionInfo } from './selection';
+import { buildStopRouteTypeMap } from '../transit/stop-route-type-map';
 import { filterVisibleRouteShapes } from './route-shapes';
 import { excludeStopsByIds, filterStopsByType } from './stop-filter';
 
@@ -66,16 +67,7 @@ export function buildMapSelectionLayers({
 
   const routeStopMarkers = routeStops.map((m) => m.stop);
 
-  const routeStopsRouteTypeMap = new Map<string, AppRouteTypeValue[]>();
-  for (const m of routeStops) {
-    const types = m.routes.map((r) => r.route_type);
-    if (types.length > 0) {
-      routeStopsRouteTypeMap.set(
-        m.stop.stop_id,
-        [...new Set(types)].sort((a, b) => a - b),
-      );
-    }
-  }
+  const routeStopsRouteTypeMap = buildStopRouteTypeMap(routeStops);
 
   return {
     selectedRouteIds,

--- a/src/domain/transit/__tests__/stop-route-type-map.test.ts
+++ b/src/domain/transit/__tests__/stop-route-type-map.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { AppRouteTypeValue } from '../../../types/app/transit';
+import type { StopWithMeta } from '../../../types/app/transit-composed';
+import { makeRoute, makeStop } from '../../../__tests__/helpers';
+import { buildStopRouteTypeMap } from '../stop-route-type-map';
+
+function makeMeta(stopId: string, routeTypes: AppRouteTypeValue[]): StopWithMeta {
+  // One Route per requested type, distinct route_ids so dedupe is observable.
+  const routes = routeTypes.map((rt, i) => makeRoute(`${stopId}-r${i}`, rt));
+  return { stop: makeStop(stopId), distance: 0, agencies: [], routes };
+}
+
+describe('buildStopRouteTypeMap', () => {
+  it('returns an empty map for an empty input array', () => {
+    expect(buildStopRouteTypeMap([])).toEqual(new Map());
+  });
+
+  it('maps a single stop with a single route', () => {
+    const map = buildStopRouteTypeMap([makeMeta('s1', [3])]);
+    expect(map.size).toBe(1);
+    expect(map.get('s1')).toEqual([3]);
+  });
+
+  it('deduplicates and sorts ascending for a stop with multiple routes', () => {
+    const map = buildStopRouteTypeMap([makeMeta('s1', [3, 1, 3, 2, 1])]);
+    expect(map.get('s1')).toEqual([1, 2, 3]);
+  });
+
+  it('omits stops whose routes array is empty', () => {
+    const empty: StopWithMeta = { stop: makeStop('s1'), distance: 0, agencies: [], routes: [] };
+    const withRoute = makeMeta('s2', [3]);
+    const map = buildStopRouteTypeMap([empty, withRoute]);
+    expect(map.has('s1')).toBe(false);
+    expect(map.get('s2')).toEqual([3]);
+    expect(map.size).toBe(1);
+  });
+
+  it('lets the last occurrence win when stop_id appears more than once', () => {
+    // Mirrors how `app.tsx` concatenates inBoundStops and radiusStops: a
+    // stop_id present in both passes ends up with the second pass's
+    // route_types in the resulting Map.
+    const first = makeMeta('s1', [3]);
+    const second = makeMeta('s1', [1, 2]);
+    const map = buildStopRouteTypeMap([first, second]);
+    expect(map.get('s1')).toEqual([1, 2]);
+  });
+
+  it('does not mutate the input stops or their routes arrays', () => {
+    const routesA = [makeRoute('r0', 3), makeRoute('r1', 1)];
+    const stop: StopWithMeta = {
+      stop: makeStop('s1'),
+      distance: 0,
+      agencies: [],
+      routes: routesA,
+    };
+    const input = [stop];
+    const snapshotRouteIds = routesA.map((r) => r.route_id);
+    const snapshotRouteTypes = routesA.map((r) => r.route_type);
+
+    buildStopRouteTypeMap(input);
+
+    expect(input).toHaveLength(1);
+    expect(stop.routes).toBe(routesA);
+    expect(routesA.map((r) => r.route_id)).toEqual(snapshotRouteIds);
+    expect(routesA.map((r) => r.route_type)).toEqual(snapshotRouteTypes);
+  });
+
+  it('returns a freshly constructed Map each call', () => {
+    const stops = [makeMeta('s1', [3])];
+    const first = buildStopRouteTypeMap(stops);
+    const second = buildStopRouteTypeMap(stops);
+    expect(first).not.toBe(second);
+    expect(first.get('s1')).toEqual(second.get('s1'));
+  });
+});

--- a/src/domain/transit/stop-route-type-map.ts
+++ b/src/domain/transit/stop-route-type-map.ts
@@ -1,0 +1,38 @@
+import type { AppRouteTypeValue } from '../../types/app/transit';
+import type { StopWithMeta } from '../../types/app/transit-composed';
+
+/**
+ * Build a stop_id -> route_types lookup from {@link StopWithMeta} array.
+ *
+ * Synchronously derives route types from each stop's `routes` field
+ * (same data the repo's internal `stopRouteTypeMap` is built from in
+ * `merge-sources-v2.ts`), so the result can be committed in the same
+ * React render as the stops themselves — avoiding the marker-color
+ * flash that an async lookup would cause.
+ *
+ * - Stops with empty `routes` are omitted from the map. Callers fall
+ *   back to `[-1]` (Unknown) via `routeTypeMap.get(stopId) ?? [-1]` at
+ *   marker render time.
+ * - When the same `stop_id` appears multiple times in the input, the
+ *   last occurrence wins (Map.set semantics). Callers that pass a
+ *   concatenation of `inBoundStops` and `radiusStops` should be aware
+ *   that the radius pass overrides the in-bounds pass for shared ids.
+ * - Output `AppRouteTypeValue[]` values are deduplicated and sorted
+ *   ascending so callers can compare them without re-normalizing.
+ *
+ * @param stops - Source stops to derive lookup entries from.
+ * @returns Fresh `Map` — input is never mutated.
+ */
+export function buildStopRouteTypeMap(
+  stops: readonly StopWithMeta[],
+): Map<string, AppRouteTypeValue[]> {
+  const map = new Map<string, AppRouteTypeValue[]>();
+  for (const meta of stops) {
+    if (meta.routes.length === 0) {
+      continue;
+    }
+    const types = [...new Set(meta.routes.map((r) => r.route_type))].sort((a, b) => a - b);
+    map.set(meta.stop.stop_id, types);
+  }
+  return map;
+}

--- a/src/utils/__tests__/route-type-emoji.test.ts
+++ b/src/utils/__tests__/route-type-emoji.test.ts
@@ -44,6 +44,10 @@ describe('routeTypesEmoji', () => {
     expect(routeTypesEmoji([0, 3])).toBe('🚊🚌');
   });
 
+  it('preserves duplicate route types', () => {
+    expect(routeTypesEmoji([3, 3, 1])).toBe('🚌🚌🚇');
+  });
+
   it('handles unknown route types in the array', () => {
     expect(routeTypesEmoji([3, 99])).toBe('🚌🛸');
   });


### PR DESCRIPTION
## Summary

Replace the async `useState` + `useEffect` + `Promise.all` pattern that built `routeTypeMap` in `src/app.tsx` with a synchronous `useMemo` deriving the lookup from `StopWithMeta.routes`. Add a shared helper used by both `app.tsx` and `src/domain/map/map-selection-layers.ts`.

## Problem

During app use (pan / zoom), stop markers and edge markers briefly rendered in **gray** (`#455A64`, route_type `-1` = Unknown) before flipping to their real colour (bus = green, train = blue, etc.). The flash was continuous, not just a startup artefact.

### Mechanism

`routeTypeMap` was built asynchronously:

```tsx
const [routeTypeMap, setRouteTypeMap] = useState(() => new Map());
useEffect(() => {
  void Promise.all(uniqueIds.map(async (stopId) => {
    const result = await repo.getRouteTypesForStop(stopId);
    return [stopId, result.success ? result.data : [-1 as const]] as const;
  })).then((entries) => {
    setRouteTypeMap(new Map(entries));
  });
}, [inBoundStops, radiusStops, repo]);
```

A bounds update produced a structural two-commit gap:

1. **Commit A** — stops state updates → new stop_ids not yet in `routeTypeMap` fall back to `routeTypeMap.get(...) ?? [-1]` at marker render → drawn in gray.
2. **Commit B** — `useEffect` resolves → `setRouteTypeMap(new Map(entries))` → markers re-render in their real colours.

The gap is conditional: it only shows for stop_ids newly entering the viewport. Stops already present in the previous map are unaffected (the stale entry still resolves correctly).

The fallback to `-1` has been in place since `a1263f92` (2026-04-09); the flash only became perceptible recently. Likely the surrounding work (PR #239 / #240 / #241 — `MapSlotProvider`, `MapViewContainer`, state lift) increased per-commit overhead and widened the gap past the sub-frame threshold. That is a hypothesis, not a measurement — but it does not change the fix, since the gap is structural.

## Fix

`StopWithMeta.routes[].route_type` and the repo's internal `stopRouteTypeMap` are populated from the **same merge loop** in `src/repositories/athenai-repository/merge-sources-v2.ts`. Deriving the lookup synchronously from `StopWithMeta.routes` is therefore equivalent to the previous async lookup. The new code commits the lookup in the same React render as the stops themselves, removing the gap structurally.

```tsx
const routeTypeMap = useMemo(
  () => buildStopRouteTypeMap([...inBoundStops, ...radiusStops]),
  [inBoundStops, radiusStops],
);
```

## What changed

| File | Change |
|---|---|
| `src/domain/transit/stop-route-type-map.ts` | **New** — pure helper `buildStopRouteTypeMap(stops): Map<stopId, route_types[]>`. |
| `src/domain/transit/__tests__/stop-route-type-map.test.ts` | **New** — 7 unit tests (empty input, single / multi-route, dedupe + sort, empty `routes` omission, duplicate `stop_id` last-wins, input non-mutation, fresh Map per call). |
| `src/app.tsx` | Async `useState` + `useEffect` block (22 lines) replaced with sync `useMemo` calling the helper (7 lines + import). |
| `src/domain/map/map-selection-layers.ts` | Inline `routeStopsRouteTypeMap` derivation (10 lines) consolidated onto the same helper. |

Per the project [data-viewer philosophy](https://github.com/F88/athenai-transit/blob/main/CLAUDE.md), display behaviour for a stop with no routes is preserved: callers still see the `[-1]` fallback via `routeTypeMap.get(stopId) ?? [-1]` at the marker layer.

## Compatibility

- `repo.getRouteTypesForStop` is no longer called from this code path, but is still used by callback-time lookups (`handleFetchStopTimes`, the v2 `selectStopByIdAndOpen` flow). Those flows are unaffected.
- `buildHistoryNavigationPayload` (`src/domain/transit/stop-navigation.ts`) → `resolveStopRouteTypes` was already a synchronous `routeTypeMap.get(...)` + `StopWithMeta.routes` fallback. Sync `routeTypeMap` works the same way through this path (fallback to `stopMeta.routes` continues to apply when the map has no entry).
- `app.test.tsx` does not mock `routeTypeMap` / `setRouteTypeMap` / `getRouteTypesForStop`, so no test fixtures need to change.

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit -p tsconfig.app.json` | ✅ |
| `npm run lint` | ✅ |
| `npm run format:check` | ✅ |
| `npx vitest run` | ✅ 4066 / 4066 (= 7 new helper tests added) |
| `npm run build` | ✅ |
| Local A/B (old async vs new sync) on dev server | ✅ — gray flash gone on pan / zoom (verified by reverting `app.tsx` only) |

## Out of scope

- `repo.getRouteTypesForStop` callback paths (`handleFetchStopTimes`, `useStopNavigation` etc.) are intentionally untouched. They are callback-time lookups, not render-time, so they have no equivalent flash problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)