### PR TITLE
Refactor app orchestration boundaries

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner';
 
 // types
 import type { AutoLocateOffReason } from './types/app/auto-locate';
-import type { Bounds, LatLng, RouteShape, UserLocation } from './types/app/map';
+import type { RouteShape, UserLocation } from './types/app/map';
 import type { StopsCounts } from './types/app/stop';
 import type { AppRouteTypeValue, Stop, TimetableEntriesState } from './types/app/transit';
 import type {
@@ -60,6 +60,7 @@ import { useLoadResult } from './hooks/use-load-result';
 import { useNearbyStopTimes } from './hooks/use-nearby-stop-times';
 import { useRouteStops } from './hooks/use-route-stops';
 import { useSelection } from './hooks/use-selection';
+import { useStopsForBounds } from './hooks/use-stops-for-bounds';
 import { useStopHistory, type UseStopHistoryReturn } from './hooks/use-stop-history';
 import { useStopNavigation } from './hooks/use-stop-navigation';
 import { useTimetable } from './hooks/use-timetable';
@@ -99,7 +100,6 @@ import { Toaster } from './components/ui/sonner';
 import { MapSlotProvider } from './contexts/map-slot-provider';
 
 const logger = createLogger('App');
-const DEBOUNCE_MS = 300;
 const LATE_NIGHT_THRESHOLD_MINUTES = 22 * 60;
 
 export default function App() {
@@ -149,11 +149,26 @@ export default function App() {
     }
   }, [settings.lang, langChain]);
 
-  const [inBoundStops, setInBoundStops] = useState<StopWithMeta[]>([]);
-  const [radiusStops, setNearbyStops] = useState<StopWithMeta[]>([]);
-  const [mapCenter, setMapCenter] = useState<LatLng | null>(null);
+  const perfProfile = PERF_PROFILES[settings.perfMode];
+
+  // `clearFocus` originates from `useSelection`, which itself depends
+  // on the stops produced by `useStopsForBounds`. To break that
+  // circular dependency without re-creating callbacks on every render,
+  // `useStopsForBounds` is given a stable `onStopsCommitted` callback
+  // that reads the latest `clearFocus` from a ref; the ref is updated
+  // in an effect right after `useSelection` returns.
+  const clearFocusRef = useRef<() => void>(() => {});
+  const handleStopsCommitted = useCallback(() => {
+    clearFocusRef.current();
+  }, []);
+
+  const { inBoundStops, radiusStops, mapCenter, hasNearbyLoaded, handleBoundsChanged } =
+    useStopsForBounds({
+      repo,
+      perfProfile,
+      onStopsCommitted: handleStopsCommitted,
+    });
   const [routeShapes, setRouteShapes] = useState<RouteShape[]>([]);
-  const [hasNearbyLoaded, setHasNearbyLoaded] = useState(false);
   // Auto-tracking flag is intentionally not persisted: a tracking
   // permission/intent shouldn't silently survive a reload, so it always
   // starts off and the user must opt in each session. Lives in app.tsx
@@ -288,6 +303,13 @@ export default function App() {
     radiusStops,
     inBoundStops,
   });
+
+  // Publish the live `clearFocus` to the ref read by
+  // `useStopsForBounds`'s `onStopsCommitted`. See the ref declaration
+  // above for the circular-dependency rationale.
+  useEffect(() => {
+    clearFocusRef.current = clearFocus;
+  }, [clearFocus]);
 
   const routeStops = useRouteStops(selectionInfo?.routeIds ?? null, repo);
   // console.debug('routeStops', routeStops.length);
@@ -513,55 +535,6 @@ export default function App() {
       }
     });
   }, [repo]);
-
-  const debounceTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
-
-  const perfProfile = PERF_PROFILES[settings.perfMode];
-
-  // Fetch stops when map bounds change (debounced). Auto-pan-driven
-  // moveends (= the locate watch) are treated identically to manual
-  // pans; the natural "near" guards (resolveLocateAction's 10 m
-  // threshold for manual locate, Leaflet's `panTo` equality check for
-  // the tracking auto-pan) prevent fetches when the position has not
-  // actually changed.
-  const handleBoundsChanged = useCallback(
-    (bounds: Bounds, center: LatLng) => {
-      // Keep `mapCenter` in sync with the latest map center; the bottom
-      // sheet computes per-stop distance from it.
-      setMapCenter(center);
-      clearTimeout(debounceTimer.current);
-      debounceTimer.current = setTimeout(() => {
-        const { nearbyRadius, maxResults } = perfProfile.data.stops;
-        if (logger.isEnabled('debug')) {
-          logger.debug(
-            'bounds changed: fetching stops via repo',
-            `radius=${nearbyRadius}`,
-            `maxResults=${maxResults}`,
-            `center=(${center.lat.toFixed(4)}, ${center.lng.toFixed(4)})`,
-          );
-        }
-        void Promise.all([
-          repo.getStopsInBounds(bounds, maxResults),
-          repo.getStopsNearby(center, nearbyRadius, maxResults),
-        ]).then(([inBoundsResult, nearbyResult]) => {
-          const inBounds = inBoundsResult.success ? inBoundsResult.data : [];
-          const nearby = nearbyResult.success ? nearbyResult.data : [];
-          logger.info(
-            'bounds changed:',
-            `radius=${nearbyRadius}`,
-            `nearby=${nearby.length}`,
-            `inBound=${inBounds.length}`,
-            `center=(${center.lat.toFixed(4)}, ${center.lng.toFixed(4)})`,
-          );
-          setInBoundStops(inBounds);
-          setNearbyStops(nearby);
-          setHasNearbyLoaded(true);
-          clearFocus();
-        });
-      }, DEBOUNCE_MS);
-    },
-    [repo, perfProfile, clearFocus],
-  );
 
   const handleFetchStopTimes = useCallback(
     async (stopId: string): Promise<StopWithContext | null> => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,8 +7,7 @@ import { toast } from 'sonner';
 // types
 import type { AutoLocateOffReason } from './types/app/auto-locate';
 import type { RouteShape, UserLocation } from './types/app/map';
-import type { StopsCounts } from './types/app/stop';
-import type { AppRouteTypeValue, Stop, TimetableEntriesState } from './types/app/transit';
+import type { AppRouteTypeValue, Stop } from './types/app/transit';
 import type {
   StopWithContext,
   StopWithMeta,
@@ -36,7 +35,7 @@ import {
   type AnchorEntry,
 } from './domain/portal/anchor';
 import { formatDateKey } from './domain/transit/calendar-utils';
-import { computeStopsCounts } from './domain/transit/compute-stops-counts';
+import { deriveFilteredNearbyStops } from './domain/transit/derive-filtered-nearby-stops';
 import { resolveLangChain, type LangChain } from './domain/transit/i18n/resolve-lang-chain';
 import { getStopDisplayNames } from './domain/transit/name-resolver/get-stop-display-names';
 import { resolveStopRouteTypes } from './domain/transit/resolve-stop-route-types';
@@ -46,11 +45,7 @@ import { findVisibleStopMetaById } from './domain/transit/stop-meta-lookup';
 import { buildHistoryNavigationPayload } from './domain/transit/stop-navigation';
 import { createStopReferenceSnapshot } from './domain/transit/stop-reference-snapshot';
 import { buildStopRouteTypeMap } from './domain/transit/stop-route-type-map';
-import {
-  applyStopEventAttributeTogglesToStops,
-  omitStopsWithoutStopTimes,
-} from './domain/transit/timetable-filter';
-import { getStopServiceState, getTimetableEntriesState } from './domain/transit/timetable-utils';
+import { getStopServiceState } from './domain/transit/timetable-utils';
 
 // hooks
 import { useAnchors } from './hooks/use-anchors';
@@ -903,56 +898,38 @@ export default function App() {
     [settings.visibleStopTypes],
   );
 
-  const routeTypesFilteredNearbyStopTimes = useMemo(
-    () => nearbyStopTimes.filter((d) => d.routeTypes.some((rt) => enabledRouteTypes.has(rt))),
-    [nearbyStopTimes, enabledRouteTypes],
-  );
-
-  // Apply origin / boardable filter (= app-wide `globalFilter` toggles)
-  // per-stop while preserving the outer stop list. Empty-stop omission
-  // happens in the next memo so the two responsibilities stay distinct.
-  const stopEventAttributesAppliedNearbyStopTimes = useMemo(
+  // Derive the visible nearby-stop state in one selector: route-type
+  // filter (settings), origin/boardable filter (globalFilter),
+  // empty-stop omit policy, pre-globalFilter `TimetableEntriesState`
+  // snapshot, and pre/post-filter counts. Internally this is still a
+  // multi-pass pipeline (filter → state map → toggles → omit → counts);
+  // the consolidation is structural — one derivation block instead of
+  // a chain of `useMemo` — not a single-traversal optimization.
+  // Aliases below keep the existing call sites untouched while the
+  // selector owns the pipeline. See `deriveFilteredNearbyStops` for
+  // the step ordering and the pre-globalFilter rationale for the
+  // state map.
+  const {
+    filtered: stopEventAttributesNonEmptyNearbyStopTimes,
+    timetableEntriesStateByStopId,
+    rawCounts: nearbyStopsCounts,
+    filteredCounts: filteredNearbyStopsCounts,
+  } = useMemo(
     () =>
-      applyStopEventAttributeTogglesToStops(routeTypesFilteredNearbyStopTimes, {
+      deriveFilteredNearbyStops({
+        nearbyStopTimes,
+        enabledRouteTypes,
         showOriginOnly,
         showBoardableOnly,
+        omitEmptyStops: effectiveOmitEmptyStops,
       }),
-    [routeTypesFilteredNearbyStopTimes, showOriginOnly, showBoardableOnly],
-  );
-
-  // Apply the app-wide empty-stop visibility policy on top of the
-  // entry-level filter result. When omitted, only non-empty stops are
-  // rendered; when disabled, empty stops remain visible for placeholder UI.
-  const stopEventAttributesNonEmptyNearbyStopTimes = useMemo(() => {
-    return effectiveOmitEmptyStops
-      ? omitStopsWithoutStopTimes(stopEventAttributesAppliedNearbyStopTimes)
-      : stopEventAttributesAppliedNearbyStopTimes;
-  }, [effectiveOmitEmptyStops, stopEventAttributesAppliedNearbyStopTimes]);
-
-  // Per-stop pre-`globalFilter` `TimetableEntriesState` map. The base
-  // is intentionally `routeTypesFilteredNearbyStopTimes` (= settings
-  // filter applied, origin/boardable toggles NOT yet applied), so
-  // consumers can distinguish `'filter-hidden'` (entries existed
-  // pre-`globalFilter`, removed by user toggles) from `'no-service'`
-  // (no entries at all). Computing this against the post-`globalFilter`
-  // `stopEventAttributesFilteredNearbyStopTimes` would collapse those
-  // two states.
-  const timetableEntriesStateByStopId = useMemo(() => {
-    const map = new Map<string, TimetableEntriesState>();
-    for (const swc of routeTypesFilteredNearbyStopTimes) {
-      map.set(swc.stop.stop_id, getTimetableEntriesState(swc.stopTimes));
-    }
-    return map;
-  }, [routeTypesFilteredNearbyStopTimes]);
-
-  const nearbyStopsCounts: StopsCounts = useMemo(
-    () => computeStopsCounts(routeTypesFilteredNearbyStopTimes),
-    [routeTypesFilteredNearbyStopTimes],
-  );
-
-  const filteredNearbyStopsCounts: StopsCounts = useMemo(
-    () => computeStopsCounts(stopEventAttributesNonEmptyNearbyStopTimes),
-    [stopEventAttributesNonEmptyNearbyStopTimes],
+    [
+      nearbyStopTimes,
+      enabledRouteTypes,
+      showOriginOnly,
+      showBoardableOnly,
+      effectiveOmitEmptyStops,
+    ],
   );
 
   const handleToggleStopType = useCallback(

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,6 @@
+import type L from 'leaflet';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type L from 'leaflet';
 
 import { toast } from 'sonner';
 
@@ -46,6 +46,7 @@ import { buildHistoryNavigationPayload } from './domain/transit/stop-navigation'
 import { createStopReferenceSnapshot } from './domain/transit/stop-reference-snapshot';
 import { buildStopRouteTypeMap } from './domain/transit/stop-route-type-map';
 import { getStopServiceState } from './domain/transit/timetable-utils';
+import { getTripInspectionNoDataMessageKey } from './domain/transit/trip-inspection-message';
 
 // hooks
 import { useAnchors } from './hooks/use-anchors';
@@ -55,9 +56,9 @@ import { useLoadResult } from './hooks/use-load-result';
 import { useNearbyStopTimes } from './hooks/use-nearby-stop-times';
 import { useRouteStops } from './hooks/use-route-stops';
 import { useSelection } from './hooks/use-selection';
-import { useStopsForBounds } from './hooks/use-stops-for-bounds';
 import { useStopHistory, type UseStopHistoryReturn } from './hooks/use-stop-history';
 import { useStopNavigation } from './hooks/use-stop-navigation';
+import { useStopsForBounds } from './hooks/use-stops-for-bounds';
 import { useTimetable } from './hooks/use-timetable';
 import { useTransitRepository } from './hooks/use-transit-repository';
 import { useTripInspection } from './hooks/use-trip-inspection';
@@ -81,13 +82,13 @@ import {
 } from './utils/settings-cycle';
 
 // components
+import { AppLayout } from './components/app-layout';
 import { DataSourceSettingsDialog } from './components/dialog/data-source-settings-dialog';
 import { InfoDialog } from './components/dialog/info-dialog';
 import { ShortcutHelpDialog } from './components/dialog/shortcut-help-dialog';
 import { StopSearchDialog } from './components/dialog/stop-search-dialog';
 import { TimetableModal } from './components/dialog/timetable-modal';
 import { TripInspectionDialog } from './components/dialog/trip-inspection-dialog';
-import { AppLayout } from './components/app-layout';
 import { MapOverlay } from './components/map/map-overlay';
 import { MapView } from './components/map/map-view';
 import { MapViewContainer } from './components/map/map-view-container';
@@ -616,13 +617,7 @@ export default function App() {
         serviceDate,
       }).then((status) => {
         if (status.status === 'no-data') {
-          const messageKey =
-            status.reason === 'no-stop-data'
-              ? 'tripInspection.messages.noStopData'
-              : status.reason === 'no-service-on-this-day'
-                ? 'tripInspection.messages.noServiceOnThisDay'
-                : 'tripInspection.messages.noData';
-          toast.warning(t(messageKey));
+          toast.warning(t(getTripInspectionNoDataMessageKey(status.reason)));
           return;
         }
 
@@ -638,13 +633,7 @@ export default function App() {
     (target: TripInspectionTarget) => {
       void openTripInspectionFromTarget(target, 'direct-open').then((status) => {
         if (status.status === 'no-data') {
-          const messageKey =
-            status.reason === 'no-stop-data'
-              ? 'tripInspection.messages.noStopData'
-              : status.reason === 'no-service-on-this-day'
-                ? 'tripInspection.messages.noServiceOnThisDay'
-                : 'tripInspection.messages.noData';
-          toast.warning(t(messageKey));
+          toast.warning(t(getTripInspectionNoDataMessageKey(status.reason)));
           return;
         }
 
@@ -660,13 +649,7 @@ export default function App() {
     (target: TripInspectionTarget) => {
       void openTripInspectionFromTarget(target, 'trip-stops-time-select').then((status) => {
         if (status.status === 'no-data') {
-          const messageKey =
-            status.reason === 'no-stop-data'
-              ? 'tripInspection.messages.noStopData'
-              : status.reason === 'no-service-on-this-day'
-                ? 'tripInspection.messages.noServiceOnThisDay'
-                : 'tripInspection.messages.noData';
-          toast.warning(t(messageKey));
+          toast.warning(t(getTripInspectionNoDataMessageKey(status.reason)));
           return;
         }
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -45,8 +45,9 @@ import { findVisibleStopMetaById } from './domain/transit/stop-meta-lookup';
 import { buildHistoryNavigationPayload } from './domain/transit/stop-navigation';
 import { createStopReferenceSnapshot } from './domain/transit/stop-reference-snapshot';
 import { buildStopRouteTypeMap } from './domain/transit/stop-route-type-map';
+import { getTimetableOpenOutcomeMessage } from './domain/transit/timetable-message';
 import { getStopServiceState } from './domain/transit/timetable-utils';
-import { getTripInspectionNoDataMessageKey } from './domain/transit/trip-inspection-message';
+import { getTripInspectionOpenOutcomeMessage } from './domain/transit/trip-inspection-message';
 
 // hooks
 import { useAnchors } from './hooks/use-anchors';
@@ -97,6 +98,27 @@ import { MapSlotProvider } from './contexts/map-slot-provider';
 
 const logger = createLogger('App');
 const LATE_NIGHT_THRESHOLD_MINUTES = 22 * 60;
+
+interface OpenOutcomeToastMessage {
+  severity: 'warning' | 'error';
+  messageKey: string;
+}
+
+function showOpenOutcomeToast(
+  message: OpenOutcomeToastMessage | null,
+  t: ReturnType<typeof useTranslation>['t'],
+): void {
+  if (!message) {
+    return;
+  }
+
+  if (message.severity === 'warning') {
+    toast.warning(t(message.messageKey));
+    return;
+  }
+
+  toast.error(t(message.messageKey));
+}
 
 export default function App() {
   const { t } = useTranslation();
@@ -570,19 +592,7 @@ export default function App() {
         headsign,
         dateTime,
       }).then((status) => {
-        if (status.status === 'not-found') {
-          toast.warning(t('timetable.messages.stopNotFound'));
-          return;
-        }
-
-        if (status.status === 'route-not-found') {
-          toast.warning(t('timetable.messages.routeNotFound'));
-          return;
-        }
-
-        if (status.status === 'error') {
-          toast.error(t('timetable.messages.openFailed'));
-        }
+        showOpenOutcomeToast(getTimetableOpenOutcomeMessage(status.status), t);
       });
     },
     [dateTime, openRouteHeadsignTimetable, t],
@@ -594,14 +604,7 @@ export default function App() {
         stopId,
         dateTime,
       }).then((status) => {
-        if (status.status === 'not-found') {
-          toast.warning(t('timetable.messages.stopNotFound'));
-          return;
-        }
-
-        if (status.status === 'error') {
-          toast.error(t('timetable.messages.openFailed'));
-        }
+        showOpenOutcomeToast(getTimetableOpenOutcomeMessage(status.status), t);
       });
     },
     [dateTime, openStopTimetable, t],
@@ -616,14 +619,7 @@ export default function App() {
         now: dateTime,
         serviceDate,
       }).then((status) => {
-        if (status.status === 'no-data') {
-          toast.warning(t(getTripInspectionNoDataMessageKey(status.reason)));
-          return;
-        }
-
-        if (status.status === 'error') {
-          toast.error(t('tripInspection.messages.openFailed'));
-        }
+        showOpenOutcomeToast(getTripInspectionOpenOutcomeMessage(status), t);
       });
     },
     [dateTime, openTripInspectionFromStopId, t],
@@ -632,14 +628,7 @@ export default function App() {
   const handleInspectTrip = useCallback(
     (target: TripInspectionTarget) => {
       void openTripInspectionFromTarget(target, 'direct-open').then((status) => {
-        if (status.status === 'no-data') {
-          toast.warning(t(getTripInspectionNoDataMessageKey(status.reason)));
-          return;
-        }
-
-        if (status.status === 'error') {
-          toast.error(t('tripInspection.messages.openFailed'));
-        }
+        showOpenOutcomeToast(getTripInspectionOpenOutcomeMessage(status), t);
       });
     },
     [openTripInspectionFromTarget, t],
@@ -648,14 +637,7 @@ export default function App() {
   const handleInspectTripFromDialog = useCallback(
     (target: TripInspectionTarget) => {
       void openTripInspectionFromTarget(target, 'trip-stops-time-select').then((status) => {
-        if (status.status === 'no-data') {
-          toast.warning(t(getTripInspectionNoDataMessageKey(status.reason)));
-          return;
-        }
-
-        if (status.status === 'error') {
-          toast.error(t('tripInspection.messages.openFailed'));
-        }
+        showOpenOutcomeToast(getTripInspectionOpenOutcomeMessage(status), t);
       });
     },
     [openTripInspectionFromTarget, t],

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -902,13 +902,13 @@ export default function App() {
   // filter (settings), origin/boardable filter (globalFilter),
   // empty-stop omit policy, pre-globalFilter `TimetableEntriesState`
   // snapshot, and pre/post-filter counts. Internally this is still a
-  // multi-pass pipeline (filter → state map → toggles → omit → counts);
-  // the consolidation is structural — one derivation block instead of
-  // a chain of `useMemo` — not a single-traversal optimization.
-  // Aliases below keep the existing call sites untouched while the
-  // selector owns the pipeline. See `deriveFilteredNearbyStops` for
-  // the step ordering and the pre-globalFilter rationale for the
-  // state map.
+  // multi-pass pipeline (filter -> state map -> toggles -> omit ->
+  // counts); the consolidation is structural -- one derivation block
+  // instead of a chain of `useMemo` -- not a single-traversal
+  // optimization. Aliases below keep the existing call sites
+  // untouched while the selector owns the pipeline. See
+  // `deriveFilteredNearbyStops` for the step ordering and the
+  // pre-globalFilter rationale for the state map.
   const {
     filtered: stopEventAttributesNonEmptyNearbyStopTimes,
     timetableEntriesStateByStopId,

--- a/src/domain/transit/__tests__/derive-filtered-nearby-stops.test.ts
+++ b/src/domain/transit/__tests__/derive-filtered-nearby-stops.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import type { AppRouteTypeValue } from '../../../types/app/transit';
-import type { ContextualTimetableEntry, StopWithContext } from '../../../types/app/transit-composed';
+import type {
+  ContextualTimetableEntry,
+  StopWithContext,
+} from '../../../types/app/transit-composed';
 import { deriveFilteredNearbyStops } from '../derive-filtered-nearby-stops';
 
 function makeEntry(
@@ -170,8 +173,8 @@ describe('deriveFilteredNearbyStops', () => {
       [3],
       [
         makeEntry({ isOrigin: false, isTerminal: false, pickupType: 0 }), // boardable middle
-        makeEntry({ isOrigin: false, isTerminal: true, pickupType: 0 }), // pure terminal — drops
-        makeEntry({ isOrigin: true, pickupType: 1 }), // non-boardable origin — drops
+        makeEntry({ isOrigin: false, isTerminal: true, pickupType: 0 }), // pure terminal -- drops
+        makeEntry({ isOrigin: true, pickupType: 1 }), // non-boardable origin -- drops
       ],
     );
 
@@ -185,6 +188,183 @@ describe('deriveFilteredNearbyStops', () => {
 
     expect(result.filtered).toHaveLength(1);
     expect(result.filtered[0].stopTimes).toHaveLength(1);
+  });
+
+  it('narrows entries to the intersection (origin AND boardable) when both toggles are on', () => {
+    // applyStopEventAttributeToggles applies each toggle as a separate
+    // narrowing step, so the result is the AND of both. The selector
+    // must propagate that intersection through to `filtered` and have
+    // `filteredCounts` reflect the post-AND tally.
+    const stop = makeStopWithContext(
+      's',
+      [3],
+      [
+        // (a) origin + boardable middle-style -> KEEP
+        makeEntry({ isOrigin: true, isTerminal: false, pickupType: 0 }),
+        // (b) origin + non-boardable -> drops (boardable filter)
+        makeEntry({ isOrigin: true, isTerminal: false, pickupType: 1 }),
+        // (c) middle + boardable -> drops (origin filter)
+        makeEntry({ isOrigin: false, isTerminal: false, pickupType: 0 }),
+        // (d) terminal + boardable -> drops (origin filter; isOrigin=false)
+        makeEntry({ isOrigin: false, isTerminal: true, pickupType: 0 }),
+      ],
+    );
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [stop],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: true,
+      showBoardableOnly: true,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered).toHaveLength(1);
+    expect(result.filtered[0].stopTimes).toHaveLength(1);
+    const survivor = result.filtered[0].stopTimes[0];
+    expect(survivor.patternPosition.isOrigin).toBe(true);
+    expect(survivor.boarding.pickupType).toBe(0);
+
+    // rawCounts is pre-globalFilter -- still sees the whole entry list
+    // (1 stop, originCount=1 since the stop has at least one origin
+    // entry, boardableCount=1 since at least one boardable entry exists).
+    expect(result.rawCounts.total).toBe(1);
+    expect(result.rawCounts.originCount).toBe(1);
+    expect(result.rawCounts.boardableCount).toBe(1);
+
+    // filteredCounts is post-globalFilter; still 1 stop because we did
+    // not enable omitEmptyStops, and the remaining entry is both an
+    // origin and boardable so all per-attribute counts are 1.
+    expect(result.filteredCounts.total).toBe(1);
+    expect(result.filteredCounts.originCount).toBe(1);
+    expect(result.filteredCounts.boardableCount).toBe(1);
+  });
+
+  it('returns drop-off-only state when every pre-globalFilter entry is drop-off-only', () => {
+    // Two drop-off-only entries via two different signals:
+    //   - explicit pickupType=1
+    //   - pattern inference (isTerminal=true), which the state helper
+    //     also classifies as drop-off-only.
+    const stop = makeStopWithContext(
+      'dropoff',
+      [3],
+      [
+        makeEntry({ isOrigin: false, isTerminal: false, pickupType: 1 }),
+        makeEntry({ isOrigin: false, isTerminal: true, pickupType: 0 }),
+      ],
+    );
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [stop],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.timetableEntriesStateByStopId.get('dropoff')).toBe('drop-off-only');
+  });
+
+  it('produces a new stop object when toggles transform its stopTimes (does not mutate input)', () => {
+    // With showOriginOnly on, `applyStopEventAttributeTogglesToStops`
+    // produces a fresh outer object whose `stopTimes` is the narrowed
+    // entry array. The wrapper must NOT be the same reference as the
+    // input -- that would mean we mutated input -- but the inner `stop`
+    // object should pass through by reference (we only swapped
+    // stopTimes).
+    const inputStopTimes = [
+      makeEntry({ isOrigin: true, pickupType: 0 }),
+      makeEntry({ isOrigin: false, pickupType: 0 }),
+    ];
+    const inputWrapper = makeStopWithContext('s', [3], inputStopTimes);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [inputWrapper],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: true,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered[0]).not.toBe(inputWrapper);
+    expect(result.filtered[0].stop).toBe(inputWrapper.stop);
+    // The input must not have been mutated.
+    expect(inputWrapper.stopTimes).toBe(inputStopTimes);
+    expect(inputWrapper.stopTimes).toHaveLength(2);
+  });
+
+  it('reports every count field consistently across a realistic mixed-stop scenario', () => {
+    // Five stops covering every classification the selector deals with:
+    //   - dropped pre-filter (route type out of `enabledRouteTypes`)
+    //   - origin + boardable
+    //   - middle + boardable
+    //   - drop-off-only (isTerminal=true) -> not boardable
+    //   - empty stopTimes -> no service
+    const subwayOnly = makeStopWithContext(
+      'subway-only',
+      [1],
+      [makeEntry({ isOrigin: true, pickupType: 0 })],
+    );
+    const originBoardable = makeStopWithContext(
+      'origin-boardable',
+      [3],
+      [makeEntry({ isOrigin: true, isTerminal: false, pickupType: 0 })],
+    );
+    const middleBoardable = makeStopWithContext(
+      'middle-boardable',
+      [3],
+      [makeEntry({ isOrigin: false, isTerminal: false, pickupType: 0 })],
+    );
+    const dropOffOnly = makeStopWithContext(
+      'drop-off-only',
+      [3],
+      [makeEntry({ isOrigin: false, isTerminal: true, pickupType: 0 })],
+    );
+    const noService = makeStopWithContext('no-service', [3], []);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [subwayOnly, originBoardable, middleBoardable, dropOffOnly, noService],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: false,
+      showBoardableOnly: true,
+      omitEmptyStops: true,
+    });
+
+    // rawCounts: post-routeType, pre-globalFilter. The subway-only
+    // stop is dropped; the four bus stops remain. nonEmpty excludes
+    // `no-service`. originCount counts only `origin-boardable`.
+    // boardableCount counts stops with >=1 boardable entry: the two
+    // boardable ones; `drop-off-only` and `no-service` are excluded.
+    expect(result.rawCounts).toEqual({
+      total: 4,
+      nonEmpty: 3,
+      originCount: 1,
+      boardableCount: 2,
+    });
+
+    // filteredCounts: showBoardableOnly removes the entries inside
+    // `drop-off-only`, which then becomes empty. omitEmptyStops then
+    // drops both `drop-off-only` (newly empty) and `no-service`
+    // (always empty). `origin-boardable` + `middle-boardable` remain.
+    expect(result.filteredCounts).toEqual({
+      total: 2,
+      nonEmpty: 2,
+      originCount: 1,
+      boardableCount: 2,
+    });
+
+    // Filtered list reflects the same two stops in input order.
+    expect(result.filtered.map((s) => s.stop.stop_id)).toEqual([
+      'origin-boardable',
+      'middle-boardable',
+    ]);
+
+    // State map snapshots the pre-globalFilter tier for all four
+    // route-type-matched stops; subway-only must not appear.
+    expect(result.timetableEntriesStateByStopId.has('subway-only')).toBe(false);
+    expect(result.timetableEntriesStateByStopId.get('origin-boardable')).toBe('boardable');
+    expect(result.timetableEntriesStateByStopId.get('middle-boardable')).toBe('boardable');
+    expect(result.timetableEntriesStateByStopId.get('drop-off-only')).toBe('drop-off-only');
+    expect(result.timetableEntriesStateByStopId.get('no-service')).toBe('no-service');
   });
 
   it('omits stops whose stopTimes become empty when omitEmptyStops is true', () => {
@@ -201,7 +381,7 @@ describe('deriveFilteredNearbyStops', () => {
 
     expect(result.filtered).toHaveLength(1);
     expect(result.filtered[0].stop.stop_id).toBe('full');
-    // rawCounts still sees both — it's pre-omit.
+    // rawCounts still sees both -- it's pre-omit.
     expect(result.rawCounts.total).toBe(2);
     expect(result.filteredCounts.total).toBe(1);
   });
@@ -297,6 +477,62 @@ describe('deriveFilteredNearbyStops', () => {
     expect(result.timetableEntriesStateByStopId.size).toBe(0);
     expect(result.rawCounts.total).toBe(0);
     expect(result.filteredCounts.total).toBe(0);
+  });
+
+  it('drops every stop when the entire input falls outside enabledRouteTypes', () => {
+    // Operational scenario: the user opens an area where every nearby
+    // stop is a non-bus mode (e.g. only subway / train stops near a
+    // hub) while their settings have those modes off. Every stop must
+    // disappear from filtered / counts / state map, and the result
+    // shape must still be valid (empty Map, zeroed counts).
+    const subwayStop = makeStopWithContext('subway', [1], [makeEntry()]);
+    const trainStop = makeStopWithContext('train', [2], [makeEntry()]);
+    const ferryStop = makeStopWithContext('ferry', [4], [makeEntry()]);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [subwayStop, trainStop, ferryStop],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered).toEqual([]);
+    expect(result.timetableEntriesStateByStopId.size).toBe(0);
+    expect(result.rawCounts).toEqual({ total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 });
+    expect(result.filteredCounts).toEqual({
+      total: 0,
+      nonEmpty: 0,
+      originCount: 0,
+      boardableCount: 0,
+    });
+  });
+
+  it('drops every stop when enabledRouteTypes is an empty set', () => {
+    // Operational scenario: the user has deselected every entry under
+    // the route-type filter, so settings.visibleStopTypes is empty.
+    // The selector must treat this as "nothing is enabled" rather than
+    // "everything is enabled" -- `some()` over an empty set is false.
+    const busStop = makeStopWithContext('bus', [3], [makeEntry()]);
+    const subwayStop = makeStopWithContext('subway', [1], [makeEntry()]);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [busStop, subwayStop],
+      enabledRouteTypes: new Set<number>(),
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered).toEqual([]);
+    expect(result.timetableEntriesStateByStopId.size).toBe(0);
+    expect(result.rawCounts).toEqual({ total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 });
+    expect(result.filteredCounts).toEqual({
+      total: 0,
+      nonEmpty: 0,
+      originCount: 0,
+      boardableCount: 0,
+    });
   });
 
   it('returns the same stops list reference when no filter touches it', () => {

--- a/src/domain/transit/__tests__/derive-filtered-nearby-stops.test.ts
+++ b/src/domain/transit/__tests__/derive-filtered-nearby-stops.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AppRouteTypeValue } from '../../../types/app/transit';
+import type { ContextualTimetableEntry, StopWithContext } from '../../../types/app/transit-composed';
+import { deriveFilteredNearbyStops } from '../derive-filtered-nearby-stops';
+
+function makeEntry(
+  overrides: {
+    isOrigin?: boolean;
+    isTerminal?: boolean;
+    pickupType?: 0 | 1 | 2 | 3;
+  } = {},
+): ContextualTimetableEntry {
+  return {
+    schedule: { departureMinutes: 480, arrivalMinutes: 480 },
+    routeDirection: {
+      route: {
+        route_id: 'route-1',
+        route_type: 3,
+        agency_id: 'agency-1',
+        route_short_name: '1',
+        route_short_names: {},
+        route_long_name: 'Route 1',
+        route_long_names: {},
+        route_color: '000000',
+        route_text_color: 'FFFFFF',
+      },
+      tripHeadsign: { name: 'Terminal', names: {} },
+    },
+    boarding: { pickupType: overrides.pickupType ?? 0, dropOffType: 0 },
+    patternPosition: {
+      stopIndex: 0,
+      totalStops: 3,
+      isOrigin: overrides.isOrigin ?? false,
+      isTerminal: overrides.isTerminal ?? false,
+    },
+    tripLocator: { patternId: 'pattern-1', serviceId: 'svc-1', tripIndex: 0 },
+    serviceDate: new Date('2026-01-01'),
+  } as ContextualTimetableEntry;
+}
+
+function makeStopWithContext(
+  stopId: string,
+  routeTypes: AppRouteTypeValue[],
+  stopTimes: ContextualTimetableEntry[],
+): StopWithContext {
+  return {
+    stop: {
+      stop_id: stopId,
+      stop_name: stopId,
+      stop_names: {},
+      stop_lat: 35,
+      stop_lon: 139,
+      agency_id: 'agency-1',
+      // The narrow type asserts the rest as well; cast keeps the test
+      // setup short while still exercising the selector.
+    } as StopWithContext['stop'],
+    routeTypes,
+    stopTimes,
+    stopServiceState: stopTimes.length === 0 ? 'no-service' : 'boardable',
+    agencies: [],
+    routes: [],
+  };
+}
+
+const ENABLED_BUS: ReadonlySet<number> = new Set([3]);
+const ENABLED_BUS_TRAIN: ReadonlySet<number> = new Set([3, 2]);
+const ENABLED_SUBWAY: ReadonlySet<number> = new Set([1]);
+
+describe('deriveFilteredNearbyStops', () => {
+  it('returns empty result for empty input', () => {
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered).toEqual([]);
+    expect(result.timetableEntriesStateByStopId.size).toBe(0);
+    expect(result.rawCounts).toEqual({ total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 });
+    expect(result.filteredCounts).toEqual({
+      total: 0,
+      nonEmpty: 0,
+      originCount: 0,
+      boardableCount: 0,
+    });
+  });
+
+  it('drops stops whose routeTypes do not intersect with enabledRouteTypes', () => {
+    const busStop = makeStopWithContext('bus', [3], [makeEntry()]);
+    const subwayStop = makeStopWithContext('subway', [1], [makeEntry()]);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [busStop, subwayStop],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered).toHaveLength(1);
+    expect(result.filtered[0].stop.stop_id).toBe('bus');
+    expect(result.timetableEntriesStateByStopId.has('bus')).toBe(true);
+    expect(result.timetableEntriesStateByStopId.has('subway')).toBe(false);
+    expect(result.rawCounts.total).toBe(1);
+    expect(result.filteredCounts.total).toBe(1);
+  });
+
+  it('keeps a stop when any of its routeTypes is enabled', () => {
+    // Multi-modal stop: bus + train. Enabling only train still keeps
+    // the stop because `some` is the matching rule.
+    const multiModalStop = makeStopWithContext('hub', [3, 2], [makeEntry()]);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [multiModalStop],
+      enabledRouteTypes: new Set([2]),
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered).toHaveLength(1);
+    expect(result.filtered[0].stop.stop_id).toBe('hub');
+  });
+
+  it('builds timetableEntriesStateByStopId from the pre-globalFilter (route-type-filtered) list', () => {
+    // Origin-only filter would hide everything for this stop, but the
+    // state map must still reflect the pre-globalFilter state so the
+    // UI can distinguish "filter-hidden" from "no-service".
+    const stop = makeStopWithContext('s', [3], [makeEntry({ isOrigin: false, pickupType: 0 })]);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [stop],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: true,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.timetableEntriesStateByStopId.get('s')).toBe('boardable');
+    // But the filtered list is empty (no origin entries after the toggle).
+    expect(result.filtered[0].stopTimes).toHaveLength(0);
+  });
+
+  it('narrows entries with showOriginOnly while keeping the stop in the list', () => {
+    const stop = makeStopWithContext(
+      's',
+      [3],
+      [makeEntry({ isOrigin: true, pickupType: 0 }), makeEntry({ isOrigin: false, pickupType: 0 })],
+    );
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [stop],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: true,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered).toHaveLength(1);
+    expect(result.filtered[0].stopTimes).toHaveLength(1);
+    expect(result.filtered[0].stopTimes[0].patternPosition.isOrigin).toBe(true);
+  });
+
+  it('narrows entries with showBoardableOnly by pickup type and pattern position', () => {
+    const stop = makeStopWithContext(
+      's',
+      [3],
+      [
+        makeEntry({ isOrigin: false, isTerminal: false, pickupType: 0 }), // boardable middle
+        makeEntry({ isOrigin: false, isTerminal: true, pickupType: 0 }), // pure terminal — drops
+        makeEntry({ isOrigin: true, pickupType: 1 }), // non-boardable origin — drops
+      ],
+    );
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [stop],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: false,
+      showBoardableOnly: true,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered).toHaveLength(1);
+    expect(result.filtered[0].stopTimes).toHaveLength(1);
+  });
+
+  it('omits stops whose stopTimes become empty when omitEmptyStops is true', () => {
+    const emptyStop = makeStopWithContext('empty', [3], []);
+    const populatedStop = makeStopWithContext('full', [3], [makeEntry({ pickupType: 0 })]);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [emptyStop, populatedStop],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: true,
+    });
+
+    expect(result.filtered).toHaveLength(1);
+    expect(result.filtered[0].stop.stop_id).toBe('full');
+    // rawCounts still sees both — it's pre-omit.
+    expect(result.rawCounts.total).toBe(2);
+    expect(result.filteredCounts.total).toBe(1);
+  });
+
+  it('keeps empty-stopTimes stops when omitEmptyStops is false', () => {
+    const emptyStop = makeStopWithContext('empty', [3], []);
+    const populatedStop = makeStopWithContext('full', [3], [makeEntry({ pickupType: 0 })]);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [emptyStop, populatedStop],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered).toHaveLength(2);
+    expect(result.filtered.map((s) => s.stop.stop_id)).toEqual(['empty', 'full']);
+  });
+
+  it('reports rawCounts pre-globalFilter and filteredCounts post-globalFilter', () => {
+    const originBoardable = makeStopWithContext(
+      'origin',
+      [3],
+      [makeEntry({ isOrigin: true, pickupType: 0 })],
+    );
+    const middleBoardable = makeStopWithContext(
+      'middle',
+      [3],
+      [makeEntry({ isOrigin: false, pickupType: 0 })],
+    );
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [originBoardable, middleBoardable],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: true,
+      showBoardableOnly: false,
+      omitEmptyStops: true,
+    });
+
+    // rawCounts: both stops counted, route-type filter only.
+    expect(result.rawCounts.total).toBe(2);
+    expect(result.rawCounts.originCount).toBe(1);
+    // filteredCounts: only the origin stop survives the globalFilter + omit.
+    expect(result.filteredCounts.total).toBe(1);
+    expect(result.filteredCounts.originCount).toBe(1);
+  });
+
+  it('returns no-service state for stops with empty stopTimes pre-filter', () => {
+    const emptyStop = makeStopWithContext('empty', [3], []);
+    const populatedStop = makeStopWithContext('full', [3], [makeEntry()]);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [emptyStop, populatedStop],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.timetableEntriesStateByStopId.get('empty')).toBe('no-service');
+    expect(result.timetableEntriesStateByStopId.get('full')).toBe('boardable');
+  });
+
+  it('preserves input order through the filter pipeline', () => {
+    const a = makeStopWithContext('a', [3], [makeEntry()]);
+    const b = makeStopWithContext('b', [2], [makeEntry()]);
+    const c = makeStopWithContext('c', [3], [makeEntry()]);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [a, b, c],
+      enabledRouteTypes: ENABLED_BUS_TRAIN,
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered.map((s) => s.stop.stop_id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns an empty result when no route type is enabled', () => {
+    const stop = makeStopWithContext('s', [3], [makeEntry()]);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [stop],
+      enabledRouteTypes: ENABLED_SUBWAY,
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered).toEqual([]);
+    expect(result.timetableEntriesStateByStopId.size).toBe(0);
+    expect(result.rawCounts.total).toBe(0);
+    expect(result.filteredCounts.total).toBe(0);
+  });
+
+  it('returns the same stops list reference when no filter touches it', () => {
+    // When all globalFilter toggles are off and omitEmptyStops is false,
+    // applyStopEventAttributeTogglesToStops returns its input unchanged,
+    // so `filtered` should be the route-type-filtered slice directly.
+    // The element references themselves must be preserved.
+    const stop = makeStopWithContext('s', [3], [makeEntry()]);
+
+    const result = deriveFilteredNearbyStops({
+      nearbyStopTimes: [stop],
+      enabledRouteTypes: ENABLED_BUS,
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+    });
+
+    expect(result.filtered[0]).toBe(stop);
+  });
+});

--- a/src/domain/transit/__tests__/timetable-message.test.ts
+++ b/src/domain/transit/__tests__/timetable-message.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TimetableOpenOutcomeStatus } from '../timetable-message';
+import { getTimetableOpenOutcomeMessage } from '../timetable-message';
+
+describe('getTimetableOpenOutcomeMessage', () => {
+  it('returns no message for silent statuses', () => {
+    expect(getTimetableOpenOutcomeMessage('opened')).toBeNull();
+    expect(getTimetableOpenOutcomeMessage('cancelled')).toBeNull();
+  });
+
+  it('returns a warning for an unknown stop', () => {
+    expect(getTimetableOpenOutcomeMessage('not-found')).toEqual({
+      severity: 'warning',
+      messageKey: 'timetable.messages.stopNotFound',
+    });
+  });
+
+  it('returns a warning for a route missing at the stop', () => {
+    expect(getTimetableOpenOutcomeMessage('route-not-found')).toEqual({
+      severity: 'warning',
+      messageKey: 'timetable.messages.routeNotFound',
+    });
+  });
+
+  it('returns an error for open failures', () => {
+    expect(getTimetableOpenOutcomeMessage('error')).toEqual({
+      severity: 'error',
+      messageKey: 'timetable.messages.openFailed',
+    });
+  });
+
+  it('covers every TimetableOpenOutcomeStatus via exhaustive switch', () => {
+    const statuses: TimetableOpenOutcomeStatus[] = [
+      'opened',
+      'cancelled',
+      'not-found',
+      'route-not-found',
+      'error',
+    ];
+
+    for (const status of statuses) {
+      const message = getTimetableOpenOutcomeMessage(status);
+      expect(message === null || message.messageKey.startsWith('timetable.messages.')).toBe(true);
+    }
+  });
+});

--- a/src/domain/transit/__tests__/trip-inspection-message.test.ts
+++ b/src/domain/transit/__tests__/trip-inspection-message.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import type { TripInspectionNoDataReason } from '../../../types/app/repository';
-import { getTripInspectionNoDataMessageKey } from '../trip-inspection-message';
+import {
+  getTripInspectionNoDataMessageKey,
+  getTripInspectionOpenOutcomeMessage,
+} from '../trip-inspection-message';
 
 describe('getTripInspectionNoDataMessageKey', () => {
   it('returns the stop-data key for the no-stop-data reason', () => {
@@ -45,5 +48,31 @@ describe('getTripInspectionNoDataMessageKey', () => {
       const key = getTripInspectionNoDataMessageKey(reason);
       expect(key).toMatch(/^tripInspection\.messages\./);
     }
+  });
+});
+
+describe('getTripInspectionOpenOutcomeMessage', () => {
+  it('returns no message for silent statuses', () => {
+    expect(getTripInspectionOpenOutcomeMessage({ status: 'opened' })).toBeNull();
+    expect(getTripInspectionOpenOutcomeMessage({ status: 'cancelled' })).toBeNull();
+  });
+
+  it('returns a warning for no-data outcomes', () => {
+    expect(
+      getTripInspectionOpenOutcomeMessage({
+        status: 'no-data',
+        reason: 'no-service-on-this-day',
+      }),
+    ).toEqual({
+      severity: 'warning',
+      messageKey: 'tripInspection.messages.noServiceOnThisDay',
+    });
+  });
+
+  it('returns an error for open failures', () => {
+    expect(getTripInspectionOpenOutcomeMessage({ status: 'error' })).toEqual({
+      severity: 'error',
+      messageKey: 'tripInspection.messages.openFailed',
+    });
   });
 });

--- a/src/domain/transit/__tests__/trip-inspection-message.test.ts
+++ b/src/domain/transit/__tests__/trip-inspection-message.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TripInspectionNoDataReason } from '../../../types/app/repository';
+import { getTripInspectionNoDataMessageKey } from '../trip-inspection-message';
+
+describe('getTripInspectionNoDataMessageKey', () => {
+  it('returns the stop-data key for the no-stop-data reason', () => {
+    expect(getTripInspectionNoDataMessageKey('no-stop-data')).toBe(
+      'tripInspection.messages.noStopData',
+    );
+  });
+
+  it('returns the no-service key for the no-service-on-this-day reason', () => {
+    expect(getTripInspectionNoDataMessageKey('no-service-on-this-day')).toBe(
+      'tripInspection.messages.noServiceOnThisDay',
+    );
+  });
+
+  it('collapses snapshot-unavailable to the generic noData key', () => {
+    expect(getTripInspectionNoDataMessageKey('snapshot-unavailable')).toBe(
+      'tripInspection.messages.noData',
+    );
+  });
+
+  it('collapses target-missing to the generic noData key', () => {
+    expect(getTripInspectionNoDataMessageKey('target-missing')).toBe(
+      'tripInspection.messages.noData',
+    );
+  });
+
+  it('covers every TripInspectionNoDataReason via exhaustive switch (compile-time guard)', () => {
+    // Runtime sanity: iterating over the literal union ensures every
+    // member produces a non-empty key. If a new reason is added to
+    // the union without a matching case, the switch in the helper
+    // is non-exhaustive and TypeScript fails to compile this file,
+    // because the helper's return type is `string` but the missing
+    // branch makes it `string | undefined`.
+    const reasons: TripInspectionNoDataReason[] = [
+      'no-stop-data',
+      'no-service-on-this-day',
+      'snapshot-unavailable',
+      'target-missing',
+    ];
+    for (const reason of reasons) {
+      const key = getTripInspectionNoDataMessageKey(reason);
+      expect(key).toMatch(/^tripInspection\.messages\./);
+    }
+  });
+});

--- a/src/domain/transit/derive-filtered-nearby-stops.ts
+++ b/src/domain/transit/derive-filtered-nearby-stops.ts
@@ -47,7 +47,7 @@ export interface DeriveFilteredNearbyStopsResult {
   /**
    * Per-stop `TimetableEntriesState` snapshot taken from the
    * pre-globalFilter list (route-type filter only). The pre-filter
-   * base is intentional — it lets consumers distinguish
+   * base is intentional -- it lets consumers distinguish
    * `filter-hidden` (entries existed pre-globalFilter, removed by
    * user toggles) from `no-service` (no entries at all). Computing
    * this against the post-globalFilter list would collapse those two

--- a/src/domain/transit/derive-filtered-nearby-stops.ts
+++ b/src/domain/transit/derive-filtered-nearby-stops.ts
@@ -1,0 +1,114 @@
+import type { StopsCounts } from '../../types/app/stop';
+import type { TimetableEntriesState } from '../../types/app/transit';
+import type { StopWithContext } from '../../types/app/transit-composed';
+
+import { computeStopsCounts } from './compute-stops-counts';
+import {
+  applyStopEventAttributeTogglesToStops,
+  omitStopsWithoutStopTimes,
+} from './timetable-filter';
+import { getTimetableEntriesState } from './timetable-utils';
+
+/**
+ * Inputs to {@link deriveFilteredNearbyStops}.
+ */
+export interface DeriveFilteredNearbyStopsInput {
+  /** Latest fetched stop-time list for nearby stops. */
+  nearbyStopTimes: readonly StopWithContext[];
+  /**
+   * Route-type filter from user settings (`visibleStopTypes`).
+   * A stop is kept when any of its `routeTypes` is in this set.
+   */
+  enabledRouteTypes: ReadonlySet<number>;
+  /** App-wide toggle: keep only entries that are an origin trip. */
+  showOriginOnly: boolean;
+  /** App-wide toggle: keep only boardable entries. */
+  showBoardableOnly: boolean;
+  /**
+   * Effective empty-stop omit policy. Already merged from the user's
+   * explicit override, the late-night default, and the
+   * `showOriginOnly` / `showBoardableOnly` "force" rule by the caller.
+   */
+  omitEmptyStops: boolean;
+}
+
+/**
+ * Result of {@link deriveFilteredNearbyStops}. All fields are fresh
+ * objects on every call; wrap the call in `useMemo` at the call site
+ * so unchanged inputs produce stable references for downstream memos.
+ */
+export interface DeriveFilteredNearbyStopsResult {
+  /**
+   * Final visible list: route-type filter + origin/boardable filter +
+   * empty-stop omit policy applied. Rendered to MapView and the
+   * bottom sheet.
+   */
+  filtered: StopWithContext[];
+  /**
+   * Per-stop `TimetableEntriesState` snapshot taken from the
+   * pre-globalFilter list (route-type filter only). The pre-filter
+   * base is intentional — it lets consumers distinguish
+   * `filter-hidden` (entries existed pre-globalFilter, removed by
+   * user toggles) from `no-service` (no entries at all). Computing
+   * this against the post-globalFilter list would collapse those two
+   * states.
+   */
+  timetableEntriesStateByStopId: Map<string, TimetableEntriesState>;
+  /**
+   * Counts BEFORE the app-wide origin / boardable / empty filters
+   * (route-type filter applied only). Used by chrome that surfaces
+   * "total stops matching settings at this zoom".
+   */
+  rawCounts: StopsCounts;
+  /**
+   * Counts AFTER all filters are applied. Used by chrome that
+   * surfaces "stops currently displayed".
+   */
+  filteredCounts: StopsCounts;
+}
+
+/**
+ * Pure selector that derives the final visible nearby-stop state from
+ * `nearbyStopTimes` + user settings + app-wide filter toggles.
+ * Replaces a chain of `useMemo` blocks previously inlined in
+ * `app.tsx`. Steps, in order:
+ *
+ * 1. route-type filter (user settings)
+ * 2. `TimetableEntriesState` snapshot of the pre-globalFilter list
+ * 3. origin / boardable filter (app-wide globalFilter)
+ * 4. empty-stop omit policy (late-night default / explicit override /
+ *    forced when origin or boardable is on)
+ * 5. counts at the pre-filter and post-filter stages
+ *
+ * The function returns a fresh object on every call; identity stability
+ * is the caller's responsibility (wrap in `useMemo`).
+ */
+export function deriveFilteredNearbyStops(
+  input: DeriveFilteredNearbyStopsInput,
+): DeriveFilteredNearbyStopsResult {
+  const { nearbyStopTimes, enabledRouteTypes, showOriginOnly, showBoardableOnly, omitEmptyStops } =
+    input;
+
+  const routeTypesFiltered = nearbyStopTimes.filter((swc) =>
+    swc.routeTypes.some((rt) => enabledRouteTypes.has(rt)),
+  );
+
+  const timetableEntriesStateByStopId = new Map<string, TimetableEntriesState>();
+  for (const swc of routeTypesFiltered) {
+    timetableEntriesStateByStopId.set(swc.stop.stop_id, getTimetableEntriesState(swc.stopTimes));
+  }
+
+  const stopEventAttributesApplied = applyStopEventAttributeTogglesToStops(routeTypesFiltered, {
+    showOriginOnly,
+    showBoardableOnly,
+  });
+
+  const filtered = omitEmptyStops
+    ? omitStopsWithoutStopTimes(stopEventAttributesApplied)
+    : stopEventAttributesApplied;
+
+  const rawCounts = computeStopsCounts(routeTypesFiltered);
+  const filteredCounts = computeStopsCounts(filtered);
+
+  return { filtered, timetableEntriesStateByStopId, rawCounts, filteredCounts };
+}

--- a/src/domain/transit/timetable-message.ts
+++ b/src/domain/transit/timetable-message.ts
@@ -1,0 +1,40 @@
+export interface TimetableOpenOutcomeMessage {
+  severity: 'warning' | 'error';
+  messageKey: string;
+}
+
+export type TimetableOpenOutcomeStatus =
+  | 'opened'
+  | 'cancelled'
+  | 'not-found'
+  | 'route-not-found'
+  | 'error';
+
+/**
+ * Convert a timetable open outcome status into the toast message that should be
+ * shown by the UI. Opened and cancelled outcomes are intentionally silent.
+ */
+export function getTimetableOpenOutcomeMessage(
+  status: TimetableOpenOutcomeStatus,
+): TimetableOpenOutcomeMessage | null {
+  switch (status) {
+    case 'opened':
+    case 'cancelled':
+      return null;
+    case 'not-found':
+      return {
+        severity: 'warning',
+        messageKey: 'timetable.messages.stopNotFound',
+      };
+    case 'route-not-found':
+      return {
+        severity: 'warning',
+        messageKey: 'timetable.messages.routeNotFound',
+      };
+    case 'error':
+      return {
+        severity: 'error',
+        messageKey: 'timetable.messages.openFailed',
+      };
+  }
+}

--- a/src/domain/transit/trip-inspection-message.ts
+++ b/src/domain/transit/trip-inspection-message.ts
@@ -1,0 +1,28 @@
+import type { TripInspectionNoDataReason } from '../../types/app/repository';
+
+/**
+ * Map a trip-inspection `no-data` reason to its i18n message key.
+ *
+ * The repository-level reasons (`'no-stop-data'`,
+ * `'no-service-on-this-day'`) get dedicated keys so the UI can show
+ * the specific cause. The hook-only reasons
+ * (`'snapshot-unavailable'`, `'target-missing'`) collapse to the
+ * generic `noData` key because the user-visible distinction is the
+ * same: "we could not open trip inspection here".
+ *
+ * Toast firing (`toast.warning(t(key))`) and the `'error'` branch of
+ * the open outcome remain at the call site, per the Phase 3 plan to
+ * keep status->key as pure data while wording assembly stays in UI
+ * code.
+ */
+export function getTripInspectionNoDataMessageKey(reason: TripInspectionNoDataReason): string {
+  switch (reason) {
+    case 'no-stop-data':
+      return 'tripInspection.messages.noStopData';
+    case 'no-service-on-this-day':
+      return 'tripInspection.messages.noServiceOnThisDay';
+    case 'snapshot-unavailable':
+    case 'target-missing':
+      return 'tripInspection.messages.noData';
+  }
+}

--- a/src/domain/transit/trip-inspection-message.ts
+++ b/src/domain/transit/trip-inspection-message.ts
@@ -1,5 +1,19 @@
 import type { TripInspectionNoDataReason } from '../../types/app/repository';
 
+export interface TripInspectionOpenOutcomeMessage {
+  severity: 'warning' | 'error';
+  messageKey: string;
+}
+
+export type TripInspectionOpenOutcomeMessageInput =
+  | { status: 'opened' }
+  | { status: 'cancelled' }
+  | { status: 'error' }
+  | {
+      status: 'no-data';
+      reason: TripInspectionNoDataReason;
+    };
+
 /**
  * Map a trip-inspection `no-data` reason to its i18n message key.
  *
@@ -10,10 +24,8 @@ import type { TripInspectionNoDataReason } from '../../types/app/repository';
  * generic `noData` key because the user-visible distinction is the
  * same: "we could not open trip inspection here".
  *
- * Toast firing (`toast.warning(t(key))`) and the `'error'` branch of
- * the open outcome remain at the call site, per the Phase 3 plan to
- * keep status->key as pure data while wording assembly stays in UI
- * code.
+ * Toast firing remains at the call site, per the Phase 3 plan to keep
+ * status-to-message mapping as pure data while UI effects stay in UI code.
  */
 export function getTripInspectionNoDataMessageKey(reason: TripInspectionNoDataReason): string {
   switch (reason) {
@@ -24,5 +36,29 @@ export function getTripInspectionNoDataMessageKey(reason: TripInspectionNoDataRe
     case 'snapshot-unavailable':
     case 'target-missing':
       return 'tripInspection.messages.noData';
+  }
+}
+
+/**
+ * Convert a trip-inspection open outcome into the toast message that should be
+ * shown by the UI. Opened and cancelled outcomes are intentionally silent.
+ */
+export function getTripInspectionOpenOutcomeMessage(
+  outcome: TripInspectionOpenOutcomeMessageInput,
+): TripInspectionOpenOutcomeMessage | null {
+  switch (outcome.status) {
+    case 'opened':
+    case 'cancelled':
+      return null;
+    case 'no-data':
+      return {
+        severity: 'warning',
+        messageKey: getTripInspectionNoDataMessageKey(outcome.reason),
+      };
+    case 'error':
+      return {
+        severity: 'error',
+        messageKey: 'tripInspection.messages.openFailed',
+      };
   }
 }

--- a/src/hooks/__tests__/use-stops-for-bounds.test.ts
+++ b/src/hooks/__tests__/use-stops-for-bounds.test.ts
@@ -1,0 +1,300 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PERF_PROFILES } from '../../config/perf-profiles';
+import type { Bounds, LatLng } from '../../types/app/map';
+import { makeRepo, makeStopMeta } from '../../__tests__/helpers';
+import { useStopsForBounds } from '../use-stops-for-bounds';
+
+const TEST_DEBOUNCE_MS = 50;
+
+const BOUNDS_A: Bounds = {
+  north: 35.7,
+  south: 35.6,
+  east: 139.8,
+  west: 139.7,
+};
+const CENTER_A: LatLng = { lat: 35.65, lng: 139.75 };
+
+const BOUNDS_B: Bounds = {
+  north: 35.5,
+  south: 35.4,
+  east: 139.6,
+  west: 139.5,
+};
+const CENTER_B: LatLng = { lat: 35.45, lng: 139.55 };
+
+describe('useStopsForBounds', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts with empty stops, null mapCenter, and hasNearbyLoaded=false', () => {
+    const repo = makeRepo();
+    const { result } = renderHook(() =>
+      useStopsForBounds({
+        repo,
+        perfProfile: PERF_PROFILES.lite,
+        debounceMs: TEST_DEBOUNCE_MS,
+      }),
+    );
+
+    expect(result.current.inBoundStops).toEqual([]);
+    expect(result.current.radiusStops).toEqual([]);
+    expect(result.current.mapCenter).toBeNull();
+    expect(result.current.hasNearbyLoaded).toBe(false);
+  });
+
+  it('updates mapCenter immediately without waiting for the debounce', () => {
+    const repo = makeRepo();
+    const { result } = renderHook(() =>
+      useStopsForBounds({
+        repo,
+        perfProfile: PERF_PROFILES.lite,
+        debounceMs: TEST_DEBOUNCE_MS,
+      }),
+    );
+
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+
+    // No timers advanced, debounce has not elapsed — but mapCenter is set.
+    expect(result.current.mapCenter).toEqual(CENTER_A);
+    expect(result.current.hasNearbyLoaded).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(repo.getStopsInBounds).not.toHaveBeenCalled();
+  });
+
+  it('commits stops and fires onStopsCommitted after the debounced fetch succeeds', async () => {
+    const stopA = makeStopMeta('inbound-a');
+    const stopB = makeStopMeta('nearby-b');
+    const repo = makeRepo({
+      getStopsInBounds: vi.fn().mockResolvedValue({
+        success: true,
+        data: [stopA],
+        truncated: false,
+      }),
+      getStopsNearby: vi.fn().mockResolvedValue({
+        success: true,
+        data: [stopB],
+        truncated: false,
+      }),
+    });
+    const onStopsCommitted = vi.fn();
+
+    const { result } = renderHook(() =>
+      useStopsForBounds({
+        repo,
+        perfProfile: PERF_PROFILES.lite,
+        onStopsCommitted,
+        debounceMs: TEST_DEBOUNCE_MS,
+      }),
+    );
+
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    expect(result.current.hasNearbyLoaded).toBe(true);
+    expect(result.current.inBoundStops).toEqual([stopA]);
+    expect(result.current.radiusStops).toEqual([stopB]);
+    expect(onStopsCommitted).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops stale responses so a slow old fetch cannot overwrite a fresh result', async () => {
+    const oldStop = makeStopMeta('old-stop');
+    const newStop = makeStopMeta('new-stop');
+
+    // Old request: stays pending until we resolve it manually.
+    let resolveOldInBounds!: () => void;
+    let resolveOldNearby!: () => void;
+    const oldInBoundsPromise = new Promise<{
+      success: true;
+      data: (typeof oldStop)[];
+      truncated: false;
+    }>((resolve) => {
+      resolveOldInBounds = () => {
+        resolve({ success: true, data: [oldStop], truncated: false });
+      };
+    });
+    const oldNearbyPromise = new Promise<{
+      success: true;
+      data: (typeof oldStop)[];
+      truncated: false;
+    }>((resolve) => {
+      resolveOldNearby = () => {
+        resolve({ success: true, data: [oldStop], truncated: false });
+      };
+    });
+
+    const getStopsInBounds = vi
+      .fn()
+      .mockReturnValueOnce(oldInBoundsPromise)
+      .mockResolvedValue({ success: true, data: [newStop], truncated: false });
+    const getStopsNearby = vi
+      .fn()
+      .mockReturnValueOnce(oldNearbyPromise)
+      .mockResolvedValue({ success: true, data: [newStop], truncated: false });
+
+    const repo = makeRepo({ getStopsInBounds, getStopsNearby });
+    const onStopsCommitted = vi.fn();
+
+    const { result } = renderHook(() =>
+      useStopsForBounds({
+        repo,
+        perfProfile: PERF_PROFILES.lite,
+        onStopsCommitted,
+        debounceMs: TEST_DEBOUNCE_MS,
+      }),
+    );
+
+    // First bounds change -> debounce -> issue OLD request (pending).
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    // Second bounds change -> debounce -> issue NEW request (resolves immediately).
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_B, CENTER_B);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    expect(result.current.hasNearbyLoaded).toBe(true);
+    expect(result.current.inBoundStops).toEqual([newStop]);
+    expect(result.current.radiusStops).toEqual([newStop]);
+    expect(onStopsCommitted).toHaveBeenCalledTimes(1);
+
+    // Now resolve the OLD request last. Stale-response guard must drop it.
+    await act(async () => {
+      resolveOldInBounds();
+      resolveOldNearby();
+      // Flush microtasks so the `.then` callback runs.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.inBoundStops).toEqual([newStop]);
+    expect(result.current.radiusStops).toEqual([newStop]);
+    expect(onStopsCommitted).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to empty arrays when the repo returns failed results', async () => {
+    const repo = makeRepo({
+      getStopsInBounds: vi.fn().mockResolvedValue({ success: false, error: 'boom-bounds' }),
+      getStopsNearby: vi.fn().mockResolvedValue({ success: false, error: 'boom-nearby' }),
+    });
+
+    const { result } = renderHook(() =>
+      useStopsForBounds({
+        repo,
+        perfProfile: PERF_PROFILES.lite,
+        debounceMs: TEST_DEBOUNCE_MS,
+      }),
+    );
+
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    expect(result.current.hasNearbyLoaded).toBe(true);
+    expect(result.current.inBoundStops).toEqual([]);
+    expect(result.current.radiusStops).toEqual([]);
+  });
+
+  it('passes nearbyRadius and maxResults from the active perfProfile to the repo', async () => {
+    const repo = makeRepo();
+
+    const { result } = renderHook(() =>
+      useStopsForBounds({
+        repo,
+        perfProfile: PERF_PROFILES.lite,
+        debounceMs: TEST_DEBOUNCE_MS,
+      }),
+    );
+
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    const { nearbyRadius, maxResults } = PERF_PROFILES.lite.data.stops;
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(repo.getStopsInBounds).toHaveBeenCalledWith(BOUNDS_A, maxResults);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(repo.getStopsNearby).toHaveBeenCalledWith(CENTER_A, nearbyRadius, maxResults);
+  });
+
+  it('coalesces rapid bounds changes within the debounce window into a single fetch', async () => {
+    const repo = makeRepo();
+
+    const { result } = renderHook(() =>
+      useStopsForBounds({
+        repo,
+        perfProfile: PERF_PROFILES.lite,
+        debounceMs: TEST_DEBOUNCE_MS,
+      }),
+    );
+
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    act(() => {
+      // Within the debounce window: must reset the timer, not enqueue a 2nd fetch.
+      result.current.handleBoundsChanged(BOUNDS_B, CENTER_B);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(repo.getStopsInBounds).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(repo.getStopsInBounds).toHaveBeenCalledWith(BOUNDS_B, expect.any(Number));
+    // mapCenter follows the most recent bounds change, regardless of debounce.
+    expect(result.current.mapCenter).toEqual(CENTER_B);
+  });
+
+  it('cancels the pending debounce on unmount so the fetch never fires', async () => {
+    const repo = makeRepo();
+
+    const { result, unmount } = renderHook(() =>
+      useStopsForBounds({
+        repo,
+        perfProfile: PERF_PROFILES.lite,
+        debounceMs: TEST_DEBOUNCE_MS,
+      }),
+    );
+
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS * 2);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(repo.getStopsInBounds).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/use-stops-for-bounds.test.ts
+++ b/src/hooks/__tests__/use-stops-for-bounds.test.ts
@@ -429,6 +429,212 @@ describe('useStopsForBounds', () => {
     expect(onStopsCommitted).not.toHaveBeenCalled();
   });
 
+  it('invalidates pending and in-flight requests when the perf profile changes', async () => {
+    const oldStop = makeStopMeta('old-stop');
+
+    let resolveOldInBounds!: () => void;
+    let resolveOldNearby!: () => void;
+    const oldInBoundsPromise = new Promise<{
+      success: true;
+      data: (typeof oldStop)[];
+      truncated: false;
+    }>((resolve) => {
+      resolveOldInBounds = () => {
+        resolve({ success: true, data: [oldStop], truncated: false });
+      };
+    });
+    const oldNearbyPromise = new Promise<{
+      success: true;
+      data: (typeof oldStop)[];
+      truncated: false;
+    }>((resolve) => {
+      resolveOldNearby = () => {
+        resolve({ success: true, data: [oldStop], truncated: false });
+      };
+    });
+
+    const repo = makeRepo({
+      getStopsInBounds: vi.fn().mockReturnValue(oldInBoundsPromise),
+      getStopsNearby: vi.fn().mockReturnValue(oldNearbyPromise),
+    });
+    const onStopsCommitted = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ perfProfile }) =>
+        useStopsForBounds({
+          repo,
+          perfProfile,
+          onStopsCommitted,
+          debounceMs: TEST_DEBOUNCE_MS,
+        }),
+      { initialProps: { perfProfile: PERF_PROFILES.lite } },
+    );
+
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    // Switch perf profile while the fetch is in flight. The
+    // invalidation effect must classify the pending response as stale.
+    rerender({ perfProfile: PERF_PROFILES.normal });
+
+    await act(async () => {
+      resolveOldInBounds();
+      resolveOldNearby();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.inBoundStops).toEqual([]);
+    expect(result.current.radiusStops).toEqual([]);
+    expect(result.current.hasNearbyLoaded).toBe(false);
+    expect(onStopsCommitted).not.toHaveBeenCalled();
+  });
+
+  it('treats a half-failed response as success on the succeeding side and empty on the failing side', async () => {
+    const stop = makeStopMeta('present');
+    const repoInBoundsFails = makeRepo({
+      getStopsInBounds: vi.fn().mockResolvedValue({ success: false, error: 'boom-bounds' }),
+      getStopsNearby: vi.fn().mockResolvedValue({ success: true, data: [stop], truncated: false }),
+    });
+
+    const { result, unmount } = renderHook(() =>
+      useStopsForBounds({
+        repo: repoInBoundsFails,
+        perfProfile: PERF_PROFILES.lite,
+        debounceMs: TEST_DEBOUNCE_MS,
+      }),
+    );
+
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    expect(result.current.inBoundStops).toEqual([]);
+    expect(result.current.radiusStops).toEqual([stop]);
+    expect(result.current.hasNearbyLoaded).toBe(true);
+
+    unmount();
+
+    // Reverse the failing side: nearby fails, bounds succeeds.
+    const repoNearbyFails = makeRepo({
+      getStopsInBounds: vi
+        .fn()
+        .mockResolvedValue({ success: true, data: [stop], truncated: false }),
+      getStopsNearby: vi.fn().mockResolvedValue({ success: false, error: 'boom-nearby' }),
+    });
+
+    const { result: result2 } = renderHook(() =>
+      useStopsForBounds({
+        repo: repoNearbyFails,
+        perfProfile: PERF_PROFILES.lite,
+        debounceMs: TEST_DEBOUNCE_MS,
+      }),
+    );
+
+    act(() => {
+      result2.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    expect(result2.current.inBoundStops).toEqual([stop]);
+    expect(result2.current.radiusStops).toEqual([]);
+    expect(result2.current.hasNearbyLoaded).toBe(true);
+  });
+
+  it('keeps handleBoundsChanged identity stable when only onStopsCommitted changes', () => {
+    const repo = makeRepo();
+
+    const { result, rerender } = renderHook(
+      ({ onStopsCommitted }) =>
+        useStopsForBounds({
+          repo,
+          perfProfile: PERF_PROFILES.lite,
+          onStopsCommitted,
+          debounceMs: TEST_DEBOUNCE_MS,
+        }),
+      { initialProps: { onStopsCommitted: vi.fn() } },
+    );
+
+    const initialHandler = result.current.handleBoundsChanged;
+
+    // Swap to a brand-new callback identity (the typical case when the
+    // caller does not memoize). The handler must NOT be re-created,
+    // because that would force MapView to re-bind its `onBoundsChanged`
+    // listener on every parent render.
+    rerender({ onStopsCommitted: vi.fn() });
+
+    expect(result.current.handleBoundsChanged).toBe(initialHandler);
+  });
+
+  it('routes onStopsCommitted through a ref so callback replacements take effect on the next commit', async () => {
+    const repo = makeRepo({
+      getStopsInBounds: vi.fn().mockResolvedValue({ success: true, data: [], truncated: false }),
+      getStopsNearby: vi.fn().mockResolvedValue({ success: true, data: [], truncated: false }),
+    });
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ onStopsCommitted }) =>
+        useStopsForBounds({
+          repo,
+          perfProfile: PERF_PROFILES.lite,
+          onStopsCommitted,
+          debounceMs: TEST_DEBOUNCE_MS,
+        }),
+      { initialProps: { onStopsCommitted: first } },
+    );
+
+    // Swap callbacks before any fetch fires. The hook reads the
+    // latest callback at commit time, so only `second` should run.
+    rerender({ onStopsCommitted: second });
+
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves mapCenter when repo or perfProfile changes invalidate in-flight requests', () => {
+    const repo = makeRepo();
+
+    const { result, rerender } = renderHook(
+      ({ perfProfile }) =>
+        useStopsForBounds({
+          repo,
+          perfProfile,
+          debounceMs: TEST_DEBOUNCE_MS,
+        }),
+      { initialProps: { perfProfile: PERF_PROFILES.lite } },
+    );
+
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    expect(result.current.mapCenter).toEqual(CENTER_A);
+
+    // Invalidation must clear pending fetches but leave the visible
+    // map center intact — the user's pan is independent of the data
+    // source they happen to be looking at.
+    rerender({ perfProfile: PERF_PROFILES.normal });
+
+    expect(result.current.mapCenter).toEqual(CENTER_A);
+  });
+
   it('cancels the pending debounce on unmount so the fetch never fires', async () => {
     const repo = makeRepo();
 

--- a/src/hooks/__tests__/use-stops-for-bounds.test.ts
+++ b/src/hooks/__tests__/use-stops-for-bounds.test.ts
@@ -273,6 +273,162 @@ describe('useStopsForBounds', () => {
     expect(result.current.mapCenter).toEqual(CENTER_B);
   });
 
+  it('drops an in-flight response when a newer bounds event arrives before the next fetch is even issued', async () => {
+    const oldStop = makeStopMeta('old-stop');
+    const newStop = makeStopMeta('new-stop');
+
+    // First call: stays pending until we resolve it manually so we can
+    // land its response strictly between bounds B's event and bounds
+    // B's debounced fetch dispatch.
+    let resolveOldInBounds!: () => void;
+    let resolveOldNearby!: () => void;
+    const oldInBoundsPromise = new Promise<{
+      success: true;
+      data: (typeof oldStop)[];
+      truncated: false;
+    }>((resolve) => {
+      resolveOldInBounds = () => {
+        resolve({ success: true, data: [oldStop], truncated: false });
+      };
+    });
+    const oldNearbyPromise = new Promise<{
+      success: true;
+      data: (typeof oldStop)[];
+      truncated: false;
+    }>((resolve) => {
+      resolveOldNearby = () => {
+        resolve({ success: true, data: [oldStop], truncated: false });
+      };
+    });
+
+    const getStopsInBounds = vi
+      .fn()
+      .mockReturnValueOnce(oldInBoundsPromise)
+      .mockResolvedValue({ success: true, data: [newStop], truncated: false });
+    const getStopsNearby = vi
+      .fn()
+      .mockReturnValueOnce(oldNearbyPromise)
+      .mockResolvedValue({ success: true, data: [newStop], truncated: false });
+
+    const repo = makeRepo({ getStopsInBounds, getStopsNearby });
+    const onStopsCommitted = vi.fn();
+
+    const { result } = renderHook(() =>
+      useStopsForBounds({
+        repo,
+        perfProfile: PERF_PROFILES.lite,
+        onStopsCommitted,
+        debounceMs: TEST_DEBOUNCE_MS,
+      }),
+    );
+
+    // First bounds change -> debounce expires -> OLD fetch issued (pending).
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    // Second bounds change arrives, but its debounced fetch has NOT
+    // been dispatched yet. The OLD response now resolves — the guard
+    // must still classify it as stale because a newer viewport has
+    // already been registered.
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_B, CENTER_B);
+    });
+    await act(async () => {
+      resolveOldInBounds();
+      resolveOldNearby();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.inBoundStops).toEqual([]);
+    expect(result.current.radiusStops).toEqual([]);
+    expect(result.current.hasNearbyLoaded).toBe(false);
+    expect(onStopsCommitted).not.toHaveBeenCalled();
+
+    // Let the second fetch run to completion to confirm the new result
+    // is committed normally.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    expect(result.current.inBoundStops).toEqual([newStop]);
+    expect(result.current.radiusStops).toEqual([newStop]);
+    expect(result.current.hasNearbyLoaded).toBe(true);
+    expect(onStopsCommitted).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates pending and in-flight requests when the repository changes', async () => {
+    const oldStop = makeStopMeta('old-stop');
+
+    let resolveOldInBounds!: () => void;
+    let resolveOldNearby!: () => void;
+    const oldInBoundsPromise = new Promise<{
+      success: true;
+      data: (typeof oldStop)[];
+      truncated: false;
+    }>((resolve) => {
+      resolveOldInBounds = () => {
+        resolve({ success: true, data: [oldStop], truncated: false });
+      };
+    });
+    const oldNearbyPromise = new Promise<{
+      success: true;
+      data: (typeof oldStop)[];
+      truncated: false;
+    }>((resolve) => {
+      resolveOldNearby = () => {
+        resolve({ success: true, data: [oldStop], truncated: false });
+      };
+    });
+
+    const oldRepo = makeRepo({
+      getStopsInBounds: vi.fn().mockReturnValue(oldInBoundsPromise),
+      getStopsNearby: vi.fn().mockReturnValue(oldNearbyPromise),
+    });
+    const newRepo = makeRepo();
+    const onStopsCommitted = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ repo }) =>
+        useStopsForBounds({
+          repo,
+          perfProfile: PERF_PROFILES.lite,
+          onStopsCommitted,
+          debounceMs: TEST_DEBOUNCE_MS,
+        }),
+      { initialProps: { repo: oldRepo } },
+    );
+
+    // Issue a fetch under `oldRepo`.
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    // Swap in `newRepo` while the old fetch is still pending. The
+    // hook's invalidation effect must bump the request id so the
+    // old response cannot land on top of the new repo's state.
+    rerender({ repo: newRepo });
+
+    await act(async () => {
+      resolveOldInBounds();
+      resolveOldNearby();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.inBoundStops).toEqual([]);
+    expect(result.current.radiusStops).toEqual([]);
+    expect(result.current.hasNearbyLoaded).toBe(false);
+    expect(onStopsCommitted).not.toHaveBeenCalled();
+  });
+
   it('cancels the pending debounce on unmount so the fetch never fires', async () => {
     const repo = makeRepo();
 

--- a/src/hooks/__tests__/use-stops-for-bounds.test.ts
+++ b/src/hooks/__tests__/use-stops-for-bounds.test.ts
@@ -63,7 +63,7 @@ describe('useStopsForBounds', () => {
       result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
     });
 
-    // No timers advanced, debounce has not elapsed — but mapCenter is set.
+    // No timers advanced, debounce has not elapsed -- but mapCenter is set.
     expect(result.current.mapCenter).toEqual(CENTER_A);
     expect(result.current.hasNearbyLoaded).toBe(false);
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -331,7 +331,7 @@ describe('useStopsForBounds', () => {
     });
 
     // Second bounds change arrives, but its debounced fetch has NOT
-    // been dispatched yet. The OLD response now resolves — the guard
+    // been dispatched yet. The OLD response now resolves -- the guard
     // must still classify it as stale because a newer viewport has
     // already been registered.
     act(() => {
@@ -628,7 +628,7 @@ describe('useStopsForBounds', () => {
     expect(result.current.mapCenter).toEqual(CENTER_A);
 
     // Invalidation must clear pending fetches but leave the visible
-    // map center intact — the user's pan is independent of the data
+    // map center intact -- the user's pan is independent of the data
     // source they happen to be looking at.
     rerender({ perfProfile: PERF_PROFILES.normal });
 

--- a/src/hooks/use-stops-for-bounds.ts
+++ b/src/hooks/use-stops-for-bounds.ts
@@ -32,7 +32,7 @@ export interface UseStopsForBoundsParams {
   onStopsCommitted?: () => void;
   /**
    * Debounce in ms for the stops fetch. `mapCenter` is NOT debounced
-   * — it follows every bounds-changed event immediately so that
+   * -- it follows every bounds-changed event immediately so that
    * map-anchored UI (e.g. the bottom sheet's per-stop distances)
    * tracks the pan in real time.
    */
@@ -142,8 +142,8 @@ export function useStopsForBounds(params: UseStopsForBoundsParams): UseStopsForB
           if (requestId !== latestRequestIdRef.current) {
             // A newer viewport (or a repo / perfProfile change) has
             // invalidated this request. Drop the result so it cannot
-            // overwrite the fresher state already committed — or about
-            // to be — by the newer request.
+            // overwrite the fresher state already committed -- or
+            // about to be -- by the newer request.
             if (logger.isEnabled('debug')) {
               logger.debug(
                 `stale response dropped (requestId=${requestId}, latest=${latestRequestIdRef.current})`,

--- a/src/hooks/use-stops-for-bounds.ts
+++ b/src/hooks/use-stops-for-bounds.ts
@@ -74,7 +74,11 @@ export interface UseStopsForBoundsReturn {
  * 2. immediate update of `mapCenter` so it tracks the pan even while
  *    the fetch is being debounced
  * 3. latest-only commit via a request-id counter so a slow response
- *    from an older bounds cannot overwrite a fresher result
+ *    from an older request cannot overwrite a fresher result. The
+ *    counter is bumped at the moment a new viewport arrives (or the
+ *    repo / perfProfile changes), not when the debounced fetch is
+ *    dispatched, so an in-flight response that lands before its
+ *    successor's fetch is even issued is still classified as stale.
  * 4. `onStopsCommitted` callback that fires only after the latest
  *    fetch has been committed (used by the caller to clear focus)
  *
@@ -112,9 +116,15 @@ export function useStopsForBounds(params: UseStopsForBoundsParams): UseStopsForB
       // for the debounced fetch. The fetch result is allowed to be
       // late; the visible map center is not.
       setMapCenter(center);
+      // Bump the request id at the moment a new viewport arrives, not
+      // when its debounced fetch is dispatched. Otherwise an old
+      // in-flight response that lands between a new bounds event and
+      // its yet-to-be-issued fetch would still see itself as `latest`
+      // and overwrite the fresher state. The newly bumped id is the
+      // one the upcoming fetch will own.
+      const requestId = ++latestRequestIdRef.current;
       clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = setTimeout(() => {
-        const requestId = ++latestRequestIdRef.current;
         const { nearbyRadius, maxResults } = perfProfile.data.stops;
         if (logger.isEnabled('debug')) {
           logger.debug(
@@ -130,9 +140,10 @@ export function useStopsForBounds(params: UseStopsForBoundsParams): UseStopsForB
           repo.getStopsNearby(center, nearbyRadius, maxResults),
         ]).then(([inBoundsResult, nearbyResult]) => {
           if (requestId !== latestRequestIdRef.current) {
-            // A newer request was issued before this one resolved.
-            // Drop the result so it cannot overwrite the fresher state
-            // already committed (or about to be) by the newer request.
+            // A newer viewport (or a repo / perfProfile change) has
+            // invalidated this request. Drop the result so it cannot
+            // overwrite the fresher state already committed — or about
+            // to be — by the newer request.
             if (logger.isEnabled('debug')) {
               logger.debug(
                 `stale response dropped (requestId=${requestId}, latest=${latestRequestIdRef.current})`,
@@ -158,6 +169,21 @@ export function useStopsForBounds(params: UseStopsForBoundsParams): UseStopsForB
     },
     [repo, perfProfile, debounceMs],
   );
+
+  // Invalidate any in-flight request and clear the pending debounce
+  // when the upstream data source or perf profile changes. Without
+  // this, a response that started under the old `repo` / `perfProfile`
+  // would still pass the latest-request guard (its id is the most
+  // recent one ever issued) and overwrite state that should reflect
+  // the new source.
+  //
+  // Bumping `latestRequestIdRef` here is safe even on the very first
+  // render: no fetch has been dispatched yet, so there is no id to
+  // collide with.
+  useEffect(() => {
+    ++latestRequestIdRef.current;
+    clearTimeout(debounceTimerRef.current);
+  }, [repo, perfProfile]);
 
   // Cancel any pending debounce on unmount so the timeout cannot fire
   // a fetch after the consumer has gone away. The request-id guard

--- a/src/hooks/use-stops-for-bounds.ts
+++ b/src/hooks/use-stops-for-bounds.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { PerfProfile } from '../config/perf-profiles';
+import { createLogger } from '../lib/logger';
+import type { TransitRepository } from '../repositories/transit-repository';
+import type { Bounds, LatLng } from '../types/app/map';
+import type { StopWithMeta } from '../types/app/transit-composed';
+
+const logger = createLogger('StopsForBounds');
+
+const DEFAULT_DEBOUNCE_MS = 300;
+
+/**
+ * Parameters for {@link useStopsForBounds}.
+ */
+export interface UseStopsForBoundsParams {
+  /** Transit data repository. */
+  repo: TransitRepository;
+  /**
+   * Active performance profile. Read for `nearbyRadius` / `maxResults`.
+   * The profile may change at runtime (perf-mode toggle); each
+   * `handleBoundsChanged` call reads the current profile via deps so
+   * subsequent fetches use the latest values.
+   */
+  perfProfile: PerfProfile;
+  /**
+   * Fires after a fetch has won the latest-only race and its result
+   * has been committed to state. Lets the caller drop state that
+   * should be reset when the visible stop set changes (e.g. clearing
+   * focus). Does not fire when a stale response is discarded.
+   */
+  onStopsCommitted?: () => void;
+  /**
+   * Debounce in ms for the stops fetch. `mapCenter` is NOT debounced
+   * — it follows every bounds-changed event immediately so that
+   * map-anchored UI (e.g. the bottom sheet's per-stop distances)
+   * tracks the pan in real time.
+   */
+  debounceMs?: number;
+}
+
+/**
+ * Return value of {@link useStopsForBounds}.
+ */
+export interface UseStopsForBoundsReturn {
+  /** Stops contained within the current map viewport. */
+  inBoundStops: StopWithMeta[];
+  /** Stops within `nearbyRadius` of the current map center. */
+  radiusStops: StopWithMeta[];
+  /**
+   * Latest map center, updated immediately on every bounds-changed
+   * event (not debounced).
+   */
+  mapCenter: LatLng | null;
+  /**
+   * Becomes `true` after the first committed fetch. Distinguishes
+   * "haven't fetched yet" from "fetched and got zero stops" so the UI
+   * can hide a loading placeholder once a real result arrives.
+   */
+  hasNearbyLoaded: boolean;
+  /**
+   * Callback to feed into `MapView`'s `onBoundsChanged`. Pushes the
+   * latest viewport into the hook; the hook handles debounce,
+   * latest-only commit, and `onStopsCommitted` firing internally.
+   */
+  handleBoundsChanged: (bounds: Bounds, center: LatLng) => void;
+}
+
+/**
+ * Owns viewport-driven stop fetching. Encapsulates four concerns that
+ * previously lived inline in `app.tsx`:
+ *
+ * 1. debounce of the fetch to coalesce rapid pan events
+ * 2. immediate update of `mapCenter` so it tracks the pan even while
+ *    the fetch is being debounced
+ * 3. latest-only commit via a request-id counter so a slow response
+ *    from an older bounds cannot overwrite a fresher result
+ * 4. `onStopsCommitted` callback that fires only after the latest
+ *    fetch has been committed (used by the caller to clear focus)
+ *
+ * The latest-only guard is about state correctness, not cancellation:
+ * the underlying repository call still completes its I/O / CPU work,
+ * but its result is discarded if a newer request has been issued. If
+ * actual cancellation is needed, the repository layer must be
+ * extended to accept an `AbortController` (or equivalent).
+ */
+export function useStopsForBounds(params: UseStopsForBoundsParams): UseStopsForBoundsReturn {
+  const { repo, perfProfile, onStopsCommitted, debounceMs = DEFAULT_DEBOUNCE_MS } = params;
+
+  const [inBoundStops, setInBoundStops] = useState<StopWithMeta[]>([]);
+  const [radiusStops, setRadiusStops] = useState<StopWithMeta[]>([]);
+  const [mapCenter, setMapCenter] = useState<LatLng | null>(null);
+  const [hasNearbyLoaded, setHasNearbyLoaded] = useState(false);
+
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const latestRequestIdRef = useRef(0);
+
+  // Hold the latest `onStopsCommitted` in a ref so `handleBoundsChanged`
+  // does not need to list it as a dep. Without this, the callback
+  // identity churn at the call site (typical for inline arrows or
+  // un-memoized callbacks) would re-create `handleBoundsChanged` on
+  // every parent render and force `MapView` re-renders.
+  const onStopsCommittedRef = useRef(onStopsCommitted);
+  useEffect(() => {
+    onStopsCommittedRef.current = onStopsCommitted;
+  }, [onStopsCommitted]);
+
+  const handleBoundsChanged = useCallback(
+    (bounds: Bounds, center: LatLng) => {
+      // Update `mapCenter` synchronously so per-stop distance displays
+      // and any other map-anchored UI follow the pan without waiting
+      // for the debounced fetch. The fetch result is allowed to be
+      // late; the visible map center is not.
+      setMapCenter(center);
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = setTimeout(() => {
+        const requestId = ++latestRequestIdRef.current;
+        const { nearbyRadius, maxResults } = perfProfile.data.stops;
+        if (logger.isEnabled('debug')) {
+          logger.debug(
+            'bounds changed: fetching stops via repo',
+            `radius=${nearbyRadius}`,
+            `maxResults=${maxResults}`,
+            `center=(${center.lat.toFixed(4)}, ${center.lng.toFixed(4)})`,
+            `requestId=${requestId}`,
+          );
+        }
+        void Promise.all([
+          repo.getStopsInBounds(bounds, maxResults),
+          repo.getStopsNearby(center, nearbyRadius, maxResults),
+        ]).then(([inBoundsResult, nearbyResult]) => {
+          if (requestId !== latestRequestIdRef.current) {
+            // A newer request was issued before this one resolved.
+            // Drop the result so it cannot overwrite the fresher state
+            // already committed (or about to be) by the newer request.
+            if (logger.isEnabled('debug')) {
+              logger.debug(
+                `stale response dropped (requestId=${requestId}, latest=${latestRequestIdRef.current})`,
+              );
+            }
+            return;
+          }
+          const inBounds = inBoundsResult.success ? inBoundsResult.data : [];
+          const nearby = nearbyResult.success ? nearbyResult.data : [];
+          logger.info(
+            'bounds changed:',
+            `radius=${nearbyRadius}`,
+            `nearby=${nearby.length}`,
+            `inBound=${inBounds.length}`,
+            `center=(${center.lat.toFixed(4)}, ${center.lng.toFixed(4)})`,
+          );
+          setInBoundStops(inBounds);
+          setRadiusStops(nearby);
+          setHasNearbyLoaded(true);
+          onStopsCommittedRef.current?.();
+        });
+      }, debounceMs);
+    },
+    [repo, perfProfile, debounceMs],
+  );
+
+  // Cancel any pending debounce on unmount so the timeout cannot fire
+  // a fetch after the consumer has gone away. The request-id guard
+  // already protects against stale commits while mounted; this is the
+  // matching cleanup for unmount.
+  useEffect(() => {
+    return () => {
+      clearTimeout(debounceTimerRef.current);
+    };
+  }, []);
+
+  return { inBoundStops, radiusStops, mapCenter, hasNearbyLoaded, handleBoundsChanged };
+}

--- a/src/hooks/use-trip-inspection.ts
+++ b/src/hooks/use-trip-inspection.ts
@@ -16,7 +16,7 @@ import {
 import { createLogger, type Logger } from '../lib/logger';
 import type { TransitRepository } from '../repositories/transit-repository';
 import type {
-  TripInspectionTargetsEmptyReason,
+  TripInspectionNoDataReason,
   TripInspectionTargetsResult,
 } from '../types/app/repository';
 import type { SelectedTripSnapshot, TripInspectionTarget } from '../types/app/transit-composed';
@@ -28,11 +28,6 @@ interface OpenTripInspectionByStopIdParams {
   now: Date;
   serviceDate: Date;
 }
-
-export type TripInspectionNoDataReason =
-  | TripInspectionTargetsEmptyReason
-  | 'snapshot-unavailable'
-  | 'target-missing';
 
 type TripInspectionOpenOutcome =
   | { status: 'opened' }

--- a/src/types/app/repository.ts
+++ b/src/types/app/repository.ts
@@ -111,6 +111,16 @@ export type TripSnapshotResult = Result<TripSnapshot>;
 /** Programmatic reason for an empty trip-inspection target result. */
 export type TripInspectionTargetsEmptyReason = 'no-stop-data' | 'no-service-on-this-day';
 
+/**
+ * Programmatic reason a hook-level trip-inspection open attempt
+ * cannot proceed. Superset of {@link TripInspectionTargetsEmptyReason}
+ * with reasons unique to the hook layer (snapshot/target lookup).
+ */
+export type TripInspectionNoDataReason =
+  | TripInspectionTargetsEmptyReason
+  | 'snapshot-unavailable'
+  | 'target-missing';
+
 /** Non-empty trip-inspection target list. */
 type NonEmptyTripInspectionTargets = [TripInspectionTarget, ...TripInspectionTarget[]];
 


### PR DESCRIPTION
## Summary

Refactors `src/app.tsx` orchestration responsibilities across the first three cleanup phases:

- Extract viewport-bound stop fetching into `useStopsForBounds` with latest-only request handling.
- Move nearby stop filtering/count derivation into a pure transit selector.
- Centralize timetable and trip-inspection open outcome message mapping outside `App`.

## Verification

- `npm run format`
- `npm run lint`
- `npm run build`
- Focused Vitest coverage for the new hook, selector, and message helpers
- `src/__tests__/app.test.tsx` with the relevant helper tests