### PR TITLE
refactor(app): extract useAppDialogs hook

### DIFF
--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -33,6 +33,9 @@ const {
   mockAppLayout,
   mockMapView,
   mockMapOverlay,
+  mockInfoDialog,
+  mockDataSourceSettingsDialog,
+  mockUseKeyboardShortcuts,
   mockUseTimetable,
   mockOpenStopTimetable,
   mockOpenRouteHeadsignTimetable,
@@ -52,6 +55,9 @@ const {
   mockAppLayout: vi.fn(),
   mockMapView: vi.fn(),
   mockMapOverlay: vi.fn(),
+  mockInfoDialog: vi.fn(),
+  mockDataSourceSettingsDialog: vi.fn(),
+  mockUseKeyboardShortcuts: vi.fn(),
   mockUseTimetable: vi.fn<() => UseTimetableReturn>(),
   mockOpenStopTimetable: vi.fn(),
   mockOpenRouteHeadsignTimetable: vi.fn(),
@@ -192,11 +198,23 @@ vi.mock('../components/dialog/stop-search-dialog', () => ({
 }));
 
 vi.mock('../components/dialog/info-dialog', () => ({
-  InfoDialog: () => null,
+  InfoDialog: (props: unknown) => {
+    mockInfoDialog(props);
+    return null;
+  },
 }));
 
 vi.mock('../components/dialog/data-source-settings-dialog', () => ({
-  DataSourceSettingsDialog: () => null,
+  DataSourceSettingsDialog: (props: unknown) => {
+    mockDataSourceSettingsDialog(props);
+    return null;
+  },
+}));
+
+vi.mock('../hooks/use-keyboard-shortcuts', () => ({
+  useKeyboardShortcuts: (options: unknown) => {
+    mockUseKeyboardShortcuts(options);
+  },
 }));
 
 describe('App anchor error toast', () => {
@@ -289,6 +307,9 @@ describe('App anchor error toast', () => {
     mockAppLayout.mockReset();
     mockMapView.mockReset();
     mockMapOverlay.mockReset();
+    mockInfoDialog.mockReset();
+    mockDataSourceSettingsDialog.mockReset();
+    mockUseKeyboardShortcuts.mockReset();
     mockUseTimetable.mockReset();
     mockOpenStopTimetable.mockReset();
     mockOpenRouteHeadsignTimetable.mockReset();
@@ -722,6 +743,138 @@ describe('App anchor error toast', () => {
     await waitFor(() => {
       expect(recordStopSelection).not.toHaveBeenCalled();
       expect(mockFocusStop).not.toHaveBeenCalled();
+    });
+  });
+
+  // Phase 4 dialog controller wiring: verify that the `useAppDialogs`
+  // hook is wired so the App-level cross-dialog flow (info -> data
+  // source settings) and the keyboard-shortcut suppression contract
+  // both still hold after the dialog open state was lifted out of
+  // `App.tsx` into `useAppDialogs`.
+  it('opens DataSourceSettingsDialog when InfoDialog requests it via onOpenDataSourceSettings', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockInfoDialog).toHaveBeenCalled();
+      expect(mockDataSourceSettingsDialog).toHaveBeenCalled();
+    });
+
+    const initialInfoProps = mockInfoDialog.mock.lastCall?.[0] as {
+      open: boolean;
+      onOpenDataSourceSettings: () => void;
+    };
+    const initialDssProps = mockDataSourceSettingsDialog.mock.lastCall?.[0] as {
+      open: boolean;
+    };
+    expect(initialInfoProps.open).toBe(false);
+    expect(initialDssProps.open).toBe(false);
+
+    act(() => {
+      initialInfoProps.onOpenDataSourceSettings();
+    });
+
+    await waitFor(() => {
+      const dssProps = mockDataSourceSettingsDialog.mock.lastCall?.[0] as { open: boolean };
+      expect(dssProps.open).toBe(true);
+    });
+  });
+
+  it('closes DataSourceSettingsDialog when its onOpenChange is called with false', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockInfoDialog).toHaveBeenCalled();
+    });
+
+    const infoProps = mockInfoDialog.mock.lastCall?.[0] as {
+      onOpenDataSourceSettings: () => void;
+    };
+    act(() => {
+      infoProps.onOpenDataSourceSettings();
+    });
+
+    await waitFor(() => {
+      const dssProps = mockDataSourceSettingsDialog.mock.lastCall?.[0] as { open: boolean };
+      expect(dssProps.open).toBe(true);
+    });
+
+    const openedDssProps = mockDataSourceSettingsDialog.mock.lastCall?.[0] as {
+      onOpenChange: (open: boolean) => void;
+    };
+    act(() => {
+      openedDssProps.onOpenChange(false);
+    });
+
+    await waitFor(() => {
+      const dssProps = mockDataSourceSettingsDialog.mock.lastCall?.[0] as { open: boolean };
+      expect(dssProps.open).toBe(false);
+    });
+  });
+
+  it('suppresses keyboard shortcuts while InfoDialog is open and re-enables on close', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockUseKeyboardShortcuts).toHaveBeenCalled();
+      expect(mockMapOverlay).toHaveBeenCalled();
+    });
+
+    const initialOptions = mockUseKeyboardShortcuts.mock.lastCall?.[0] as { enabled: boolean };
+    expect(initialOptions.enabled).toBe(true);
+
+    const overlayProps = mockMapOverlay.mock.lastCall?.[0] as { onInfoClick: () => void };
+    act(() => {
+      overlayProps.onInfoClick();
+    });
+
+    await waitFor(() => {
+      const options = mockUseKeyboardShortcuts.mock.lastCall?.[0] as { enabled: boolean };
+      expect(options.enabled).toBe(false);
+    });
+
+    const openedInfoProps = mockInfoDialog.mock.lastCall?.[0] as {
+      onOpenChange: (open: boolean) => void;
+    };
+    act(() => {
+      openedInfoProps.onOpenChange(false);
+    });
+
+    await waitFor(() => {
+      const options = mockUseKeyboardShortcuts.mock.lastCall?.[0] as { enabled: boolean };
+      expect(options.enabled).toBe(true);
+    });
+  });
+
+  it('suppresses keyboard shortcuts while DataSourceSettingsDialog is open and re-enables on close', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockUseKeyboardShortcuts).toHaveBeenCalled();
+      expect(mockInfoDialog).toHaveBeenCalled();
+    });
+
+    const infoProps = mockInfoDialog.mock.lastCall?.[0] as {
+      onOpenDataSourceSettings: () => void;
+    };
+    act(() => {
+      infoProps.onOpenDataSourceSettings();
+    });
+
+    await waitFor(() => {
+      const options = mockUseKeyboardShortcuts.mock.lastCall?.[0] as { enabled: boolean };
+      expect(options.enabled).toBe(false);
+    });
+
+    const openedDssProps = mockDataSourceSettingsDialog.mock.lastCall?.[0] as {
+      onOpenChange: (open: boolean) => void;
+    };
+    act(() => {
+      openedDssProps.onOpenChange(false);
+    });
+
+    await waitFor(() => {
+      const options = mockUseKeyboardShortcuts.mock.lastCall?.[0] as { enabled: boolean };
+      expect(options.enabled).toBe(true);
     });
   });
 });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -51,6 +51,7 @@ import { getTripInspectionOpenOutcomeMessage } from './domain/transit/trip-inspe
 
 // hooks
 import { useAnchors } from './hooks/use-anchors';
+import { useAppDialogs } from './hooks/use-app-dialogs';
 import { useDateTime } from './hooks/use-date-time';
 import { useKeyboardShortcuts } from './hooks/use-keyboard-shortcuts';
 import { useLoadResult } from './hooks/use-load-result';
@@ -248,8 +249,14 @@ export default function App() {
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
 
   const [searchModalOpen, setSearchModalOpen] = useState(false);
-  const [infoDialogOpen, setInfoDialogOpen] = useState(false);
-  const [dataSourceSettingsDialogOpen, setDataSourceSettingsDialogOpen] = useState(false);
+  const {
+    infoDialogOpen,
+    setInfoDialogOpen,
+    dataSourceSettingsDialogOpen,
+    setDataSourceSettingsDialogOpen,
+    openInfoDialog,
+    openDataSourceSettingsDialog,
+  } = useAppDialogs();
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
   const {
     tripInspectionSnapshot,
@@ -1098,7 +1105,7 @@ export default function App() {
             dataLang={langChain}
             onToggleStopType={handleToggleStopType}
             onSearchClick={() => setSearchModalOpen(true)}
-            onInfoClick={() => setInfoDialogOpen(true)}
+            onInfoClick={openInfoDialog}
             onLocated={handleLocated}
             autoLocateEnabled={autoLocateEnabled}
             onEnableAutoLocate={enableAutoLocate}
@@ -1165,7 +1172,7 @@ export default function App() {
       <InfoDialog
         open={infoDialogOpen}
         onOpenChange={setInfoDialogOpen}
-        onOpenDataSourceSettings={() => setDataSourceSettingsDialogOpen(true)}
+        onOpenDataSourceSettings={openDataSourceSettingsDialog}
       />
       <DataSourceSettingsDialog
         open={dataSourceSettingsDialogOpen}

--- a/src/hooks/__tests__/use-app-dialogs.test.ts
+++ b/src/hooks/__tests__/use-app-dialogs.test.ts
@@ -1,0 +1,136 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useAppDialogs } from '../use-app-dialogs';
+
+describe('useAppDialogs', () => {
+  it('starts with both dialogs closed', () => {
+    const { result } = renderHook(() => useAppDialogs());
+
+    expect(result.current.infoDialogOpen).toBe(false);
+    expect(result.current.dataSourceSettingsDialogOpen).toBe(false);
+  });
+
+  it('opens the info dialog via openInfoDialog', () => {
+    const { result } = renderHook(() => useAppDialogs());
+
+    act(() => {
+      result.current.openInfoDialog();
+    });
+
+    expect(result.current.infoDialogOpen).toBe(true);
+    expect(result.current.dataSourceSettingsDialogOpen).toBe(false);
+  });
+
+  it('opens the data source settings dialog via openDataSourceSettingsDialog', () => {
+    const { result } = renderHook(() => useAppDialogs());
+
+    act(() => {
+      result.current.openDataSourceSettingsDialog();
+    });
+
+    expect(result.current.dataSourceSettingsDialogOpen).toBe(true);
+    expect(result.current.infoDialogOpen).toBe(false);
+  });
+
+  it('closes the info dialog via setInfoDialogOpen(false)', () => {
+    const { result } = renderHook(() => useAppDialogs());
+
+    act(() => {
+      result.current.openInfoDialog();
+    });
+    expect(result.current.infoDialogOpen).toBe(true);
+
+    act(() => {
+      result.current.setInfoDialogOpen(false);
+    });
+    expect(result.current.infoDialogOpen).toBe(false);
+  });
+
+  it('closes the data source settings dialog via setDataSourceSettingsDialogOpen(false)', () => {
+    const { result } = renderHook(() => useAppDialogs());
+
+    act(() => {
+      result.current.openDataSourceSettingsDialog();
+    });
+    expect(result.current.dataSourceSettingsDialogOpen).toBe(true);
+
+    act(() => {
+      result.current.setDataSourceSettingsDialogOpen(false);
+    });
+    expect(result.current.dataSourceSettingsDialogOpen).toBe(false);
+  });
+
+  it('keeps the two dialogs independent', () => {
+    const { result } = renderHook(() => useAppDialogs());
+
+    act(() => {
+      result.current.openInfoDialog();
+      result.current.openDataSourceSettingsDialog();
+    });
+    expect(result.current.infoDialogOpen).toBe(true);
+    expect(result.current.dataSourceSettingsDialogOpen).toBe(true);
+
+    act(() => {
+      result.current.setInfoDialogOpen(false);
+    });
+    expect(result.current.infoDialogOpen).toBe(false);
+    expect(result.current.dataSourceSettingsDialogOpen).toBe(true);
+  });
+
+  it('returns stable references for openInfoDialog and openDataSourceSettingsDialog across renders', () => {
+    const { result, rerender } = renderHook(() => useAppDialogs());
+    const firstOpenInfo = result.current.openInfoDialog;
+    const firstOpenDss = result.current.openDataSourceSettingsDialog;
+
+    rerender();
+
+    expect(result.current.openInfoDialog).toBe(firstOpenInfo);
+    expect(result.current.openDataSourceSettingsDialog).toBe(firstOpenDss);
+  });
+
+  it('opens the info dialog via setInfoDialogOpen(true) (Radix onOpenChange path)', () => {
+    const { result } = renderHook(() => useAppDialogs());
+
+    act(() => {
+      result.current.setInfoDialogOpen(true);
+    });
+
+    expect(result.current.infoDialogOpen).toBe(true);
+  });
+
+  it('opens the data source settings dialog via setDataSourceSettingsDialogOpen(true) (Radix onOpenChange path)', () => {
+    const { result } = renderHook(() => useAppDialogs());
+
+    act(() => {
+      result.current.setDataSourceSettingsDialogOpen(true);
+    });
+
+    expect(result.current.dataSourceSettingsDialogOpen).toBe(true);
+  });
+
+  it('supports the updater form on setInfoDialogOpen', () => {
+    const { result } = renderHook(() => useAppDialogs());
+
+    act(() => {
+      result.current.setInfoDialogOpen((prev) => !prev);
+    });
+    expect(result.current.infoDialogOpen).toBe(true);
+
+    act(() => {
+      result.current.setInfoDialogOpen((prev) => !prev);
+    });
+    expect(result.current.infoDialogOpen).toBe(false);
+  });
+
+  it('returns stable references for setInfoDialogOpen and setDataSourceSettingsDialogOpen across renders', () => {
+    const { result, rerender } = renderHook(() => useAppDialogs());
+    const firstSetInfo = result.current.setInfoDialogOpen;
+    const firstSetDss = result.current.setDataSourceSettingsDialogOpen;
+
+    rerender();
+
+    expect(result.current.setInfoDialogOpen).toBe(firstSetInfo);
+    expect(result.current.setDataSourceSettingsDialogOpen).toBe(firstSetDss);
+  });
+});

--- a/src/hooks/use-app-dialogs.ts
+++ b/src/hooks/use-app-dialogs.ts
@@ -1,0 +1,48 @@
+import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
+
+/**
+ * Return shape of {@link useAppDialogs}.
+ */
+export interface UseAppDialogsReturn {
+  infoDialogOpen: boolean;
+  setInfoDialogOpen: Dispatch<SetStateAction<boolean>>;
+  dataSourceSettingsDialogOpen: boolean;
+  setDataSourceSettingsDialogOpen: Dispatch<SetStateAction<boolean>>;
+  openInfoDialog: () => void;
+  openDataSourceSettingsDialog: () => void;
+}
+
+/**
+ * Owns the open state for the `App`-root info / data-source-settings dialog
+ * pair.
+ *
+ * These two dialogs share an opening flow: `InfoDialog` exposes a button
+ * that opens `DataSourceSettingsDialog` via `onOpenDataSourceSettings`,
+ * so their state lives together. Other primary modals (search /
+ * shortcut-help / timetable / trip-inspection) intentionally stay
+ * outside this hook; they are tracked separately because each has its
+ * own opening trigger and lifecycle.
+ *
+ * @returns Open state, setter, and named open action for each dialog.
+ */
+export function useAppDialogs(): UseAppDialogsReturn {
+  const [infoDialogOpen, setInfoDialogOpen] = useState(false);
+  const [dataSourceSettingsDialogOpen, setDataSourceSettingsDialogOpen] = useState(false);
+
+  const openInfoDialog = useCallback(() => {
+    setInfoDialogOpen(true);
+  }, []);
+
+  const openDataSourceSettingsDialog = useCallback(() => {
+    setDataSourceSettingsDialogOpen(true);
+  }, []);
+
+  return {
+    infoDialogOpen,
+    setInfoDialogOpen,
+    dataSourceSettingsDialogOpen,
+    setDataSourceSettingsDialogOpen,
+    openInfoDialog,
+    openDataSourceSettingsDialog,
+  };
+}


### PR DESCRIPTION
## Summary

- Lift `infoDialogOpen` / `dataSourceSettingsDialogOpen` out of `App` into a new `useAppDialogs` hook. The two are grouped because `InfoDialog` opens `DataSourceSettingsDialog` via `onOpenDataSourceSettings`, so their state shares a lifecycle.
- Other primary modals (search / shortcut-help / timetable / trip-inspection) intentionally stay outside this hook for now; each has its own opening trigger and is tracked separately.
- `useKeyboardShortcuts.enabled` keeps reading the individual open states. The hook deliberately returns separate booleans so the existing AND-aggregation in `App` is preserved verbatim.
- First PR of Phase 4 in the `app.tsx` refactor plan. State inventory completion (Phase 4 sub-task 1) is intentionally deferred to a follow-up.

## Changes

- New: `src/hooks/use-app-dialogs.ts`
- New: `src/hooks/__tests__/use-app-dialogs.test.ts` (11 cases)
- Modified: `src/app.tsx` (replace 2 `useState` calls with `useAppDialogs()`, swap 2 inline arrows for named actions)
- Modified: `src/__tests__/app.test.tsx` (4 new wiring cases; mocks for `InfoDialog` / `DataSourceSettingsDialog` switched to prop-capturing; new mock for `useKeyboardShortcuts`)

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (293 files / 4121 tests pass, including 15 new cases)
- [x] `npm run build` (tsc + vite, exit 0)
- [x] `npm run format` (no diff)
- [x] Browser-verify:
  - [x] Info dialog opens and closes via header info button
  - [x] Info dialog -> Data source settings dialog navigation works
  - [x] Keyboard shortcuts (\`/\`, \`?\`) are suppressed while either dialog is open, and re-enabled on close
  - [x] No regression on other dialogs (search / shortcut help / timetable / trip inspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)