### PR TITLE
refactor(app): extract useRouteShapes hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - App orchestration: viewport stop fetch を `useStopsForBounds` に分離し、nearby stop 派生データを `deriveFilteredNearbyStops` に集約、timetable / trip inspection の open outcome message mapping を pure helper に移した。これにより `App` の責務を縮小し、viewport fetch の stale response が最新 state を上書きしないようにした。
 - App dialogs: 4 つの primary modal (`InfoDialog` / `DataSourceSettingsDialog` / `StopSearchDialog` / `ShortcutHelpDialog`) の open state を `useAppDialogs` に集約し、`App` の dialog state owner を 1 controller に統一した。
+- Route shapes loading: `App` 直下の mount-once fetch (`useState<RouteShape[]>` + `useEffect`) を `useRouteShapes` hook に分離した。`MapView` に渡す `routeShapes` の値・挙動は変えていない。
 
 ## [2026.05.25]
 

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -9,6 +9,7 @@ import type { UseStopHistoryReturn } from '../hooks/use-stop-history';
 import type { UseAnchorsReturn } from '../hooks/use-anchors';
 import type { TransitRepository } from '../repositories/transit-repository';
 import type { UseTimetableReturn } from '../hooks/use-timetable';
+import type { RouteShape } from '../types/app/map';
 import type { ContextualTimetableEntry, StopWithContext } from '../types/app/transit-composed';
 
 type UseDateTimeReturn = ReturnType<typeof import('../hooks/use-date-time').useDateTime>;
@@ -958,6 +959,37 @@ describe('App anchor error toast', () => {
     await waitFor(() => {
       const options = mockUseKeyboardShortcuts.mock.lastCall?.[0] as { enabled: boolean };
       expect(options.enabled).toBe(true);
+    });
+  });
+
+  // Phase 4 third PR wiring: confirm that `routeShapes` resolved by
+  // `useRouteShapes` actually reaches `MapView`. The hook itself is
+  // unit-tested separately; this asserts the `App` -> MapView prop
+  // flow so a missed prop / import would surface here.
+  it('passes loaded route shapes down to MapView via useRouteShapes', async () => {
+    const shapeFixture: RouteShape = {
+      routeId: 'wiring-fixture-route',
+      routeType: 3,
+      color: '#3FB',
+      route: null,
+      points: [
+        [35.0, 139.0],
+        [35.1, 139.1],
+      ],
+    };
+    mockGetRouteShapes.mockResolvedValue({
+      success: true,
+      data: [shapeFixture],
+      truncated: false,
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      const mapViewProps = mockMapView.mock.lastCall?.[0] as {
+        routeShapes: RouteShape[];
+      };
+      expect(mapViewProps.routeShapes).toEqual([shapeFixture]);
     });
   });
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner';
 
 // types
 import type { AutoLocateOffReason } from './types/app/auto-locate';
-import type { RouteShape, UserLocation } from './types/app/map';
+import type { UserLocation } from './types/app/map';
 import type { AppRouteTypeValue, Stop } from './types/app/transit';
 import type {
   StopWithContext,
@@ -56,6 +56,7 @@ import { useDateTime } from './hooks/use-date-time';
 import { useKeyboardShortcuts } from './hooks/use-keyboard-shortcuts';
 import { useLoadResult } from './hooks/use-load-result';
 import { useNearbyStopTimes } from './hooks/use-nearby-stop-times';
+import { useRouteShapes } from './hooks/use-route-shapes';
 import { useRouteStops } from './hooks/use-route-stops';
 import { useSelection } from './hooks/use-selection';
 import { useStopHistory, type UseStopHistoryReturn } from './hooks/use-stop-history';
@@ -187,7 +188,7 @@ export default function App() {
       perfProfile,
       onStopsCommitted: handleStopsCommitted,
     });
-  const [routeShapes, setRouteShapes] = useState<RouteShape[]>([]);
+  const routeShapes = useRouteShapes(repo);
   // Auto-tracking flag is intentionally not persisted: a tracking
   // permission/intent shouldn't silently survive a reload, so it always
   // starts off and the user must opt in each session. Lives in app.tsx
@@ -555,15 +556,6 @@ export default function App() {
       markStopParamHandled();
     });
   }, [navigateAndFocusStop, recordStopMetaSelection, repo]);
-
-  // Load route shapes once on mount
-  useEffect(() => {
-    void repo.getRouteShapes().then((result) => {
-      if (result.success) {
-        setRouteShapes(result.data);
-      }
-    });
-  }, [repo]);
 
   const handleFetchStopTimes = useCallback(
     async (stopId: string): Promise<StopWithContext | null> => {

--- a/src/hooks/__tests__/use-route-shapes.test.ts
+++ b/src/hooks/__tests__/use-route-shapes.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { makeRepo } from '../../__tests__/helpers';
+import type { RouteShape } from '../../types/app/map';
+import { useRouteShapes } from '../use-route-shapes';
+
+const SHAPE_A: RouteShape = {
+  routeId: 'route-a',
+  routeType: 3,
+  color: '#000000',
+  route: null,
+  points: [
+    [35.65, 139.75],
+    [35.66, 139.76],
+  ],
+};
+
+const SHAPE_B: RouteShape = {
+  routeId: 'route-b',
+  routeType: 1,
+  color: '#FF0000',
+  route: null,
+  points: [
+    [35.45, 139.55],
+    [35.46, 139.56],
+  ],
+};
+
+describe('useRouteShapes', () => {
+  it('returns an empty array before the fetch resolves', async () => {
+    const repo = makeRepo();
+    const { result } = renderHook(() => useRouteShapes(repo));
+
+    expect(result.current).toEqual([]);
+
+    // Flush the pending mount effect so the deferred state update
+    // happens inside act() and does not leak to the next test.
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
+  it('returns the loaded shapes after the repo resolves successfully', async () => {
+    const repo = makeRepo({
+      getRouteShapes: vi.fn().mockResolvedValue({
+        success: true,
+        data: [SHAPE_A, SHAPE_B],
+        truncated: false,
+      }),
+    });
+    const { result } = renderHook(() => useRouteShapes(repo));
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(2);
+    });
+    expect(result.current).toEqual([SHAPE_A, SHAPE_B]);
+  });
+
+  it('keeps the empty fallback when the repo returns failure', async () => {
+    const repo = makeRepo({
+      getRouteShapes: vi.fn().mockResolvedValue({
+        success: false,
+        error: new Error('boom'),
+      }),
+    });
+    const { result } = renderHook(() => useRouteShapes(repo));
+
+    // Flush microtasks so the failure path settles inside act().
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('calls repo.getRouteShapes exactly once per repo instance', async () => {
+    const getRouteShapes = vi.fn().mockResolvedValue({
+      success: true,
+      data: [SHAPE_A],
+      truncated: false,
+    });
+    const repo = makeRepo({ getRouteShapes });
+    const { rerender, result } = renderHook(() => useRouteShapes(repo));
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1);
+    });
+    expect(getRouteShapes).toHaveBeenCalledTimes(1);
+
+    rerender();
+    rerender();
+
+    expect(getRouteShapes).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches when the repo identity changes', async () => {
+    const getRouteShapesA = vi.fn().mockResolvedValue({
+      success: true,
+      data: [SHAPE_A],
+      truncated: false,
+    });
+    const getRouteShapesB = vi.fn().mockResolvedValue({
+      success: true,
+      data: [SHAPE_B],
+      truncated: false,
+    });
+    const repoA = makeRepo({ getRouteShapes: getRouteShapesA });
+    const repoB = makeRepo({ getRouteShapes: getRouteShapesB });
+
+    const { rerender, result } = renderHook(({ repo }) => useRouteShapes(repo), {
+      initialProps: { repo: repoA },
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual([SHAPE_A]);
+    });
+
+    rerender({ repo: repoB });
+    await waitFor(() => {
+      expect(result.current).toEqual([SHAPE_B]);
+    });
+    expect(getRouteShapesA).toHaveBeenCalledTimes(1);
+    expect(getRouteShapesB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/__tests__/use-route-shapes.test.ts
+++ b/src/hooks/__tests__/use-route-shapes.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { makeRepo } from '../../__tests__/helpers';
 import type { RouteShape } from '../../types/app/map';
@@ -28,6 +28,13 @@ const SHAPE_B: RouteShape = {
 };
 
 describe('useRouteShapes', () => {
+  afterEach(() => {
+    // Match the convention used by other hook test files in this repo.
+    // The tests below only create local `vi.fn()` mocks (no spies on
+    // shared globals), so this is preventive rather than load-bearing.
+    vi.restoreAllMocks();
+  });
+
   it('returns an empty array before the fetch resolves', async () => {
     const repo = makeRepo();
     const { result } = renderHook(() => useRouteShapes(repo));

--- a/src/hooks/use-route-shapes.ts
+++ b/src/hooks/use-route-shapes.ts
@@ -8,16 +8,30 @@ import type { RouteShape } from '../types/app/map';
  *
  * Mount-once fetch effect: kicks off `repo.getRouteShapes()` when the
  * hook mounts (or `repo` changes) and stores the success payload in
- * local state. Failures are silently ignored, leaving the empty-array
- * fallback in place; `MapView` simply renders no shape layer until
- * shapes arrive. Wire visible failure reporting here (toast / retry)
- * if route-shape loading needs to surface errors.
+ * local state.
+ *
+ * `TransitRepository.getRouteShapes()` is documented as "Always
+ * succeeds", so under the contract `result.success` is always true.
+ * The `if (result.success)` guard is therefore defensive: it is
+ * required by the `Result<T>` discriminated union for type
+ * narrowing, not because a `{ success: false }` outcome is expected.
+ * A rejected Promise (e.g. the underlying data fetch fails) is
+ * unhandled here and leaves the empty-array fallback in place;
+ * `MapView` simply renders no shape layer until shapes arrive. Wire
+ * visible failure reporting here (toast / retry) if route-shape
+ * loading needs to surface errors.
  *
  * No request cancellation: if `repo` changes mid-flight the previous
  * fetch's success may still write to state. This mirrors the original
- * inline effect in `App` and matches today's behaviour. Switch to a
- * requestId / AbortSignal pattern (see `useStopsForBounds`) when this
- * race becomes user-visible.
+ * inline effect in `App` and matches today's behaviour. In this
+ * codebase `repo` identity is stable for the React app lifetime --
+ * the repository flows from `TransitRepositoryProvider` whose
+ * `readyState.repository` only changes via `window.location.reload()`
+ * after a data-source toggle (see
+ * `components/dialog/data-source-settings-dialog.tsx`), so the
+ * mid-flight race is currently hypothetical. Switch to a requestId
+ * / AbortSignal pattern (see `useStopsForBounds`) if a future change
+ * makes `repo` swap at runtime.
  *
  * @param repo - Active transit repository.
  * @returns The loaded route shapes, or an empty array while pending /

--- a/src/hooks/use-route-shapes.ts
+++ b/src/hooks/use-route-shapes.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+import type { TransitRepository } from '../repositories/transit-repository';
+import type { RouteShape } from '../types/app/map';
+
+/**
+ * Load route shapes from the repository once per `repo` instance.
+ *
+ * Mount-once fetch effect: kicks off `repo.getRouteShapes()` when the
+ * hook mounts (or `repo` changes) and stores the success payload in
+ * local state. Failures are silently ignored, leaving the empty-array
+ * fallback in place; `MapView` simply renders no shape layer until
+ * shapes arrive. Wire visible failure reporting here (toast / retry)
+ * if route-shape loading needs to surface errors.
+ *
+ * No request cancellation: if `repo` changes mid-flight the previous
+ * fetch's success may still write to state. This mirrors the original
+ * inline effect in `App` and matches today's behaviour. Switch to a
+ * requestId / AbortSignal pattern (see `useStopsForBounds`) when this
+ * race becomes user-visible.
+ *
+ * @param repo - Active transit repository.
+ * @returns The loaded route shapes, or an empty array while pending /
+ * on failure.
+ */
+export function useRouteShapes(repo: TransitRepository): RouteShape[] {
+  const [routeShapes, setRouteShapes] = useState<RouteShape[]>([]);
+
+  useEffect(() => {
+    void repo.getRouteShapes().then((result) => {
+      if (result.success) {
+        setRouteShapes(result.data);
+      }
+    });
+  }, [repo]);
+
+  return routeShapes;
+}


### PR DESCRIPTION
## Summary

- Move the mount-once `routeShapes` fetch out of `App` into a new `useRouteShapes(repo)` hook. `App` was holding `useState<RouteShape[]>` plus a `useEffect` that called `repo.getRouteShapes()`; both collapse into a single `const routeShapes = useRouteShapes(repo);` line.
- `MapView` and `useSelection` keep their `RouteShape[]` input type and observable behaviour. No type changes at the consumer side.
- Race characteristic (no cancellation when `repo` changes mid-flight; last write wins) is preserved verbatim; the hook's TSDoc explicitly calls this out so a future reader can decide whether to add requestId / AbortSignal.
- Third PR of Phase 4 in the `app.tsx` refactor plan. After this PR, `App` no longer owns any data-fetch effect of its own; the remaining state-owner candidates are the filter cluster and the state-inventory documentation pass.

## Changes

- New: `src/hooks/use-route-shapes.ts` (TSDoc + mount-once fetch effect)
- New: `src/hooks/__tests__/use-route-shapes.test.ts` (5 cases)
- Modified: `src/app.tsx` (drop `useState<RouteShape[]>` and the `useEffect`, replace with `useRouteShapes(repo)`, drop now-unused `RouteShape` type import, add hook import in alphabetical position)
- Modified: `src/__tests__/app.test.tsx` (+1 wiring case asserting `useRouteShapes` output reaches `MapView.routeShapes`)
- Modified: `CHANGELOG.md` (Unreleased / Changed: add an entry for the move)

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (294 files / 4143 tests pass, including 6 new cases)
- [x] `npm run build` (tsc + vite, exit 0)
- [x] `npm run format` (no diff)
- [x] Browser-verify (confirmed locally):
  - [x] Route shapes render on the map after startup
  - [x] No regression on data source loading, viewport stop fetch, or nearby stop times

🤖 Generated with [Claude Code](https://claude.com/claude-code)