### PR TITLE
refactor(app): extract useGlobalFilter hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - App orchestration: viewport stop fetch を `useStopsForBounds` に分離し、nearby stop 派生データを `deriveFilteredNearbyStops` に集約、timetable / trip inspection の open outcome message mapping を pure helper に移した。これにより `App` の責務を縮小し、viewport fetch の stale response が最新 state を上書きしないようにした。
 - App dialogs: 4 つの primary modal (`InfoDialog` / `DataSourceSettingsDialog` / `StopSearchDialog` / `ShortcutHelpDialog`) の open state を `useAppDialogs` に集約し、`App` の dialog state owner を 1 controller に統一した。
 - Route shapes loading: `App` 直下の mount-once fetch (`useState<RouteShape[]>` + `useEffect`) を `useRouteShapes` hook に分離した。`MapView` に渡す `routeShapes` の値・挙動は変えていない。
+- App-wide filter: `showOriginOnly` / `showBoardableOnly` / `omitEmptyStopsOverride` と派生する late-night policy (`isLateNight` / `effectiveOmitEmptyStops` / forced-on rules) を `useGlobalFilter(dateTime)` に集約した。`globalFilter` の object shape と toggle handlers の挙動、`BottomSheet` / `TimetableModal` / nearby selector への入力は変えていない。
 
 ## [2026.05.25]
 

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -515,6 +515,37 @@ describe('App anchor error toast', () => {
     });
   });
 
+  it('forces omitEmptyStops on for boardable filter and updates filtered counts', async () => {
+    mockUseNearbyStopTimes.mockReturnValue({
+      stopTimes: [
+        makeNearbyStop('boardable-stop', [makeEntry({ pickupType: 0 })]),
+        makeNearbyStop('non-boardable-stop', [makeEntry({ pickupType: 1 })]),
+      ],
+      isNearbyLoading: false,
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      const props = getLastLayoutProps();
+      expect(props.globalFilter.omitEmptyStops).toBe(false);
+      expect(props.globalFilter.isOmitEmptyStopsForced).toBe(false);
+      expect(props.filteredNearbyStopsCounts.total).toBe(2);
+    });
+
+    act(() => {
+      getLastLayoutProps().globalFilter.onToggleShowBoardableOnly();
+    });
+
+    await waitFor(() => {
+      const props = getLastLayoutProps();
+      expect(props.globalFilter.omitEmptyStops).toBe(true);
+      expect(props.globalFilter.isOmitEmptyStopsForced).toBe(true);
+      expect(props.filteredNearbyStopsCounts.total).toBe(1);
+      expect(props.filteredNearbyStopsCounts.boardableCount).toBe(1);
+    });
+  });
+
   it('auto-enables omitEmptyStops late at night and allows manual override off when not forced', async () => {
     mockGetServiceDayMinutes.mockReturnValue(22 * 60 + 30);
     mockUseNearbyStopTimes.mockReturnValue({

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -39,7 +39,7 @@ import { deriveFilteredNearbyStops } from './domain/transit/derive-filtered-near
 import { resolveLangChain, type LangChain } from './domain/transit/i18n/resolve-lang-chain';
 import { getStopDisplayNames } from './domain/transit/name-resolver/get-stop-display-names';
 import { resolveStopRouteTypes } from './domain/transit/resolve-stop-route-types';
-import { getServiceDay, getServiceDayMinutes } from './domain/transit/service-day';
+import { getServiceDay } from './domain/transit/service-day';
 import { type StopHistoryEntry } from './domain/transit/stop-history';
 import { findVisibleStopMetaById } from './domain/transit/stop-meta-lookup';
 import { buildHistoryNavigationPayload } from './domain/transit/stop-navigation';
@@ -53,6 +53,7 @@ import { getTripInspectionOpenOutcomeMessage } from './domain/transit/trip-inspe
 import { useAnchors } from './hooks/use-anchors';
 import { useAppDialogs } from './hooks/use-app-dialogs';
 import { useDateTime } from './hooks/use-date-time';
+import { useGlobalFilter } from './hooks/use-global-filter';
 import { useKeyboardShortcuts } from './hooks/use-keyboard-shortcuts';
 import { useLoadResult } from './hooks/use-load-result';
 import { useNearbyStopTimes } from './hooks/use-nearby-stop-times';
@@ -99,7 +100,6 @@ import { Toaster } from './components/ui/sonner';
 import { MapSlotProvider } from './contexts/map-slot-provider';
 
 const logger = createLogger('App');
-const LATE_NIGHT_THRESHOLD_MINUTES = 22 * 60;
 
 interface OpenOutcomeToastMessage {
   severity: 'warning' | 'error';
@@ -806,58 +806,17 @@ export default function App() {
 
   // --- App-wide filter state (shared across surfaces) ---
 
-  // Stop-event-level filter toggles. Lifted to app.tsx so MapView,
-  // BottomSheet, TripInspectionDialog, and TimetableModal can share the
-  // same data state (= "what kind of trips the user is currently
-  // interested in"). The toggles control entry-level filtering through
-  // `applyStopEventAttributeToggles`; each surface decides how to apply
-  // it given its own data shape.
-  const [showOriginOnly, setShowOriginOnly] = useState(false);
-  const [showBoardableOnly, setShowBoardableOnly] = useState(false);
-  const isLateNight = getServiceDayMinutes(dateTime) >= LATE_NIGHT_THRESHOLD_MINUTES;
-  const [omitEmptyStopsOverride, setOmitEmptyStopsOverride] = useState<boolean | null>(null);
-  const omitEmptyStops = omitEmptyStopsOverride ?? isLateNight;
-  const isOmitEmptyStopsForced = showOriginOnly || showBoardableOnly;
-  const effectiveOmitEmptyStops = omitEmptyStops || isOmitEmptyStopsForced;
-
-  const toggleShowOriginOnly = useCallback(() => {
-    setShowOriginOnly((prev) => !prev);
-  }, []);
-  const toggleShowBoardableOnly = useCallback(() => {
-    setShowBoardableOnly((prev) => !prev);
-  }, []);
-  const toggleOmitEmptyStops = useCallback(() => {
-    if (isOmitEmptyStopsForced) {
-      return;
-    }
-    setOmitEmptyStopsOverride((prev) => !(prev ?? isLateNight));
-  }, [isLateNight, isOmitEmptyStopsForced]);
-
-  // Bundle the app-wide filter state + toggle handlers into a single
-  // memoized object so consumers (BottomSheet / TimetableModal /
-  // future MapView etc.) receive a stable reference between toggles.
-  const globalFilter = useMemo(
-    () => ({
-      showOriginOnly,
-      showBoardableOnly,
-      omitEmptyStops: effectiveOmitEmptyStops,
-      isOmitEmptyStopsForced,
-      onToggleShowOriginOnly: toggleShowOriginOnly,
-      onToggleShowBoardableOnly: toggleShowBoardableOnly,
-      onToggleOmitEmptyStops: toggleOmitEmptyStops,
-    }),
-    [
-      showOriginOnly,
-      showBoardableOnly,
-      effectiveOmitEmptyStops,
-      isOmitEmptyStopsForced,
-      toggleShowOriginOnly,
-      toggleShowBoardableOnly,
-      toggleOmitEmptyStops,
-    ],
-  );
-
-  // logger.debug('GlobalFilter', globalFilter);
+  // Stop-event-level filter toggles owned by `useGlobalFilter`. The
+  // hook bundles state (`showOriginOnly` / `showBoardableOnly` /
+  // `omitEmptyStopsOverride`), late-night derived policy
+  // (`isLateNight` / `effectiveOmitEmptyStops` / forced-on rules),
+  // and the memoized `globalFilter` object that BottomSheet /
+  // TimetableModal consume. `App` keeps `showOriginOnly`,
+  // `showBoardableOnly`, and `effectiveOmitEmptyStops` to feed
+  // `deriveFilteredNearbyStops`; MapView reads the filtered result
+  // (`stopTimes`) rather than `globalFilter` itself.
+  const { showOriginOnly, showBoardableOnly, effectiveOmitEmptyStops, globalFilter } =
+    useGlobalFilter(dateTime);
 
   // --- Settings handlers ---
 

--- a/src/hooks/__tests__/use-global-filter.test.ts
+++ b/src/hooks/__tests__/use-global-filter.test.ts
@@ -1,0 +1,155 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useGlobalFilter } from '../use-global-filter';
+
+// Service day: 03:00 boundary. Use a fixed local-time noon for stable
+// `getServiceDayMinutes` results across runs. JST midday is 12:00 ->
+// 540 service-day minutes (well below the 22:00 = 1320 late-night
+// threshold), and JST 23:00 is 23 * 60 = 1380 minutes (above).
+const NOON_LOCAL = new Date(2026, 4, 26, 12, 0, 0);
+const LATE_NIGHT_LOCAL = new Date(2026, 4, 26, 23, 0, 0);
+
+describe('useGlobalFilter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts with all three filter inputs off (daytime baseline)', () => {
+    const { result } = renderHook(() => useGlobalFilter(NOON_LOCAL));
+
+    expect(result.current.showOriginOnly).toBe(false);
+    expect(result.current.showBoardableOnly).toBe(false);
+    expect(result.current.effectiveOmitEmptyStops).toBe(false);
+    expect(result.current.globalFilter).toMatchObject({
+      showOriginOnly: false,
+      showBoardableOnly: false,
+      omitEmptyStops: false,
+      isOmitEmptyStopsForced: false,
+    });
+  });
+
+  it('auto-enables omitEmptyStops when dateTime is past the late-night threshold', () => {
+    const { result } = renderHook(() => useGlobalFilter(LATE_NIGHT_LOCAL));
+
+    expect(result.current.effectiveOmitEmptyStops).toBe(true);
+    expect(result.current.globalFilter.omitEmptyStops).toBe(true);
+    expect(result.current.globalFilter.isOmitEmptyStopsForced).toBe(false);
+  });
+
+  it('toggles showOriginOnly via onToggleShowOriginOnly and forces omitEmptyStops on', () => {
+    const { result } = renderHook(() => useGlobalFilter(NOON_LOCAL));
+
+    act(() => {
+      result.current.globalFilter.onToggleShowOriginOnly();
+    });
+
+    expect(result.current.showOriginOnly).toBe(true);
+    expect(result.current.effectiveOmitEmptyStops).toBe(true);
+    expect(result.current.globalFilter.isOmitEmptyStopsForced).toBe(true);
+  });
+
+  it('toggles showBoardableOnly via onToggleShowBoardableOnly and forces omitEmptyStops on', () => {
+    const { result } = renderHook(() => useGlobalFilter(NOON_LOCAL));
+
+    act(() => {
+      result.current.globalFilter.onToggleShowBoardableOnly();
+    });
+
+    expect(result.current.showBoardableOnly).toBe(true);
+    expect(result.current.effectiveOmitEmptyStops).toBe(true);
+    expect(result.current.globalFilter.isOmitEmptyStopsForced).toBe(true);
+  });
+
+  it('treats onToggleOmitEmptyStops as a no-op while forced', () => {
+    const { result } = renderHook(() => useGlobalFilter(NOON_LOCAL));
+
+    // Force on via showOriginOnly.
+    act(() => {
+      result.current.globalFilter.onToggleShowOriginOnly();
+    });
+    expect(result.current.effectiveOmitEmptyStops).toBe(true);
+    expect(result.current.globalFilter.isOmitEmptyStopsForced).toBe(true);
+
+    // Attempting to toggle while forced must not flip the underlying
+    // override state.
+    act(() => {
+      result.current.globalFilter.onToggleOmitEmptyStops();
+    });
+    expect(result.current.effectiveOmitEmptyStops).toBe(true);
+    expect(result.current.globalFilter.isOmitEmptyStopsForced).toBe(true);
+  });
+
+  it('allows manual override off via onToggleOmitEmptyStops at late night when not forced', () => {
+    const { result } = renderHook(() => useGlobalFilter(LATE_NIGHT_LOCAL));
+
+    expect(result.current.effectiveOmitEmptyStops).toBe(true);
+
+    act(() => {
+      result.current.globalFilter.onToggleOmitEmptyStops();
+    });
+
+    expect(result.current.effectiveOmitEmptyStops).toBe(false);
+    expect(result.current.globalFilter.omitEmptyStops).toBe(false);
+  });
+
+  it('allows manual override on via onToggleOmitEmptyStops during daytime when not forced', () => {
+    const { result } = renderHook(() => useGlobalFilter(NOON_LOCAL));
+
+    expect(result.current.effectiveOmitEmptyStops).toBe(false);
+
+    act(() => {
+      result.current.globalFilter.onToggleOmitEmptyStops();
+    });
+
+    expect(result.current.effectiveOmitEmptyStops).toBe(true);
+    expect(result.current.globalFilter.omitEmptyStops).toBe(true);
+    expect(result.current.globalFilter.isOmitEmptyStopsForced).toBe(false);
+  });
+
+  it('returns a stable globalFilter reference across renders when no input changes', () => {
+    const { result, rerender } = renderHook(({ dt }) => useGlobalFilter(dt), {
+      initialProps: { dt: NOON_LOCAL },
+    });
+    const firstBundle = result.current.globalFilter;
+
+    rerender({ dt: NOON_LOCAL });
+    rerender({ dt: NOON_LOCAL });
+
+    expect(result.current.globalFilter).toBe(firstBundle);
+  });
+
+  it('recomputes globalFilter when isLateNight flips because dateTime crosses the threshold', () => {
+    const { result, rerender } = renderHook(({ dt }) => useGlobalFilter(dt), {
+      initialProps: { dt: NOON_LOCAL },
+    });
+    expect(result.current.effectiveOmitEmptyStops).toBe(false);
+
+    rerender({ dt: LATE_NIGHT_LOCAL });
+
+    expect(result.current.effectiveOmitEmptyStops).toBe(true);
+    expect(result.current.globalFilter.omitEmptyStops).toBe(true);
+  });
+
+  it('keeps manual override sticky as dateTime crosses the threshold', () => {
+    const { result, rerender } = renderHook(({ dt }) => useGlobalFilter(dt), {
+      initialProps: { dt: NOON_LOCAL },
+    });
+
+    // Manually override on during daytime.
+    act(() => {
+      result.current.globalFilter.onToggleOmitEmptyStops();
+    });
+    expect(result.current.effectiveOmitEmptyStops).toBe(true);
+
+    // Crossing into late night does not undo the manual override.
+    rerender({ dt: LATE_NIGHT_LOCAL });
+    expect(result.current.effectiveOmitEmptyStops).toBe(true);
+
+    // Toggling off works even at late night because forced is false.
+    act(() => {
+      result.current.globalFilter.onToggleOmitEmptyStops();
+    });
+    expect(result.current.effectiveOmitEmptyStops).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/use-global-filter.test.ts
+++ b/src/hooks/__tests__/use-global-filter.test.ts
@@ -3,10 +3,18 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useGlobalFilter } from '../use-global-filter';
 
-// Service day: 03:00 boundary. Use a fixed local-time noon for stable
-// `getServiceDayMinutes` results across runs. JST midday is 12:00 ->
-// 540 service-day minutes (well below the 22:00 = 1320 late-night
-// threshold), and JST 23:00 is 23 * 60 = 1380 minutes (above).
+// `getServiceDayMinutes` returns midnight-based local-time minutes
+// when `getHours() >= 03:00` (the service-day boundary), and adds
+// 1440 for pre-boundary times. The hook compares the result against
+// `LATE_NIGHT_THRESHOLD_MINUTES = 22 * 60 = 1320`:
+//
+//   - Local-time 12:00 -> 12 * 60 = 720, below the threshold (daytime).
+//   - Local-time 23:00 -> 23 * 60 = 1380, above the threshold (late
+//     night).
+//
+// `new Date(year, month, day, hours, ...)` uses the runner's local
+// timezone, and `getHours()` returns the same local hour, so this
+// stays deterministic regardless of where the test runs.
 const NOON_LOCAL = new Date(2026, 4, 26, 12, 0, 0);
 const LATE_NIGHT_LOCAL = new Date(2026, 4, 26, 23, 0, 0);
 

--- a/src/hooks/use-global-filter.ts
+++ b/src/hooks/use-global-filter.ts
@@ -1,0 +1,108 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { getServiceDayMinutes } from '../domain/transit/service-day';
+import type { GlobalFilter } from '../types/app/global-filter';
+
+/**
+ * Service-day minute at which the empty-stop omit policy auto-enables.
+ * Matches the original inline value in `App`; 22:00 chosen so the
+ * BottomSheet stops drowning in `no-service` entries late at night
+ * when most routes have stopped running.
+ */
+const LATE_NIGHT_THRESHOLD_MINUTES = 22 * 60;
+
+/**
+ * Return shape of {@link useGlobalFilter}.
+ */
+export interface UseGlobalFilterReturn {
+  /** Pass-through of the `showOriginOnly` filter flag. */
+  showOriginOnly: boolean;
+  /** Pass-through of the `showBoardableOnly` filter flag. */
+  showBoardableOnly: boolean;
+  /** Final empty-stop omit policy after `isLateNight` and forced-on rules. */
+  effectiveOmitEmptyStops: boolean;
+  /** Bundled {@link GlobalFilter} for drilling into BottomSheet / TimetableModal. */
+  globalFilter: GlobalFilter;
+}
+
+/**
+ * Own the app-wide display filter state shared across surfaces.
+ *
+ * Bundles:
+ *
+ *   - Three user-toggleable inputs (`showOriginOnly`,
+ *     `showBoardableOnly`, `omitEmptyStopsOverride`).
+ *   - Derived empty-stop policy: `isLateNight` (from `dateTime` vs.
+ *     {@link LATE_NIGHT_THRESHOLD_MINUTES}), forced-on rules
+ *     (origin-only or boardable-only force empty-stop omit on), and
+ *     the final `effectiveOmitEmptyStops`.
+ *   - The memoized {@link GlobalFilter} bundle that `BottomSheet` and
+ *     `TimetableModal` consume directly.
+ *
+ * The selector-level inputs (`showOriginOnly`, `showBoardableOnly`,
+ * `effectiveOmitEmptyStops`) are exposed alongside the bundle because
+ * `App` feeds them into `deriveFilteredNearbyStops` to produce the
+ * filtered `stopTimes` that `MapView` consumes indirectly. The bundle
+ * carries the user-facing toggle handlers; `App` does not call them.
+ *
+ * `omitEmptyStops` is `dateTime`-dependent through `isLateNight`, so
+ * `dateTime` is taken as a parameter rather than read from
+ * `useDateTime` inside the hook: the caller already owns `dateTime`
+ * and threads it through everything else.
+ *
+ * @param dateTime - Current date / time used to compute the
+ * late-night empty-stop policy.
+ * @returns Filter inputs needed by the App-level selector plus the
+ * memoized `globalFilter` bundle for prop drilling.
+ */
+export function useGlobalFilter(dateTime: Date): UseGlobalFilterReturn {
+  const [showOriginOnly, setShowOriginOnly] = useState(false);
+  const [showBoardableOnly, setShowBoardableOnly] = useState(false);
+  const [omitEmptyStopsOverride, setOmitEmptyStopsOverride] = useState<boolean | null>(null);
+
+  const isLateNight = getServiceDayMinutes(dateTime) >= LATE_NIGHT_THRESHOLD_MINUTES;
+  const omitEmptyStops = omitEmptyStopsOverride ?? isLateNight;
+  const isOmitEmptyStopsForced = showOriginOnly || showBoardableOnly;
+  const effectiveOmitEmptyStops = omitEmptyStops || isOmitEmptyStopsForced;
+
+  const toggleShowOriginOnly = useCallback(() => {
+    setShowOriginOnly((prev) => !prev);
+  }, []);
+  const toggleShowBoardableOnly = useCallback(() => {
+    setShowBoardableOnly((prev) => !prev);
+  }, []);
+  const toggleOmitEmptyStops = useCallback(() => {
+    if (isOmitEmptyStopsForced) {
+      return;
+    }
+    setOmitEmptyStopsOverride((prev) => !(prev ?? isLateNight));
+  }, [isLateNight, isOmitEmptyStopsForced]);
+
+  const globalFilter = useMemo<GlobalFilter>(
+    () => ({
+      showOriginOnly,
+      showBoardableOnly,
+      omitEmptyStops: effectiveOmitEmptyStops,
+      isOmitEmptyStopsForced,
+      onToggleShowOriginOnly: toggleShowOriginOnly,
+      onToggleShowBoardableOnly: toggleShowBoardableOnly,
+      onToggleOmitEmptyStops: toggleOmitEmptyStops,
+    }),
+    [
+      showOriginOnly,
+      showBoardableOnly,
+      effectiveOmitEmptyStops,
+      isOmitEmptyStopsForced,
+      toggleShowOriginOnly,
+      toggleShowBoardableOnly,
+      toggleOmitEmptyStops,
+    ],
+  );
+
+  return {
+    showOriginOnly,
+    showBoardableOnly,
+    effectiveOmitEmptyStops,
+    globalFilter,
+  };
+}

--- a/src/types/app/global-filter.ts
+++ b/src/types/app/global-filter.ts
@@ -1,11 +1,23 @@
 /**
- * App-wide display filter state shared across surfaces (BottomSheet,
- * TimetableModal, MapView, TripInspectionDialog, etc.).
+ * App-wide display filter state shared across surfaces.
  *
- * Owned by `app.tsx` and threaded through props as a single
- * `globalFilter` object so the namespace is explicit at every
- * receiver. Drilling depth is shallow (1–2 levels), so explicit
- * props are clearer than a Context provider.
+ * Direct consumers (receive the `globalFilter` prop):
+ *
+ *   - `BottomSheet` (via `AppLayout` -> `MapBottomSheetLayout` /
+ *     `StopPanel` -> `StopBrowser`)
+ *   - `TimetableModal`
+ *
+ * Indirect consumers (read the filter's *output*, not this object):
+ *
+ *   - `MapView` and other surfaces that render `stopTimes` produced
+ *     by `deriveFilteredNearbyStops` already see the filtered result.
+ *     They do not receive `GlobalFilter`.
+ *
+ * Owned by `useGlobalFilter(dateTime)` (`src/hooks/use-global-filter.ts`)
+ * and threaded through props as a single `globalFilter` object so the
+ * namespace is explicit at every receiver. Drilling depth is shallow
+ * (1-2 levels), so explicit props are clearer than a Context
+ * provider.
  */
 export interface GlobalFilter {
   /** When true, narrow to entries whose patternPosition.isOrigin is true. */


### PR DESCRIPTION
## Summary

- Move the app-wide display filter cluster (3 toggleable inputs + late-night derived policy + memoized `globalFilter` bundle) out of `App` into `useGlobalFilter(dateTime)`. After this PR `App` no longer owns the filter state itself; the hook is the SSOT.
- `App` keeps reading `showOriginOnly`, `showBoardableOnly`, and `effectiveOmitEmptyStops` from the hook to feed `deriveFilteredNearbyStops`; the `globalFilter` bundle and the toggle handlers flow through unchanged to `BottomSheet` (via `AppLayout` -> `MapBottomSheetLayout` / `StopPanel` -> `StopBrowser`) and `TimetableModal`. `MapView` is unaffected (it consumes the filtered `stopTimes` produced by the selector, not `globalFilter`).
- The `GlobalFilter` interface TSDoc is rewritten so the owner is `useGlobalFilter` (not `app.tsx`) and the direct vs. indirect consumer split is explicit. `TripInspectionDialog` is removed from the consumer list because it never receives `globalFilter` in code.
- Fourth PR of Phase 4 in the `app.tsx` refactor plan. Phase 4 low-risk state owner moves are now essentially complete; remaining `App`-owned state is the locate / map bridge cluster (high risk, kept per PR #240) and lifecycle / bridge refs (stay in `App` by design).

## Changes

- New: `src/hooks/use-global-filter.ts` (hook + `LATE_NIGHT_THRESHOLD_MINUTES` constant moved out of `App`)
- New: `src/hooks/__tests__/use-global-filter.test.ts` (10 cases: daytime / late-night initial state, each toggle path, forced-on no-op, manual override stickiness across the threshold, `globalFilter` reference stability, `dateTime` threshold recompute)
- Modified: `src/app.tsx` (drop ~45 lines of filter state / derived / toggles / `useMemo` bundle, replace with destructure from `useGlobalFilter(dateTime)`, drop the `getServiceDayMinutes` import and the local `LATE_NIGHT_THRESHOLD_MINUTES` constant)
- Modified: `src/types/app/global-filter.ts` (TSDoc: update owner to `useGlobalFilter`, accurate direct/indirect consumer split, remove non-consumers)
- Modified: `src/__tests__/app.test.tsx` (+1 wiring case for `showBoardableOnly` mirroring the existing `showOriginOnly` case so both `AppLayout` -> `globalFilter` toggle paths are explicit)
- Modified: `CHANGELOG.md` (Unreleased / Changed: add an entry for the move)

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (295 files / 4154 tests pass, including 11 new / extended cases)
- [x] `npm run build` (tsc + vite, exit 0)
- [x] `npm run format` (no diff)
- [x] Browser-verify:
  - [x] Filter pill toggles in BottomSheet / TimetableModal: `Show origin only`, `Show boardable only`, `Omit empty stops` each behave as before; `origin` or `boardable` ON forces `Omit empty stops` ON and disables its toggle
  - [x] Late-night auto-enable: opening with `?time=<today>T22:30:00+09:00` auto-enables `Omit empty stops`; manual toggle off works (forced is false)
  - [x] Manual override is sticky as `dateTime` crosses 22:00
  - [x] No regression on info / data source settings / search / shortcut help dialogs, route shape rendering, or keyboard shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)