### PR TITLE
refactor(app): extract stop reference helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - App dialogs: 4 つの primary modal (`InfoDialog` / `DataSourceSettingsDialog` / `StopSearchDialog` / `ShortcutHelpDialog`) の open state を `useAppDialogs` に集約し、`App` の dialog state owner を 1 controller に統一した。
 - Route shapes loading: `App` 直下の mount-once fetch (`useState<RouteShape[]>` + `useEffect`) を `useRouteShapes` hook に分離した。`MapView` に渡す `routeShapes` の値・挙動は変えていない。
 - App-wide filter: `showOriginOnly` / `showBoardableOnly` / `omitEmptyStopsOverride` と派生する late-night policy (`isLateNight` / `effectiveOmitEmptyStops` / forced-on rules) を `useGlobalFilter(dateTime)` に集約した。`globalFilter` の object shape と toggle handlers の挙動、`BottomSheet` / `TimetableModal` / nearby selector への入力は変えていない。
+- Stop reference helpers: `App` 内に inline で書かれていた stop 参照解決の重複 (anchor / history map lookup と、live meta / bare Stop からの `StopReferenceSnapshot` 構築) を `domain/transit/stop-meta-lookup.ts` の `lookupStopMetaFromMap` と `domain/transit/stop-navigation.ts` の `buildSelectionSnapshotFromMeta` / `buildSelectionSnapshotFromStop` に切り出した。`buildHistoryNavigationPayload` も内部で新しい builder を使うよう更新。挙動は維持。
 
 ## [2026.05.25]
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -38,11 +38,14 @@ import { formatDateKey } from './domain/transit/calendar-utils';
 import { deriveFilteredNearbyStops } from './domain/transit/derive-filtered-nearby-stops';
 import { resolveLangChain, type LangChain } from './domain/transit/i18n/resolve-lang-chain';
 import { getStopDisplayNames } from './domain/transit/name-resolver/get-stop-display-names';
-import { resolveStopRouteTypes } from './domain/transit/resolve-stop-route-types';
 import { getServiceDay } from './domain/transit/service-day';
 import { type StopHistoryEntry } from './domain/transit/stop-history';
-import { findVisibleStopMetaById } from './domain/transit/stop-meta-lookup';
-import { buildHistoryNavigationPayload } from './domain/transit/stop-navigation';
+import { findVisibleStopMetaById, lookupStopMetaFromMap } from './domain/transit/stop-meta-lookup';
+import {
+  buildHistoryNavigationPayload,
+  buildSelectionSnapshotFromMeta,
+  buildSelectionSnapshotFromStop,
+} from './domain/transit/stop-navigation';
 import { createStopReferenceSnapshot } from './domain/transit/stop-reference-snapshot';
 import { buildStopRouteTypeMap } from './domain/transit/stop-route-type-map';
 import { getTimetableOpenOutcomeMessage } from './domain/transit/timetable-message';
@@ -424,7 +427,7 @@ export default function App() {
   // (e.g. cross-source anchor in mock mode, or a stop deleted from
   // GTFS); callers should fall back to the AnchorEntry snapshot.
   const lookupAnchorStopMeta = useCallback(
-    (stopId: string): StopWithMeta | null => anchorStopMetaMap.get(stopId) ?? null,
+    (stopId: string): StopWithMeta | null => lookupStopMetaFromMap(stopId, anchorStopMetaMap),
     [anchorStopMetaMap],
   );
 
@@ -442,7 +445,7 @@ export default function App() {
   }, [history, repo]);
 
   const lookupHistoryStopMeta = useCallback(
-    (stopId: string): StopWithMeta | null => historyStopMetaMap.get(stopId) ?? null,
+    (stopId: string): StopWithMeta | null => lookupStopMetaFromMap(stopId, historyStopMetaMap),
     [historyStopMetaMap],
   );
 
@@ -454,13 +457,7 @@ export default function App() {
 
   const recordStopMetaSelection = useCallback(
     (stopMeta: StopWithMeta) => {
-      const routeTypes = resolveStopRouteTypes({
-        stopId: stopMeta.stop.stop_id,
-        routeTypeMap,
-        routes: stopMeta.routes,
-        unknownPolicy: 'include-unknown',
-      });
-      const snapshot = createStopReferenceSnapshot(stopMeta, routeTypes, langChain);
+      const snapshot = buildSelectionSnapshotFromMeta(stopMeta, routeTypeMap, langChain);
       void recordStopSelection(snapshot);
     },
     [langChain, recordStopSelection, routeTypeMap],
@@ -478,13 +475,7 @@ export default function App() {
         return;
       }
 
-      const routeTypes = resolveStopRouteTypes({
-        stopId: fallbackStop.stop_id,
-        routeTypeMap,
-        routes: [],
-        unknownPolicy: 'include-unknown',
-      });
-      const snapshot = createStopReferenceSnapshot(fallbackStop, routeTypes, langChain);
+      const snapshot = buildSelectionSnapshotFromStop(fallbackStop, routeTypeMap, langChain);
       void recordStopSelection(snapshot);
     },
     [

--- a/src/domain/transit/__tests__/stop-navigation.test.ts
+++ b/src/domain/transit/__tests__/stop-navigation.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { makeStop, makeStopMeta } from '../../../__tests__/helpers';
-import { findVisibleStopMetaById } from '../stop-meta-lookup';
-import { buildHistoryNavigationPayload } from '../stop-navigation';
+import type { AppRouteTypeValue } from '../../../types/app/transit';
+import { findVisibleStopMetaById, lookupStopMetaFromMap } from '../stop-meta-lookup';
+import {
+  buildHistoryNavigationPayload,
+  buildSelectionSnapshotFromMeta,
+  buildSelectionSnapshotFromStop,
+} from '../stop-navigation';
 import type { StopHistoryEntry } from '../stop-history';
 
 describe('findNavigableStopMeta', () => {
@@ -45,6 +50,95 @@ describe('findNavigableStopMeta', () => {
 
     expect(radiusStops).toEqual([radiusMeta]);
     expect(inBoundStops).toEqual([inBoundMeta]);
+  });
+});
+
+describe('lookupStopMetaFromMap', () => {
+  it('returns the matching StopWithMeta when the id is present', () => {
+    const meta = makeStopMeta('A');
+    const map = new Map([['A', meta]]);
+
+    expect(lookupStopMetaFromMap('A', map)).toBe(meta);
+  });
+
+  it('returns null when the id is absent', () => {
+    const map = new Map([['A', makeStopMeta('A')]]);
+
+    expect(lookupStopMetaFromMap('missing', map)).toBeNull();
+  });
+
+  it('returns null for an empty map', () => {
+    expect(lookupStopMetaFromMap('A', new Map())).toBeNull();
+  });
+
+  it('does not mutate the input map', () => {
+    const meta = makeStopMeta('A');
+    const map = new Map([['A', meta]]);
+
+    lookupStopMetaFromMap('A', map);
+
+    expect(map.size).toBe(1);
+    expect(map.get('A')).toBe(meta);
+  });
+});
+
+describe('buildSelectionSnapshotFromMeta', () => {
+  it('builds a snapshot using meta.routes when routeTypeMap has no entry for the stop', () => {
+    const stopMeta = makeStopMeta(makeStop('A', 35, 139));
+    stopMeta.routes = [];
+
+    const snapshot = buildSelectionSnapshotFromMeta(stopMeta, new Map(), ['ja']);
+
+    expect(snapshot).toEqual({
+      stopId: 'A',
+      name: 'Stop A',
+      lat: 35,
+      lon: 139,
+      // Empty routes + no map entry collapses to the unknown sentinel
+      // because the policy is 'include-unknown'.
+      routeTypes: [-1],
+      agencyNames: [],
+      platformCode: undefined,
+    });
+  });
+
+  it('uses routeTypes from the routeTypeMap when present', () => {
+    const stopMeta = makeStopMeta(makeStop('A', 35, 139));
+    stopMeta.routes = [];
+    const routeTypeMap = new Map<string, AppRouteTypeValue[]>([['A', [3, 1]]]);
+
+    const snapshot = buildSelectionSnapshotFromMeta(stopMeta, routeTypeMap, ['ja']);
+
+    expect(snapshot.routeTypes).toEqual([3, 1]);
+    expect(snapshot.stopId).toBe('A');
+  });
+});
+
+describe('buildSelectionSnapshotFromStop', () => {
+  it('builds a snapshot with empty agencyNames when no live meta is available', () => {
+    const stop = makeStop('B', 36, 140);
+    const routeTypeMap = new Map<string, AppRouteTypeValue[]>([['B', [2]]]);
+
+    const snapshot = buildSelectionSnapshotFromStop(stop, routeTypeMap, ['ja']);
+
+    expect(snapshot).toEqual({
+      stopId: 'B',
+      name: 'Stop B',
+      lat: 36,
+      lon: 140,
+      routeTypes: [2],
+      agencyNames: [],
+      platformCode: undefined,
+    });
+  });
+
+  it('collapses to unknown sentinel when the routeTypeMap has no entry', () => {
+    const stop = makeStop('C', 0, 0);
+
+    const snapshot = buildSelectionSnapshotFromStop(stop, new Map(), ['ja']);
+
+    expect(snapshot.routeTypes).toEqual([-1]);
+    expect(snapshot.agencyNames).toEqual([]);
   });
 });
 

--- a/src/domain/transit/__tests__/stop-navigation.test.ts
+++ b/src/domain/transit/__tests__/stop-navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { makeStop, makeStopMeta } from '../../../__tests__/helpers';
+import { makeRoute, makeStop, makeStopMeta } from '../../../__tests__/helpers';
 import type { AppRouteTypeValue } from '../../../types/app/transit';
 import { findVisibleStopMetaById, lookupStopMetaFromMap } from '../stop-meta-lookup';
 import {
@@ -83,7 +83,7 @@ describe('lookupStopMetaFromMap', () => {
 });
 
 describe('buildSelectionSnapshotFromMeta', () => {
-  it('builds a snapshot using meta.routes when routeTypeMap has no entry for the stop', () => {
+  it('falls back to the unknown sentinel when routeTypeMap has no entry and meta.routes is empty', () => {
     const stopMeta = makeStopMeta(makeStop('A', 35, 139));
     stopMeta.routes = [];
 
@@ -110,6 +110,16 @@ describe('buildSelectionSnapshotFromMeta', () => {
     const snapshot = buildSelectionSnapshotFromMeta(stopMeta, routeTypeMap, ['ja']);
 
     expect(snapshot.routeTypes).toEqual([3, 1]);
+    expect(snapshot.stopId).toBe('A');
+  });
+
+  it('derives routeTypes from meta.routes (deduped and ascending) when routeTypeMap has no entry', () => {
+    const stopMeta = makeStopMeta(makeStop('A', 35, 139));
+    stopMeta.routes = [makeRoute('r1', 3), makeRoute('r2', 1), makeRoute('r3', 3)];
+
+    const snapshot = buildSelectionSnapshotFromMeta(stopMeta, new Map(), ['ja']);
+
+    expect(snapshot.routeTypes).toEqual([1, 3]);
     expect(snapshot.stopId).toBe('A');
   });
 });

--- a/src/domain/transit/stop-meta-lookup.ts
+++ b/src/domain/transit/stop-meta-lookup.ts
@@ -11,3 +11,27 @@ export function findVisibleStopMetaById(
     null
   );
 }
+
+/**
+ * Look up a stop's live `StopWithMeta` from a pre-built map keyed by
+ * `stop_id`. Returns `null` when the id is absent (rather than
+ * `undefined` from `Map.get`) so call sites can fall through to
+ * persisted-snapshot fallbacks consistently.
+ *
+ * Used to back curried lookup callbacks like `lookupAnchorStopMeta` /
+ * `lookupHistoryStopMeta` in `App`: the call site captures the map in
+ * a `useCallback` closure and exposes the `(stopId) => ...` signature
+ * that consumers (Portal, StopHistory dropdown, navigation payload
+ * builder) depend on.
+ *
+ * @param stopId - Persisted stop id to resolve.
+ * @param metaMap - Pre-built map of currently resolvable
+ * `StopWithMeta` entries.
+ * @returns The matching `StopWithMeta`, or `null` when not present.
+ */
+export function lookupStopMetaFromMap(
+  stopId: string,
+  metaMap: ReadonlyMap<string, StopWithMeta>,
+): StopWithMeta | null {
+  return metaMap.get(stopId) ?? null;
+}

--- a/src/domain/transit/stop-navigation.ts
+++ b/src/domain/transit/stop-navigation.ts
@@ -6,6 +6,61 @@ import { resolveStopRouteTypes } from './resolve-stop-route-types';
 import { buildHistorySelectionStop, type StopHistoryEntry } from './stop-history';
 import { createStopReferenceSnapshot } from './stop-reference-snapshot';
 
+/**
+ * Build a `StopReferenceSnapshot` from live `StopWithMeta`.
+ *
+ * Wraps the two-step "resolve routeTypes from the route map plus the
+ * meta's own routes, then create snapshot" pattern that originated
+ * inline in `App` and inside `buildHistoryNavigationPayload`. Used
+ * whenever the caller already has the live metadata (anchor map,
+ * history map, viewport lookup, or repository fetch) and wants the
+ * canonical snapshot for persistence / navigation.
+ *
+ * `unknownPolicy: 'include-unknown'` matches the historical inline
+ * call sites: stops whose route_type cannot be classified are kept,
+ * not dropped, so the snapshot still records something.
+ */
+export function buildSelectionSnapshotFromMeta(
+  stopMeta: StopWithMeta,
+  routeTypeMap: ReadonlyMap<string, AppRouteTypeValue[]>,
+  dataLang: LangChain,
+): StopReferenceSnapshot {
+  const routeTypes = resolveStopRouteTypes({
+    stopId: stopMeta.stop.stop_id,
+    routeTypeMap,
+    routes: stopMeta.routes,
+    unknownPolicy: 'include-unknown',
+  });
+  return createStopReferenceSnapshot(stopMeta, routeTypes, dataLang);
+}
+
+/**
+ * Build a `StopReferenceSnapshot` from a bare `Stop` (no live meta).
+ *
+ * Used by selection flows whose only handle on a stop is the `Stop`
+ * itself (e.g. when a viewport lookup misses but the caller still has
+ * the click target), where there is no `StopWithMeta.routes` to feed
+ * to `resolveStopRouteTypes`. Passes an empty `routes` array so the
+ * resolver leans entirely on the route-type map for the stop id.
+ *
+ * The resulting snapshot has `agencyNames: []` because
+ * `createStopReferenceSnapshot` only resolves agency names when the
+ * argument carries `agencies` (i.e. is a `StopWithMeta`).
+ */
+export function buildSelectionSnapshotFromStop(
+  stop: Stop,
+  routeTypeMap: ReadonlyMap<string, AppRouteTypeValue[]>,
+  dataLang: LangChain,
+): StopReferenceSnapshot {
+  const routeTypes = resolveStopRouteTypes({
+    stopId: stop.stop_id,
+    routeTypeMap,
+    routes: [],
+    unknownPolicy: 'include-unknown',
+  });
+  return createStopReferenceSnapshot(stop, routeTypes, dataLang);
+}
+
 export interface HistoryNavigationPayload {
   stop: Stop;
   snapshot: StopReferenceSnapshot;
@@ -20,17 +75,9 @@ export function buildHistoryNavigationPayload(
   const stopMeta = lookupHistoryStopMeta(stopHistoryEntry.snapshot.stopId);
 
   if (stopMeta != null) {
-    const stop = stopMeta.stop;
-    const routeTypes = resolveStopRouteTypes({
-      stopId: stop.stop_id,
-      routeTypeMap,
-      routes: stopMeta.routes,
-      unknownPolicy: 'include-unknown',
-    });
-    const snapshot = createStopReferenceSnapshot(stopMeta, routeTypes, dataLang);
     return {
-      stop,
-      snapshot,
+      stop: stopMeta.stop,
+      snapshot: buildSelectionSnapshotFromMeta(stopMeta, routeTypeMap, dataLang),
     };
   }
 


### PR DESCRIPTION
## Summary

- Lift the small "lookup live meta + build snapshot" duplication out of `App` callbacks into pure helpers under `domain/transit/`.
- Helpers added: `lookupStopMetaFromMap` in `stop-meta-lookup.ts`; `buildSelectionSnapshotFromMeta` and `buildSelectionSnapshotFromStop` in `stop-navigation.ts`.
- `buildHistoryNavigationPayload` is updated to use the new snapshot builder internally; behaviour and signature are preserved.
- `App` callbacks (`lookupAnchorStopMeta`, `lookupHistoryStopMeta`, `recordStopMetaSelection`, `recordStopSelectionByVisibleStop` fallback) now delegate to the helpers. Callback shapes, dependencies, and observable side effects are unchanged.
- First Phase 5 PR in the `app.tsx` refactor plan, scoped to the safe pure-helper extraction. Generalizing the helper into a `buildSelectionNavigationPayload` for anchor / search is intentionally not pursued; remaining selection flows have meaningfully different semantics (see commit body).

## Changes

- Modified: `src/domain/transit/stop-meta-lookup.ts` (add `lookupStopMetaFromMap`)
- Modified: `src/domain/transit/stop-navigation.ts` (add `buildSelectionSnapshotFromMeta` / `buildSelectionSnapshotFromStop`; route `buildHistoryNavigationPayload` live-meta path through the new builder)
- Modified: `src/domain/transit/__tests__/stop-navigation.test.ts` (+8 cases for the three new helpers; existing `buildHistoryNavigationPayload` cases continue to pass unchanged)
- Modified: `src/app.tsx` (replace inline lookup / snapshot construction in 4 callbacks; drop `resolveStopRouteTypes` import since `App` no longer references it directly)
- Modified: `CHANGELOG.md` (Unreleased / Changed: `Stop reference helpers` entry)

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (295 files / 4163 tests pass, including 8 new cases)
- [x] `npm run build` (tsc + vite, exit 0)
- [x] `npm run format` (no diff)
- [x] Browser-verify (no behaviour change expected; spot-check regression):
  - [x] Selecting a stop from the Portal dropdown still pans the map and records the snapshot
  - [x] Selecting a stop from the StopHistory dropdown still resolves either to current GTFS metadata (live name) or the stored snapshot
  - [x] Selecting a stop from the map / BottomSheet still records history with the live-meta route types
  - [x] Selecting a stop from the search dialog still pans / records / closes the modal
  - [x] `?stop=<id>` URL still focuses the stop and records the snapshot on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)