### PR TITLE
refactor(app): extract startup lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - Route shapes loading: `App` 直下の mount-once fetch (`useState<RouteShape[]>` + `useEffect`) を `useRouteShapes` hook に分離した。`MapView` に渡す `routeShapes` の値・挙動は変えていない。
 - App-wide filter: `showOriginOnly` / `showBoardableOnly` / `omitEmptyStopsOverride` と派生する late-night policy (`isLateNight` / `effectiveOmitEmptyStops` / forced-on rules) を `useGlobalFilter(dateTime)` に集約した。`globalFilter` の object shape と toggle handlers の挙動、`BottomSheet` / `TimetableModal` / nearby selector への入力は変えていない。
 - Stop reference helpers: `App` 内に inline で書かれていた stop 参照解決の重複 (anchor / history map lookup と、live meta / bare Stop からの `StopReferenceSnapshot` 構築) を `domain/transit/stop-meta-lookup.ts` の `lookupStopMetaFromMap` と `domain/transit/stop-navigation.ts` の `buildSelectionSnapshotFromMeta` / `buildSelectionSnapshotFromStop` に切り出した。`buildHistoryNavigationPayload` も内部で新しい builder を使うよう更新。挙動は維持。
+- App startup lifecycle hooks: `App` 直下の 2 つの起動時 side effect (anchor metadata refresh と `?stop=` URL param 解決) をそれぞれ `useAnchorRefresh` / `useStopParamHandler` に分離した。one-shot guard ref + useEffect の pattern を hook 内に閉じ込め、App は hook の 1 行呼出しのみになった。挙動は維持 (anchor refresh は依然「初回 anchors が non-empty になった時に 1 回だけ」、`?stop=` は依然 mid-flight guard 込みの 1 回限り)。
 
 ## [2026.05.25]
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -26,14 +26,9 @@ import i18n from './i18n';
 // lib
 import { applyAppTheme } from './lib/app-theme';
 import { createLogger } from './lib/logger';
-import { getStopParam } from './lib/query-params';
 
 // domain
-import {
-  buildAnchorRefreshUpdates,
-  buildAnchorSelectionStop,
-  type AnchorEntry,
-} from './domain/portal/anchor';
+import { buildAnchorSelectionStop, type AnchorEntry } from './domain/portal/anchor';
 import { formatDateKey } from './domain/transit/calendar-utils';
 import { deriveFilteredNearbyStops } from './domain/transit/derive-filtered-nearby-stops';
 import { resolveLangChain, type LangChain } from './domain/transit/i18n/resolve-lang-chain';
@@ -53,6 +48,7 @@ import { getStopServiceState } from './domain/transit/timetable-utils';
 import { getTripInspectionOpenOutcomeMessage } from './domain/transit/trip-inspection-message';
 
 // hooks
+import { useAnchorRefresh } from './hooks/use-anchor-refresh';
 import { useAnchors } from './hooks/use-anchors';
 import { useAppDialogs } from './hooks/use-app-dialogs';
 import { useDateTime } from './hooks/use-date-time';
@@ -65,6 +61,7 @@ import { useRouteStops } from './hooks/use-route-stops';
 import { useSelection } from './hooks/use-selection';
 import { useStopHistory, type UseStopHistoryReturn } from './hooks/use-stop-history';
 import { useStopNavigation } from './hooks/use-stop-navigation';
+import { useStopParamHandler } from './hooks/use-stop-param-handler';
 import { useStopsForBounds } from './hooks/use-stops-for-bounds';
 import { useTimetable } from './hooks/use-timetable';
 import { useTransitRepository } from './hooks/use-transit-repository';
@@ -160,7 +157,7 @@ export default function App() {
 
   // Resolve language fallback chain once when lang changes.
   // Components receive this as dataLang (ordered priority list for
-  // GTFS/ODPT data translation resolution).
+  // data translation resolution).
   const langChain: LangChain = useMemo(
     () => resolveLangChain(settings.lang, SUPPORTED_LANGS),
     [settings.lang],
@@ -388,26 +385,10 @@ export default function App() {
     clearAnchorError();
   }, [anchorError, clearAnchorError, t]);
 
-  // Refresh anchor entries with latest GTFS data on app load.
-  // Runs once after repo is ready. Updates stopName, stopLat, stopLon,
-  // and routeTypes if they have changed since the anchor was saved.
-  const anchorRefreshDone = useRef(false);
-  useEffect(() => {
-    if (anchorRefreshDone.current || anchors.length === 0) {
-      return;
-    }
-    const stopIds = new Set(anchors.map((a) => a.snapshot.stopId));
-    const metas = repo.getStopMetaByIds(stopIds);
-    // Mark as done regardless of result. repo is fully loaded before
-    // injection (all GTFS data is in memory), so metas is only empty
-    // when all anchor stopIds have been removed from the dataset.
-    // We must not retry on every dependency change.
-    anchorRefreshDone.current = true;
-    const updates = buildAnchorRefreshUpdates(anchors, metas, langChain);
-    if (updates.length > 0) {
-      void batchUpdateAnchors(updates);
-    }
-  }, [anchors, repo, batchUpdateAnchors, langChain]);
+  // Refresh anchor entries with latest data once per session.
+  // See `useAnchorRefresh` for the "first non-empty anchors" timing
+  // semantics (driven by `useAnchors`'s async load).
+  useAnchorRefresh({ anchors, repo, batchUpdateAnchors, langChain });
 
   // Pre-resolved StopWithMeta map for every anchored stop_id.
   // Built from the repository's full dataset (not just the visible
@@ -425,7 +406,7 @@ export default function App() {
   // Lookup an anchored stop's current StopWithMeta. Returns null
   // when the anchor's stop_id is not present in the active dataset
   // (e.g. cross-source anchor in mock mode, or a stop deleted from
-  // GTFS); callers should fall back to the AnchorEntry snapshot.
+  // the data); callers should fall back to the AnchorEntry snapshot.
   const lookupAnchorStopMeta = useCallback(
     (stopId: string): StopWithMeta | null => lookupStopMetaFromMap(stopId, anchorStopMetaMap),
     [anchorStopMetaMap],
@@ -512,41 +493,10 @@ export default function App() {
     [recordStopSelectionByVisibleStop, selectStop],
   );
 
-  // Apply ?stop= query param: select and pan to the stop after data loads.
-  // Uses a ref to ensure the effect runs only once (the first time
-  // the repo resolves the stop). Same pattern as handleHistorySelect —
-  // focusStop sets directFocusPosition so the map pans even when the
-  // stop is outside the initial viewport.
-  const hasHandledStopParamRef = useRef(false);
-  useEffect(() => {
-    if (hasHandledStopParamRef.current) {
-      return;
-    }
-
-    const markStopParamHandled = () => {
-      hasHandledStopParamRef.current = true;
-    };
-
-    const stopId = getStopParam();
-    if (!stopId) {
-      markStopParamHandled();
-      return;
-    }
-
-    void repo.getStopMetaById(stopId).then((result) => {
-      if (hasHandledStopParamRef.current) {
-        return;
-      }
-      if (!result.success) {
-        logger.warn(`?stop=${stopId}: not found`);
-        markStopParamHandled();
-        return;
-      }
-      navigateAndFocusStop('apply-stop-param', result.data.stop);
-      recordStopMetaSelection(result.data);
-      markStopParamHandled();
-    });
-  }, [navigateAndFocusStop, recordStopMetaSelection, repo]);
+  // Apply ?stop= query param: resolve via repo, then pan / record once.
+  // See `useStopParamHandler` for the mid-flight guard semantics that
+  // keep this safe when dep callbacks change during the async resolve.
+  useStopParamHandler({ repo, navigateAndFocusStop, recordStopMetaSelection });
 
   const handleFetchStopTimes = useCallback(
     async (stopId: string): Promise<StopWithContext | null> => {
@@ -694,7 +644,7 @@ export default function App() {
     (stopId: string) => {
       if (isStopAnchor(stopId)) {
         // Capture anchor data before removal (entry won't exist after removeAnchor).
-        // Resolve display name from current GTFS so the toast follows
+        // Resolve display name from current data so the toast follows
         // the user's current language even though the stored entry
         // only has a snapshot stopName. We use `lookupAnchorStopMeta`
         // (full-dataset scan over the anchor set) rather than

--- a/src/hooks/__tests__/use-anchor-refresh.test.ts
+++ b/src/hooks/__tests__/use-anchor-refresh.test.ts
@@ -1,0 +1,132 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { makeRepo, makeStop, makeStopMeta } from '../../__tests__/helpers';
+import type { AnchorEntry } from '../../domain/portal/anchor';
+import { useAnchorRefresh } from '../use-anchor-refresh';
+
+function makeAnchor(stopId: string, name: string, lat = 35, lon = 139): AnchorEntry {
+  return {
+    snapshot: {
+      stopId,
+      name,
+      lat,
+      lon,
+      routeTypes: [3],
+      agencyNames: [],
+    },
+    createdAt: 1000,
+  };
+}
+
+describe('useAnchorRefresh', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not call batchUpdateAnchors when anchors is empty', () => {
+    const batchUpdateAnchors = vi.fn().mockResolvedValue({ success: true, data: [] });
+    const repo = makeRepo({ getStopMetaByIds: vi.fn(() => []) });
+
+    renderHook(() =>
+      useAnchorRefresh({ anchors: [], repo, batchUpdateAnchors, langChain: ['ja'] }),
+    );
+
+    expect(batchUpdateAnchors).not.toHaveBeenCalled();
+  });
+
+  it('fires the refresh exactly once when anchors transitions from empty to non-empty', () => {
+    const batchUpdateAnchors = vi.fn().mockResolvedValue({ success: true, data: [] });
+    const stop = makeStop('A', 36, 140); // live coords differ from anchor snapshot (35, 139)
+    const meta = makeStopMeta(stop);
+    const getStopMetaByIds = vi.fn((ids: Set<string>) =>
+      ids.has(meta.stop.stop_id) ? [meta] : [],
+    );
+    const repo = makeRepo({ getStopMetaByIds });
+
+    const { rerender } = renderHook(
+      ({ anchors }) => useAnchorRefresh({ anchors, repo, batchUpdateAnchors, langChain: ['ja'] }),
+      {
+        initialProps: { anchors: [] as AnchorEntry[] },
+      },
+    );
+
+    // First render with empty anchors: no fetch, no update.
+    expect(getStopMetaByIds).not.toHaveBeenCalled();
+
+    // Async-loaded anchors arrive.
+    rerender({ anchors: [makeAnchor('A', 'Old Name')] });
+
+    expect(getStopMetaByIds).toHaveBeenCalledTimes(1);
+    expect(batchUpdateAnchors).toHaveBeenCalledTimes(1);
+
+    // Further anchor mutations during the session must not re-fire.
+    rerender({ anchors: [makeAnchor('A', 'Old Name'), makeAnchor('B', 'New Anchor')] });
+    rerender({ anchors: [makeAnchor('A', 'Old Name')] });
+
+    expect(getStopMetaByIds).toHaveBeenCalledTimes(1);
+    expect(batchUpdateAnchors).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips batchUpdateAnchors when buildAnchorRefreshUpdates yields no diffs', () => {
+    const batchUpdateAnchors = vi.fn().mockResolvedValue({ success: true, data: [] });
+    // Stop coords + name match the anchor snapshot so the diff is empty.
+    const stop = makeStop('A', 35, 139);
+    const meta = makeStopMeta(stop);
+    const repo = makeRepo({
+      getStopMetaByIds: vi.fn((ids: Set<string>) => (ids.has(meta.stop.stop_id) ? [meta] : [])),
+    });
+
+    const anchor: AnchorEntry = {
+      snapshot: {
+        stopId: 'A',
+        name: 'Stop A', // matches makeStop helper's stop_name format
+        lat: 35,
+        lon: 139,
+        routeTypes: [3],
+        agencyNames: [],
+      },
+      createdAt: 1000,
+    };
+
+    renderHook(() =>
+      useAnchorRefresh({ anchors: [anchor], repo, batchUpdateAnchors, langChain: ['ja'] }),
+    );
+
+    expect(batchUpdateAnchors).not.toHaveBeenCalled();
+  });
+
+  it('does not re-fire when langChain changes after the first refresh has run', () => {
+    const batchUpdateAnchors = vi.fn().mockResolvedValue({ success: true, data: [] });
+    const stop = makeStop('A', 36, 140);
+    const meta = makeStopMeta(stop);
+    const getStopMetaByIds = vi.fn((ids: Set<string>) =>
+      ids.has(meta.stop.stop_id) ? [meta] : [],
+    );
+    const repo = makeRepo({ getStopMetaByIds });
+
+    const { rerender } = renderHook(
+      ({ langChain }) =>
+        useAnchorRefresh({
+          anchors: [makeAnchor('A', 'Old Name')],
+          repo,
+          batchUpdateAnchors,
+          langChain,
+        }),
+      {
+        initialProps: { langChain: ['ja'] as readonly string[] },
+      },
+    );
+
+    expect(getStopMetaByIds).toHaveBeenCalledTimes(1);
+    expect(batchUpdateAnchors).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      rerender({ langChain: ['en', 'ja'] });
+    });
+
+    // done.current already true, so the dep change does NOT re-fire.
+    expect(getStopMetaByIds).toHaveBeenCalledTimes(1);
+    expect(batchUpdateAnchors).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/__tests__/use-stop-param-handler.test.ts
+++ b/src/hooks/__tests__/use-stop-param-handler.test.ts
@@ -1,0 +1,114 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeRepo, makeStop, makeStopMeta } from '../../__tests__/helpers';
+import * as queryParams from '../../lib/query-params';
+import { useStopParamHandler } from '../use-stop-param-handler';
+
+describe('useStopParamHandler', () => {
+  beforeEach(() => {
+    vi.spyOn(queryParams, 'getStopParam').mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('marks handled without calling repo when there is no ?stop= param', async () => {
+    const getStopMetaById = vi.fn();
+    const repo = makeRepo({ getStopMetaById });
+    const navigateAndFocusStop = vi.fn();
+    const recordStopMetaSelection = vi.fn();
+
+    renderHook(() => useStopParamHandler({ repo, navigateAndFocusStop, recordStopMetaSelection }));
+
+    // Flush microtasks so any deferred state would have run.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getStopMetaById).not.toHaveBeenCalled();
+    expect(navigateAndFocusStop).not.toHaveBeenCalled();
+    expect(recordStopMetaSelection).not.toHaveBeenCalled();
+  });
+
+  it('navigates and records when ?stop= resolves successfully', async () => {
+    vi.spyOn(queryParams, 'getStopParam').mockReturnValue('A');
+    const stopMeta = makeStopMeta(makeStop('A', 35, 139));
+    const getStopMetaById = vi.fn().mockResolvedValue({ success: true, data: stopMeta });
+    const repo = makeRepo({ getStopMetaById });
+    const navigateAndFocusStop = vi.fn();
+    const recordStopMetaSelection = vi.fn();
+
+    renderHook(() => useStopParamHandler({ repo, navigateAndFocusStop, recordStopMetaSelection }));
+
+    await waitFor(() => {
+      expect(navigateAndFocusStop).toHaveBeenCalledTimes(1);
+    });
+    expect(navigateAndFocusStop).toHaveBeenCalledWith('apply-stop-param', stopMeta.stop);
+    expect(recordStopMetaSelection).toHaveBeenCalledTimes(1);
+    expect(recordStopMetaSelection).toHaveBeenCalledWith(stopMeta);
+  });
+
+  it('marks handled without navigating when the stop is not found', async () => {
+    vi.spyOn(queryParams, 'getStopParam').mockReturnValue('missing');
+    const getStopMetaById = vi.fn().mockResolvedValue({ success: false, error: 'not found' });
+    const repo = makeRepo({ getStopMetaById });
+    const navigateAndFocusStop = vi.fn();
+    const recordStopMetaSelection = vi.fn();
+
+    renderHook(() => useStopParamHandler({ repo, navigateAndFocusStop, recordStopMetaSelection }));
+
+    // Wait for repo promise + post-resolve handler to settle.
+    await waitFor(() => {
+      expect(getStopMetaById).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(navigateAndFocusStop).not.toHaveBeenCalled();
+    expect(recordStopMetaSelection).not.toHaveBeenCalled();
+  });
+
+  it('does not re-fire after the initial handle, even when dep callbacks change', async () => {
+    vi.spyOn(queryParams, 'getStopParam').mockReturnValue('A');
+    const stopMeta = makeStopMeta(makeStop('A', 35, 139));
+    const getStopMetaById = vi.fn().mockResolvedValue({ success: true, data: stopMeta });
+    const repo = makeRepo({ getStopMetaById });
+    const initialNavigate = vi.fn();
+    const initialRecord = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ navigate, record }) =>
+        useStopParamHandler({
+          repo,
+          navigateAndFocusStop: navigate,
+          recordStopMetaSelection: record,
+        }),
+      {
+        initialProps: { navigate: initialNavigate, record: initialRecord },
+      },
+    );
+
+    await waitFor(() => {
+      expect(initialNavigate).toHaveBeenCalledTimes(1);
+    });
+    expect(getStopMetaById).toHaveBeenCalledTimes(1);
+
+    // Swap dep callbacks (simulates `App` re-render with new closures).
+    const nextNavigate = vi.fn();
+    const nextRecord = vi.fn();
+    rerender({ navigate: nextNavigate, record: nextRecord });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Even though the effect re-runs (deps changed), the `handled` ref
+    // short-circuits before the fetch.
+    expect(getStopMetaById).toHaveBeenCalledTimes(1);
+    expect(nextNavigate).not.toHaveBeenCalled();
+    expect(nextRecord).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-anchor-refresh.ts
+++ b/src/hooks/use-anchor-refresh.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from 'react';
+
+import { buildAnchorRefreshUpdates, type AnchorEntry } from '../domain/portal/anchor';
+import type { LangChain } from '../domain/transit/i18n/resolve-lang-chain';
+import type { TransitRepository } from '../repositories/transit-repository';
+import type { Result } from '../types/app/repository';
+
+/**
+ * Arguments for {@link useAnchorRefresh}.
+ */
+export interface UseAnchorRefreshParams {
+  /** Live anchor list owned by `useAnchors`. */
+  anchors: AnchorEntry[];
+  /** Active transit repository, used to read the latest `StopWithMeta` per anchored stop_id. */
+  repo: TransitRepository;
+  /** Atomic batch update on the anchor repository (single state + single persistence write). */
+  batchUpdateAnchors: (updates: Omit<AnchorEntry, 'createdAt'>[]) => Promise<Result<AnchorEntry[]>>;
+  /** Resolved language fallback chain, used to pick the canonical display name on refresh. */
+  langChain: LangChain;
+}
+
+/**
+ * Refresh anchor entries with the latest GTFS metadata once per app
+ * session.
+ *
+ * Mechanically the effect fires when `anchors` becomes non-empty, not
+ * at component mount: `useAnchors` initializes its state to `[]` and
+ * loads from the repository asynchronously, so for a returning user
+ * the refresh happens the moment that load resolves; for a first-time
+ * user (no persisted anchors) the refresh happens when they add their
+ * first anchor in the current session (with the just-added snapshot,
+ * the comparison is a no-op, so this remains a correctness-safe
+ * trigger).
+ *
+ * The internal `done` ref guarantees the comparison + batch update
+ * runs at most once per `useAnchorRefresh` lifetime, so subsequent
+ * anchor mutations (add / remove / update during the session) do not
+ * re-trigger refresh.
+ *
+ * Side effects:
+ *
+ *   - Calls {@link buildAnchorRefreshUpdates} to compute diffs
+ *     between persisted snapshots and live `StopWithMeta`.
+ *   - Calls `batchUpdateAnchors(updates)` only when at least one
+ *     anchor's name / coordinates / route types changed.
+ *
+ * @param params - See {@link UseAnchorRefreshParams}.
+ */
+export function useAnchorRefresh({
+  anchors,
+  repo,
+  batchUpdateAnchors,
+  langChain,
+}: UseAnchorRefreshParams): void {
+  const done = useRef(false);
+  useEffect(() => {
+    if (done.current || anchors.length === 0) {
+      return;
+    }
+    const stopIds = new Set(anchors.map((a) => a.snapshot.stopId));
+    const metas = repo.getStopMetaByIds(stopIds);
+    // Mark as done regardless of result. repo is fully loaded before
+    // injection (all GTFS data is in memory), so metas is only empty
+    // when all anchor stopIds have been removed from the dataset.
+    // We must not retry on every dependency change.
+    done.current = true;
+    const updates = buildAnchorRefreshUpdates(anchors, metas, langChain);
+    if (updates.length > 0) {
+      void batchUpdateAnchors(updates);
+    }
+  }, [anchors, repo, batchUpdateAnchors, langChain]);
+}

--- a/src/hooks/use-stop-param-handler.ts
+++ b/src/hooks/use-stop-param-handler.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react';
+
+import { createLogger } from '../lib/logger';
+import { getStopParam } from '../lib/query-params';
+import type { TransitRepository } from '../repositories/transit-repository';
+import type { AutoLocateOffReason } from '../types/app/auto-locate';
+import type { Stop } from '../types/app/transit';
+import type { StopWithMeta } from '../types/app/transit-composed';
+
+const logger = createLogger('StopParamHandler');
+
+/**
+ * Arguments for {@link useStopParamHandler}.
+ */
+export interface UseStopParamHandlerParams {
+  /** Active transit repository, used to resolve the `?stop=<id>` value. */
+  repo: TransitRepository;
+  /** Caller-supplied focus + pan-to-stop side effect. */
+  navigateAndFocusStop: (reason: AutoLocateOffReason, stop: Stop) => void;
+  /** Caller-supplied history record side effect for the resolved stop. */
+  recordStopMetaSelection: (stopMeta: StopWithMeta) => void;
+}
+
+/**
+ * Apply the `?stop=<id>` URL query parameter once per app session:
+ * resolve the stop_id against the repository, pan / focus the map to
+ * it, and record the resolved snapshot in history.
+ *
+ * The internal `handled` ref guarantees the workflow runs at most
+ * once per `useStopParamHandler` lifetime, including across the
+ * async repository fetch -- the post-resolve continuation re-checks
+ * `handled.current` so a re-render that swaps the dep callbacks does
+ * not double-fire focus / record.
+ *
+ * No-param path: the ref is marked handled immediately so subsequent
+ * re-renders are no-ops.
+ *
+ * Not-found path: a warn is logged (`'StopParamHandler'` namespace,
+ * separate from the App-level logger so the source is unambiguous)
+ * and the ref is marked handled; the map is not panned and no
+ * history entry is recorded.
+ *
+ * @param params - See {@link UseStopParamHandlerParams}.
+ */
+export function useStopParamHandler({
+  repo,
+  navigateAndFocusStop,
+  recordStopMetaSelection,
+}: UseStopParamHandlerParams): void {
+  const handled = useRef(false);
+  useEffect(() => {
+    if (handled.current) {
+      return;
+    }
+
+    const markHandled = () => {
+      handled.current = true;
+    };
+
+    const stopId = getStopParam();
+    if (!stopId) {
+      markHandled();
+      return;
+    }
+
+    void repo.getStopMetaById(stopId).then((result) => {
+      if (handled.current) {
+        return;
+      }
+      if (!result.success) {
+        logger.warn(`?stop=${stopId}: not found`);
+        markHandled();
+        return;
+      }
+      navigateAndFocusStop('apply-stop-param', result.data.stop);
+      recordStopMetaSelection(result.data);
+      markHandled();
+    });
+  }, [navigateAndFocusStop, recordStopMetaSelection, repo]);
+}


### PR DESCRIPTION
## Summary

- Move the two `App`-startup `useRef` + `useEffect` blocks (anchor metadata refresh, `?stop=<id>` URL param resolution) out of `App` into dedicated hooks under `src/hooks/`. Both follow the same "one-shot guard ref + effect" pattern, so the result is two single-line hook calls in `App`.
- `useAnchorRefresh` TSDoc explicitly documents the actual timing: because `useAnchors` async-loads its state, the refresh fires when `anchors` becomes non-empty (which for a returning user is the moment the async load resolves, and for a first-time user is the moment they add their first anchor -- a no-op comparison either way).
- `useStopParamHandler` keeps the mid-flight guard (the `handled` ref is checked both at effect start and after the async `repo.getStopMetaById` resolves) so a `useEffect` re-run triggered by dep callback churn cannot double-fire focus / record.
- Second Phase 5 PR in the `app.tsx` refactor plan. With this, the inventory's two low-risk lifecycle refs (`anchorRefreshDone`, `hasHandledStopParamRef`) are moved; remaining `App`-owned state is either intentionally kept (high-risk locate / map bridge cluster, `clearFocusRef` bridge ref) or requires a product decision (anchor-selection live-meta refresh).

## Changes

- New: `src/hooks/use-anchor-refresh.ts` (object-arg hook, TSDoc with the "first non-empty anchors" semantics)
- New: `src/hooks/use-stop-param-handler.ts` (object-arg hook, TSDoc with the mid-flight guard semantics; uses its own `'StopParamHandler'` logger namespace)
- New: `src/hooks/__tests__/use-anchor-refresh.test.ts` (4 cases: empty -> no-op, empty -> non-empty fires once, no-diff path skips `batchUpdateAnchors`, `langChain` change after the first refresh does not re-fire)
- New: `src/hooks/__tests__/use-stop-param-handler.test.ts` (4 cases: no param -> no repo call, success -> navigate + record, not-found -> silent (no focus / no record), dep callback churn after handle does not re-fire)
- Modified: `src/app.tsx` (replace each block with a single hook call; drop `useRef` declarations, the two `useEffect` blocks, and now-unused `buildAnchorRefreshUpdates` / `getStopParam` imports)
- Modified: `CHANGELOG.md` (Unreleased / Changed: add an entry for the move)

## Notes for reviewers

- Logger namespace shift: `?stop=<id>` not-found warn moves from the `'App'` logger to a new `'StopParamHandler'` logger. If anything greps logs for `'App'` namespace specifically, that's a knock-on -- the upside is the source is now unambiguous in field traces.
- No `app.test.tsx` change required; the existing filter / anchor / history wiring cases continue to pass against the hooks-backed App.
- `useAnchorRefresh` keeps the original `done.current` semantic (set inside the effect only after the metadata fetch is performed) so the rule "first non-empty anchors triggers refresh, nothing thereafter" is preserved exactly.

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (297 files / 4172 tests pass, including 8 new cases)
- [x] `npm run build` (tsc + vite, exit 0)
- [x] `npm run format` (no diff after run)
- [x] Browser-verify:
  - [x] `?stop=<valid-id>` URL focuses the stop and records history on first load; reloading the same URL does not record duplicate history (the hook resets per mount, so this is "once per session" rather than "once forever")
  - [x] `?stop=invalid` logs the not-found warn under the `'StopParamHandler'` namespace and the map stays at default
  - [x] No `?stop=` param -> normal startup, no extra effect
  - [x] Returning user with persisted anchors -> on load, anchors with changed live names / coordinates / route types are refreshed once
  - [x] First-time user with no anchors -> adding the first anchor in the session does not cause a visible glitch (the refresh fires but is a no-op compared to the just-added snapshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)