### PR TITLE
fix(app): avoid duplicate stop param fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - Route shapes loading: `App` 直下の mount-once fetch (`useState<RouteShape[]>` + `useEffect`) を `useRouteShapes` hook に分離した。`MapView` に渡す `routeShapes` の値・挙動は変えていない。
 - App-wide filter: `showOriginOnly` / `showBoardableOnly` / `omitEmptyStopsOverride` と派生する late-night policy (`isLateNight` / `effectiveOmitEmptyStops` / forced-on rules) を `useGlobalFilter(dateTime)` に集約した。`globalFilter` の object shape と toggle handlers の挙動、`BottomSheet` / `TimetableModal` / nearby selector への入力は変えていない。
 - Stop reference helpers: `App` 内に inline で書かれていた stop 参照解決の重複 (anchor / history map lookup と、live meta / bare Stop からの `StopReferenceSnapshot` 構築) を `domain/transit/stop-meta-lookup.ts` の `lookupStopMetaFromMap` と `domain/transit/stop-navigation.ts` の `buildSelectionSnapshotFromMeta` / `buildSelectionSnapshotFromStop` に切り出した。`buildHistoryNavigationPayload` も内部で新しい builder を使うよう更新。挙動は維持。
-- App startup lifecycle hooks: `App` 直下の 2 つの起動時 side effect (anchor metadata refresh と `?stop=` URL param 解決) をそれぞれ `useAnchorRefresh` / `useStopParamHandler` に分離した。one-shot guard ref + useEffect の pattern を hook 内に閉じ込め、App は hook の 1 行呼出しのみになった。挙動は維持 (anchor refresh は依然「初回 anchors が non-empty になった時に 1 回だけ」、`?stop=` は依然 mid-flight guard 込みの 1 回限り)。
+- App startup lifecycle hooks: `App` 直下の 2 つの起動時 side effect (anchor metadata refresh と `?stop=` URL param 解決) をそれぞれ `useAnchorRefresh` / `useStopParamHandler` に分離した。one-shot guard ref + useEffect の pattern を hook 内に閉じ込め、App は hook の 1 行呼出しのみになった。挙動は維持 (anchor refresh は依然「初回 anchors が non-empty になった時に 1 回だけ」、`?stop=` は callback churn 中も duplicate fetch しない 1 回限り)。
 
 ## [2026.05.25]
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -494,8 +494,8 @@ export default function App() {
   );
 
   // Apply ?stop= query param: resolve via repo, then pan / record once.
-  // See `useStopParamHandler` for the mid-flight guard semantics that
-  // keep this safe when dep callbacks change during the async resolve.
+  // See `useStopParamHandler` for the ref-backed callback pattern that
+  // avoids duplicate fetches when callbacks change during async resolve.
   useStopParamHandler({ repo, navigateAndFocusStop, recordStopMetaSelection });
 
   const handleFetchStopTimes = useCallback(

--- a/src/hooks/__tests__/use-stop-param-handler.test.ts
+++ b/src/hooks/__tests__/use-stop-param-handler.test.ts
@@ -72,10 +72,16 @@ describe('useStopParamHandler', () => {
     expect(recordStopMetaSelection).not.toHaveBeenCalled();
   });
 
-  it('does not re-fire after the initial handle, even when dep callbacks change', async () => {
+  it('does not re-fetch and uses latest callbacks when dep callbacks change mid-flight', async () => {
     vi.spyOn(queryParams, 'getStopParam').mockReturnValue('A');
     const stopMeta = makeStopMeta(makeStop('A', 35, 139));
-    const getStopMetaById = vi.fn().mockResolvedValue({ success: true, data: stopMeta });
+    let resolveLookup: (value: { success: true; data: typeof stopMeta }) => void = () => {};
+    const getStopMetaById = vi.fn(
+      () =>
+        new Promise<{ success: true; data: typeof stopMeta }>((resolve) => {
+          resolveLookup = resolve;
+        }),
+    );
     const repo = makeRepo({ getStopMetaById });
     const initialNavigate = vi.fn();
     const initialRecord = vi.fn();
@@ -92,23 +98,39 @@ describe('useStopParamHandler', () => {
       },
     );
 
-    await waitFor(() => {
-      expect(initialNavigate).toHaveBeenCalledTimes(1);
-    });
     expect(getStopMetaById).toHaveBeenCalledTimes(1);
 
-    // Swap dep callbacks (simulates `App` re-render with new closures).
+    // Swap dep callbacks while the repository lookup is still pending.
     const nextNavigate = vi.fn();
     const nextRecord = vi.fn();
     rerender({ navigate: nextNavigate, record: nextRecord });
+
+    expect(getStopMetaById).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveLookup({ success: true, data: stopMeta });
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(nextNavigate).toHaveBeenCalledTimes(1);
+    });
+
+    expect(nextNavigate).toHaveBeenCalledWith('apply-stop-param', stopMeta.stop);
+    expect(nextRecord).toHaveBeenCalledWith(stopMeta);
+    expect(initialNavigate).not.toHaveBeenCalled();
+    expect(initialRecord).not.toHaveBeenCalled();
+
+    // Later callback churn is still ignored for fetching because the
+    // hook has already started handling the URL param.
+    const thirdNavigate = vi.fn();
+    const thirdRecord = vi.fn();
+    rerender({ navigate: thirdNavigate, record: thirdRecord });
     await act(async () => {
       await Promise.resolve();
     });
 
-    // Even though the effect re-runs (deps changed), the `handled` ref
-    // short-circuits before the fetch.
     expect(getStopMetaById).toHaveBeenCalledTimes(1);
-    expect(nextNavigate).not.toHaveBeenCalled();
-    expect(nextRecord).not.toHaveBeenCalled();
+    expect(thirdNavigate).not.toHaveBeenCalled();
+    expect(thirdRecord).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/use-stop-param-handler.ts
+++ b/src/hooks/use-stop-param-handler.ts
@@ -26,19 +26,18 @@ export interface UseStopParamHandlerParams {
  * resolve the stop_id against the repository, pan / focus the map to
  * it, and record the resolved snapshot in history.
  *
- * The internal `handled` ref guarantees the workflow runs at most
- * once per `useStopParamHandler` lifetime, including across the
- * async repository fetch -- the post-resolve continuation re-checks
- * `handled.current` so a re-render that swaps the dep callbacks does
- * not double-fire focus / record.
+ * The internal `started` ref guarantees the repository lookup starts
+ * at most once per `useStopParamHandler` lifetime. The caller
+ * callbacks are kept in a ref so callback identity churn during the
+ * async lookup neither starts duplicate fetches nor forces the
+ * continuation to use stale callbacks.
  *
- * No-param path: the ref is marked handled immediately so subsequent
+ * No-param path: the ref is marked started immediately so subsequent
  * re-renders are no-ops.
  *
  * Not-found path: a warn is logged (`'StopParamHandler'` namespace,
- * separate from the App-level logger so the source is unambiguous)
- * and the ref is marked handled; the map is not panned and no
- * history entry is recorded.
+ * separate from the App-level logger so the source is unambiguous);
+ * the map is not panned and no history entry is recorded.
  *
  * @param params - See {@link UseStopParamHandlerParams}.
  */
@@ -47,34 +46,35 @@ export function useStopParamHandler({
   navigateAndFocusStop,
   recordStopMetaSelection,
 }: UseStopParamHandlerParams): void {
-  const handled = useRef(false);
+  const started = useRef(false);
+  const callbacksRef = useRef({ navigateAndFocusStop, recordStopMetaSelection });
+
   useEffect(() => {
-    if (handled.current) {
+    callbacksRef.current = { navigateAndFocusStop, recordStopMetaSelection };
+  }, [navigateAndFocusStop, recordStopMetaSelection]);
+
+  useEffect(() => {
+    if (started.current) {
       return;
     }
 
-    const markHandled = () => {
-      handled.current = true;
-    };
-
     const stopId = getStopParam();
+    started.current = true;
+
     if (!stopId) {
-      markHandled();
       return;
     }
 
     void repo.getStopMetaById(stopId).then((result) => {
-      if (handled.current) {
-        return;
-      }
       if (!result.success) {
         logger.warn(`?stop=${stopId}: not found`);
-        markHandled();
         return;
       }
-      navigateAndFocusStop('apply-stop-param', result.data.stop);
-      recordStopMetaSelection(result.data);
-      markHandled();
+
+      const { navigateAndFocusStop: navigate, recordStopMetaSelection: record } =
+        callbacksRef.current;
+      navigate('apply-stop-param', result.data.stop);
+      record(result.data);
     });
-  }, [navigateAndFocusStop, recordStopMetaSelection, repo]);
+  }, [repo]);
 }


### PR DESCRIPTION
## Summary

- Prevent `useStopParamHandler` from issuing duplicate `getStopMetaById` calls when callback dependencies change while the `?stop=` lookup is pending.
- Keep the latest `navigateAndFocusStop` / `recordStopMetaSelection` callbacks in a ref so the resolved lookup uses current callbacks without re-running the fetch effect.
- Strengthen the hook test to cover mid-flight callback churn and update the call-site comment / changelog wording.

## Test plan

- `npm run format`
- `npm run lint -- --quiet`
- `npm run build`
- Focused tests: `use-stop-param-handler.test.ts` + `app.test.tsx` (24 passed)

Follow-up to review comments on PR #249.