### PR TITLE
refactor(app): align stop selection handling

### DIFF
--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -6,6 +6,7 @@ import { RootErrorBoundary } from '../components/error-boundary';
 import { makeRepo, makeRoute, makeStop, makeStopMeta } from './helpers';
 import type { StopHistoryEntry } from '../domain/transit/stop-history';
 import type { UseStopHistoryReturn } from '../hooks/use-stop-history';
+import type { UseAnchorToggleReturn } from '../hooks/use-anchor-toggle';
 import type { UseAnchorsReturn } from '../hooks/use-anchors';
 import type { TransitRepository } from '../repositories/transit-repository';
 import type { UseTimetableReturn } from '../hooks/use-timetable';
@@ -23,6 +24,7 @@ const {
   mockToastError,
   mockToastWarning,
   mockUseAnchors,
+  mockUseAnchorToggle,
   mockGetRouteShapes,
   mockClearAnchorError,
   mockGetServiceDayMinutes,
@@ -47,6 +49,7 @@ const {
   mockToastError: vi.fn(),
   mockToastWarning: vi.fn(),
   mockUseAnchors: vi.fn<(...args: unknown[]) => UseAnchorsReturn>(),
+  mockUseAnchorToggle: vi.fn<() => UseAnchorToggleReturn>(),
   mockGetRouteShapes: vi.fn(),
   mockClearAnchorError: vi.fn(),
   mockGetServiceDayMinutes: vi.fn<GetServiceDayMinutes>(),
@@ -151,6 +154,10 @@ vi.mock('../hooks/use-route-stops', () => ({
 
 vi.mock('../hooks/use-anchors', () => ({
   useAnchors: (...args: unknown[]) => mockUseAnchors(...args),
+}));
+
+vi.mock('../hooks/use-anchor-toggle', () => ({
+  useAnchorToggle: () => mockUseAnchorToggle(),
 }));
 
 vi.mock('../lib/query-params', () => ({
@@ -311,6 +318,7 @@ describe('App anchor error toast', () => {
     mockToastError.mockReset();
     mockToastWarning.mockReset();
     mockUseAnchors.mockReset();
+    mockUseAnchorToggle.mockReset();
     mockGetRouteShapes.mockReset();
     mockClearAnchorError.mockReset();
     mockGetServiceDayMinutes.mockReset();
@@ -353,6 +361,9 @@ describe('App anchor error toast', () => {
       updateAnchor: vi.fn(),
       batchUpdateAnchors: vi.fn(),
       hasAnchor: vi.fn(() => false),
+    });
+    mockUseAnchorToggle.mockReturnValue({
+      handleToggleAnchorByStopId: vi.fn(),
     });
     mockUseDateTime.mockReturnValue({
       dateTime: new Date('2026-03-28T12:00:00Z'),
@@ -1056,6 +1067,35 @@ describe('App anchor error toast', () => {
     await waitFor(() => {
       const searchProps = mockStopSearchDialog.mock.lastCall?.[0] as { open: boolean };
       expect(searchProps.open).toBe(false);
+    });
+  });
+
+  it('passes the anchor toggle handler through to all App entry points', async () => {
+    const handleToggleAnchorByStopId = vi.fn();
+    mockUseAnchorToggle.mockReturnValue({
+      handleToggleAnchorByStopId,
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      const layoutProps = mockAppLayout.mock.lastCall?.[0] as {
+        bottomSheetProps: {
+          onToggleAnchor: typeof handleToggleAnchorByStopId;
+        };
+      };
+      const mapOverlayProps = mockMapOverlay.mock.lastCall?.[0] as {
+        onPortalRemove: (entry: { snapshot: { stopId: string } }) => void;
+      };
+      const stopSearchDialogProps = mockStopSearchDialog.mock.lastCall?.[0] as {
+        onToggleAnchor: typeof handleToggleAnchorByStopId;
+      };
+
+      expect(layoutProps.bottomSheetProps.onToggleAnchor).toBe(handleToggleAnchorByStopId);
+      expect(stopSearchDialogProps.onToggleAnchor).toBe(handleToggleAnchorByStopId);
+
+      mapOverlayProps.onPortalRemove({ snapshot: { stopId: 'portal-stop' } });
+      expect(handleToggleAnchorByStopId).toHaveBeenCalledWith('portal-stop');
     });
   });
 });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -18,7 +18,7 @@ import type {
 import { PERF_PROFILES } from './config/perf-profiles';
 import { SUPPORTED_LANGS } from './config/supported-langs';
 import { TILE_SOURCES } from './config/tile-sources';
-import { DEFAULT_TIMEZONE, resolveAgencyLang } from './config/transit-defaults';
+import { DEFAULT_TIMEZONE } from './config/transit-defaults';
 
 // i18n
 import i18n from './i18n';
@@ -28,16 +28,16 @@ import { applyAppTheme } from './lib/app-theme';
 import { createLogger } from './lib/logger';
 
 // domain
-import { buildAnchorSelectionStop, type AnchorEntry } from './domain/portal/anchor';
+import { type AnchorEntry } from './domain/portal/anchor';
 import { formatDateKey } from './domain/transit/calendar-utils';
 import { deriveFilteredNearbyStops } from './domain/transit/derive-filtered-nearby-stops';
 import { resolveLangChain, type LangChain } from './domain/transit/i18n/resolve-lang-chain';
-import { getStopDisplayNames } from './domain/transit/name-resolver/get-stop-display-names';
 import { getServiceDay } from './domain/transit/service-day';
 import { type StopHistoryEntry } from './domain/transit/stop-history';
 import { findVisibleStopMetaById, lookupStopMetaFromMap } from './domain/transit/stop-meta-lookup';
 import {
   buildHistoryNavigationPayload,
+  buildPortalNavigationPayload,
   buildSelectionSnapshotFromMeta,
   buildSelectionSnapshotFromStop,
 } from './domain/transit/stop-navigation';
@@ -49,7 +49,8 @@ import { getTripInspectionOpenOutcomeMessage } from './domain/transit/trip-inspe
 
 // hooks
 import { useAnchorRefresh } from './hooks/use-anchor-refresh';
-import { useAnchors } from './hooks/use-anchors';
+import { useAnchorToggle } from './hooks/use-anchor-toggle';
+import { useAnchors, type UseAnchorsReturn } from './hooks/use-anchors';
 import { useAppDialogs } from './hooks/use-app-dialogs';
 import { useDateTime } from './hooks/use-date-time';
 import { useGlobalFilter } from './hooks/use-global-filter';
@@ -76,7 +77,6 @@ import { LocalStorageStopSelectionRepository } from './repositories/stop-selecti
 import { formatDateParts } from './utils/datetime';
 import { toggleGroupInList } from './utils/list-toggle';
 import { routeTypeGroup } from './utils/route-type-category';
-import { routeTypesEmoji } from './utils/route-type-emoji';
 import {
   nextInfoLevel,
   nextLang,
@@ -342,7 +342,14 @@ export default function App() {
   }, [clearFocus]);
 
   const routeStops = useRouteStops(selectionInfo?.routeIds ?? null, repo);
-  // console.debug('routeStops', routeStops.length);
+
+  const { selectStop, navigateAndFocusStop } = useStopNavigation({
+    disableAutoLocate,
+    selectStopById,
+    focusStop,
+  });
+
+  // --- History state and metadata lookup ---
 
   const {
     history,
@@ -363,55 +370,6 @@ export default function App() {
     clearHistoryError();
   }, [clearHistoryError, historyError, t]);
 
-  const {
-    anchors,
-    lastError: anchorError,
-    clearError: clearAnchorError,
-    addAnchor,
-    removeAnchor,
-    batchUpdateAnchors,
-    hasAnchor: isStopAnchor,
-  } = useAnchors(anchorRepo);
-
-  useEffect(() => {
-    if (!anchorError) {
-      return;
-    }
-    logger.warn(`anchor operation failed: ${anchorError}`);
-    toast.error(t('anchor.anchorUpdateFailed'), {
-      description: anchorError,
-      duration: 4_000,
-    });
-    clearAnchorError();
-  }, [anchorError, clearAnchorError, t]);
-
-  // Refresh anchor entries with latest data once per session.
-  // See `useAnchorRefresh` for the "first non-empty anchors" timing
-  // semantics (driven by `useAnchors`'s async load).
-  useAnchorRefresh({ anchors, repo, batchUpdateAnchors, langChain });
-
-  // Pre-resolved StopWithMeta map for every anchored stop_id.
-  // Built from the repository's full dataset (not just the visible
-  // viewport) so that `Portals` can look up the latest translated
-  // display name for any anchor regardless of where it is on the map.
-  const anchorStopMetaMap = useMemo(() => {
-    if (anchors.length === 0) {
-      return new Map<string, StopWithMeta>();
-    }
-    const stopIds = new Set(anchors.map((a) => a.snapshot.stopId));
-    const metas = repo.getStopMetaByIds(stopIds);
-    return new Map(metas.map((m) => [m.stop.stop_id, m]));
-  }, [anchors, repo]);
-
-  // Lookup an anchored stop's current StopWithMeta. Returns null
-  // when the anchor's stop_id is not present in the active dataset
-  // (e.g. cross-source anchor in mock mode, or a stop deleted from
-  // the data); callers should fall back to the AnchorEntry snapshot.
-  const lookupAnchorStopMeta = useCallback(
-    (stopId: string): StopWithMeta | null => lookupStopMetaFromMap(stopId, anchorStopMetaMap),
-    [anchorStopMetaMap],
-  );
-
   const historyStopMetaMap = useMemo(() => {
     if (history.length === 0) {
       return new Map<string, StopWithMeta>();
@@ -429,12 +387,6 @@ export default function App() {
     (stopId: string): StopWithMeta | null => lookupStopMetaFromMap(stopId, historyStopMetaMap),
     [historyStopMetaMap],
   );
-
-  const { selectStop, navigateAndFocusStop } = useStopNavigation({
-    disableAutoLocate,
-    selectStopById,
-    focusStop,
-  });
 
   const recordStopMetaSelection = useCallback(
     (stopMeta: StopWithMeta) => {
@@ -497,6 +449,70 @@ export default function App() {
   // See `useStopParamHandler` for the ref-backed callback pattern that
   // avoids duplicate fetches when callbacks change during async resolve.
   useStopParamHandler({ repo, navigateAndFocusStop, recordStopMetaSelection });
+
+  // --- Anchor state and metadata lookup ---
+
+  const {
+    anchors,
+    lastError: anchorError,
+    clearError: clearAnchorError,
+    addAnchor,
+    removeAnchor,
+    batchUpdateAnchors,
+    hasAnchor: isStopAnchor,
+  }: UseAnchorsReturn = useAnchors(anchorRepo);
+
+  const anchorIds = useMemo(() => new Set(anchors.map((a) => a.snapshot.stopId)), [anchors]);
+
+  // Pre-resolved StopWithMeta map for every anchored stop_id.
+  // Built from the repository's full dataset (not just the visible
+  // viewport) so that `Portals` can look up the latest translated
+  // display name for any anchor regardless of where it is on the map.
+  const anchorStopMetaMap = useMemo(() => {
+    if (anchors.length === 0) {
+      return new Map<string, StopWithMeta>();
+    }
+    const stopIds = new Set(anchors.map((a) => a.snapshot.stopId));
+    const metas = repo.getStopMetaByIds(stopIds);
+    return new Map(metas.map((m) => [m.stop.stop_id, m]));
+  }, [anchors, repo]);
+
+  // Lookup an anchored stop's current StopWithMeta. Returns null
+  // when the anchor's stop_id is not present in the active dataset
+  // (e.g. cross-source anchor in mock mode, or a stop deleted from
+  // the data); callers should fall back to the AnchorEntry snapshot.
+  const lookupAnchorStopMeta = useCallback(
+    (stopId: string): StopWithMeta | null => lookupStopMetaFromMap(stopId, anchorStopMetaMap),
+    [anchorStopMetaMap],
+  );
+
+  const { handleToggleAnchorByStopId } = useAnchorToggle({
+    anchors,
+    hasAnchor: isStopAnchor,
+    addAnchor,
+    removeAnchor,
+    repo,
+    lookupAnchorStopMeta,
+    langChain,
+    t,
+  });
+
+  useEffect(() => {
+    if (!anchorError) {
+      return;
+    }
+    logger.warn(`anchor operation failed: ${anchorError}`);
+    toast.error(t('anchor.anchorUpdateFailed'), {
+      description: anchorError,
+      duration: 4_000,
+    });
+    clearAnchorError();
+  }, [anchorError, clearAnchorError, t]);
+
+  // Refresh anchor entries with latest data once per session.
+  // See `useAnchorRefresh` for the "first non-empty anchors" timing
+  // semantics (driven by `useAnchors`'s async load).
+  useAnchorRefresh({ anchors, repo, batchUpdateAnchors, langChain });
 
   const handleFetchStopTimes = useCallback(
     async (stopId: string): Promise<StopWithContext | null> => {
@@ -636,82 +652,6 @@ export default function App() {
     [langChain, lookupHistoryStopMeta, navigateAndFocusStop, recordStopSelection, routeTypeMap],
   );
 
-  // Anchor stop_id set for efficient lookup in BottomSheet
-  const anchorIds = useMemo(() => new Set(anchors.map((a) => a.snapshot.stopId)), [anchors]);
-
-  // Toggle anchor (bookmark) status for a stop
-  const handleToggleAnchorByStopId = useCallback(
-    (stopId: string) => {
-      if (isStopAnchor(stopId)) {
-        // Capture anchor data before removal (entry won't exist after removeAnchor).
-        // Resolve display name from current data so the toast follows
-        // the user's current language even though the stored entry
-        // only has a snapshot stopName. We use `lookupAnchorStopMeta`
-        // (full-dataset scan over the anchor set) rather than
-        // the stop-navigation viewport lookup here because the stop_id
-        // is a persistent anchor reference and may, in some future UI
-        // path, be triggered for an anchor that is not currently in
-        // radiusStops / inBoundStops. See `DEVELOPMENT.md > Stop ID
-        // lookup の選び方` for the rule.
-        const anchor = anchors.find((a) => a.snapshot.stopId === stopId);
-        const meta = lookupAnchorStopMeta(stopId);
-        const stopName = meta
-          ? getStopDisplayNames(
-              meta.stop,
-              langChain,
-              resolveAgencyLang(meta.agencies, meta.stop.agency_id),
-            ).name ||
-            anchor?.snapshot.name ||
-            stopId
-          : (anchor?.snapshot.name ?? stopId);
-        logger.debug(`handleToggleAnchor: removing stopId=${stopId}`);
-        void removeAnchor(stopId).then((result) => {
-          if (result.success) {
-            const prefix = anchor ? `${routeTypesEmoji(anchor.snapshot.routeTypes)} ` : '';
-            toast.warning(t('anchor.removed'), { description: `${prefix}${stopName}` });
-          }
-        });
-      } else {
-        void Promise.all([repo.getStopMetaById(stopId), repo.getRouteTypesForStop(stopId)]).then(
-          ([metaResult, routeTypesResult]) => {
-            if (!metaResult.success) {
-              logger.warn('handleToggleAnchorByStopId: stop metadata lookup failed', {
-                stopId,
-                error: metaResult.error,
-              });
-              return;
-            }
-
-            const meta = metaResult.data;
-            const routeTypes = routeTypesResult.success ? routeTypesResult.data : [-1 as const];
-            const displayName =
-              getStopDisplayNames(
-                meta.stop,
-                langChain,
-                resolveAgencyLang(meta.agencies, meta.stop.agency_id),
-              ).name || meta.stop.stop_name;
-            if (logger.isEnabled('debug')) {
-              logger.debug(
-                `handleToggleAnchorByStopId: adding stopId=${stopId}, name=${displayName}`,
-              );
-            }
-            const snapshot = createStopReferenceSnapshot(meta, routeTypes, langChain);
-            void addAnchor({
-              snapshot,
-            }).then((result) => {
-              if (result.success) {
-                toast.success(t('anchor.added'), {
-                  description: `${routeTypesEmoji(routeTypes)} ${displayName}`,
-                });
-              }
-            });
-          },
-        );
-      }
-    },
-    [isStopAnchor, anchors, removeAnchor, addAnchor, repo, lookupAnchorStopMeta, langChain, t],
-  );
-
   // Select + pan to a stop from Portal dropdown.
   // See `handleHistorySelect` for the rationale of disabling
   // auto-tracking before panning.
@@ -720,15 +660,20 @@ export default function App() {
       logger.debug(
         `handlePortalSelect [Portal]: stopId=${entry.snapshot.stopId}, name=${entry.snapshot.name}`,
       );
-      const stop = buildAnchorSelectionStop(entry);
-      if (stop === null) {
+      const payload = buildPortalNavigationPayload(
+        entry,
+        routeTypeMap,
+        langChain,
+        lookupAnchorStopMeta,
+      );
+      if (payload == null) {
         logger.warn(`handlePortalSelect unresolved stopId=${entry.snapshot.stopId}`);
         return;
       }
-      navigateAndFocusStop('select-portal', stop);
-      void recordStopSelection(entry.snapshot);
+      navigateAndFocusStop('select-portal', payload.stop);
+      void recordStopSelection(payload.snapshot);
     },
-    [navigateAndFocusStop, recordStopSelection],
+    [langChain, lookupAnchorStopMeta, navigateAndFocusStop, recordStopSelection, routeTypeMap],
   );
 
   // Select + pan to a stop chosen from the search dialog.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -421,30 +421,6 @@ export default function App() {
     ],
   );
 
-  // Wrap selectStop to also record in history.
-  //
-  // Disables auto-tracking because selecting a stop pans the map to
-  // the stop's coordinates (via `PanToFocus` reading `focusPosition`),
-  // which would fight the auto-pan effect and make subsequent
-  // `moveend` events ineligible for nearby/in-bounds refetch.
-  const handleSelectStop = useCallback(
-    (stop: Stop) => {
-      selectStop({ reason: 'select-marker', stopId: stop.stop_id, fallbackStop: stop });
-      recordStopSelectionByVisibleStop(stop.stop_id, stop);
-    },
-    [recordStopSelectionByVisibleStop, selectStop],
-  );
-
-  // Wrap selectStopById to also record in history.
-  // See `handleSelectStop` for the rationale of disabling auto-tracking.
-  const handleSelectStopById = useCallback(
-    (stopId: string) => {
-      selectStop({ reason: 'select-bottom-sheet', stopId });
-      recordStopSelectionByVisibleStop(stopId);
-    },
-    [recordStopSelectionByVisibleStop, selectStop],
-  );
-
   // Apply ?stop= query param: resolve via repo, then pan / record once.
   // See `useStopParamHandler` for the ref-backed callback pattern that
   // avoids duplicate fetches when callbacks change during async resolve.
@@ -625,6 +601,30 @@ export default function App() {
       }
     },
     [closeTripInspection],
+  );
+
+  // Wrap selectStop to also record in history.
+  //
+  // Disables auto-tracking because selecting a stop pans the map to
+  // the stop's coordinates (via `PanToFocus` reading `focusPosition`),
+  // which would fight the auto-pan effect and make subsequent
+  // `moveend` events ineligible for nearby/in-bounds refetch.
+  const handleSelectStop = useCallback(
+    (stop: Stop) => {
+      selectStop({ reason: 'select-marker', stopId: stop.stop_id, fallbackStop: stop });
+      recordStopSelectionByVisibleStop(stop.stop_id, stop);
+    },
+    [recordStopSelectionByVisibleStop, selectStop],
+  );
+
+  // Wrap selectStopById to also record in history.
+  // See `handleSelectStop` for the rationale of disabling auto-tracking.
+  const handleSelectStopById = useCallback(
+    (stopId: string) => {
+      selectStop({ reason: 'select-bottom-sheet', stopId });
+      recordStopSelectionByVisibleStop(stopId);
+    },
+    [recordStopSelectionByVisibleStop, selectStop],
   );
 
   // Select + pan to a stop from history.

--- a/src/domain/portal/anchor.ts
+++ b/src/domain/portal/anchor.ts
@@ -1,5 +1,5 @@
 import type { StopReferenceSnapshot } from '@/types/app/stop-reference-snapshot';
-import type { AppRouteTypeValue, Stop } from '@/types/app/transit';
+import type { AppRouteTypeValue } from '@/types/app/transit';
 import type { StopWithMeta } from '@/types/app/transit-composed';
 
 import { createStopReferenceSnapshot } from '@/domain/transit/stop-reference-snapshot';
@@ -173,24 +173,4 @@ export function buildAnchorRefreshUpdates(
         anchor.snapshot.agencyNames.some((name, i) => name !== update.snapshot.agencyNames[i]),
     )
     .map(({ update }) => update);
-}
-
-/**
- * Build a minimal Stop for anchor navigation from the persisted snapshot.
- */
-export function buildAnchorSelectionStop(entry: AnchorEntry): Stop | null {
-  if (entry.snapshot.lat === null || entry.snapshot.lon === null) {
-    return null;
-  }
-
-  return {
-    stop_id: entry.snapshot.stopId,
-    stop_name: entry.snapshot.name,
-    stop_names: {},
-    stop_lat: entry.snapshot.lat,
-    stop_lon: entry.snapshot.lon,
-    location_type: 0,
-    agency_id: '',
-    platform_code: entry.snapshot.platformCode,
-  };
 }

--- a/src/domain/transit/__tests__/stop-history.test.ts
+++ b/src/domain/transit/__tests__/stop-history.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { makeStop } from '../../../__tests__/helpers';
 import type { AppRouteTypeValue } from '../../../types/app/transit';
 import type { StopHistoryEntry } from '../stop-history';
-import { addToHistory, buildHistorySelectionStop, MAX_HISTORY_SIZE } from '../stop-history';
+import { addToHistory, MAX_HISTORY_SIZE } from '../stop-history';
 import { createStopReferenceSnapshot } from '../stop-reference-snapshot';
 
 function makeEntry(
@@ -141,38 +141,5 @@ describe('createStopReferenceSnapshot', () => {
     const result = createStopReferenceSnapshot(stop, [3]);
 
     expect(result.platformCode).toBe('P1');
-  });
-});
-
-describe('buildHistorySelectionStop', () => {
-  it('builds a minimal Stop from a stored history snapshot with coordinates', () => {
-    const result = buildHistorySelectionStop(makeEntry('A', [3], 1000));
-
-    expect(result).toEqual({
-      stop_id: 'A',
-      stop_name: 'A',
-      stop_names: {},
-      stop_lat: 35,
-      stop_lon: 139,
-      location_type: 0,
-      agency_id: '',
-      platform_code: undefined,
-    });
-  });
-
-  it('returns null when the stored history snapshot has no coordinates', () => {
-    const result = buildHistorySelectionStop({
-      snapshot: {
-        stopId: 'A',
-        name: 'A',
-        lat: null,
-        lon: null,
-        routeTypes: [3],
-        agencyNames: [],
-      },
-      selectedAt: 1000,
-    });
-
-    expect(result).toBeNull();
   });
 });

--- a/src/domain/transit/__tests__/stop-navigation.test.ts
+++ b/src/domain/transit/__tests__/stop-navigation.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { makeRoute, makeStop, makeStopMeta } from '../../../__tests__/helpers';
 import type { AppRouteTypeValue } from '../../../types/app/transit';
+import type { AnchorEntry } from '../../portal/anchor';
 import { findVisibleStopMetaById, lookupStopMetaFromMap } from '../stop-meta-lookup';
 import {
+  buildPersistedStopNavigationPayload,
   buildHistoryNavigationPayload,
+  buildPortalNavigationPayload,
   buildSelectionSnapshotFromMeta,
+  buildFallbackStopFromSnapshot,
   buildSelectionSnapshotFromStop,
 } from '../stop-navigation';
 import type { StopHistoryEntry } from '../stop-history';
@@ -152,6 +156,133 @@ describe('buildSelectionSnapshotFromStop', () => {
   });
 });
 
+describe('buildFallbackStopFromSnapshot', () => {
+  it('builds a minimal Stop when snapshot coordinates exist', () => {
+    expect(
+      buildFallbackStopFromSnapshot({
+        stopId: 'A',
+        name: 'Snapshot A',
+        lat: 35,
+        lon: 139,
+        routeTypes: [3],
+        agencyNames: ['Agency A'],
+        platformCode: '1',
+      }),
+    ).toEqual({
+      stop_id: 'A',
+      stop_name: 'Snapshot A',
+      stop_names: {},
+      stop_lat: 35,
+      stop_lon: 139,
+      location_type: 0,
+      agency_id: '',
+      platform_code: '1',
+    });
+  });
+
+  it('returns null when snapshot coordinates are missing', () => {
+    expect(
+      buildFallbackStopFromSnapshot({
+        stopId: 'A',
+        name: 'Snapshot A',
+        lat: null,
+        lon: null,
+        routeTypes: [3],
+        agencyNames: [],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('buildPersistedStopNavigationPayload', () => {
+  it('returns stop and snapshot from current stop metadata when available', () => {
+    const entry: AnchorEntry = {
+      snapshot: {
+        stopId: 'A',
+        name: 'Snapshot A',
+        lat: 35,
+        lon: 139,
+        routeTypes: [3],
+        agencyNames: ['Agency A'],
+        platformCode: '1',
+      },
+      createdAt: 1000,
+    };
+    const stopMeta = makeStopMeta(makeStop('A', 36, 140));
+    stopMeta.routes = [];
+
+    const result = buildPersistedStopNavigationPayload(entry, new Map(), ['ja'], () => stopMeta);
+
+    expect(result).toEqual({
+      stop: stopMeta.stop,
+      snapshot: {
+        stopId: 'A',
+        name: 'Stop A',
+        lat: 36,
+        lon: 140,
+        routeTypes: [-1],
+        agencyNames: [],
+        platformCode: undefined,
+      },
+    });
+  });
+
+  it('returns stop and snapshot from the persisted entry when current metadata is unavailable', () => {
+    const entry: AnchorEntry = {
+      snapshot: {
+        stopId: 'A',
+        name: 'Snapshot A',
+        lat: 35,
+        lon: 139,
+        routeTypes: [3],
+        agencyNames: ['Agency A'],
+        platformCode: '1',
+      },
+      createdAt: 1000,
+    };
+
+    const result = buildPersistedStopNavigationPayload(entry, new Map(), ['ja'], () => null);
+
+    expect(result).toEqual({
+      stop: {
+        stop_id: 'A',
+        stop_name: 'Snapshot A',
+        stop_names: {},
+        stop_lat: 35,
+        stop_lon: 139,
+        location_type: 0,
+        agency_id: '',
+        platform_code: '1',
+      },
+      snapshot: {
+        stopId: 'A',
+        name: 'Snapshot A',
+        lat: 35,
+        lon: 139,
+        routeTypes: [3],
+        agencyNames: ['Agency A'],
+        platformCode: '1',
+      },
+    });
+  });
+
+  it('returns null when the persisted entry cannot rebuild a stop', () => {
+    const entry: AnchorEntry = {
+      snapshot: {
+        stopId: 'A',
+        name: 'Snapshot A',
+        lat: null,
+        lon: null,
+        routeTypes: [3],
+        agencyNames: [],
+      },
+      createdAt: 1000,
+    };
+
+    expect(buildPersistedStopNavigationPayload(entry, new Map(), ['ja'], () => null)).toBeNull();
+  });
+});
+
 describe('buildHistoryNavigationPayload', () => {
   it('returns stop and snapshot from current stop metadata when available', () => {
     const entry: StopHistoryEntry = {
@@ -243,5 +374,78 @@ describe('buildHistoryNavigationPayload', () => {
     );
 
     expect(result).toBeNull();
+  });
+});
+
+describe('buildPortalNavigationPayload', () => {
+  it('returns stop and snapshot from current stop metadata when available', () => {
+    const entry: AnchorEntry = {
+      snapshot: {
+        stopId: 'A',
+        name: 'Snapshot A',
+        lat: 35,
+        lon: 139,
+        routeTypes: [3],
+        agencyNames: ['Agency A'],
+        platformCode: '1',
+      },
+      createdAt: 1000,
+    };
+    const stopMeta = makeStopMeta(makeStop('A', 36, 140));
+    stopMeta.routes = [];
+
+    const result = buildPortalNavigationPayload(entry, new Map(), ['ja'], () => stopMeta);
+
+    expect(result).toEqual({
+      stop: stopMeta.stop,
+      snapshot: {
+        stopId: 'A',
+        name: 'Stop A',
+        lat: 36,
+        lon: 140,
+        routeTypes: [-1],
+        agencyNames: [],
+        platformCode: undefined,
+      },
+    });
+  });
+
+  it('returns stop and snapshot from the persisted anchor when current metadata is unavailable', () => {
+    const entry: AnchorEntry = {
+      snapshot: {
+        stopId: 'A',
+        name: 'Snapshot A',
+        lat: 35,
+        lon: 139,
+        routeTypes: [3],
+        agencyNames: ['Agency A'],
+        platformCode: '1',
+      },
+      createdAt: 1000,
+    };
+
+    const result = buildPortalNavigationPayload(entry, new Map(), ['ja'], () => null);
+
+    expect(result).toEqual({
+      stop: {
+        stop_id: 'A',
+        stop_name: 'Snapshot A',
+        stop_names: {},
+        stop_lat: 35,
+        stop_lon: 139,
+        location_type: 0,
+        agency_id: '',
+        platform_code: '1',
+      },
+      snapshot: {
+        stopId: 'A',
+        name: 'Snapshot A',
+        lat: 35,
+        lon: 139,
+        routeTypes: [3],
+        agencyNames: ['Agency A'],
+        platformCode: '1',
+      },
+    });
   });
 });

--- a/src/domain/transit/stop-history.ts
+++ b/src/domain/transit/stop-history.ts
@@ -1,5 +1,4 @@
 import type { StopReferenceSnapshot } from '@/types/app/stop-reference-snapshot';
-import type { Stop } from '@/types/app/transit';
 
 /** Maximum number of stops retained in history. */
 export const MAX_HISTORY_SIZE = 20;
@@ -44,25 +43,4 @@ export function addToHistory(
     selectedAt: now,
   };
   return [entry, ...filtered].slice(0, MAX_HISTORY_SIZE);
-}
-
-/**
- * Build a minimal Stop for history-based selection when current repository
- * metadata is unavailable but the persisted snapshot still has coordinates.
- */
-export function buildHistorySelectionStop(entry: StopHistoryEntry): Stop | null {
-  if (entry.snapshot.lat === null || entry.snapshot.lon === null) {
-    return null;
-  }
-
-  return {
-    stop_id: entry.snapshot.stopId,
-    stop_name: entry.snapshot.name,
-    stop_names: {},
-    stop_lat: entry.snapshot.lat,
-    stop_lon: entry.snapshot.lon,
-    location_type: 0,
-    agency_id: '',
-    platform_code: entry.snapshot.platformCode,
-  };
 }

--- a/src/domain/transit/stop-navigation.ts
+++ b/src/domain/transit/stop-navigation.ts
@@ -1,10 +1,19 @@
 import type { StopReferenceSnapshot } from '../../types/app/stop-reference-snapshot';
 import type { AppRouteTypeValue, Stop } from '../../types/app/transit';
 import type { StopWithMeta } from '../../types/app/transit-composed';
+import type { AnchorEntry } from '../portal/anchor';
 import type { LangChain } from './i18n/resolve-lang-chain';
 import { resolveStopRouteTypes } from './resolve-stop-route-types';
-import { buildHistorySelectionStop, type StopHistoryEntry } from './stop-history';
+import type { StopHistoryEntry } from './stop-history';
 import { createStopReferenceSnapshot } from './stop-reference-snapshot';
+
+/**
+ * Minimal persisted entry shape accepted by stop-navigation helpers.
+ */
+export interface SnapshotBackedStopEntry {
+  /** Durable stop snapshot used for fallback navigation. */
+  snapshot: StopReferenceSnapshot;
+}
 
 /**
  * Build a `StopReferenceSnapshot` from live `StopWithMeta`.
@@ -61,18 +70,61 @@ export function buildSelectionSnapshotFromStop(
   return createStopReferenceSnapshot(stop, routeTypes, dataLang);
 }
 
-export interface HistoryNavigationPayload {
+/**
+ * Resolved stop target and snapshot used by selection flows.
+ */
+export interface StopNavigationPayload {
   stop: Stop;
   snapshot: StopReferenceSnapshot;
 }
 
-export function buildHistoryNavigationPayload(
-  stopHistoryEntry: StopHistoryEntry,
+/**
+ * Build a minimal Stop from a persisted stop snapshot.
+ *
+ * Used as the fallback navigation target when current repository
+ * metadata is unavailable but the durable snapshot still has
+ * coordinates.
+ *
+ * @param snapshot - Persisted stop snapshot.
+ * @returns Minimal Stop for navigation, or null when coordinates are missing.
+ */
+export function buildFallbackStopFromSnapshot(snapshot: StopReferenceSnapshot): Stop | null {
+  if (snapshot.lat === null || snapshot.lon === null) {
+    return null;
+  }
+
+  return {
+    stop_id: snapshot.stopId,
+    stop_name: snapshot.name,
+    stop_names: {},
+    stop_lat: snapshot.lat,
+    stop_lon: snapshot.lon,
+    location_type: 0,
+    agency_id: '',
+    platform_code: snapshot.platformCode,
+  };
+}
+
+/**
+ * Resolve a durable stop reference into a navigation payload.
+ *
+ * The resolution strategy is shared by history and portal selection:
+ * prefer current repository metadata when available, otherwise fall
+ * back to the persisted snapshot.
+ *
+ * @param entry - Durable stop reference entry.
+ * @param routeTypeMap - Route-type lookup used when rebuilding snapshots from live meta.
+ * @param dataLang - Preferred display language chain.
+ * @param lookupStopMeta - Live metadata lookup for the entry's stopId.
+ * @returns Navigation payload, or null when neither live nor persisted coordinates can navigate.
+ */
+export function buildPersistedStopNavigationPayload(
+  entry: SnapshotBackedStopEntry,
   routeTypeMap: ReadonlyMap<string, AppRouteTypeValue[]>,
   dataLang: LangChain,
-  lookupHistoryStopMeta: (stopId: string) => StopWithMeta | null,
-): HistoryNavigationPayload | null {
-  const stopMeta = lookupHistoryStopMeta(stopHistoryEntry.snapshot.stopId);
+  lookupStopMeta: (stopId: string) => StopWithMeta | null,
+): StopNavigationPayload | null {
+  const stopMeta = lookupStopMeta(entry.snapshot.stopId);
 
   if (stopMeta != null) {
     return {
@@ -81,8 +133,7 @@ export function buildHistoryNavigationPayload(
     };
   }
 
-  // create a minimal Stop from the snapshot
-  const minimalStop = buildHistorySelectionStop(stopHistoryEntry);
+  const minimalStop = buildFallbackStopFromSnapshot(entry.snapshot);
 
   if (minimalStop == null) {
     return null;
@@ -90,6 +141,42 @@ export function buildHistoryNavigationPayload(
 
   return {
     stop: minimalStop,
-    snapshot: stopHistoryEntry.snapshot,
+    snapshot: entry.snapshot,
   };
+}
+
+/**
+ * Resolve a history entry into a navigation payload.
+ *
+ * @param entry - Persisted history entry.
+ * @param routeTypeMap - Route-type lookup used when rebuilding snapshots from live meta.
+ * @param dataLang - Preferred display language chain.
+ * @param lookupStopMeta - Live metadata lookup for the history entry's stopId.
+ * @returns Navigation payload, or null when neither live nor persisted coordinates can navigate.
+ */
+export function buildHistoryNavigationPayload(
+  entry: StopHistoryEntry,
+  routeTypeMap: ReadonlyMap<string, AppRouteTypeValue[]>,
+  dataLang: LangChain,
+  lookupStopMeta: (stopId: string) => StopWithMeta | null,
+): StopNavigationPayload | null {
+  return buildPersistedStopNavigationPayload(entry, routeTypeMap, dataLang, lookupStopMeta);
+}
+
+/**
+ * Resolve a portal anchor into a navigation payload.
+ *
+ * @param entry - Selected anchor entry.
+ * @param routeTypeMap - Route-type lookup used when rebuilding snapshots from live meta.
+ * @param dataLang - Preferred display language chain.
+ * @param lookupStopMeta - Live metadata lookup for the anchor stopId.
+ * @returns Navigation payload, or null when neither live nor persisted coordinates can navigate.
+ */
+export function buildPortalNavigationPayload(
+  entry: AnchorEntry,
+  routeTypeMap: ReadonlyMap<string, AppRouteTypeValue[]>,
+  dataLang: LangChain,
+  lookupStopMeta: (stopId: string) => StopWithMeta | null,
+): StopNavigationPayload | null {
+  return buildPersistedStopNavigationPayload(entry, routeTypeMap, dataLang, lookupStopMeta);
 }

--- a/src/hooks/__tests__/use-anchor-toggle.test.ts
+++ b/src/hooks/__tests__/use-anchor-toggle.test.ts
@@ -1,0 +1,127 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { TFunction } from 'i18next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeRepo, makeStopMeta } from '../../__tests__/helpers';
+import type { AnchorEntry } from '../../domain/portal/anchor';
+import type { UseAnchorsReturn } from '../use-anchors';
+import { useAnchorToggle } from '../use-anchor-toggle';
+import type { TransitRepository } from '../../repositories/transit-repository';
+
+type ToastOptions = {
+  description?: string;
+};
+
+const { mockToastSuccess, mockToastWarning } = vi.hoisted(() => ({
+  mockToastSuccess: vi.fn<(message: string, options?: ToastOptions) => void>(),
+  mockToastWarning: vi.fn<(message: string, options?: ToastOptions) => void>(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: mockToastSuccess,
+    warning: mockToastWarning,
+  },
+}));
+
+function makeAnchorEntry(stopId: string, name = `Snapshot ${stopId}`): AnchorEntry {
+  return {
+    snapshot: {
+      stopId,
+      name,
+      lat: 35,
+      lon: 139,
+      routeTypes: [3],
+      agencyNames: [],
+    },
+    createdAt: 1000,
+  };
+}
+
+describe('useAnchorToggle', () => {
+  beforeEach(() => {
+    mockToastSuccess.mockReset();
+    mockToastWarning.mockReset();
+  });
+
+  it('removes an existing anchor and shows a warning toast with the current display name', async () => {
+    const removeAnchor = vi
+      .fn<UseAnchorsReturn['removeAnchor']>()
+      .mockResolvedValue({ success: true, data: undefined });
+    const meta = makeStopMeta('A');
+    meta.stop.stop_name = 'Current A';
+
+    const { result } = renderHook(() =>
+      useAnchorToggle({
+        anchors: [makeAnchorEntry('A', 'Stored A')],
+        hasAnchor: vi.fn((stopId: string) => stopId === 'A'),
+        addAnchor: vi.fn(),
+        removeAnchor,
+        repo: makeRepo(),
+        lookupAnchorStopMeta: vi.fn(() => meta),
+        langChain: ['ja'],
+        t: ((key: string) => key) as TFunction,
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleAnchorByStopId('A');
+    });
+
+    await waitFor(() => {
+      expect(removeAnchor).toHaveBeenCalledWith('A');
+      expect(mockToastWarning).toHaveBeenCalled();
+      const [, options] = mockToastWarning.mock.calls[0] ?? [];
+      expect(options).toBeDefined();
+      expect(options?.description).toContain('Current A');
+    });
+  });
+
+  it('adds a new anchor and shows a success toast', async () => {
+    const addAnchor = vi
+      .fn<UseAnchorsReturn['addAnchor']>()
+      .mockResolvedValue({ success: true, data: makeAnchorEntry('A') });
+    const meta = makeStopMeta('A');
+    meta.stop.stop_name = 'Current A';
+    const getStopMetaById = vi
+      .fn<TransitRepository['getStopMetaById']>()
+      .mockResolvedValue({ success: true, data: meta });
+    const getRouteTypesForStop = vi
+      .fn<TransitRepository['getRouteTypesForStop']>()
+      .mockResolvedValue({ success: true, data: [3] });
+    const repo = makeRepo({
+      getStopMetaById,
+      getRouteTypesForStop,
+    });
+
+    const { result } = renderHook(() =>
+      useAnchorToggle({
+        anchors: [],
+        hasAnchor: vi.fn(() => false),
+        addAnchor,
+        removeAnchor: vi.fn(),
+        repo,
+        lookupAnchorStopMeta: vi.fn(() => null),
+        langChain: ['ja'],
+        t: ((key: string) => key) as TFunction,
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleAnchorByStopId('A');
+    });
+
+    await waitFor(() => {
+      expect(addAnchor).toHaveBeenCalled();
+      const [entry] = addAnchor.mock.calls[0] ?? [];
+      expect(entry).toBeDefined();
+      expect(entry?.snapshot.stopId).toBe('A');
+      expect(entry?.snapshot.name).toBe('Current A');
+
+      expect(mockToastSuccess).toHaveBeenCalled();
+      const [, options] = mockToastSuccess.mock.calls[0] ?? [];
+      expect(options).toBeDefined();
+      expect(options?.description).toContain('Current A');
+    });
+  });
+});

--- a/src/hooks/__tests__/use-anchor-toggle.test.ts
+++ b/src/hooks/__tests__/use-anchor-toggle.test.ts
@@ -12,16 +12,28 @@ type ToastOptions = {
   description?: string;
 };
 
-const { mockToastSuccess, mockToastWarning } = vi.hoisted(() => ({
-  mockToastSuccess: vi.fn<(message: string, options?: ToastOptions) => void>(),
-  mockToastWarning: vi.fn<(message: string, options?: ToastOptions) => void>(),
-}));
+const { mockToastSuccess, mockToastWarning, mockLoggerWarn, mockLoggerDebug, mockLoggerIsEnabled } =
+  vi.hoisted(() => ({
+    mockToastSuccess: vi.fn<(message: string, options?: ToastOptions) => void>(),
+    mockToastWarning: vi.fn<(message: string, options?: ToastOptions) => void>(),
+    mockLoggerWarn: vi.fn<(message: string, context?: object) => void>(),
+    mockLoggerDebug: vi.fn<(message: string) => void>(),
+    mockLoggerIsEnabled: vi.fn<(level: string) => boolean>(),
+  }));
 
 vi.mock('sonner', () => ({
   toast: {
     success: mockToastSuccess,
     warning: mockToastWarning,
   },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    warn: mockLoggerWarn,
+    debug: mockLoggerDebug,
+    isEnabled: mockLoggerIsEnabled,
+  }),
 }));
 
 function makeAnchorEntry(stopId: string, name = `Snapshot ${stopId}`): AnchorEntry {
@@ -42,6 +54,10 @@ describe('useAnchorToggle', () => {
   beforeEach(() => {
     mockToastSuccess.mockReset();
     mockToastWarning.mockReset();
+    mockLoggerWarn.mockReset();
+    mockLoggerDebug.mockReset();
+    mockLoggerIsEnabled.mockReset();
+    mockLoggerIsEnabled.mockReturnValue(true);
   });
 
   it('removes an existing anchor and shows a warning toast with the current display name', async () => {
@@ -123,5 +139,153 @@ describe('useAnchorToggle', () => {
       expect(options).toBeDefined();
       expect(options?.description).toContain('Current A');
     });
+  });
+
+  it('does not show a removal toast when removeAnchor fails', async () => {
+    const removeAnchor = vi
+      .fn<UseAnchorsReturn['removeAnchor']>()
+      .mockResolvedValue({ success: false, error: 'remove failed' });
+
+    const { result } = renderHook(() =>
+      useAnchorToggle({
+        anchors: [makeAnchorEntry('A', 'Stored A')],
+        hasAnchor: vi.fn((stopId: string) => stopId === 'A'),
+        addAnchor: vi.fn(),
+        removeAnchor,
+        repo: makeRepo(),
+        lookupAnchorStopMeta: vi.fn(() => null),
+        langChain: ['ja'],
+        t: ((key: string) => key) as TFunction,
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleAnchorByStopId('A');
+    });
+
+    await waitFor(() => {
+      expect(removeAnchor).toHaveBeenCalledWith('A');
+    });
+
+    expect(mockToastWarning).not.toHaveBeenCalled();
+  });
+
+  it('logs a warning and skips addAnchor when stop metadata lookup fails', async () => {
+    const addAnchor = vi.fn<UseAnchorsReturn['addAnchor']>();
+    const getStopMetaById = vi
+      .fn<TransitRepository['getStopMetaById']>()
+      .mockResolvedValue({ success: false, error: 'missing stop' });
+    const repo = makeRepo({
+      getStopMetaById,
+    });
+
+    const { result } = renderHook(() =>
+      useAnchorToggle({
+        anchors: [],
+        hasAnchor: vi.fn(() => false),
+        addAnchor,
+        removeAnchor: vi.fn(),
+        repo,
+        lookupAnchorStopMeta: vi.fn(() => null),
+        langChain: ['ja'],
+        t: ((key: string) => key) as TFunction,
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleAnchorByStopId('A');
+    });
+
+    await waitFor(() => {
+      expect(getStopMetaById).toHaveBeenCalledWith('A');
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        'handleToggleAnchorByStopId: stop metadata lookup failed',
+        expect.objectContaining({
+          stopId: 'A',
+          error: 'missing stop',
+        }),
+      );
+    });
+
+    expect(addAnchor).not.toHaveBeenCalled();
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it('does not show a success toast when addAnchor fails', async () => {
+    const addAnchor = vi
+      .fn<UseAnchorsReturn['addAnchor']>()
+      .mockResolvedValue({ success: false, error: 'add failed' });
+    const meta = makeStopMeta('A');
+    const getStopMetaById = vi
+      .fn<TransitRepository['getStopMetaById']>()
+      .mockResolvedValue({ success: true, data: meta });
+    const repo = makeRepo({
+      getStopMetaById,
+    });
+
+    const { result } = renderHook(() =>
+      useAnchorToggle({
+        anchors: [],
+        hasAnchor: vi.fn(() => false),
+        addAnchor,
+        removeAnchor: vi.fn(),
+        repo,
+        lookupAnchorStopMeta: vi.fn(() => null),
+        langChain: ['ja'],
+        t: ((key: string) => key) as TFunction,
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleAnchorByStopId('A');
+    });
+
+    await waitFor(() => {
+      expect(addAnchor).toHaveBeenCalled();
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it('falls back to [-1] when route type lookup fails', async () => {
+    const addAnchor = vi
+      .fn<UseAnchorsReturn['addAnchor']>()
+      .mockResolvedValue({ success: true, data: makeAnchorEntry('A') });
+    const meta = makeStopMeta('A');
+    const getStopMetaById = vi
+      .fn<TransitRepository['getStopMetaById']>()
+      .mockResolvedValue({ success: true, data: meta });
+    const getRouteTypesForStop = vi
+      .fn<TransitRepository['getRouteTypesForStop']>()
+      .mockResolvedValue({ success: false, error: 'missing route types' });
+    const repo = makeRepo({
+      getStopMetaById,
+      getRouteTypesForStop,
+    });
+
+    const { result } = renderHook(() =>
+      useAnchorToggle({
+        anchors: [],
+        hasAnchor: vi.fn(() => false),
+        addAnchor,
+        removeAnchor: vi.fn(),
+        repo,
+        lookupAnchorStopMeta: vi.fn(() => null),
+        langChain: ['ja'],
+        t: ((key: string) => key) as TFunction,
+      }),
+    );
+
+    act(() => {
+      result.current.handleToggleAnchorByStopId('A');
+    });
+
+    await waitFor(() => {
+      expect(addAnchor).toHaveBeenCalled();
+    });
+
+    const [entry] = addAnchor.mock.calls[0] ?? [];
+    expect(entry).toBeDefined();
+    expect(entry?.snapshot.routeTypes).toEqual([-1]);
   });
 });

--- a/src/hooks/use-anchor-toggle.ts
+++ b/src/hooks/use-anchor-toggle.ts
@@ -1,0 +1,164 @@
+import { useCallback } from 'react';
+import type { TFunction } from 'i18next';
+import { toast } from 'sonner';
+
+import { resolveAgencyLang } from '@/config/transit-defaults';
+import type { AnchorEntry } from '@/domain/portal/anchor';
+import type { LangChain } from '@/domain/transit/i18n/resolve-lang-chain';
+import { getStopDisplayNames } from '@/domain/transit/name-resolver/get-stop-display-names';
+import { createStopReferenceSnapshot } from '@/domain/transit/stop-reference-snapshot';
+import type { UseAnchorsReturn } from '@/hooks/use-anchors';
+import { createLogger } from '@/lib/logger';
+import type { TransitRepository } from '@/repositories/transit-repository';
+import type { StopWithMeta } from '@/types/app/transit-composed';
+import { routeTypesEmoji } from '@/utils/route-type-emoji';
+
+const logger = createLogger('AnchorToggle');
+
+/**
+ * Arguments for {@link useAnchorToggle}.
+ */
+export interface UseAnchorToggleParams {
+  /** Current anchor list. */
+  anchors: AnchorEntry[];
+  /** Predicate for current anchor membership. */
+  hasAnchor: UseAnchorsReturn['hasAnchor'];
+  /** Persist a new anchor. */
+  addAnchor: UseAnchorsReturn['addAnchor'];
+  /** Remove an existing anchor. */
+  removeAnchor: UseAnchorsReturn['removeAnchor'];
+  /** Active repository used for add-side metadata lookup. */
+  repo: TransitRepository;
+  /** Full-dataset lookup for persisted anchor stop ids. */
+  lookupAnchorStopMeta: (stopId: string) => StopWithMeta | null;
+  /** Preferred display language chain. */
+  langChain: LangChain;
+  /** Translation function for toast labels. */
+  t: TFunction;
+}
+
+/**
+ * Return value for {@link useAnchorToggle}.
+ *
+ * Unlike `useAnchors`, this surface is intentionally narrow: callers
+ * get the user-facing toggle action, not raw CRUD methods.
+ */
+export interface UseAnchorToggleReturn {
+  /** Toggle anchor state for the given stop id. */
+  handleToggleAnchorByStopId: (stopId: string) => void;
+}
+
+/**
+ * Build the add/remove anchor toggle callback used by App surfaces.
+ *
+ * Keeps anchor-specific metadata lookup, snapshot creation, and toast
+ * orchestration out of `App` while preserving current behavior.
+ *
+ * Responsibility boundary:
+ *
+ * - `useAnchors` manages the anchor collection itself and talks to the
+ *   persistence repository.
+ * - `useAnchorToggle` composes `useAnchors` outputs with
+ *   `TransitRepository`, language resolution, and toast side effects to
+ *   implement the single user intent of toggling one stop's anchor
+ *   state.
+ *
+ * This split is intentional so the lower-level anchor hook stays free
+ * of App UI concerns, while `App` does not need to inline anchor add /
+ * remove orchestration.
+ *
+ * @param params - See {@link UseAnchorToggleParams}.
+ * @returns Anchor toggle callback.
+ */
+export function useAnchorToggle({
+  anchors,
+  hasAnchor,
+  addAnchor,
+  removeAnchor,
+  repo,
+  lookupAnchorStopMeta,
+  langChain,
+  t,
+}: UseAnchorToggleParams): UseAnchorToggleReturn {
+  const removeExistingAnchorByStopId = useCallback(
+    async (stopId: string): Promise<void> => {
+      const anchor = anchors.find((entry) => entry.snapshot.stopId === stopId);
+      const meta = lookupAnchorStopMeta(stopId);
+      const stopName = meta
+        ? getStopDisplayNames(
+            meta.stop,
+            langChain,
+            resolveAgencyLang(meta.agencies, meta.stop.agency_id),
+          ).name ||
+          anchor?.snapshot.name ||
+          stopId
+        : (anchor?.snapshot.name ?? stopId);
+
+      logger.debug(`handleToggleAnchor: removing stopId=${stopId}`);
+
+      const result = await removeAnchor(stopId);
+      if (!result.success) {
+        return;
+      }
+
+      const prefix = anchor ? `${routeTypesEmoji(anchor.snapshot.routeTypes)} ` : '';
+      toast.warning(t('anchor.removed'), { description: `${prefix}${stopName}` });
+    },
+    [anchors, langChain, lookupAnchorStopMeta, removeAnchor, t],
+  );
+
+  const addNewAnchorByStopId = useCallback(
+    async (stopId: string): Promise<void> => {
+      const [metaResult, routeTypesResult] = await Promise.all([
+        repo.getStopMetaById(stopId),
+        repo.getRouteTypesForStop(stopId),
+      ]);
+
+      if (!metaResult.success) {
+        logger.warn('handleToggleAnchorByStopId: stop metadata lookup failed', {
+          stopId,
+          error: metaResult.error,
+        });
+        return;
+      }
+
+      const meta = metaResult.data;
+      const routeTypes = routeTypesResult.success ? routeTypesResult.data : [-1 as const];
+      const displayName =
+        getStopDisplayNames(
+          meta.stop,
+          langChain,
+          resolveAgencyLang(meta.agencies, meta.stop.agency_id),
+        ).name || meta.stop.stop_name;
+
+      if (logger.isEnabled('debug')) {
+        logger.debug(`handleToggleAnchorByStopId: adding stopId=${stopId}, name=${displayName}`);
+      }
+
+      const snapshot = createStopReferenceSnapshot(meta, routeTypes, langChain);
+      const result = await addAnchor({ snapshot });
+      if (!result.success) {
+        return;
+      }
+
+      toast.success(t('anchor.added'), {
+        description: `${routeTypesEmoji(routeTypes)} ${displayName}`,
+      });
+    },
+    [addAnchor, langChain, repo, t],
+  );
+
+  const handleToggleAnchorByStopId = useCallback(
+    (stopId: string) => {
+      if (hasAnchor(stopId)) {
+        void removeExistingAnchorByStopId(stopId);
+        return;
+      }
+
+      void addNewAnchorByStopId(stopId);
+    },
+    [addNewAnchorByStopId, hasAnchor, removeExistingAnchorByStopId],
+  );
+
+  return { handleToggleAnchorByStopId };
+}

--- a/src/hooks/use-anchor-toggle.ts
+++ b/src/hooks/use-anchor-toggle.ts
@@ -94,7 +94,9 @@ export function useAnchorToggle({
           stopId
         : (anchor?.snapshot.name ?? stopId);
 
-      logger.debug(`handleToggleAnchor: removing stopId=${stopId}`);
+      if (logger.isEnabled('debug')) {
+        logger.debug(`handleToggleAnchor: removing stopId=${stopId}`);
+      }
 
       const result = await removeAnchor(stopId);
       if (!result.success) {

--- a/src/hooks/use-anchors.ts
+++ b/src/hooks/use-anchors.ts
@@ -12,6 +12,11 @@ const logger = createLogger('Anchors');
 
 /**
  * Return type for the useAnchors hook.
+ *
+ * This hook exposes anchor state and persistence-facing mutations.
+ * UI-specific orchestration such as toast messages, display-name
+ * resolution, and toggle branching belongs in `useAnchorToggle`, not
+ * here.
  */
 export interface UseAnchorsReturn {
   /** Anchor entries, most recently added first. */
@@ -38,6 +43,20 @@ export interface UseAnchorsReturn {
  * The hook owns the React state and delegates persistence to the repository.
  * All mutation methods are async and return {@link Result} — the repository
  * determines the actual storage mechanism (localStorage, Web API, etc.).
+ *
+ * Responsibility boundary:
+ *
+ * - `useAnchors` owns anchor state, repository synchronization, and
+ *   persistence-shaped CRUD methods.
+ * - `useAnchorToggle` sits one layer above this hook and handles
+ *   App-specific toggle orchestration such as deciding add vs remove,
+ *   resolving live metadata for labels, building snapshots for new
+ *   anchors, and emitting toast notifications.
+ *
+ * Reach for this hook when the caller needs the anchor collection or
+ * repository-backed mutations directly. Reach for `useAnchorToggle`
+ * when the caller needs the user-facing "toggle this stop's anchor
+ * state" behavior.
  *
  * @param repo - The repository to use for persistence.
  * @returns Anchor state and mutation functions.


### PR DESCRIPTION
## Summary
- align portal stop selection with history selection by using shared stop-navigation payload builders
- extract anchor toggle orchestration into `useAnchorToggle` and clarify the boundary with `useAnchors`
- add focused hook and app wiring tests, and move UI-facing stop selection handlers into the shared handler section in `App`

## Validation
- `npm run format`
- `npm run lint`
- `npm run build`