### PR TITLE
Add global all-on/all-off to DataSourceSettingsDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [CalVer](https://calver.org/).
 ### Added
 
 - Web Storage 不可環境への対応: Chrome の「全 Cookie とサイトデータをブロック」設定等で `globalThis.localStorage` の getter が `SecurityError` を投げる環境でも、 App が起動 crash せず graceful に動作するようにした。 `resolveWebStorage(kind)` / `isWebStorageAvailable(kind)` / `useWebStorageAvailability(kind)` を新設し、 storage 不可検出時は起動時に `storage.unavailable` toast (`duration: Infinity`、 close button) で 1 度だけ通知する。 永続化対象と Web Storage 不可時の要件は PRD 3.H に明文化、 storage 層の挙動仕様は `docs/web-storage.md` / `docs/storage.md` を参照 (Issue #237)。
+- DataSourceSettingsDialog の global 一括切替: footer に「全てON」 / 「全てOFF」 ボタンを追加し、 表示中の全 data source group に対して一括で有効化 / 無効化できるようにした (i18n キー `dataSourceSettings.bulkAction.enableAllGlobal` / `disableAllGlobal`)。 per-section の bulk action と合わせて shadcn `ButtonGroup` で segmented 表示に統一し、 footer 全体は `flex-wrap` の 3 要素 (Reset / 一括切替 ButtonGroup / Restart) で狭幅にも自動追従する。 `forcedSourcesMode` 時は他 dialog action と同じく disabled。
 
 ### Changed
 

--- a/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
+++ b/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
@@ -363,6 +363,40 @@ describe('DataSourceSettingsDialog — normal mode', () => {
     expect(ids).toContain('toei-bus');
   });
 
+  it('clicking the global "All on" button calls setGroupsEnabled with every visible group id and true', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    const enableAllGlobal = screen.getByRole('button', {
+      name: 'dataSourceSettings.bulkAction.enableAllGlobal.aria',
+    });
+    fireEvent.click(enableAllGlobal);
+    expect(mockSetGroupsEnabled).toHaveBeenCalledTimes(1);
+    const [ids, enabled] = mockSetGroupsEnabled.mock.calls[0];
+    expect(enabled).toBe(true);
+    // The full visible set in the default test fixture (normal mode +
+    // empty load status) is every group with `systemEnabledByDefault`.
+    // Use exact match (not `toContain`) so a regression that drops or
+    // duplicates an id is caught.
+    const expectedVisibleIds = settings
+      .filter((g) => g.systemEnabledByDefault)
+      .map((g) => g.id);
+    expect([...ids]).toEqual(expectedVisibleIds);
+  });
+
+  it('clicking the global "All off" button calls setGroupsEnabled with every visible group id and false', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    const disableAllGlobal = screen.getByRole('button', {
+      name: 'dataSourceSettings.bulkAction.disableAllGlobal.aria',
+    });
+    fireEvent.click(disableAllGlobal);
+    expect(mockSetGroupsEnabled).toHaveBeenCalledTimes(1);
+    const [ids, enabled] = mockSetGroupsEnabled.mock.calls[0];
+    expect(enabled).toBe(false);
+    const expectedVisibleIds = settings
+      .filter((g) => g.systemEnabledByDefault)
+      .map((g) => g.id);
+    expect([...ids]).toEqual(expectedVisibleIds);
+  });
+
   it('honours group-vs-prefix semantics (overlap does NOT carry through to Switch state)', () => {
     // toei-bus and toko both contain `minkuru`. If the user has enabled
     // toei-bus but not toko, toko's Switch must be OFF — Switch state is
@@ -491,5 +525,17 @@ describe('DataSourceSettingsDialog — forced-sources mode', () => {
     });
     expect(enableAllBus).toBeDisabled();
     expect(disableAllBus).toBeDisabled();
+  });
+
+  it('disables the global all-on / all-off buttons', () => {
+    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    const enableAllGlobal = screen.getByRole('button', {
+      name: 'dataSourceSettings.bulkAction.enableAllGlobal.aria',
+    });
+    const disableAllGlobal = screen.getByRole('button', {
+      name: 'dataSourceSettings.bulkAction.disableAllGlobal.aria',
+    });
+    expect(enableAllGlobal).toBeDisabled();
+    expect(disableAllGlobal).toBeDisabled();
   });
 });

--- a/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
+++ b/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
@@ -376,9 +376,7 @@ describe('DataSourceSettingsDialog — normal mode', () => {
     // empty load status) is every group with `systemEnabledByDefault`.
     // Use exact match (not `toContain`) so a regression that drops or
     // duplicates an id is caught.
-    const expectedVisibleIds = settings
-      .filter((g) => g.systemEnabledByDefault)
-      .map((g) => g.id);
+    const expectedVisibleIds = settings.filter((g) => g.systemEnabledByDefault).map((g) => g.id);
     expect([...ids]).toEqual(expectedVisibleIds);
   });
 
@@ -391,9 +389,7 @@ describe('DataSourceSettingsDialog — normal mode', () => {
     expect(mockSetGroupsEnabled).toHaveBeenCalledTimes(1);
     const [ids, enabled] = mockSetGroupsEnabled.mock.calls[0];
     expect(enabled).toBe(false);
-    const expectedVisibleIds = settings
-      .filter((g) => g.systemEnabledByDefault)
-      .map((g) => g.id);
+    const expectedVisibleIds = settings.filter((g) => g.systemEnabledByDefault).map((g) => g.id);
     expect([...ids]).toEqual(expectedVisibleIds);
   });
 

--- a/src/components/dialog/data-source-settings-dialog.tsx
+++ b/src/components/dialog/data-source-settings-dialog.tsx
@@ -280,6 +280,7 @@ export function DataSourceSettingsDialog({ open, onOpenChange }: DataSourceSetti
     t,
   );
   const counts = countDistinctGroupStatuses(visibleGroups, loadStatusByPrefix);
+  const allVisibleGroupIds = visibleGroups.map((g) => g.id);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -391,6 +392,30 @@ export function DataSourceSettingsDialog({ open, onOpenChange }: DataSourceSetti
           })}
         </div>
         <DialogFooter className="shrink-0 gap-2 border-t pt-3 sm:justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setGroupsEnabled(allVisibleGroupIds, true);
+            }}
+            disabled={isForcedSourcesMode}
+            aria-label={t('dataSourceSettings.bulkAction.enableAllGlobal.aria')}
+            className="cursor-pointer"
+          >
+            {t('dataSourceSettings.bulkAction.enableAllGlobal.label')}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setGroupsEnabled(allVisibleGroupIds, false);
+            }}
+            disabled={isForcedSourcesMode}
+            aria-label={t('dataSourceSettings.bulkAction.disableAllGlobal.aria')}
+            className="cursor-pointer"
+          >
+            {t('dataSourceSettings.bulkAction.disableAllGlobal.label')}
+          </Button>
           <Button
             variant="destructive"
             size="sm"

--- a/src/components/dialog/data-source-settings-dialog.tsx
+++ b/src/components/dialog/data-source-settings-dialog.tsx
@@ -1,6 +1,7 @@
 import { DataSourceGroupItem } from '@/components/datasource/data-source-group-item';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import { ButtonGroup } from '@/components/ui/button-group';
 import {
   Dialog,
   DialogContent,
@@ -339,7 +340,7 @@ export function DataSourceSettingsDialog({ open, onOpenChange }: DataSourceSetti
                   <span className="opacity-60">
                     ({sectionEnabledCount}/{section.rows.length})
                   </span>
-                  <div className="ml-auto flex gap-1">
+                  <ButtonGroup className="ml-auto">
                     <Button
                       size="sm"
                       variant="outline"
@@ -368,7 +369,7 @@ export function DataSourceSettingsDialog({ open, onOpenChange }: DataSourceSetti
                     >
                       {t('dataSourceSettings.bulkAction.disableAll.label')}
                     </Button>
-                  </div>
+                  </ButtonGroup>
                 </h3>
                 <div>
                   {section.rows.map((row) => (
@@ -391,31 +392,7 @@ export function DataSourceSettingsDialog({ open, onOpenChange }: DataSourceSetti
             );
           })}
         </div>
-        <DialogFooter className="shrink-0 gap-2 border-t pt-3 sm:justify-end">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              setGroupsEnabled(allVisibleGroupIds, true);
-            }}
-            disabled={isForcedSourcesMode}
-            aria-label={t('dataSourceSettings.bulkAction.enableAllGlobal.aria')}
-            className="cursor-pointer"
-          >
-            {t('dataSourceSettings.bulkAction.enableAllGlobal.label')}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              setGroupsEnabled(allVisibleGroupIds, false);
-            }}
-            disabled={isForcedSourcesMode}
-            aria-label={t('dataSourceSettings.bulkAction.disableAllGlobal.aria')}
-            className="cursor-pointer"
-          >
-            {t('dataSourceSettings.bulkAction.disableAllGlobal.label')}
-          </Button>
+        <DialogFooter className="shrink-0 flex-row flex-wrap justify-between gap-2 border-t pt-3 sm:justify-between">
           <Button
             variant="destructive"
             size="sm"
@@ -425,6 +402,33 @@ export function DataSourceSettingsDialog({ open, onOpenChange }: DataSourceSetti
           >
             {t('dataSourceSettings.resetToDefaults')}
           </Button>
+          <ButtonGroup>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setGroupsEnabled(allVisibleGroupIds, true);
+              }}
+              disabled={isForcedSourcesMode}
+              aria-label={t('dataSourceSettings.bulkAction.enableAllGlobal.aria')}
+              className="cursor-pointer"
+            >
+              {t('dataSourceSettings.bulkAction.enableAllGlobal.label')}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setGroupsEnabled(allVisibleGroupIds, false);
+              }}
+              disabled={isForcedSourcesMode}
+              aria-label={t('dataSourceSettings.bulkAction.disableAllGlobal.aria')}
+              className="cursor-pointer"
+            >
+              {t('dataSourceSettings.bulkAction.disableAllGlobal.label')}
+            </Button>
+          </ButtonGroup>
+
           <Button
             variant="default"
             size="sm"

--- a/src/components/ui/button-group.tsx
+++ b/src/components/ui/button-group.tsx
@@ -1,0 +1,79 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+import { Separator } from '@/components/ui/separator';
+
+const buttonGroupVariants = cva(
+  "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          '[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none',
+        vertical:
+          'flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none',
+      },
+    },
+    defaultVariants: {
+      orientation: 'horizontal',
+    },
+  },
+);
+
+function ButtonGroup({
+  className,
+  orientation,
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+function ButtonGroupText({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'div'> & {
+  asChild?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : 'div';
+
+  return (
+    <Comp
+      className={cn(
+        "bg-muted flex items-center gap-2 rounded-md border px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = 'vertical',
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn(
+        'bg-input relative m-0! self-stretch data-[orientation=vertical]:h-auto',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export { ButtonGroup, ButtonGroupSeparator, ButtonGroupText, buttonGroupVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -59,5 +59,5 @@ function Button({
   );
 }
 
-// eslint-disable-next-line react-refresh/only-export-components -- shadcn/ui pattern
+// eslint-disable-next-line react-refresh/only-export-components
 export { Button, buttonVariants };

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Separator as SeparatorPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Separator({
+  className,
+  orientation = 'horizontal',
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -289,6 +289,14 @@
       "disableAll": {
         "label": "All off",
         "aria": "Disable all {{section}} groups"
+      },
+      "enableAllGlobal": {
+        "label": "All on",
+        "aria": "Enable all groups"
+      },
+      "disableAllGlobal": {
+        "label": "All off",
+        "aria": "Disable all groups"
       }
     },
     "section": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -276,7 +276,7 @@
       "title": "Restart to apply",
       "description": "Changes take effect after the app is restarted. Click Restart below, or refresh the browser."
     },
-    "resetToDefaults": "Reset to defaults",
+    "resetToDefaults": "Reset",
     "restart": {
       "label": "Restart",
       "aria": "Restart to apply settings"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -289,6 +289,14 @@
       "disableAll": {
         "label": "全て OFF",
         "aria": "{{section}} 内の全グループを無効化"
+      },
+      "enableAllGlobal": {
+        "label": "全て ON",
+        "aria": "全グループを有効化"
+      },
+      "disableAllGlobal": {
+        "label": "全て OFF",
+        "aria": "全グループを無効化"
       }
     },
     "section": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -276,26 +276,26 @@
       "title": "再起動で反映",
       "description": "設定は再起動後に反映されます"
     },
-    "resetToDefaults": "初期値に戻す",
+    "resetToDefaults": "リセット",
     "restart": {
       "label": "再起動",
       "aria": "再起動して設定を反映"
     },
     "bulkAction": {
       "enableAll": {
-        "label": "全て ON",
+        "label": "全てON",
         "aria": "{{section}} 内の全グループを有効化"
       },
       "disableAll": {
-        "label": "全て OFF",
+        "label": "全てOFF",
         "aria": "{{section}} 内の全グループを無効化"
       },
       "enableAllGlobal": {
-        "label": "全て ON",
+        "label": "全てON",
         "aria": "全グループを有効化"
       },
       "disableAllGlobal": {
-        "label": "全て OFF",
+        "label": "全てOFF",
         "aria": "全グループを無効化"
       }
     },


### PR DESCRIPTION
## Summary

- New global "全てON" / "全てOFF" buttons in the DataSourceSettingsDialog footer that toggle every visible group at once. Per-section bulk actions are unchanged.
- Both per-section and global on/off pairs now use shadcn `ButtonGroup` so the pair reads as a single segmented control. Pulled in `@shadcn/button-group` (and its `Separator` dependency) via `npx shadcn add`; the existing project-local `button.tsx` was found to be identical to the current shadcn output (only formatting / `eslint-disable` comment differed).
- DialogFooter is now three direct children -- Reset / global ButtonGroup / Restart -- laid out with `flex-row flex-wrap justify-between sm:justify-between`. The trailing `sm:` override is needed because shadcn's `DialogFooter` bakes in `sm:justify-end`; without it the base `justify-between` is overridden at the `sm` breakpoint and Restart appears right-aligned on wide screens.
- Tightened labels: `resetToDefaults` -> "リセット" / "Reset" (was "初期値に戻す" / "Reset to defaults"), bulk action labels -> "全てON" / "全てOFF" (whitespace removed).
- Tests: new assertions for the global buttons (exact `setGroupsEnabled(allVisibleGroupIds, true|false)` payload derived from `settings.filter(systemEnabledByDefault)`), plus a forced-sources-mode disabled regression test. CHANGELOG Unreleased updated.

## Test plan

- [x] `npm run typecheck` / `npm run lint` / `npm test` / `npm run build` all green.
- [x] Open the DataSource settings dialog (Settings -> Data sources). Verify "全てON" / "全てOFF" appear in the footer as a segmented ButtonGroup between Reset and Restart.
- [x] Click "全てON": every group's Switch flips to on. Click "全てOFF": every Switch flips to off. Per-section bulk buttons are unaffected (still scoped to their section).
- [x] Open with `?sources=all` to enter forced-sources mode: the global on/off buttons should appear disabled along with Reset / Restart / per-section bulk.
- [x] Resize the viewport: footer wraps cleanly between Reset / ButtonGroup / Restart on narrow widths, fits on one row at `sm`+ with `justify-between` spacing. No right-aligned Restart drift on wide screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)