### PR TITLE
refactor(dialog): rename TimetableModal to TimetableDialog

### DIFF
--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -201,8 +201,8 @@ vi.mock('../components/time-controls', () => ({
   TimeControls: () => null,
 }));
 
-vi.mock('../components/dialog/timetable-modal', () => ({
-  TimetableModal: () => null,
+vi.mock('../components/dialog/timetable-dialog', () => ({
+  TimetableDialog: () => null,
 }));
 
 vi.mock('../components/dialog/stop-search-dialog', () => ({

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -92,7 +92,7 @@ import { DataSourceSettingsDialog } from './components/dialog/data-source-settin
 import { InfoDialog } from './components/dialog/info-dialog';
 import { ShortcutHelpDialog } from './components/dialog/shortcut-help-dialog';
 import { StopSearchDialog } from './components/dialog/stop-search-dialog';
-import { TimetableModal } from './components/dialog/timetable-modal';
+import { TimetableDialog } from './components/dialog/timetable-dialog';
 import { TripInspectionDialog } from './components/dialog/trip-inspection-dialog';
 import { MapOverlay } from './components/map/map-overlay';
 import { MapView } from './components/map/map-view';
@@ -720,7 +720,7 @@ export default function App() {
   // `omitEmptyStopsOverride`), late-night derived policy
   // (`isLateNight` / `effectiveOmitEmptyStops` / forced-on rules),
   // and the memoized `globalFilter` object that BottomSheet /
-  // TimetableModal consume. `App` keeps `showOriginOnly`,
+  // TimetableDialog consume. `App` keeps `showOriginOnly`,
   // `showBoardableOnly`, and `effectiveOmitEmptyStops` to feed
   // `deriveFilteredNearbyStops`; MapView reads the filtered result
   // (`stopTimes`) rather than `globalFilter` itself.
@@ -1058,7 +1058,7 @@ export default function App() {
         onSelectStopById={handleSelectStopFromTripInspection}
         onOpenChange={handleTripInspectionOpenChange}
       />
-      <TimetableModal
+      <TimetableDialog
         key={timetableData?.stop.stop_id ?? 'closed'}
         data={timetableData}
         time={dateTime}

--- a/src/components/dialog/__tests__/dialog-memoization.test.tsx
+++ b/src/components/dialog/__tests__/dialog-memoization.test.tsx
@@ -40,6 +40,7 @@ vi.mock('@/hooks/use-scroll-fades', () => ({
 }));
 
 vi.mock('@/hooks/use-is-low-contrast-against-theme', () => ({
+  useThemeContrastBackgroundColor: () => '#ffffff',
   useThemeContrastAssessment: () => ({
     isLowContrast: false,
     ratio: 10,
@@ -66,27 +67,27 @@ vi.mock('@/domain/transit/timetable-stats', () => ({
   computeTimetableEntryStats: computeTimetableEntryStatsMock,
 }));
 
-vi.mock('../filter/boardability-filter', () => ({
+vi.mock('@/components/filter/boardability-filter', () => ({
   BoardabilityFilter: () => null,
 }));
 
-vi.mock('../filter/origin-filter', () => ({
+vi.mock('@/components/filter/origin-filter', () => ({
   OriginFilter: () => null,
 }));
 
-vi.mock('../timetable/timetable-grid', () => ({
+vi.mock('@/components/timetable/timetable-grid', () => ({
   TimetableGrid: () => null,
 }));
 
-vi.mock('../timetable/timetable-header', () => ({
+vi.mock('@/components/timetable/timetable-header', () => ({
   TimetableHeader: () => null,
 }));
 
-vi.mock('../timetable/timetable-headsign-filter', () => ({
+vi.mock('@/components/timetable/timetable-headsign-filter', () => ({
   TimetableHeadsignFilter: () => null,
 }));
 
-vi.mock('../timetable/timetable-metadata', () => ({
+vi.mock('@/components/timetable/timetable-metadata', () => ({
   TimetableMetadata: () => null,
 }));
 
@@ -110,7 +111,13 @@ vi.mock('@/domain/transit/color-resolver/route-colors', () => ({
 }));
 
 vi.mock('@/domain/transit/name-resolver/get-headsign-display-names', () => ({
-  getHeadsignDisplayNames: () => ({ resolved: { name: 'Headsign' } }),
+  getHeadsignDisplayNames: () => ({
+    resolved: { name: 'Headsign', subNames: [] },
+    resolvedSource: 'trip',
+    tripName: { name: 'Headsign', subNames: [] },
+    stopName: undefined,
+  }),
+  getSelectedHeadsignDisplayName: () => 'Headsign',
 }));
 
 vi.mock('@/domain/transit/name-resolver/get-stop-display-names', () => ({
@@ -141,50 +148,50 @@ vi.mock('@/utils/color/contrast-alpha-suffixes', () => ({
   }),
 }));
 
-vi.mock('../badge/id-badge', () => ({
+vi.mock('@/components/badge/id-badge', () => ({
   IdBadge: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
 }));
 
-vi.mock('../label/trip-position-indicator', () => ({
+vi.mock('@/components/label/trip-position-indicator', () => ({
   TripPositionIndicator: () => null,
 }));
 
-vi.mock('../trip/trip-basic-info', () => ({
+vi.mock('@/components/trip/trip-basic-info', () => ({
   TripBasicInfo: () => null,
 }));
 
-vi.mock('../trip/trip-stop-row-dom', () => ({
+vi.mock('@/components/trip/trip-stop-row-dom', () => ({
   findTripStopRow: () => null,
   tripStopRowDataAttrs: (stopIndex: number) => ({ 'data-trip-stop-index': String(stopIndex) }),
 }));
 
-vi.mock('../trip/trip-stop-scroll', () => ({
+vi.mock('@/components/trip/trip-stop-scroll', () => ({
   computeScrolledStopIndex: () => null,
   getSelectedRowScrollTop: () => 0,
 }));
 
-vi.mock('../trip/trip-stops', () => ({
+vi.mock('@/components/trip/trip-stops', () => ({
   TripStops: (props: unknown) => {
     tripStopsRenderMock(props);
     return null;
   },
 }));
 
-vi.mock('../trip/trip-pager', () => ({
+vi.mock('@/components/trip/trip-pager', () => ({
   TripPager: () => null,
 }));
 
-vi.mock('../verbose/verbose-trip-locator', () => ({
+vi.mock('@/components/verbose/verbose-trip-locator', () => ({
   VerboseTripLocator: () => null,
 }));
 
-vi.mock('../verbose/verbose-trip-stop-time', () => ({
+vi.mock('@/components/verbose/verbose-trip-stop-time', () => ({
   VerboseTripStopTime: () => null,
 }));
 
-import { TimetableModal } from './timetable-modal';
-import { StopSearchDialog } from './stop-search-dialog';
-import { TripInspectionDialog } from './trip-inspection-dialog';
+import { TimetableModal } from '@/components/dialog/timetable-modal';
+import { StopSearchDialog } from '@/components/dialog/stop-search-dialog';
+import { TripInspectionDialog } from '@/components/dialog/trip-inspection-dialog';
 
 function makeRoute(id: string): Route {
   return {

--- a/src/components/dialog/__tests__/dialog-memoization.test.tsx
+++ b/src/components/dialog/__tests__/dialog-memoization.test.tsx
@@ -189,7 +189,7 @@ vi.mock('@/components/verbose/verbose-trip-stop-time', () => ({
   VerboseTripStopTime: () => null,
 }));
 
-import { TimetableModal } from '@/components/dialog/timetable-modal';
+import { TimetableDialog } from '@/components/dialog/timetable-dialog';
 import { StopSearchDialog } from '@/components/dialog/stop-search-dialog';
 import { TripInspectionDialog } from '@/components/dialog/trip-inspection-dialog';
 
@@ -333,7 +333,7 @@ afterEach(() => {
 });
 
 describe('dialog memoization regressions', () => {
-  it('TimetableModal skips stats recomputation when only time changes', () => {
+  it('TimetableDialog skips stats recomputation when only time changes', () => {
     const data = makeTimetableData();
     const globalFilter = {
       showOriginOnly: false,
@@ -354,15 +354,15 @@ describe('dialog memoization regressions', () => {
       onInspectTrip: vi.fn(),
     };
 
-    const { rerender } = render(<TimetableModal {...props} />);
+    const { rerender } = render(<TimetableDialog {...props} />);
 
     expect(computeTimetableEntryStatsMock).toHaveBeenCalledTimes(2);
 
-    rerender(<TimetableModal {...props} />);
+    rerender(<TimetableDialog {...props} />);
 
     expect(computeTimetableEntryStatsMock).toHaveBeenCalledTimes(2);
 
-    rerender(<TimetableModal {...props} time={new Date(2026, 3, 1, 8, 1)} />);
+    rerender(<TimetableDialog {...props} time={new Date(2026, 3, 1, 8, 1)} />);
 
     expect(computeTimetableEntryStatsMock).toHaveBeenCalledTimes(2);
 
@@ -370,12 +370,12 @@ describe('dialog memoization regressions', () => {
       ...globalFilter,
       showBoardableOnly: true,
     };
-    rerender(<TimetableModal {...props} globalFilter={nextGlobalFilter} />);
+    rerender(<TimetableDialog {...props} globalFilter={nextGlobalFilter} />);
 
     expect(computeTimetableEntryStatsMock).toHaveBeenCalledTimes(4);
   });
 
-  it('TimetableModal skips stats recomputation when only omitEmptyStops changes', () => {
+  it('TimetableDialog skips stats recomputation when only omitEmptyStops changes', () => {
     const data = makeTimetableData();
     const globalFilter = {
       showOriginOnly: false,
@@ -396,7 +396,7 @@ describe('dialog memoization regressions', () => {
       onInspectTrip: vi.fn(),
     };
 
-    const { rerender } = render(<TimetableModal {...props} />);
+    const { rerender } = render(<TimetableDialog {...props} />);
 
     expect(computeTimetableEntryStatsMock).toHaveBeenCalledTimes(2);
 
@@ -406,7 +406,7 @@ describe('dialog memoization regressions', () => {
       isOmitEmptyStopsForced: true,
       onToggleOmitEmptyStops: vi.fn(),
     };
-    rerender(<TimetableModal {...props} globalFilter={nextGlobalFilter} />);
+    rerender(<TimetableDialog {...props} globalFilter={nextGlobalFilter} />);
 
     expect(computeTimetableEntryStatsMock).toHaveBeenCalledTimes(2);
   });

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -37,8 +37,8 @@ import { TimetableHeader } from '../timetable/timetable-header';
 import { TimetableHeadsignFilter } from '../timetable/timetable-headsign-filter';
 import { TimetableMetadata } from '../timetable/timetable-metadata';
 
-interface TimetableModalProps {
-  /** Pass null when the modal should be closed. */
+interface TimetableDialogProps {
+  /** Pass null when the dialog should be closed. */
   data: TimetableData | null;
   /** Current time reference for highlighting the active hour row. */
   time: Date;
@@ -124,9 +124,9 @@ function hasSameRelevantGlobalFilter(prev: GlobalFilter, next: GlobalFilter): bo
   );
 }
 
-function areTimetableModalPropsEqual(
-  prev: Readonly<TimetableModalProps>,
-  next: Readonly<TimetableModalProps>,
+function areTimetableDialogPropsEqual(
+  prev: Readonly<TimetableDialogProps>,
+  next: Readonly<TimetableDialogProps>,
 ): boolean {
   return (
     prev.data === next.data &&
@@ -139,7 +139,7 @@ function areTimetableModalPropsEqual(
   );
 }
 
-export const TimetableModal = memo(function TimetableModal({
+export const TimetableDialog = memo(function TimetableDialog({
   data,
   time,
   infoLevel,
@@ -147,7 +147,7 @@ export const TimetableModal = memo(function TimetableModal({
   globalFilter,
   onInspectTrip,
   onClose,
-}: TimetableModalProps) {
+}: TimetableDialogProps) {
   const { showOriginOnly, showBoardableOnly, onToggleShowOriginOnly, onToggleShowBoardableOnly } =
     globalFilter;
   const { t, i18n } = useTranslation();
@@ -295,7 +295,7 @@ export const TimetableModal = memo(function TimetableModal({
         }
       }}
     >
-      {/* border-4: intentional thick border to visually distinguish the timetable modal from the map background */}
+      {/* border-4: intentional thick border to visually distinguish the timetable dialog from the map background */}
       <DialogContent
         showCloseButton={false}
         className="flex max-h-[80dvh] w-[90dvw] max-w-5xl flex-col gap-0 overflow-hidden border-4 p-2 sm:max-w-3xl"
@@ -448,4 +448,4 @@ export const TimetableModal = memo(function TimetableModal({
       </DialogContent>
     </Dialog>
   );
-}, areTimetableModalPropsEqual);
+}, areTimetableDialogPropsEqual);

--- a/src/domain/transit/timetable-filter.ts
+++ b/src/domain/transit/timetable-filter.ts
@@ -293,7 +293,7 @@ interface StopTimesCarrier<T extends TimetableEntry = TimetableEntry> {
  * {@link filterByStopEventAttributes} (AND across toggles). When both
  * toggles are false, the input reference is returned unchanged.
  *
- * Used by both BottomSheet (per-stop entries) and TimetableModal (the
+ * Used by both BottomSheet (per-stop entries) and TimetableDialog (the
  * stop's full timetable) so the toggle semantics stay aligned across
  * surfaces.
  */

--- a/src/hooks/use-global-filter.ts
+++ b/src/hooks/use-global-filter.ts
@@ -21,7 +21,7 @@ export interface UseGlobalFilterReturn {
   showBoardableOnly: boolean;
   /** Final empty-stop omit policy after `isLateNight` and forced-on rules. */
   effectiveOmitEmptyStops: boolean;
-  /** Bundled {@link GlobalFilter} for drilling into BottomSheet / TimetableModal. */
+  /** Bundled {@link GlobalFilter} for drilling into BottomSheet / TimetableDialog. */
   globalFilter: GlobalFilter;
 }
 
@@ -37,7 +37,7 @@ export interface UseGlobalFilterReturn {
  *     (origin-only or boardable-only force empty-stop omit on), and
  *     the final `effectiveOmitEmptyStops`.
  *   - The memoized {@link GlobalFilter} bundle that `BottomSheet` and
- *     `TimetableModal` consume directly.
+ *     `TimetableDialog` consume directly.
  *
  * The selector-level inputs (`showOriginOnly`, `showBoardableOnly`,
  * `effectiveOmitEmptyStops`) are exposed alongside the bundle because

--- a/src/types/app/global-filter.ts
+++ b/src/types/app/global-filter.ts
@@ -5,7 +5,7 @@
  *
  *   - `BottomSheet` (via `AppLayout` -> `MapBottomSheetLayout` /
  *     `StopPanel` -> `StopBrowser`)
- *   - `TimetableModal`
+ *   - `TimetableDialog`
  *
  * Indirect consumers (read the filter's *output*, not this object):
  *


### PR DESCRIPTION
## Summary
- Rename `src/components/dialog/timetable-modal.tsx` to `timetable-dialog.tsx`.
- Rename the matching identifiers: `TimetableModal` -> `TimetableDialog`, `TimetableModalProps` -> `TimetableDialogProps`, `areTimetableModalPropsEqual` -> `areTimetableDialogPropsEqual`.
- Update TSDoc / comment references in `global-filter.ts`, `use-global-filter.ts`, `timetable-filter.ts`, and the dialog file itself.
- Behavior is unchanged. CHANGELOG entries that mention the historical `TimetableModal` name are left as-is.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm test` (4234 tests pass)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)