### PR TITLE
feat(timetable-dialog): add date navigation with TimetableContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [CalVer](https://calver.org/).
 - TimetableDateLabel: 表示する時刻を realtime (`time` prop) から `data.referenceDateTime` に変更し、 picker / prev / next 操作と日時表示が常に同期するようにした。
 - TimetableGrid: 時刻表行のハイライト用 prop を `currentHour` から `hourToHighlight` にリネーム (基準が realtime ではなくなったため)。
 - Utilities: HTML form 系の datetime 文字列生成 util を `src/utils/datetime.ts` から `src/utils/html-date-time.ts` に切り出し、 関数名も `toDatetimeLocalValue` → `toDatetimeLocalInputValue` に rename して用途 (HTML `<input type="datetime-local">` の value) を明示した。
+- TimetableDialog: `useTimetable` の所有を新設の `TimetableContainer` (`src/components/timetable/timetable-container.tsx`) に移し、 ダイアログ内の datetime 変更が app 全体の再 render を引き起こさないようにした。 結果として (1) DateTimeNavigation の picker 操作で StopBrowser / NearbyStops 系の無関係な component が render されなくなり体感速度が劇的に向上、 (2) 新しい時刻表の描画も即時化 (= 巨大ツリーの再 render と grid 描画の競合が解消)、 (3) `StopsSummary` 等の debug log noise も解消。 外部から `openStopTimetable` / `openRouteHeadsignTimetable` を呼ぶ経路 (map markers / BottomSheet / StopSearchDialog) は app.tsx 内の `handleShow*` callback 経由のまま、 内部実装だけ `timetableRef` (= `useImperativeHandle` 経由) に切り替えた。
+- StopsSummary: `stop-browser-header.tsx` に同居していた内部 component (logger 名は `NearbyStopsSummary`) を `src/components/stops-summary.tsx` に切り出し、 logger 名を `StopsSummary` に揃え、 サマリ文字列ビルダーを `getNearbyStopsSummaryText` → `buildStopsSummaryText` に rename した (= 「Nearby」 接頭辞を排し、 内部で条件分岐して組み立てる動作に合う動詞へ)。
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [CalVer](https://calver.org/).
 ### Added
 
 - TimetableDialog: 表示中の時刻表を別日時で見直せる datetime navigation 行を追加 (前日 / 翌日 / `<input type="datetime-local">` / 現在ボタン)。 picker の編集は 1000ms debounce で fetch をまとめ、 直接 typing 中も中間状態で再 fetch が走らないようにした。
-- TimetableDialog: datetime picker の入力範囲を mount 時刻 ± 1 年でクランプ (`min` / `max` 属性 + JS 側の範囲チェック)。 範囲外の値は `onChangeDateTime` を呼ばず無視する。
+- TimetableDialog: datetime picker のスピナー操作範囲を mount 時刻 ± 1 年でクランプ (`<input type="datetime-local">` の `min` / `max` 属性で picker UI 側から制約)。 direct typing で範囲外の値が入力された場合は JS 側では弾かず、 そのまま fetch して「該当データなし (= 空時刻表)」 を表示する (黙って無視するよりも空表示で「データがない」 と伝わる方が UX 上わかりやすいため)。 NaN (`new Date(invalid)`) だけは `Number.isNaN` チェックで弾く。
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,22 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- TimetableDialog: 表示中の時刻表を別日時で見直せる datetime navigation 行を追加 (前日 / 翌日 / `<input type="datetime-local">` / 現在ボタン)。 picker の編集は 1000ms debounce で fetch をまとめ、 直接 typing 中も中間状態で再 fetch が走らないようにした。
+- TimetableDialog: datetime picker の入力範囲を mount 時刻 ± 1 年でクランプ (`min` / `max` 属性 + JS 側の範囲チェック)。 範囲外の値は `onChangeDateTime` を呼ばず無視する。
+
 ### Changed
 
 - Dialog: `TimetableModal` を `TimetableDialog` に rename し、 app / test 側の参照を追随更新した。あわせて dialog memoization regression test を `src/components/dialog/__tests__/` へ移設した (Issue #264)。
+- TimetableDialog: 時刻表行のハイライト (`hourToHighlight`) を realtime ベースから `data.referenceDateTime` ベースに切り替え、 `TimetableData` に「いつの時点に対するデータか」 を表す `referenceDateTime` を追加 (時刻ハイライトと picker / TimetableDateLabel が同じ datetime に揃う)。
+- TimetableDateLabel: 表示する時刻を realtime (`time` prop) から `data.referenceDateTime` に変更し、 picker / prev / next 操作と日時表示が常に同期するようにした。
+- TimetableGrid: 時刻表行のハイライト用 prop を `currentHour` から `hourToHighlight` にリネーム (基準が realtime ではなくなったため)。
+- Utilities: HTML form 系の datetime 文字列生成 util を `src/utils/datetime.ts` から `src/utils/html-date-time.ts` に切り出し、 関数名も `toDatetimeLocalValue` → `toDatetimeLocalInputValue` に rename して用途 (HTML `<input type="datetime-local">` の value) を明示した。
+
+### Fixed
+
+- `toDatetimeLocalInputValue`: 1〜3 桁年 (例: 西暦 1 年) を扱う際に input value が無効文字列 (`1-05-30T13:57` など) になり、 DateTimeNavigation / TimeSettingDialog の `<input type="datetime-local">` の表示が空 (placeholder) に崩れる問題を修正。 年を 4 桁に zero-pad するようにした。
 - Documentation: `ABOUT.md` のライセンス / クレジット記述を整理し、対象データ・提供元・ライセンス表記の構成を見直して attribution を追いやすくした。
 - Map tiles: Stadia Maps の Alidade Satellite をタイル選択肢から除外した
 - Data: MLIT 国土数値情報 鉄道データを N02-24 (令和 6 年度版) から N02-25 (令和 7 年度版) へ更新 (Issue #261)。 スキーマ・operator/路線名はすべて互換で、 parser の 5 桁丸めにより生成される `shapes.json` は既存出力とバイトレベルで同一。

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -378,6 +378,7 @@ describe('App anchor error toast', () => {
       timetableData: null,
       openStopTimetable: mockOpenStopTimetable,
       openRouteHeadsignTimetable: mockOpenRouteHeadsignTimetable,
+      changeDateTime: vi.fn(),
       closeTimetable: vi.fn(),
     });
     mockOpenStopTimetable.mockResolvedValue({ status: 'opened' });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -297,8 +297,13 @@ export default function App() {
     openNextTripInspection,
     closeTripInspection,
   } = useTripInspection(repo);
-  const { timetableData, openRouteHeadsignTimetable, openStopTimetable, closeTimetable } =
-    useTimetable(repo);
+  const {
+    timetableData,
+    openRouteHeadsignTimetable,
+    openStopTimetable,
+    changeDateTime,
+    closeTimetable,
+  } = useTimetable(repo);
 
   // Disable global shortcuts while primary modal state is active. This
   // includes `useAppDialogs` boolean flags and payload-backed dialog state
@@ -555,6 +560,13 @@ export default function App() {
       });
     },
     [dateTime, openRouteHeadsignTimetable, t],
+  );
+
+  const handleChangeTimetableDateTime = useCallback(
+    (next: Date) => {
+      void changeDateTime(next);
+    },
+    [changeDateTime],
   );
 
   const handleShowStopTimetable = useCallback(
@@ -1066,6 +1078,7 @@ export default function App() {
         dataLangs={langChain}
         globalFilter={globalFilter}
         onInspectTrip={handleInspectTrip}
+        onChangeDateTime={handleChangeTimetableDateTime}
         onClose={closeTimetable}
       />
       <Toaster

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -64,7 +64,6 @@ import { useStopHistory, type UseStopHistoryReturn } from './hooks/use-stop-hist
 import { useStopNavigation } from './hooks/use-stop-navigation';
 import { useStopParamHandler } from './hooks/use-stop-param-handler';
 import { useStopsForBounds } from './hooks/use-stops-for-bounds';
-import { useTimetable } from './hooks/use-timetable';
 import { useTransitRepository } from './hooks/use-transit-repository';
 import { useTripInspection } from './hooks/use-trip-inspection';
 import { useUserSettings } from './hooks/use-user-settings';
@@ -92,7 +91,10 @@ import { DataSourceSettingsDialog } from './components/dialog/data-source-settin
 import { InfoDialog } from './components/dialog/info-dialog';
 import { ShortcutHelpDialog } from './components/dialog/shortcut-help-dialog';
 import { StopSearchDialog } from './components/dialog/stop-search-dialog';
-import { TimetableDialog } from './components/dialog/timetable-dialog';
+import {
+  TimetableContainer,
+  type TimetableContainerHandle,
+} from './components/timetable/timetable-container';
 import { TripInspectionDialog } from './components/dialog/trip-inspection-dialog';
 import { MapOverlay } from './components/map/map-overlay';
 import { MapView } from './components/map/map-view';
@@ -297,13 +299,14 @@ export default function App() {
     openNextTripInspection,
     closeTripInspection,
   } = useTripInspection(repo);
-  const {
-    timetableData,
-    openRouteHeadsignTimetable,
-    openStopTimetable,
-    changeDateTime,
-    closeTimetable,
-  } = useTimetable(repo);
+  // `useTimetable` is owned by `TimetableContainer`, not by `App`. We hold a
+  // ref to call its imperative open methods from external launch paths
+  // (map markers / BottomSheet / StopSearchDialog) without re-rendering
+  // the entire app whenever the timetable state changes. The container
+  // notifies us of open/close transitions via `onOpenChange` so we can
+  // still gate global shortcuts on dialog visibility.
+  const timetableRef = useRef<TimetableContainerHandle>(null);
+  const [isTimetableOpen, setIsTimetableOpen] = useState(false);
 
   // Disable global shortcuts while primary modal state is active. This
   // includes `useAppDialogs` boolean flags and payload-backed dialog state
@@ -320,7 +323,7 @@ export default function App() {
       !infoDialogOpen &&
       !dataSourceSettingsDialogOpen &&
       !shortcutHelpOpen &&
-      timetableData === null &&
+      !isTimetableOpen &&
       tripInspectionSnapshot === null,
     handlers: {
       onOpenSearch: openSearchModal,
@@ -550,35 +553,28 @@ export default function App() {
 
   const handleShowTimetable = useCallback(
     (stopId: string, routeId: string, headsign: string) => {
-      void openRouteHeadsignTimetable({
-        stopId,
-        routeId,
-        headsign,
-        dateTime,
-      }).then((status) => {
+      const open = timetableRef.current?.openRouteHeadsignTimetable;
+      if (!open) {
+        return;
+      }
+      void open({ stopId, routeId, headsign, dateTime }).then((status) => {
         showOpenOutcomeToast(getTimetableOpenOutcomeMessage(status.status), t);
       });
     },
-    [dateTime, openRouteHeadsignTimetable, t],
-  );
-
-  const handleChangeTimetableDateTime = useCallback(
-    (next: Date) => {
-      void changeDateTime(next);
-    },
-    [changeDateTime],
+    [dateTime, t],
   );
 
   const handleShowStopTimetable = useCallback(
     (stopId: string) => {
-      void openStopTimetable({
-        stopId,
-        dateTime,
-      }).then((status) => {
+      const open = timetableRef.current?.openStopTimetable;
+      if (!open) {
+        return;
+      }
+      void open({ stopId, dateTime }).then((status) => {
         showOpenOutcomeToast(getTimetableOpenOutcomeMessage(status.status), t);
       });
     },
-    [dateTime, openStopTimetable, t],
+    [dateTime, t],
   );
 
   const handleOpenTripInspectionByStopId = useCallback(
@@ -1070,15 +1066,14 @@ export default function App() {
         onSelectStopById={handleSelectStopFromTripInspection}
         onOpenChange={handleTripInspectionOpenChange}
       />
-      <TimetableDialog
-        key={timetableData?.stop.stop_id ?? 'closed'}
-        data={timetableData}
+      <TimetableContainer
+        ref={timetableRef}
+        repo={repo}
         infoLevel={settings.infoLevel}
         dataLangs={langChain}
         globalFilter={globalFilter}
         onInspectTrip={handleInspectTrip}
-        onChangeDateTime={handleChangeTimetableDateTime}
-        onClose={closeTimetable}
+        onOpenChange={setIsTimetableOpen}
       />
       <Toaster
         theme={settings.theme}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1073,7 +1073,6 @@ export default function App() {
       <TimetableDialog
         key={timetableData?.stop.stop_id ?? 'closed'}
         data={timetableData}
-        time={dateTime}
         infoLevel={settings.infoLevel}
         dataLangs={langChain}
         globalFilter={globalFilter}

--- a/src/components/dialog/__tests__/dialog-memoization.test.tsx
+++ b/src/components/dialog/__tests__/dialog-memoization.test.tsx
@@ -334,7 +334,7 @@ afterEach(() => {
 });
 
 describe('dialog memoization regressions', () => {
-  it('TimetableDialog skips stats recomputation when only time changes', () => {
+  it('TimetableDialog skips stats recomputation when only an unrelated prop changes', () => {
     const data = makeTimetableData();
     const globalFilter = {
       showOriginOnly: false,
@@ -347,7 +347,6 @@ describe('dialog memoization regressions', () => {
     };
     const props = {
       data,
-      time: new Date(2026, 3, 1, 8, 0),
       infoLevel: 'detailed' as const,
       dataLangs: ['ja'] as const,
       globalFilter,
@@ -361,10 +360,6 @@ describe('dialog memoization regressions', () => {
     expect(computeTimetableEntryStatsMock).toHaveBeenCalledTimes(2);
 
     rerender(<TimetableDialog {...props} />);
-
-    expect(computeTimetableEntryStatsMock).toHaveBeenCalledTimes(2);
-
-    rerender(<TimetableDialog {...props} time={new Date(2026, 3, 1, 8, 1)} />);
 
     expect(computeTimetableEntryStatsMock).toHaveBeenCalledTimes(2);
 
@@ -390,7 +385,6 @@ describe('dialog memoization regressions', () => {
     };
     const props = {
       data,
-      time: new Date(2026, 3, 1, 8, 0),
       infoLevel: 'detailed' as const,
       dataLangs: ['ja'] as const,
       globalFilter,

--- a/src/components/dialog/__tests__/dialog-memoization.test.tsx
+++ b/src/components/dialog/__tests__/dialog-memoization.test.tsx
@@ -258,6 +258,7 @@ function makeTimetableData(): TimetableData {
     type: 'stop',
     stop,
     routes: [route],
+    viewingDateTime: new Date(2026, 3, 1, 8, 0),
     serviceDate: new Date(2026, 3, 1),
     timetableEntries: [makeTimetableEntry()],
     omitted: { nonBoardable: 0 },
@@ -352,6 +353,7 @@ describe('dialog memoization regressions', () => {
       globalFilter,
       onClose: vi.fn(),
       onInspectTrip: vi.fn(),
+      onChangeDateTime: vi.fn(),
     };
 
     const { rerender } = render(<TimetableDialog {...props} />);
@@ -394,6 +396,7 @@ describe('dialog memoization regressions', () => {
       globalFilter,
       onClose: vi.fn(),
       onInspectTrip: vi.fn(),
+      onChangeDateTime: vi.fn(),
     };
 
     const { rerender } = render(<TimetableDialog {...props} />);

--- a/src/components/dialog/__tests__/dialog-memoization.test.tsx
+++ b/src/components/dialog/__tests__/dialog-memoization.test.tsx
@@ -258,7 +258,7 @@ function makeTimetableData(): TimetableData {
     type: 'stop',
     stop,
     routes: [route],
-    viewingDateTime: new Date(2026, 3, 1, 8, 0),
+    referenceDateTime: new Date(2026, 3, 1, 8, 0),
     serviceDate: new Date(2026, 3, 1),
     timetableEntries: [makeTimetableEntry()],
     omitted: { nonBoardable: 0 },

--- a/src/components/dialog/__tests__/stop-search-dialog.test.tsx
+++ b/src/components/dialog/__tests__/stop-search-dialog.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Tests for stop-search-dialog.tsx.
+ *
+ * Focuses on the dialog's observable state contract: search query drives
+ * the visible result set, and closing the dialog clears that query so it
+ * does not leak into the next open session.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { buildSearchIndexEntry } from '@/domain/transit/stop-search-index';
+import type { UseListKeyboardNavigationReturn } from '@/hooks/use-list-keyboard-navigation';
+import type { UseStopSearchIndexReturn } from '@/hooks/use-stop-search-index';
+import type { TransitRepository } from '@/repositories/transit-repository';
+import type { AppRouteTypeValue, Stop } from '@/types/app/transit';
+import type { StopWithMeta } from '@/types/app/transit-composed';
+
+import { StopSearchDialog } from '../stop-search-dialog';
+
+const {
+  useStopSearchIndexMock,
+  useStopSearchMetaMock,
+  useListKeyboardNavigationMock,
+  onSelectStopMock,
+} = vi.hoisted(() => ({
+  useStopSearchIndexMock:
+    vi.fn<(repo: TransitRepository, open: boolean) => UseStopSearchIndexReturn>(),
+  useStopSearchMetaMock:
+    vi.fn<(repo: TransitRepository, stops: readonly Stop[]) => ReadonlyMap<string, StopWithMeta>>(),
+  useListKeyboardNavigationMock: vi.fn<(...args: unknown[]) => UseListKeyboardNavigationReturn>(),
+  onSelectStopMock: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children?: React.ReactNode;
+  }) =>
+    open ? (
+      <div>
+        <button type="button" aria-label="close dialog" onClick={() => onOpenChange?.(false)}>
+          close
+        </button>
+        {children}
+      </div>
+    ) : null,
+  DialogContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/hooks/use-stop-search-index', () => ({
+  useStopSearchIndex: useStopSearchIndexMock,
+}));
+
+vi.mock('@/hooks/use-stop-search-meta', () => ({
+  useStopSearchMeta: useStopSearchMetaMock,
+}));
+
+vi.mock('@/hooks/use-list-keyboard-navigation', () => ({
+  useListKeyboardNavigation: useListKeyboardNavigationMock,
+}));
+
+vi.mock('@/components/search/stop-search-result-item', () => ({
+  StopSearchResultItem: ({ stop, onSelect }: { stop: Stop; onSelect: (stop: Stop) => void }) => (
+    <button type="button" onClick={() => onSelect(stop)}>
+      {stop.stop_name}
+    </button>
+  ),
+}));
+
+function makeStop(stopId: string, stopName: string): Stop {
+  return {
+    stop_id: stopId,
+    stop_name: stopName,
+    stop_names: {
+      ja: stopName,
+      en: stopName,
+    },
+    stop_lat: 35,
+    stop_lon: 139,
+    location_type: 0,
+    agency_id: 'agency',
+  };
+}
+
+const stopA = makeStop('stop-a', 'Shibuya');
+const stopB = makeStop('stop-b', 'Shinagawa');
+
+const defaultSearchIndex = [buildSearchIndexEntry(stopA), buildSearchIndexEntry(stopB)];
+const defaultRouteTypeMap = new Map<string, AppRouteTypeValue[]>([
+  ['stop-a', [3]],
+  ['stop-b', [2]],
+]);
+
+function StopSearchDialogHarness() {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(true)}>
+        reopen dialog
+      </button>
+      <StopSearchDialog
+        repo={{} as TransitRepository}
+        infoLevel="normal"
+        dataLang={['ja']}
+        mapCenter={null}
+        onSelectStop={onSelectStopMock}
+        open={open}
+        onOpenChange={setOpen}
+      />
+    </div>
+  );
+}
+
+beforeEach(() => {
+  onSelectStopMock.mockReset();
+  useStopSearchIndexMock.mockImplementation((_repo: TransitRepository, open: boolean) => ({
+    searchIndex: open ? defaultSearchIndex : [],
+    routeTypeMap: defaultRouteTypeMap,
+  }));
+  useStopSearchMetaMock.mockReturnValue(new Map());
+  useListKeyboardNavigationMock.mockReturnValue({
+    selectedIndex: -1,
+    handleInputKeyDown: vi.fn(),
+    registerItemRef: () => vi.fn(),
+  });
+});
+
+describe('StopSearchDialog', () => {
+  it('filters visible results from the current query and shows no-results for misses', async () => {
+    render(
+      <StopSearchDialog
+        repo={{} as TransitRepository}
+        infoLevel="normal"
+        dataLang={['ja']}
+        mapCenter={null}
+        onSelectStop={onSelectStopMock}
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'shibu' } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Shibuya' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Shinagawa' })).not.toBeInTheDocument();
+    });
+
+    fireEvent.change(input, { target: { value: 'zzz' } });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Shibuya' })).not.toBeInTheDocument();
+      expect(screen.getByText('search.noResults')).toBeInTheDocument();
+    });
+  });
+
+  it('clears the query when the dialog closes so reopen starts fresh', async () => {
+    render(<StopSearchDialogHarness />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'shibu' } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Shibuya' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'close dialog' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'reopen dialog' }));
+
+    const reopenedInput = await screen.findByRole('textbox');
+    expect(reopenedInput).toHaveValue('');
+    expect(screen.queryByRole('button', { name: 'Shibuya' })).not.toBeInTheDocument();
+    expect(screen.queryByText('search.noResults')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/dialog/__tests__/timetable-dialog-state-leak.test.tsx
+++ b/src/components/dialog/__tests__/timetable-dialog-state-leak.test.tsx
@@ -1,0 +1,319 @@
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TimetableDialog } from '../timetable-dialog';
+import type { GlobalFilter } from '@/types/app/global-filter';
+import type { TimetableData } from '@/types/app/timetable';
+import type { Route, Stop } from '@/types/app/transit';
+
+type MockDialogProps = { children: React.ReactNode; onOpenChange?: (open: boolean) => void };
+type MockHeadsignFilterProps = {
+  activeFilters: Set<string>;
+  onToggleFilter: (key: string) => void;
+};
+
+const dialogProps = vi.fn<(props: MockDialogProps) => void>();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
+vi.mock('@/hooks/use-info-level', () => ({
+  useInfoLevel: () => ({
+    isDetailedEnabled: true,
+    isVerboseEnabled: false,
+    isNormalEnabled: true,
+    isSimpleEnabled: false,
+  }),
+}));
+
+vi.mock('@/hooks/use-scroll-fades', () => ({
+  useScrollFades: () => ({
+    handleScroll: vi.fn(),
+    showTop: false,
+    showBottom: false,
+  }),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: (props: MockDialogProps) => {
+    dialogProps(props);
+    return <div>{props.children}</div>;
+  },
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/shared/scroll-fade-edge', () => ({
+  ScrollFadeEdge: () => null,
+}));
+
+vi.mock('@/components/verbose/verbose-timetable-summary', () => ({
+  VerboseTimetableSummary: () => null,
+}));
+
+vi.mock('@/domain/transit/timetable-stats', () => ({
+  computeTimetableEntryStats: () => ({
+    totalCount: 0,
+    originCount: 0,
+    terminalCount: 0,
+    boardableCount: 0,
+    nonBoardableCount: 0,
+    noPickupCount: 0,
+    noDropOffCount: 0,
+    dropOffOnlyCount: 0,
+  }),
+}));
+
+vi.mock('@/components/filter/boardability-filter', () => ({
+  BoardabilityFilter: () => null,
+}));
+
+vi.mock('@/components/filter/origin-filter', () => ({
+  OriginFilter: () => null,
+}));
+
+vi.mock('@/components/timetable/timetable-grid', () => ({
+  TimetableGrid: () => null,
+}));
+
+vi.mock('@/components/timetable/timetable-header', () => ({
+  TimetableHeader: () => null,
+}));
+
+const headsignFilterProps = vi.fn<(props: MockHeadsignFilterProps) => void>();
+vi.mock('@/components/timetable/timetable-headsign-filter', () => ({
+  TimetableHeadsignFilter: (props: MockHeadsignFilterProps) => {
+    headsignFilterProps(props);
+    return null;
+  },
+}));
+
+vi.mock('@/components/timetable/timetable-metadata', () => ({
+  TimetableMetadata: () => null,
+}));
+
+function makeStop(id: string): Stop {
+  return {
+    stop_id: id,
+    stop_name: id,
+    stop_names: {},
+    stop_lat: 0,
+    stop_lon: 0,
+    location_type: 0,
+    agency_id: 'agency-1',
+  };
+}
+
+function makeRoute(id: string): Route {
+  return {
+    route_id: id,
+    route_short_name: id,
+    route_long_name: id,
+    route_short_names: {},
+    route_long_names: {},
+    route_type: 3,
+    route_color: '',
+    route_text_color: '',
+    agency_id: 'agency-1',
+  };
+}
+
+function makeData(overrides: Partial<TimetableData>): TimetableData {
+  const stop = makeStop('stop-A');
+  const route = makeRoute('route-1');
+  return {
+    type: 'stop',
+    stop,
+    routes: [route],
+    referenceDateTime: new Date(2026, 3, 1, 8, 0),
+    serviceDate: new Date(2026, 3, 1),
+    timetableEntries: [],
+    omitted: { nonBoardable: 0 },
+    stopServiceState: 'boardable',
+    agencies: [
+      {
+        agency_id: 'agency-1',
+        agency_name: 'Agency',
+        agency_long_name: 'Agency',
+        agency_short_name: 'A',
+        agency_names: {},
+        agency_long_names: {},
+        agency_short_names: {},
+        agency_url: '',
+        agency_timezone: 'Asia/Tokyo',
+        agency_lang: 'ja',
+        agency_fare_url: '',
+        agency_colors: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+const globalFilter = {
+  showOriginOnly: false,
+  showBoardableOnly: false,
+  omitEmptyStops: false,
+  isOmitEmptyStopsForced: false,
+  onToggleShowOriginOnly: vi.fn(),
+  onToggleShowBoardableOnly: vi.fn(),
+  onToggleOmitEmptyStops: vi.fn(),
+} as unknown as GlobalFilter;
+
+function getLastFilterProps(): {
+  activeFilters: Set<string>;
+  onToggleFilter: (key: string) => void;
+} {
+  const props = headsignFilterProps.mock.lastCall?.[0];
+  if (!props) {
+    throw new Error('TimetableHeadsignFilter was not rendered');
+  }
+  return props;
+}
+
+function getLastDialogProps(): { onOpenChange?: (open: boolean) => void } {
+  const props = dialogProps.mock.lastCall?.[0];
+  if (!props) {
+    throw new Error('Dialog was not rendered');
+  }
+  return props;
+}
+
+describe('TimetableDialog activeFilters state leak', () => {
+  beforeEach(() => {
+    headsignFilterProps.mockReset();
+    dialogProps.mockReset();
+  });
+
+  it('clears activeFilters when data is retargeted to a different mode for the same stop', () => {
+    const stopData = makeData({ type: 'stop' });
+    const routeHeadsignData = makeData({
+      type: 'route-headsign',
+      headsign: '永福町',
+    });
+
+    const props = {
+      infoLevel: 'detailed' as const,
+      dataLangs: ['ja'] as const,
+      globalFilter,
+      onClose: vi.fn(),
+      onInspectTrip: vi.fn(),
+      onChangeDateTime: vi.fn(),
+    };
+
+    const { rerender } = render(<TimetableDialog {...props} data={stopData} />);
+
+    // 1. Initial state: activeFilters is empty.
+    expect(getLastFilterProps().activeFilters).toEqual(new Set());
+
+    // 2. Apply a filter by invoking the headsign filter's onToggleFilter callback
+    //    (= what a chip click would do).
+    act(() => {
+      getLastFilterProps().onToggleFilter('永福町');
+    });
+    expect(getLastFilterProps().activeFilters).toEqual(new Set(['永福町']));
+
+    // 3. Retarget the dialog to route-headsign mode for the SAME stop.
+    //    (`TimetableHeadsignFilter` is only rendered for `data.type === 'stop'`,
+    //    so we cannot directly observe `activeFilters` in route-headsign mode.)
+    rerender(<TimetableDialog {...props} data={routeHeadsignData} />);
+
+    // 4. Retarget back to stop mode and verify the filter was cleared by the
+    //    "Adjusting state on prop changes" reset, not silently leaked.
+    rerender(<TimetableDialog {...props} data={stopData} />);
+    expect(getLastFilterProps().activeFilters).toEqual(new Set());
+  });
+
+  it('keeps activeFilters when only the date changes for the same stop and mode', () => {
+    // Same identity (type / stop_id / headsign) = filter must be preserved.
+    const initialData = makeData({ type: 'stop' });
+    const sameStopLaterDate = makeData({
+      type: 'stop',
+      referenceDateTime: new Date(2026, 3, 2, 8, 0),
+      serviceDate: new Date(2026, 3, 2),
+    });
+
+    const props = {
+      infoLevel: 'detailed' as const,
+      dataLangs: ['ja'] as const,
+      globalFilter,
+      onClose: vi.fn(),
+      onInspectTrip: vi.fn(),
+      onChangeDateTime: vi.fn(),
+    };
+
+    const { rerender } = render(<TimetableDialog {...props} data={initialData} />);
+
+    act(() => {
+      getLastFilterProps().onToggleFilter('永福町');
+    });
+    expect(getLastFilterProps().activeFilters).toEqual(new Set(['永福町']));
+
+    rerender(<TimetableDialog {...props} data={sameStopLaterDate} />);
+
+    // Date changed, but (type, stop_id, headsign) are unchanged -> filter kept.
+    expect(getLastFilterProps().activeFilters).toEqual(new Set(['永福町']));
+  });
+
+  it('clears activeFilters when the stop changes within stop mode', () => {
+    const stopAData = makeData({
+      type: 'stop',
+      stop: makeStop('stop-A'),
+    });
+    const stopBData = makeData({
+      type: 'stop',
+      stop: makeStop('stop-B'),
+    });
+
+    const props = {
+      infoLevel: 'detailed' as const,
+      dataLangs: ['ja'] as const,
+      globalFilter,
+      onClose: vi.fn(),
+      onInspectTrip: vi.fn(),
+      onChangeDateTime: vi.fn(),
+    };
+
+    const { rerender } = render(<TimetableDialog {...props} data={stopAData} />);
+
+    act(() => {
+      getLastFilterProps().onToggleFilter('永福町');
+    });
+    expect(getLastFilterProps().activeFilters).toEqual(new Set(['永福町']));
+
+    rerender(<TimetableDialog {...props} data={stopBData} />);
+
+    expect(getLastFilterProps().activeFilters).toEqual(new Set());
+  });
+
+  it('clears activeFilters when the dialog closes', () => {
+    const stopData = makeData({ type: 'stop' });
+    const onClose = vi.fn();
+
+    const props = {
+      infoLevel: 'detailed' as const,
+      dataLangs: ['ja'] as const,
+      globalFilter,
+      onClose,
+      onInspectTrip: vi.fn(),
+      onChangeDateTime: vi.fn(),
+    };
+
+    render(<TimetableDialog {...props} data={stopData} />);
+
+    act(() => {
+      getLastFilterProps().onToggleFilter('永福町');
+    });
+    expect(getLastFilterProps().activeFilters).toEqual(new Set(['永福町']));
+
+    act(() => {
+      getLastDialogProps().onOpenChange?.(false);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(getLastFilterProps().activeFilters).toEqual(new Set());
+  });
+});

--- a/src/components/dialog/__tests__/timetable-dialog-state-leak.test.tsx
+++ b/src/components/dialog/__tests__/timetable-dialog-state-leak.test.tsx
@@ -289,6 +289,40 @@ describe('TimetableDialog activeFilters state leak', () => {
     expect(getLastFilterProps().activeFilters).toEqual(new Set());
   });
 
+  it('clears activeFilters when retargeted between colon-containing stop identities', () => {
+    const colonStopData = makeData({
+      type: 'stop',
+      stop: makeStop('tmm:101'),
+      headsign: undefined,
+    });
+    const routeHeadsignData = makeData({
+      type: 'route-headsign',
+      stop: makeStop('tmm'),
+      headsign: '101:',
+    });
+
+    const props = {
+      infoLevel: 'detailed' as const,
+      dataLangs: ['ja'] as const,
+      globalFilter,
+      onClose: vi.fn(),
+      onInspectTrip: vi.fn(),
+      onChangeDateTime: vi.fn(),
+    };
+
+    const { rerender } = render(<TimetableDialog {...props} data={colonStopData} />);
+
+    act(() => {
+      getLastFilterProps().onToggleFilter('永福町');
+    });
+    expect(getLastFilterProps().activeFilters).toEqual(new Set(['永福町']));
+
+    rerender(<TimetableDialog {...props} data={routeHeadsignData} />);
+    rerender(<TimetableDialog {...props} data={colonStopData} />);
+
+    expect(getLastFilterProps().activeFilters).toEqual(new Set());
+  });
+
   it('clears activeFilters when the dialog closes', () => {
     const stopData = makeData({ type: 'stop' });
     const onClose = vi.fn();

--- a/src/components/dialog/time-setting-dialog.tsx
+++ b/src/components/dialog/time-setting-dialog.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { toDatetimeLocalValue } from '@/utils/datetime';
+import { toDatetimeLocalInputValue } from '@/utils/html-date-time';
 import {
   Dialog,
   DialogContent,
@@ -45,7 +45,7 @@ export function TimeSettingDialog({
     (node: HTMLInputElement | null) => {
       inputRef.current = node;
       if (node) {
-        node.value = toDatetimeLocalValue(initialTime);
+        node.value = toDatetimeLocalInputValue(initialTime);
       }
     },
     [initialTime],

--- a/src/components/dialog/time-setting-dialog.tsx
+++ b/src/components/dialog/time-setting-dialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toDatetimeLocalInputValue } from '@/utils/html-date-time';
 import {
@@ -41,6 +41,20 @@ export function TimeSettingDialog({
 }: TimeSettingDialogProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
+  // Bound the picker to +/- 1 year from the mount-time wall clock, matching
+  // the DateTimeNavigation picker in TimetableDialog.
+  const inputBounds = useMemo(() => {
+    const now = new Date();
+    const min = new Date(now);
+    min.setFullYear(min.getFullYear() - 1);
+    const max = new Date(now);
+    max.setFullYear(max.getFullYear() + 1);
+    return {
+      minString: toDatetimeLocalInputValue(min),
+      maxString: toDatetimeLocalInputValue(max),
+    };
+  }, []);
+
   const setInputRef = useCallback(
     (node: HTMLInputElement | null) => {
       inputRef.current = node;
@@ -52,9 +66,21 @@ export function TimeSettingDialog({
   );
 
   const handleSubmit = useCallback(() => {
-    if (inputRef.current?.value) {
-      onCustomTimeSet(new Date(inputRef.current.value));
+    const raw = inputRef.current?.value;
+    if (!raw) {
+      onOpenChange(false);
+      return;
     }
+    const parsed = new Date(raw);
+    if (Number.isNaN(parsed.getTime())) {
+      // Reject Invalid Date (e.g. typed "9999-13-99T99:99") so the app
+      // never receives a NaN-backed Date. Range-based rejection is
+      // intentionally not done here: this dialog is an explicit submit,
+      // so out-of-range values typed by the user are honored.
+      onOpenChange(false);
+      return;
+    }
+    onCustomTimeSet(parsed);
     onOpenChange(false);
   }, [onCustomTimeSet, onOpenChange]);
 
@@ -90,6 +116,8 @@ export function TimeSettingDialog({
           id="custom-datetime"
           ref={setInputRef}
           type="datetime-local"
+          min={inputBounds.minString}
+          max={inputBounds.maxString}
           className="border-input bg-background w-full max-w-full min-w-0 rounded-lg border px-3 py-2.5 text-base"
         />
         <div className="flex justify-end gap-2">

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -15,7 +15,7 @@ import { getSelectedHeadsignDisplayName } from '@/domain/transit/name-resolver/g
 import { getRouteDisplayNames } from '@/domain/transit/name-resolver/get-route-display-names';
 import { getStopDisplayNames } from '@/domain/transit/name-resolver/get-stop-display-names';
 import { hasUnknownDestination } from '@/domain/transit/has-unknown-destination';
-import { getServiceDay, getServiceDayMinutes } from '@/domain/transit/service-day';
+import { getServiceDayMinutes } from '@/domain/transit/service-day';
 import { applyStopEventAttributeToggles } from '@/domain/transit/timetable-filter';
 import type { TimetableEntryStats } from '@/domain/transit/timetable-stats';
 import { computeTimetableEntryStats } from '@/domain/transit/timetable-stats';
@@ -28,8 +28,9 @@ import type { Agency } from '@/types/app/transit';
 import type { TimetableEntry, TripInspectionTarget } from '@/types/app/transit-composed';
 import { formatDateParts, toDatetimeLocalValue } from '@/utils/datetime';
 import { DAY_COLOR_CATEGORY_CLASSES } from '@/utils/day-of-week';
+import { createLogger } from '@/lib/logger';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getRouteHeadsignKey } from '../../domain/transit/get-route-headsign-key';
 import { BoardabilityFilter } from '../filter/boardability-filter';
@@ -38,6 +39,9 @@ import { TimetableGrid } from '../timetable/timetable-grid';
 import { TimetableHeader } from '../timetable/timetable-header';
 import { TimetableHeadsignFilter } from '../timetable/timetable-headsign-filter';
 import { TimetableMetadata } from '../timetable/timetable-metadata';
+import { ButtonGroup } from '../ui/button-group';
+
+const logger = createLogger('TimetableDialog');
 
 interface TimetableDialogProps {
   /** Pass null when the dialog should be closed. */
@@ -95,10 +99,6 @@ function EntriesPanel({
 interface DateTimeNavigationProps {
   /** The datetime the dialog is currently displaying. */
   viewingDateTime: Date;
-  /** Realtime reference used by the "now" reset button. */
-  currentDateTime: Date;
-  /** Whether the viewed service day matches the realtime service day. */
-  isViewingNow: boolean;
   onChangeDateTime: (dateTime: Date) => void;
 }
 
@@ -106,15 +106,10 @@ interface DateTimeNavigationProps {
  * Datetime navigation row (previous day / datetime picker / next day / now).
  *
  * Handlers are local to this component so the parent can stay focused on
- * the timetable rendering. The "now" button is only shown when the
- * viewed service day differs from the realtime service day.
+ * the timetable rendering. The "now" button always re-fetches at the
+ * current wall-clock time.
  */
-function DateTimeNavigation({
-  viewingDateTime,
-  currentDateTime,
-  isViewingNow,
-  onChangeDateTime,
-}: DateTimeNavigationProps) {
+function DateTimeNavigation({ viewingDateTime, onChangeDateTime }: DateTimeNavigationProps) {
   const { t } = useTranslation();
 
   const handlePrevDay = useCallback(() => {
@@ -130,8 +125,8 @@ function DateTimeNavigation({
   }, [viewingDateTime, onChangeDateTime]);
 
   const handleResetToNow = useCallback(() => {
-    onChangeDateTime(currentDateTime);
-  }, [currentDateTime, onChangeDateTime]);
+    onChangeDateTime(new Date());
+  }, [onChangeDateTime]);
 
   const handlePickerChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -150,34 +145,38 @@ function DateTimeNavigation({
 
   return (
     <div className="flex flex-wrap items-center justify-center gap-1.5">
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={handlePrevDay}
-        aria-label={t('timetable.dateTimeNav.previousDay')}
-      >
-        <ChevronLeft className="size-4" />
-      </Button>
-      <input
-        type="datetime-local"
-        value={toDatetimeLocalValue(viewingDateTime)}
-        onChange={handlePickerChange}
-        aria-label={t('timetable.dateTimeNav.datePickerLabel')}
-        className="border-input bg-background rounded-md border px-2 py-1 text-sm"
-      />
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={handleNextDay}
-        aria-label={t('timetable.dateTimeNav.nextDay')}
-      >
-        <ChevronRight className="size-4" />
-      </Button>
-      {!isViewingNow && (
-        <Button variant="outline" size="sm" onClick={handleResetToNow}>
-          {t('timetable.dateTimeNav.now')}
-        </Button>
-      )}
+      <ButtonGroup>
+        <ButtonGroup>
+          <Button
+            variant="outline"
+            size="icon-xs"
+            onClick={handlePrevDay}
+            aria-label={t('timetable.dateTimeNav.previousDay')}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <input
+            type="datetime-local"
+            value={toDatetimeLocalValue(viewingDateTime)}
+            onChange={handlePickerChange}
+            aria-label={t('timetable.dateTimeNav.datePickerLabel')}
+            className="border-input bg-background h-6 rounded-md border px-2 text-xs leading-none"
+          />
+          <Button
+            variant="outline"
+            size="icon-xs"
+            onClick={handleNextDay}
+            aria-label={t('timetable.dateTimeNav.nextDay')}
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button variant="outline" size="xs" onClick={handleResetToNow}>
+            {t('timetable.dateTimeNav.now')}
+          </Button>
+        </ButtonGroup>
+      </ButtonGroup>
     </div>
   );
 }
@@ -239,7 +238,7 @@ function areTimetableDialogPropsEqual(
 
 export const TimetableDialog = memo(function TimetableDialog({
   data,
-  time,
+  time: _time,
   infoLevel,
   dataLangs,
   globalFilter,
@@ -252,15 +251,18 @@ export const TimetableDialog = memo(function TimetableDialog({
   const { t, i18n } = useTranslation();
   const open = data !== null;
   const info = useInfoLevel(infoLevel);
-  // Whether the currently viewed service day matches the realtime service day.
-  // Only then is the current-hour highlight meaningful.
-  const isViewingNow = useMemo(() => {
+
+  useEffect(() => {
     if (!data) {
-      return false;
+      return;
     }
-    return getServiceDay(time).getTime() === data.serviceDate.getTime();
-  }, [data, time]);
-  const currentHour = isViewingNow ? Math.floor(getServiceDayMinutes(time) / 60) : -1;
+    logger.debug('data changed', {
+      referenceDateTime: data.referenceDateTime.toISOString(),
+      serviceDate: data.serviceDate.toISOString(),
+    });
+  }, [data]);
+
+  const hourToHighlight = data ? Math.floor(getServiceDayMinutes(data.referenceDateTime) / 60) : -1;
   const headerContainerRef = useRef<HTMLDivElement | null>(null);
   const gridContainerRef = useRef<HTMLDivElement | null>(null);
 
@@ -345,7 +347,7 @@ export const TimetableDialog = memo(function TimetableDialog({
   );
   const gridScroll = useScrollFades(
     gridContainerRef,
-    `${data?.type ?? 'closed'}:${stopEventAttributesFilteredEntries.length}:${infoLevel}:${currentHour}`,
+    `${data?.type ?? 'closed'}:${stopEventAttributesFilteredEntries.length}:${infoLevel}:${hourToHighlight}`,
   );
 
   if (!data) {
@@ -475,15 +477,19 @@ export const TimetableDialog = memo(function TimetableDialog({
             )}
 
             {/* Datetime navigation */}
-            <DateTimeNavigation
-              viewingDateTime={data.viewingDateTime}
-              currentDateTime={time}
-              isViewingNow={isViewingNow}
-              onChangeDateTime={onChangeDateTime}
-            />
+            {info.isVerboseEnabled && (
+              <DateTimeNavigation
+                viewingDateTime={data.referenceDateTime}
+                onChangeDateTime={onChangeDateTime}
+              />
+            )}
 
             {/* Date time */}
-            <TimetableDateLabel serviceDate={data.serviceDate} time={time} lang={dataLangs[0]} />
+            <TimetableDateLabel
+              serviceDate={data.serviceDate}
+              time={data.referenceDateTime}
+              lang={dataLangs[0]}
+            />
 
             <div className="flex flex-wrap gap-1">
               {/* Boardability filter */}
@@ -548,7 +554,7 @@ export const TimetableDialog = memo(function TimetableDialog({
                   ),
                 ).size > 1
               }
-              currentHour={currentHour}
+              hourToHighlight={hourToHighlight}
               infoLevel={infoLevel}
               dataLangs={dataLangs}
               agencies={data.agencies}

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -141,7 +141,10 @@ function DateTimeNavigation({ viewingDateTime, onChangeDateTime }: DateTimeNavig
     toDatetimeLocalInputValue(viewingDateTime),
   );
   const [prevViewingDateTime, setPrevViewingDateTime] = useState(viewingDateTime);
-  if (viewingDateTime !== prevViewingDateTime) {
+  // Compare timestamps (not Date references) so that a newly-allocated Date
+  // representing the same moment does not trigger an unnecessary state
+  // update / extra render of DateTimeNavigation.
+  if (viewingDateTime.getTime() !== prevViewingDateTime.getTime()) {
     setPrevViewingDateTime(viewingDateTime);
     setEditingValue(toDatetimeLocalInputValue(viewingDateTime));
   }
@@ -152,19 +155,26 @@ function DateTimeNavigation({ viewingDateTime, onChangeDateTime }: DateTimeNavig
     };
   }, []);
 
+  // Explicit navigation (prev / next / now) must override any pending
+  // picker-debounce commit. Without `clearTimeout` here, a still-pending
+  // typed value could fire after the button-triggered fetch returns and
+  // silently overwrite it.
   const handlePrevDay = useCallback(() => {
+    clearTimeout(debounceTimerRef.current);
     const next = new Date(viewingDateTime);
     next.setDate(next.getDate() - 1);
     onChangeDateTime(next);
   }, [viewingDateTime, onChangeDateTime]);
 
   const handleNextDay = useCallback(() => {
+    clearTimeout(debounceTimerRef.current);
     const next = new Date(viewingDateTime);
     next.setDate(next.getDate() + 1);
     onChangeDateTime(next);
   }, [viewingDateTime, onChangeDateTime]);
 
   const handleResetToNow = useCallback(() => {
+    clearTimeout(debounceTimerRef.current);
     onChangeDateTime(new Date());
   }, [onChangeDateTime]);
 

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -29,7 +29,6 @@ import type { TimetableEntry, TripInspectionTarget } from '@/types/app/transit-c
 import { formatDateParts } from '@/utils/datetime';
 import { toDatetimeLocalInputValue } from '@/utils/html-date-time';
 import { DAY_COLOR_CATEGORY_CLASSES } from '@/utils/day-of-week';
-import { createLogger } from '@/lib/logger';
 import { ChevronLeft, ChevronRight, Clock } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -42,13 +41,9 @@ import { TimetableHeadsignFilter } from '../timetable/timetable-headsign-filter'
 import { TimetableMetadata } from '../timetable/timetable-metadata';
 import { ButtonGroup } from '../ui/button-group';
 
-const logger = createLogger('TimetableDialog');
-
 interface TimetableDialogProps {
   /** Pass null when the dialog should be closed. */
   data: TimetableData | null;
-  /** Real-world current time used as the "today" reference. */
-  time: Date;
   infoLevel: InfoLevel;
   /** Display language chain for translated GTFS/ODPT data names. */
   dataLangs: readonly string[];
@@ -280,7 +275,6 @@ function areTimetableDialogPropsEqual(
 ): boolean {
   return (
     prev.data === next.data &&
-    prev.time === next.time &&
     prev.infoLevel === next.infoLevel &&
     prev.dataLangs === next.dataLangs &&
     prev.onInspectTrip === next.onInspectTrip &&
@@ -292,7 +286,6 @@ function areTimetableDialogPropsEqual(
 
 export const TimetableDialog = memo(function TimetableDialog({
   data,
-  time: _time,
   infoLevel,
   dataLangs,
   globalFilter,
@@ -305,16 +298,6 @@ export const TimetableDialog = memo(function TimetableDialog({
   const { t, i18n } = useTranslation();
   const open = data !== null;
   const info = useInfoLevel(infoLevel);
-
-  useEffect(() => {
-    if (!data) {
-      return;
-    }
-    logger.debug('data changed', {
-      referenceDateTime: data.referenceDateTime.toISOString(),
-      serviceDate: data.serviceDate.toISOString(),
-    });
-  }, [data]);
 
   const hourToHighlight = data ? Math.floor(getServiceDayMinutes(data.referenceDateTime) / 60) : -1;
   const headerContainerRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -1,4 +1,5 @@
 import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -14,7 +15,7 @@ import { getSelectedHeadsignDisplayName } from '@/domain/transit/name-resolver/g
 import { getRouteDisplayNames } from '@/domain/transit/name-resolver/get-route-display-names';
 import { getStopDisplayNames } from '@/domain/transit/name-resolver/get-stop-display-names';
 import { hasUnknownDestination } from '@/domain/transit/has-unknown-destination';
-import { getServiceDayMinutes } from '@/domain/transit/service-day';
+import { getServiceDay, getServiceDayMinutes } from '@/domain/transit/service-day';
 import { applyStopEventAttributeToggles } from '@/domain/transit/timetable-filter';
 import type { TimetableEntryStats } from '@/domain/transit/timetable-stats';
 import { computeTimetableEntryStats } from '@/domain/transit/timetable-stats';
@@ -25,8 +26,9 @@ import type { InfoLevel } from '@/types/app/settings';
 import type { TimetableData } from '@/types/app/timetable';
 import type { Agency } from '@/types/app/transit';
 import type { TimetableEntry, TripInspectionTarget } from '@/types/app/transit-composed';
-import { formatDateParts } from '@/utils/datetime';
+import { formatDateParts, toDatetimeLocalValue } from '@/utils/datetime';
 import { DAY_COLOR_CATEGORY_CLASSES } from '@/utils/day-of-week';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getRouteHeadsignKey } from '../../domain/transit/get-route-headsign-key';
@@ -40,7 +42,7 @@ import { TimetableMetadata } from '../timetable/timetable-metadata';
 interface TimetableDialogProps {
   /** Pass null when the dialog should be closed. */
   data: TimetableData | null;
-  /** Current time reference for highlighting the active hour row. */
+  /** Real-world current time used as the "today" reference. */
   time: Date;
   infoLevel: InfoLevel;
   /** Display language chain for translated GTFS/ODPT data names. */
@@ -48,6 +50,11 @@ interface TimetableDialogProps {
   /** App-wide filter state shared across surfaces. */
   globalFilter: GlobalFilter;
   onInspectTrip?: (target: TripInspectionTarget) => void;
+  /**
+   * Change the datetime of the currently displayed timetable, preserving
+   * the current stop and filter. Used by the date navigation row.
+   */
+  onChangeDateTime: (dateTime: Date) => void;
   onClose: () => void;
 }
 
@@ -134,6 +141,7 @@ function areTimetableDialogPropsEqual(
     prev.infoLevel === next.infoLevel &&
     prev.dataLangs === next.dataLangs &&
     prev.onInspectTrip === next.onInspectTrip &&
+    prev.onChangeDateTime === next.onChangeDateTime &&
     prev.onClose === next.onClose &&
     hasSameRelevantGlobalFilter(prev.globalFilter, next.globalFilter)
   );
@@ -146,6 +154,7 @@ export const TimetableDialog = memo(function TimetableDialog({
   dataLangs,
   globalFilter,
   onInspectTrip,
+  onChangeDateTime,
   onClose,
 }: TimetableDialogProps) {
   const { showOriginOnly, showBoardableOnly, onToggleShowOriginOnly, onToggleShowBoardableOnly } =
@@ -153,9 +162,56 @@ export const TimetableDialog = memo(function TimetableDialog({
   const { t, i18n } = useTranslation();
   const open = data !== null;
   const info = useInfoLevel(infoLevel);
-  const currentHour = Math.floor(getServiceDayMinutes(time) / 60);
+  // Whether the currently viewed service day matches the realtime service day.
+  // Only then is the current-hour highlight meaningful.
+  const isViewingToday = useMemo(() => {
+    if (!data) {
+      return false;
+    }
+    return getServiceDay(time).getTime() === data.serviceDate.getTime();
+  }, [data, time]);
+  const currentHour = isViewingToday ? Math.floor(getServiceDayMinutes(time) / 60) : -1;
   const headerContainerRef = useRef<HTMLDivElement | null>(null);
   const gridContainerRef = useRef<HTMLDivElement | null>(null);
+
+  const viewingDateTime = data?.viewingDateTime ?? null;
+
+  const handlePrevDay = useCallback(() => {
+    if (!viewingDateTime) {
+      return;
+    }
+    const next = new Date(viewingDateTime);
+    next.setDate(next.getDate() - 1);
+    onChangeDateTime(next);
+  }, [viewingDateTime, onChangeDateTime]);
+
+  const handleNextDay = useCallback(() => {
+    if (!viewingDateTime) {
+      return;
+    }
+    const next = new Date(viewingDateTime);
+    next.setDate(next.getDate() + 1);
+    onChangeDateTime(next);
+  }, [viewingDateTime, onChangeDateTime]);
+
+  const handleResetToNow = useCallback(() => {
+    onChangeDateTime(time);
+  }, [onChangeDateTime, time]);
+
+  const handlePickerChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = event.target.value;
+      if (!raw) {
+        return;
+      }
+      const parsed = new Date(raw);
+      if (Number.isNaN(parsed.getTime())) {
+        return;
+      }
+      onChangeDateTime(parsed);
+    },
+    [onChangeDateTime],
+  );
 
   // Filter state for stop timetable (route+headsign toggle).
   // Empty set = show all timetable (no filter active).
@@ -366,6 +422,38 @@ export const TimetableDialog = memo(function TimetableDialog({
                 filteredCount={routeHeadsignFilteredEntries.length}
               />
             )}
+
+            {/* Date navigation */}
+            <div className="flex flex-wrap items-center justify-center gap-1.5">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handlePrevDay}
+                aria-label={t('timetable.dateNav.previousDay')}
+              >
+                <ChevronLeft className="size-4" />
+              </Button>
+              <input
+                type="datetime-local"
+                value={toDatetimeLocalValue(data.viewingDateTime)}
+                onChange={handlePickerChange}
+                aria-label={t('timetable.dateNav.datePickerLabel')}
+                className="border-input bg-background rounded-md border px-2 py-1 text-sm"
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleNextDay}
+                aria-label={t('timetable.dateNav.nextDay')}
+              >
+                <ChevronRight className="size-4" />
+              </Button>
+              {!isViewingToday && (
+                <Button variant="outline" size="sm" onClick={handleResetToNow}>
+                  {t('timetable.dateNav.now')}
+                </Button>
+              )}
+            </div>
 
             {/* Date time */}
             <TimetableDateLabel serviceDate={data.serviceDate} time={time} lang={dataLangs[0]} />

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -331,7 +331,9 @@ export const TimetableDialog = memo(function TimetableDialog({
   // This uses the "Adjusting state on prop changes" pattern (compare
   // previous and current during render), the same idiom used by
   // `StopSearchDialog.prevDeferredQuery`.
-  const dataIdentity = data ? `${data.type}:${data.stop.stop_id}:${data.headsign ?? ''}` : null;
+  const dataIdentity = data
+    ? JSON.stringify([data.type, data.stop.stop_id, data.headsign ?? ''])
+    : null;
   const [prevDataIdentity, setPrevDataIdentity] = useState(dataIdentity);
   if (dataIdentity !== prevDataIdentity) {
     setPrevDataIdentity(dataIdentity);

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -306,6 +306,28 @@ export const TimetableDialog = memo(function TimetableDialog({
   // Empty set = show all timetable (no filter active).
   const [activeFilters, setActiveFilters] = useState<Set<string>>(() => new Set());
 
+  // Reset `activeFilters` when the dialog is retargeted to a different
+  // (stop, view-mode, headsign) tuple while still mounted.
+  //
+  // The container's `key` is bound to `stop.stop_id`, so a same-stop
+  // re-open (e.g. switching from stop timetable to route-headsign
+  // timetable for the same stop, or vice versa) keeps the dialog
+  // mounted and would otherwise leak the previous filter selection into
+  // the new view -- `TimetableHeadsignFilter` is only shown for
+  // `data.type === 'stop'`, but `routeHeadsignFilteredEntries` honors
+  // `activeFilters` regardless of mode, so a stale filter would silently
+  // drop rows in route-headsign view with no visible toggle.
+  //
+  // This uses the "Adjusting state on prop changes" pattern (compare
+  // previous and current during render), the same idiom used by
+  // `StopSearchDialog.prevDeferredQuery`.
+  const dataIdentity = data ? `${data.type}:${data.stop.stop_id}:${data.headsign ?? ''}` : null;
+  const [prevDataIdentity, setPrevDataIdentity] = useState(dataIdentity);
+  if (dataIdentity !== prevDataIdentity) {
+    setPrevDataIdentity(dataIdentity);
+    setActiveFilters(new Set());
+  }
+
   const toggleFilter = useCallback((key: string) => {
     setActiveFilters((prev) => {
       const next = new Set(prev);

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -26,10 +26,11 @@ import type { InfoLevel } from '@/types/app/settings';
 import type { TimetableData } from '@/types/app/timetable';
 import type { Agency } from '@/types/app/transit';
 import type { TimetableEntry, TripInspectionTarget } from '@/types/app/transit-composed';
-import { formatDateParts, toDatetimeLocalValue } from '@/utils/datetime';
+import { formatDateParts } from '@/utils/datetime';
+import { toDatetimeLocalInputValue } from '@/utils/html-date-time';
 import { DAY_COLOR_CATEGORY_CLASSES } from '@/utils/day-of-week';
 import { createLogger } from '@/lib/logger';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Clock } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getRouteHeadsignKey } from '../../domain/transit/get-route-headsign-key';
@@ -109,8 +110,50 @@ interface DateTimeNavigationProps {
  * the timetable rendering. The "now" button always re-fetches at the
  * current wall-clock time.
  */
+const PICKER_DEBOUNCE_MS = 1_000;
+
 function DateTimeNavigation({ viewingDateTime, onChangeDateTime }: DateTimeNavigationProps) {
   const { t } = useTranslation();
+
+  // Bound the picker to +/- 1 year from the mount-time wall clock.
+  // Snapshotted once so spinning the picker can't drift past the bounds
+  // during a long-lived dialog session.
+  const inputBounds = useMemo(() => {
+    const now = new Date();
+    const min = new Date(now);
+    min.setFullYear(min.getFullYear() - 1);
+    const max = new Date(now);
+    max.setFullYear(max.getFullYear() + 1);
+    return {
+      min,
+      max,
+      minString: toDatetimeLocalInputValue(min),
+      maxString: toDatetimeLocalInputValue(max),
+    };
+  }, []);
+
+  // Local echo of the input so direct typing (e.g. yyyy/mm/dd one digit at
+  // a time) is not interrupted by the parent's viewingDateTime updates.
+  // The committed value (= onChangeDateTime) is debounced so intermediate
+  // keystrokes do not each trigger a fetch.
+  //
+  // Uses the "Adjusting state on prop changes" pattern (compare with the
+  // previous value during render) instead of useEffect + setState, per
+  // React 19's `set-state-in-effect` rule.
+  const [editingValue, setEditingValue] = useState(() =>
+    toDatetimeLocalInputValue(viewingDateTime),
+  );
+  const [prevViewingDateTime, setPrevViewingDateTime] = useState(viewingDateTime);
+  if (viewingDateTime !== prevViewingDateTime) {
+    setPrevViewingDateTime(viewingDateTime);
+    setEditingValue(toDatetimeLocalInputValue(viewingDateTime));
+  }
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  useEffect(() => {
+    return () => {
+      clearTimeout(debounceTimerRef.current);
+    };
+  }, []);
 
   const handlePrevDay = useCallback(() => {
     const next = new Date(viewingDateTime);
@@ -131,51 +174,62 @@ function DateTimeNavigation({ viewingDateTime, onChangeDateTime }: DateTimeNavig
   const handlePickerChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const raw = event.target.value;
-      if (!raw) {
-        return;
-      }
-      const parsed = new Date(raw);
-      if (Number.isNaN(parsed.getTime())) {
-        return;
-      }
-      onChangeDateTime(parsed);
+      setEditingValue(raw);
+
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = setTimeout(() => {
+        if (!raw) {
+          return;
+        }
+        const parsed = new Date(raw);
+        if (Number.isNaN(parsed.getTime())) {
+          return;
+        }
+        if (parsed < inputBounds.min || parsed > inputBounds.max) {
+          return;
+        }
+        onChangeDateTime(parsed);
+      }, PICKER_DEBOUNCE_MS);
     },
-    [onChangeDateTime],
+    [inputBounds, onChangeDateTime],
   );
 
   return (
     <div className="flex flex-wrap items-center justify-center gap-1.5">
       <ButtonGroup>
-        <ButtonGroup>
-          <Button
-            variant="outline"
-            size="icon-xs"
-            onClick={handlePrevDay}
-            aria-label={t('timetable.dateTimeNav.previousDay')}
-          >
-            <ChevronLeft className="size-4" />
-          </Button>
-          <input
-            type="datetime-local"
-            value={toDatetimeLocalValue(viewingDateTime)}
-            onChange={handlePickerChange}
-            aria-label={t('timetable.dateTimeNav.datePickerLabel')}
-            className="border-input bg-background h-6 rounded-md border px-2 text-xs leading-none"
-          />
-          <Button
-            variant="outline"
-            size="icon-xs"
-            onClick={handleNextDay}
-            aria-label={t('timetable.dateTimeNav.nextDay')}
-          >
-            <ChevronRight className="size-4" />
-          </Button>
-        </ButtonGroup>
-        <ButtonGroup>
-          <Button variant="outline" size="xs" onClick={handleResetToNow}>
-            {t('timetable.dateTimeNav.now')}
-          </Button>
-        </ButtonGroup>
+        <Button
+          variant="outline"
+          size="icon-xs"
+          onClick={handlePrevDay}
+          aria-label={t('timetable.dateTimeNav.previousDay')}
+        >
+          <ChevronLeft className="size-4" />
+        </Button>
+        <input
+          type="datetime-local"
+          value={editingValue}
+          onChange={handlePickerChange}
+          min={inputBounds.minString}
+          max={inputBounds.maxString}
+          aria-label={t('timetable.dateTimeNav.datePickerLabel')}
+          className="border-input bg-background h-6 rounded-md border px-2 text-xs leading-none"
+        />
+        <Button
+          variant="outline"
+          size="icon-xs"
+          onClick={handleResetToNow}
+          aria-label={t('timetable.dateTimeNav.now')}
+        >
+          <Clock className="size-4" />
+        </Button>
+        <Button
+          variant="outline"
+          size="icon-xs"
+          onClick={handleNextDay}
+          aria-label={t('timetable.dateTimeNav.nextDay')}
+        >
+          <ChevronRight className="size-4" />
+        </Button>
       </ButtonGroup>
     </div>
   );
@@ -409,6 +463,14 @@ export const TimetableDialog = memo(function TimetableDialog({
         showCloseButton={false}
         className="flex max-h-[80dvh] w-[90dvw] max-w-5xl flex-col gap-0 overflow-hidden border-4 p-2 sm:max-w-3xl"
       >
+        {/* Datetime navigation */}
+        {info.isDetailedEnabled && (
+          <DateTimeNavigation
+            viewingDateTime={data.referenceDateTime}
+            onChangeDateTime={onChangeDateTime}
+          />
+        )}
+
         <div
           ref={headerContainerRef}
           onScroll={headerScroll.handleScroll}
@@ -473,14 +535,6 @@ export const TimetableDialog = memo(function TimetableDialog({
                 agencies={data.agencies}
                 dataLangs={dataLangs}
                 filteredCount={routeHeadsignFilteredEntries.length}
-              />
-            )}
-
-            {/* Datetime navigation */}
-            {info.isVerboseEnabled && (
-              <DateTimeNavigation
-                viewingDateTime={data.referenceDateTime}
-                onChangeDateTime={onChangeDateTime}
               />
             )}
 

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -52,7 +52,7 @@ interface TimetableDialogProps {
   onInspectTrip?: (target: TripInspectionTarget) => void;
   /**
    * Change the datetime of the currently displayed timetable, preserving
-   * the current stop and filter. Used by the date navigation row.
+   * the current stop and filter. Used by the datetime navigation row.
    */
   onChangeDateTime: (dateTime: Date) => void;
   onClose: () => void;
@@ -89,6 +89,96 @@ function EntriesPanel({
         />
       )}
     </>
+  );
+}
+
+interface DateTimeNavigationProps {
+  /** The datetime the dialog is currently displaying. */
+  viewingDateTime: Date;
+  /** Realtime reference used by the "now" reset button. */
+  currentDateTime: Date;
+  /** Whether the viewed service day matches the realtime service day. */
+  isViewingNow: boolean;
+  onChangeDateTime: (dateTime: Date) => void;
+}
+
+/**
+ * Datetime navigation row (previous day / datetime picker / next day / now).
+ *
+ * Handlers are local to this component so the parent can stay focused on
+ * the timetable rendering. The "now" button is only shown when the
+ * viewed service day differs from the realtime service day.
+ */
+function DateTimeNavigation({
+  viewingDateTime,
+  currentDateTime,
+  isViewingNow,
+  onChangeDateTime,
+}: DateTimeNavigationProps) {
+  const { t } = useTranslation();
+
+  const handlePrevDay = useCallback(() => {
+    const next = new Date(viewingDateTime);
+    next.setDate(next.getDate() - 1);
+    onChangeDateTime(next);
+  }, [viewingDateTime, onChangeDateTime]);
+
+  const handleNextDay = useCallback(() => {
+    const next = new Date(viewingDateTime);
+    next.setDate(next.getDate() + 1);
+    onChangeDateTime(next);
+  }, [viewingDateTime, onChangeDateTime]);
+
+  const handleResetToNow = useCallback(() => {
+    onChangeDateTime(currentDateTime);
+  }, [currentDateTime, onChangeDateTime]);
+
+  const handlePickerChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = event.target.value;
+      if (!raw) {
+        return;
+      }
+      const parsed = new Date(raw);
+      if (Number.isNaN(parsed.getTime())) {
+        return;
+      }
+      onChangeDateTime(parsed);
+    },
+    [onChangeDateTime],
+  );
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-1.5">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handlePrevDay}
+        aria-label={t('timetable.dateTimeNav.previousDay')}
+      >
+        <ChevronLeft className="size-4" />
+      </Button>
+      <input
+        type="datetime-local"
+        value={toDatetimeLocalValue(viewingDateTime)}
+        onChange={handlePickerChange}
+        aria-label={t('timetable.dateTimeNav.datePickerLabel')}
+        className="border-input bg-background rounded-md border px-2 py-1 text-sm"
+      />
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handleNextDay}
+        aria-label={t('timetable.dateTimeNav.nextDay')}
+      >
+        <ChevronRight className="size-4" />
+      </Button>
+      {!isViewingNow && (
+        <Button variant="outline" size="sm" onClick={handleResetToNow}>
+          {t('timetable.dateTimeNav.now')}
+        </Button>
+      )}
+    </div>
   );
 }
 
@@ -164,54 +254,15 @@ export const TimetableDialog = memo(function TimetableDialog({
   const info = useInfoLevel(infoLevel);
   // Whether the currently viewed service day matches the realtime service day.
   // Only then is the current-hour highlight meaningful.
-  const isViewingToday = useMemo(() => {
+  const isViewingNow = useMemo(() => {
     if (!data) {
       return false;
     }
     return getServiceDay(time).getTime() === data.serviceDate.getTime();
   }, [data, time]);
-  const currentHour = isViewingToday ? Math.floor(getServiceDayMinutes(time) / 60) : -1;
+  const currentHour = isViewingNow ? Math.floor(getServiceDayMinutes(time) / 60) : -1;
   const headerContainerRef = useRef<HTMLDivElement | null>(null);
   const gridContainerRef = useRef<HTMLDivElement | null>(null);
-
-  const viewingDateTime = data?.viewingDateTime ?? null;
-
-  const handlePrevDay = useCallback(() => {
-    if (!viewingDateTime) {
-      return;
-    }
-    const next = new Date(viewingDateTime);
-    next.setDate(next.getDate() - 1);
-    onChangeDateTime(next);
-  }, [viewingDateTime, onChangeDateTime]);
-
-  const handleNextDay = useCallback(() => {
-    if (!viewingDateTime) {
-      return;
-    }
-    const next = new Date(viewingDateTime);
-    next.setDate(next.getDate() + 1);
-    onChangeDateTime(next);
-  }, [viewingDateTime, onChangeDateTime]);
-
-  const handleResetToNow = useCallback(() => {
-    onChangeDateTime(time);
-  }, [onChangeDateTime, time]);
-
-  const handlePickerChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const raw = event.target.value;
-      if (!raw) {
-        return;
-      }
-      const parsed = new Date(raw);
-      if (Number.isNaN(parsed.getTime())) {
-        return;
-      }
-      onChangeDateTime(parsed);
-    },
-    [onChangeDateTime],
-  );
 
   // Filter state for stop timetable (route+headsign toggle).
   // Empty set = show all timetable (no filter active).
@@ -423,37 +474,13 @@ export const TimetableDialog = memo(function TimetableDialog({
               />
             )}
 
-            {/* Date navigation */}
-            <div className="flex flex-wrap items-center justify-center gap-1.5">
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handlePrevDay}
-                aria-label={t('timetable.dateNav.previousDay')}
-              >
-                <ChevronLeft className="size-4" />
-              </Button>
-              <input
-                type="datetime-local"
-                value={toDatetimeLocalValue(data.viewingDateTime)}
-                onChange={handlePickerChange}
-                aria-label={t('timetable.dateNav.datePickerLabel')}
-                className="border-input bg-background rounded-md border px-2 py-1 text-sm"
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleNextDay}
-                aria-label={t('timetable.dateNav.nextDay')}
-              >
-                <ChevronRight className="size-4" />
-              </Button>
-              {!isViewingToday && (
-                <Button variant="outline" size="sm" onClick={handleResetToNow}>
-                  {t('timetable.dateNav.now')}
-                </Button>
-              )}
-            </div>
+            {/* Datetime navigation */}
+            <DateTimeNavigation
+              viewingDateTime={data.viewingDateTime}
+              currentDateTime={time}
+              isViewingNow={isViewingNow}
+              onChangeDateTime={onChangeDateTime}
+            />
 
             {/* Date time */}
             <TimetableDateLabel serviceDate={data.serviceDate} time={time} lang={dataLangs[0]} />

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -112,7 +112,11 @@ function DateTimeNavigation({ viewingDateTime, onChangeDateTime }: DateTimeNavig
 
   // Bound the picker to +/- 1 year from the mount-time wall clock.
   // Snapshotted once so spinning the picker can't drift past the bounds
-  // during a long-lived dialog session.
+  // during a long-lived dialog session. Enforcement is delegated to the
+  // browser's picker via the input's `min` / `max` attributes; direct
+  // typing of out-of-range values is intentionally not rejected (the
+  // user would see an unexplained no-op otherwise — an empty timetable
+  // for the typed date is the clearer signal).
   const inputBounds = useMemo(() => {
     const now = new Date();
     const min = new Date(now);
@@ -120,8 +124,6 @@ function DateTimeNavigation({ viewingDateTime, onChangeDateTime }: DateTimeNavig
     const max = new Date(now);
     max.setFullYear(max.getFullYear() + 1);
     return {
-      min,
-      max,
       minString: toDatetimeLocalInputValue(min),
       maxString: toDatetimeLocalInputValue(max),
     };
@@ -180,13 +182,10 @@ function DateTimeNavigation({ viewingDateTime, onChangeDateTime }: DateTimeNavig
         if (Number.isNaN(parsed.getTime())) {
           return;
         }
-        if (parsed < inputBounds.min || parsed > inputBounds.max) {
-          return;
-        }
         onChangeDateTime(parsed);
       }, PICKER_DEBOUNCE_MS);
     },
-    [inputBounds, onChangeDateTime],
+    [onChangeDateTime],
   );
 
   return (

--- a/src/components/stop-browser-header.tsx
+++ b/src/components/stop-browser-header.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { PillButton } from './button/pill-button';
 import { BoardabilityFilter } from './filter/boardability-filter';
 import { OriginFilter } from './filter/origin-filter';
-import { LabelCountBadge } from './badge/label-count-badge';
+import { StopsSummary } from './stops-summary';
 
 interface StopBrowserHeaderProps {
   hasNearbyLoaded: boolean;
@@ -231,98 +231,6 @@ export function StopBrowserHeader({
   );
 }
 
-function formatRadius(meters: number): string {
-  if (meters >= 1000) {
-    return `${meters / 1000}km`;
-  }
-  return `${meters}m`;
-}
-
-function getNearbyStopsSummaryText(
-  hasLoaded: boolean,
-  totalCounts: StopsCounts,
-  filteredCount: number,
-  omitEmptyStops: boolean,
-  _infoLevel: InfoLevel,
-  radius: string,
-  lang: string,
-  t: (key: string, options?: Record<string, unknown>) => string,
-): string {
-  if (!hasLoaded) {
-    return t('common.loading');
-  }
-
-  if (filteredCount > 0) {
-    return t('nearbyStops.summary', {
-      count: filteredCount.toLocaleString(lang),
-      radius,
-    });
-  }
-  if (omitEmptyStops && totalCounts.total > 0) {
-    return t('nearbyStops.noOperating', { radius });
-  }
-  return t('nearbyStops.noStops', { radius });
-}
-
 function formatStopsCountsDebugLog(counts: StopsCounts): string {
   return `total=${counts.total} nonEmpty=${counts.nonEmpty} boardable=${counts.boardableCount} origin=${counts.originCount}`;
-}
-
-const summaryLogger = createLogger('NearbyStopsSummary');
-
-interface StopsSummaryProps {
-  label: string;
-  totalCount: StopsCounts;
-  filteredCount: number;
-  nearbyRadius: number;
-  omitEmptyStops: boolean;
-  hasLoaded: boolean;
-  infoLevel: InfoLevel;
-}
-
-function StopsSummary({
-  label,
-  totalCount,
-  filteredCount,
-  nearbyRadius,
-  omitEmptyStops,
-  hasLoaded,
-  infoLevel,
-}: StopsSummaryProps) {
-  const { t, i18n } = useTranslation();
-
-  if (summaryLogger.isEnabled('debug')) {
-    summaryLogger.debug(
-      hasLoaded
-        ? `[${label}] ${formatStopsCountsDebugLog(totalCount)} -> filtered=${filteredCount}`
-        : 'not loaded yet',
-    );
-  }
-
-  const text = getNearbyStopsSummaryText(
-    hasLoaded,
-    totalCount,
-    filteredCount,
-    omitEmptyStops,
-    infoLevel,
-    formatRadius(nearbyRadius),
-    i18n.language,
-    t,
-  );
-
-  return (
-    <p className="m-0 flex items-center gap-1 text-base font-bold text-[#212121] dark:text-gray-100">
-      {infoLevel === 'verbose' && (
-        <LabelCountBadge
-          label={`${totalCount.total}`}
-          count={filteredCount}
-          size="sm"
-          labelClassName="bg-info text-info-foreground"
-          countClassName="bg-background text-info"
-          frameClassName="border-info"
-        />
-      )}
-      {text}
-    </p>
-  );
 }

--- a/src/components/stops-summary.tsx
+++ b/src/components/stops-summary.tsx
@@ -1,0 +1,102 @@
+import { useTranslation } from 'react-i18next';
+
+import { createLogger } from '../lib/logger';
+import type { InfoLevel } from '../types/app/settings';
+import type { StopsCounts } from '../types/app/stop';
+import { LabelCountBadge } from './badge/label-count-badge';
+
+const summaryLogger = createLogger('StopsSummary');
+
+export interface StopsSummaryProps {
+  label: string;
+  totalCount: StopsCounts;
+  filteredCount: number;
+  nearbyRadius: number;
+  omitEmptyStops: boolean;
+  hasLoaded: boolean;
+  infoLevel: InfoLevel;
+}
+
+function formatRadius(meters: number): string {
+  if (meters >= 1000) {
+    return `${meters / 1000}km`;
+  }
+  return `${meters}m`;
+}
+
+function buildStopsSummaryText(
+  hasLoaded: boolean,
+  totalCounts: StopsCounts,
+  filteredCount: number,
+  omitEmptyStops: boolean,
+  _infoLevel: InfoLevel,
+  radius: string,
+  lang: string,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string {
+  if (!hasLoaded) {
+    return t('common.loading');
+  }
+
+  if (filteredCount > 0) {
+    return t('nearbyStops.summary', {
+      count: filteredCount.toLocaleString(lang),
+      radius,
+    });
+  }
+  if (omitEmptyStops && totalCounts.total > 0) {
+    return t('nearbyStops.noOperating', { radius });
+  }
+  return t('nearbyStops.noStops', { radius });
+}
+
+function formatStopsCountsDebugLog(counts: StopsCounts): string {
+  return `total=${counts.total} nonEmpty=${counts.nonEmpty} boardable=${counts.boardableCount} origin=${counts.originCount}`;
+}
+
+export function StopsSummary({
+  label,
+  totalCount,
+  filteredCount,
+  nearbyRadius,
+  omitEmptyStops,
+  hasLoaded,
+  infoLevel,
+}: StopsSummaryProps) {
+  const { t, i18n } = useTranslation();
+
+  if (summaryLogger.isEnabled('debug')) {
+    summaryLogger.debug(
+      hasLoaded
+        ? `[${label}] ${formatStopsCountsDebugLog(totalCount)} -> filtered=${filteredCount}`
+        : 'not loaded yet',
+    );
+  }
+
+  const text = buildStopsSummaryText(
+    hasLoaded,
+    totalCount,
+    filteredCount,
+    omitEmptyStops,
+    infoLevel,
+    formatRadius(nearbyRadius),
+    i18n.language,
+    t,
+  );
+
+  return (
+    <p className="m-0 flex items-center gap-1 text-base font-bold text-[#212121] dark:text-gray-100">
+      {infoLevel === 'verbose' && (
+        <LabelCountBadge
+          label={`${totalCount.total}`}
+          count={filteredCount}
+          size="sm"
+          labelClassName="bg-info text-info-foreground"
+          countClassName="bg-background text-info"
+          frameClassName="border-info"
+        />
+      )}
+      {text}
+    </p>
+  );
+}

--- a/src/components/timetable/__tests__/timetable-container.test.tsx
+++ b/src/components/timetable/__tests__/timetable-container.test.tsx
@@ -1,0 +1,248 @@
+import { render } from '@testing-library/react';
+import { createRef } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TimetableContainer, type TimetableContainerHandle } from '../timetable-container';
+import type { UseTimetableReturn } from '@/hooks/use-timetable';
+import type { TransitRepository } from '@/repositories/transit-repository';
+import type { GlobalFilter } from '@/types/app/global-filter';
+import type { TimetableData } from '@/types/app/timetable';
+import type { Route, Stop } from '@/types/app/transit';
+
+type TimetableDialogMockProps = {
+  data: TimetableData | null;
+  infoLevel: 'detailed' | 'verbose' | 'normal' | 'simple';
+  dataLangs: readonly string[];
+  globalFilter: GlobalFilter;
+  onInspectTrip?: (target: unknown) => void;
+  onChangeDateTime: (dateTime: Date) => void;
+  onClose: () => void;
+};
+
+const timetableDialogProps = vi.fn<(props: TimetableDialogMockProps) => void>();
+vi.mock('@/components/dialog/timetable-dialog', () => ({
+  TimetableDialog: (props: TimetableDialogMockProps) => {
+    timetableDialogProps(props);
+    return null;
+  },
+}));
+
+const useTimetableMock = vi.fn<(repo: TransitRepository) => UseTimetableReturn>();
+vi.mock('@/hooks/use-timetable', () => ({
+  useTimetable: useTimetableMock,
+}));
+
+function makeStop(id: string): Stop {
+  return {
+    stop_id: id,
+    stop_name: id,
+    stop_names: {},
+    stop_lat: 0,
+    stop_lon: 0,
+    location_type: 0,
+    agency_id: 'agency-1',
+  };
+}
+
+function makeRoute(id: string): Route {
+  return {
+    route_id: id,
+    route_short_name: id,
+    route_long_name: id,
+    route_short_names: {},
+    route_long_names: {},
+    route_type: 3,
+    route_color: '',
+    route_text_color: '',
+    agency_id: 'agency-1',
+  };
+}
+
+function makeData(overrides: Partial<TimetableData>): TimetableData {
+  const stop = makeStop('stop-A');
+  const route = makeRoute('route-1');
+  return {
+    type: 'stop',
+    stop,
+    routes: [route],
+    referenceDateTime: new Date(2026, 3, 1, 8, 0),
+    serviceDate: new Date(2026, 3, 1),
+    timetableEntries: [],
+    omitted: { nonBoardable: 0 },
+    stopServiceState: 'boardable',
+    agencies: [
+      {
+        agency_id: 'agency-1',
+        agency_name: 'Agency',
+        agency_long_name: 'Agency',
+        agency_short_name: 'A',
+        agency_names: {},
+        agency_long_names: {},
+        agency_short_names: {},
+        agency_url: '',
+        agency_timezone: 'Asia/Tokyo',
+        agency_lang: 'ja',
+        agency_fare_url: '',
+        agency_colors: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+const globalFilter = {
+  showOriginOnly: false,
+  showBoardableOnly: false,
+  omitEmptyStops: false,
+  isOmitEmptyStopsForced: false,
+  onToggleShowOriginOnly: vi.fn(),
+  onToggleShowBoardableOnly: vi.fn(),
+  onToggleOmitEmptyStops: vi.fn(),
+} as unknown as GlobalFilter;
+
+const repo = {} as TransitRepository;
+
+function getLastTimetableDialogProps(): TimetableDialogMockProps {
+  const props = timetableDialogProps.mock.lastCall?.[0];
+  if (!props) {
+    throw new Error('TimetableDialog was not rendered');
+  }
+  return props;
+}
+
+describe('TimetableContainer', () => {
+  const openStopTimetable = vi.fn().mockResolvedValue({ status: 'opened' });
+  const openRouteHeadsignTimetable = vi.fn().mockResolvedValue({ status: 'opened' });
+  const changeDateTime = vi.fn().mockResolvedValue({ status: 'opened' });
+  const closeTimetable = vi.fn();
+
+  let currentTimetableData: TimetableData | null = null;
+
+  beforeEach(() => {
+    timetableDialogProps.mockReset();
+    useTimetableMock.mockReset();
+    openStopTimetable.mockClear();
+    openRouteHeadsignTimetable.mockClear();
+    changeDateTime.mockClear();
+    closeTimetable.mockClear();
+    currentTimetableData = null;
+    useTimetableMock.mockImplementation(() => ({
+      timetableData: currentTimetableData,
+      openStopTimetable,
+      openRouteHeadsignTimetable,
+      changeDateTime,
+      closeTimetable,
+    }));
+  });
+
+  it('exposes open methods via ref', () => {
+    const containerRef = createRef<TimetableContainerHandle>();
+    render(
+      <TimetableContainer
+        ref={containerRef}
+        repo={repo}
+        infoLevel="detailed"
+        dataLangs={['ja']}
+        globalFilter={globalFilter}
+      />,
+    );
+    expect(containerRef.current?.openStopTimetable).toBe(openStopTimetable);
+    expect(containerRef.current?.openRouteHeadsignTimetable).toBe(openRouteHeadsignTimetable);
+  });
+
+  it('renders the dialog with `data: null` when no timetable is open', () => {
+    render(
+      <TimetableContainer
+        repo={repo}
+        infoLevel="detailed"
+        dataLangs={['ja']}
+        globalFilter={globalFilter}
+      />,
+    );
+    const lastProps = getLastTimetableDialogProps();
+    expect(lastProps.data).toBeNull();
+  });
+
+  it('flows new data into the dialog when the same stop is re-targeted from stop to route-headsign mode', () => {
+    const stopData = makeData({ type: 'stop' });
+    const routeHeadsignData = makeData({
+      type: 'route-headsign',
+      headsign: '永福町',
+    });
+
+    const { rerender } = render(
+      <TimetableContainer
+        repo={repo}
+        infoLevel="detailed"
+        dataLangs={['ja']}
+        globalFilter={globalFilter}
+      />,
+    );
+
+    currentTimetableData = stopData;
+    rerender(
+      <TimetableContainer
+        repo={repo}
+        infoLevel="detailed"
+        dataLangs={['ja']}
+        globalFilter={globalFilter}
+      />,
+    );
+    const afterStop = getLastTimetableDialogProps();
+    expect(afterStop.data).toBe(stopData);
+
+    currentTimetableData = routeHeadsignData;
+    rerender(
+      <TimetableContainer
+        repo={repo}
+        infoLevel="detailed"
+        dataLangs={['ja']}
+        globalFilter={globalFilter}
+      />,
+    );
+    const afterRouteHeadsign = getLastTimetableDialogProps();
+    expect(afterRouteHeadsign.data).toBe(routeHeadsignData);
+    expect(afterRouteHeadsign.data?.type).toBe('route-headsign');
+    expect(afterRouteHeadsign.data?.stop.stop_id).toBe('stop-A');
+    expect(afterRouteHeadsign.data?.headsign).toBe('永福町');
+  });
+
+  it('notifies the parent via onOpenChange when timetableData transitions between null and non-null', () => {
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <TimetableContainer
+        repo={repo}
+        infoLevel="detailed"
+        dataLangs={['ja']}
+        globalFilter={globalFilter}
+        onOpenChange={onOpenChange}
+      />,
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+
+    currentTimetableData = makeData({ type: 'stop' });
+    rerender(
+      <TimetableContainer
+        repo={repo}
+        infoLevel="detailed"
+        dataLangs={['ja']}
+        globalFilter={globalFilter}
+        onOpenChange={onOpenChange}
+      />,
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    currentTimetableData = null;
+    rerender(
+      <TimetableContainer
+        repo={repo}
+        infoLevel="detailed"
+        dataLangs={['ja']}
+        globalFilter={globalFilter}
+        onOpenChange={onOpenChange}
+      />,
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/src/components/timetable/__tests__/timetable-container.test.tsx
+++ b/src/components/timetable/__tests__/timetable-container.test.tsx
@@ -3,7 +3,6 @@ import { createRef } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TimetableContainer, type TimetableContainerHandle } from '../timetable-container';
-import type { UseTimetableReturn } from '@/hooks/use-timetable';
 import type { TransitRepository } from '@/repositories/transit-repository';
 import type { GlobalFilter } from '@/types/app/global-filter';
 import type { TimetableData } from '@/types/app/timetable';
@@ -19,7 +18,15 @@ type TimetableDialogMockProps = {
   onClose: () => void;
 };
 
-const timetableDialogProps = vi.fn<(props: TimetableDialogMockProps) => void>();
+// `vi.mock` calls are hoisted above top-level `const` declarations, so the
+// mocks have to grab their shared fns via `vi.hoisted` instead of closing
+// over locally-declared `vi.fn()`s (which would still be uninitialized when
+// the mock factory runs).
+const { timetableDialogProps, useTimetableMock } = vi.hoisted(() => ({
+  timetableDialogProps: vi.fn<(props: TimetableDialogMockProps) => void>(),
+  useTimetableMock: vi.fn(),
+}));
+
 vi.mock('@/components/dialog/timetable-dialog', () => ({
   TimetableDialog: (props: TimetableDialogMockProps) => {
     timetableDialogProps(props);
@@ -27,7 +34,6 @@ vi.mock('@/components/dialog/timetable-dialog', () => ({
   },
 }));
 
-const useTimetableMock = vi.fn<(repo: TransitRepository) => UseTimetableReturn>();
 vi.mock('@/hooks/use-timetable', () => ({
   useTimetable: useTimetableMock,
 }));

--- a/src/components/timetable/timetable-container.tsx
+++ b/src/components/timetable/timetable-container.tsx
@@ -1,0 +1,81 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle } from 'react';
+
+import { useTimetable, type UseTimetableReturn } from '@/hooks/use-timetable';
+import type { TransitRepository } from '@/repositories/transit-repository';
+import type { GlobalFilter } from '@/types/app/global-filter';
+import type { InfoLevel } from '@/types/app/settings';
+import type { TripInspectionTarget } from '@/types/app/transit-composed';
+
+import { TimetableDialog } from '../dialog/timetable-dialog';
+
+export interface TimetableContainerHandle {
+  openStopTimetable: UseTimetableReturn['openStopTimetable'];
+  openRouteHeadsignTimetable: UseTimetableReturn['openRouteHeadsignTimetable'];
+}
+
+interface TimetableContainerProps {
+  repo: TransitRepository;
+  infoLevel: InfoLevel;
+  dataLangs: readonly string[];
+  globalFilter: GlobalFilter;
+  onInspectTrip?: (target: TripInspectionTarget) => void;
+  /**
+   * Called when the dialog opens or closes. Lets the parent track
+   * dialog visibility (e.g. to suppress global keyboard shortcuts)
+   * without holding the underlying `timetableData` state.
+   */
+  onOpenChange?: (open: boolean) => void;
+}
+
+/**
+ * Owns the `useTimetable` state so that updates triggered from the dialog
+ * (changeDateTime / closeTimetable) do not re-render the rest of the app.
+ *
+ * External callers (map markers, BottomSheet, StopSearchDialog) still need
+ * to open the dialog, so `openStopTimetable` / `openRouteHeadsignTimetable`
+ * are exposed via ref through `useImperativeHandle`.
+ */
+export const TimetableContainer = forwardRef<TimetableContainerHandle, TimetableContainerProps>(
+  function TimetableContainer(
+    { repo, infoLevel, dataLangs, globalFilter, onInspectTrip, onOpenChange },
+    ref,
+  ) {
+    const {
+      timetableData,
+      openStopTimetable,
+      openRouteHeadsignTimetable,
+      changeDateTime,
+      closeTimetable,
+    } = useTimetable(repo);
+
+    const isOpen = timetableData !== null;
+    useEffect(() => {
+      onOpenChange?.(isOpen);
+    }, [isOpen, onOpenChange]);
+
+    useImperativeHandle(ref, () => ({ openStopTimetable, openRouteHeadsignTimetable }), [
+      openStopTimetable,
+      openRouteHeadsignTimetable,
+    ]);
+
+    const handleChangeDateTime = useCallback(
+      (next: Date) => {
+        void changeDateTime(next);
+      },
+      [changeDateTime],
+    );
+
+    return (
+      <TimetableDialog
+        key={timetableData?.stop.stop_id ?? 'closed'}
+        data={timetableData}
+        infoLevel={infoLevel}
+        dataLangs={dataLangs}
+        globalFilter={globalFilter}
+        onInspectTrip={onInspectTrip}
+        onChangeDateTime={handleChangeDateTime}
+        onClose={closeTimetable}
+      />
+    );
+  },
+);

--- a/src/components/timetable/timetable-grid.tsx
+++ b/src/components/timetable/timetable-grid.tsx
@@ -16,7 +16,7 @@ interface TimetableGridProps {
   timetableEntries: TimetableEntry[];
   serviceDate: Date;
   showHeadsign: boolean;
-  currentHour: number;
+  hourToHighlight: number;
   infoLevel: InfoLevel;
   dataLangs: readonly string[];
   agencies: Agency[];
@@ -44,7 +44,7 @@ export function TimetableGrid({
   timetableEntries,
   serviceDate,
   showHeadsign,
-  currentHour,
+  hourToHighlight,
   infoLevel,
   dataLangs,
   agencies,
@@ -85,7 +85,7 @@ export function TimetableGrid({
   const isDisplayPickupUnavailable = info.isVerboseEnabled;
   const isDisplayDropOffUnavailable = info.isVerboseEnabled;
 
-  const hasCurrentHour = hourGroups.has(currentHour);
+  const hasCurrentHour = hourGroups.has(hourToHighlight);
   const firstHour = hourGroups.keys().next().value as number;
 
   return (
@@ -94,13 +94,13 @@ export function TimetableGrid({
         <div
           key={hour}
           ref={
-            hour === currentHour
+            hour === hourToHighlight
               ? scrollRef
               : !hasCurrentHour && hour === firstHour
                 ? scrollRef
                 : undefined
           }
-          className={`border-border scroll-mt-6 border-b py-1.5 last:border-b-0 ${hour === currentHour ? 'bg-accent rounded' : ''}`}
+          className={`border-border scroll-mt-6 border-b py-1.5 last:border-b-0 ${hour === hourToHighlight ? 'bg-accent rounded' : ''}`}
         >
           <div className="flex items-baseline gap-2">
             <span className="text-foreground w-10 shrink-0 text-right text-sm font-bold">

--- a/src/domain/transit/timetable-stats.ts
+++ b/src/domain/transit/timetable-stats.ts
@@ -3,9 +3,9 @@ import { getHeadsignDisplayNames } from './name-resolver/get-headsign-display-na
 import { isDropOffOnly } from './timetable-utils';
 import type { Agency } from '@/types/app/transit';
 import { resolveAgencyLang } from '@/config/transit-defaults';
-import { createLogger } from '../../lib/logger';
+// import { createLogger } from '../../lib/logger';
 
-const logger = createLogger('TimetableStats');
+// const logger = createLogger('TimetableStats');
 
 /**
  * Aggregated statistics computed from a list of {@link TimetableEntry}.
@@ -172,10 +172,10 @@ export function computeTimetableEntryStats(
     trips.add(`${tl.patternId}|${tl.serviceId}|${tl.tripIndex}`);
   }
 
-  if (logger.isEnabled('debug')) {
-    logger.debug('tripsHeadsigns', [...tripsHeadsigns]);
-    logger.debug('stopHeadsigns', [...stopHeadsigns]);
-  }
+  // if (logger.isEnabled('debug')) {
+  //   logger.debug('tripsHeadsigns', [...tripsHeadsigns]);
+  //   logger.debug('stopHeadsigns', [...stopHeadsigns]);
+  // }
 
   return {
     totalCount: entries.length,

--- a/src/hooks/use-timetable.ts
+++ b/src/hooks/use-timetable.ts
@@ -258,7 +258,7 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
           stop: meta.stop,
           routes,
           headsign,
-          viewingDateTime: dateTime,
+          referenceDateTime: dateTime,
           serviceDate,
           timetableEntries: entries,
           omitted,

--- a/src/hooks/use-timetable.ts
+++ b/src/hooks/use-timetable.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 
+import { formatDateKey } from '@/domain/transit/calendar-utils';
 import { getServiceDay } from '@/domain/transit/service-day';
 import {
   prepareRouteHeadsignTimetable,
@@ -135,6 +136,7 @@ function buildTimetableEntries(
 
 function formatTimetableDebugMessage(params: {
   dateTime: Date;
+  serviceDate: Date;
   filter: TimetableFilter;
   stopId: string;
   entriesCount: number;
@@ -146,7 +148,7 @@ function formatTimetableDebugMessage(params: {
     routeSuffix = ` ${params.filter.routeId} "${params.filter.headsign}"`;
   }
 
-  return `timetable(${params.filter.type}): ${params.dateTime.toISOString()} ${params.stopId}${routeSuffix} → entries=${params.entriesCount} omitted.nonBoardable=${params.omittedNonBoardable} total=${params.totalEntries}`;
+  return `timetable(${params.filter.type}): wall=${params.dateTime.toISOString()} service=${formatDateKey(params.serviceDate)} ${params.stopId}${routeSuffix} → entries=${params.entriesCount} omitted.nonBoardable=${params.omittedNonBoardable} total=${params.totalEntries}`;
 }
 
 function formatUnknownError(error: unknown) {
@@ -229,12 +231,14 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
           timetableResult,
         );
         const headsign = filter.type === 'route-headsign' ? filter.headsign : undefined;
+        const serviceDate = getServiceDay(dateTime);
 
         if (logger.isEnabled('debug')) {
           logger.debug(
             formatTimetableDebugMessage({
               filter,
               dateTime,
+              serviceDate,
               stopId,
               entriesCount: entries.length,
               omittedNonBoardable: omitted.nonBoardable,
@@ -249,7 +253,7 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
           routes,
           headsign,
           viewingDateTime: dateTime,
-          serviceDate: getServiceDay(dateTime),
+          serviceDate,
           timetableEntries: entries,
           omitted,
           stopServiceState: getStopServiceState({

--- a/src/hooks/use-timetable.ts
+++ b/src/hooks/use-timetable.ts
@@ -169,6 +169,10 @@ interface CurrentRequest {
   stopId: string;
 }
 
+function resolveDisplayedHeadsign(filter: TimetableFilter) {
+  return filter.type === 'route-headsign' ? filter.headsign : undefined;
+}
+
 export function useTimetable(repo: TransitRepository): UseTimetableReturn {
   const [timetableData, setTimetableData] = useState<TimetableData | null>(null);
   const requestIdRef = useRef(0);
@@ -179,9 +183,14 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
       params: OpenStopTimetableParams,
       filter: TimetableFilter,
     ): Promise<TimetableOpenOutcome> => {
+
       const { dateTime, stopId } = params;
+
       const requestId = requestIdRef.current + 1;
       requestIdRef.current = requestId;
+
+      const headsign = resolveDisplayedHeadsign(filter);
+      const serviceDate = getServiceDay(dateTime);
 
       try {
         // Resolve stop metadata first so unknown stops short-circuit before the
@@ -230,8 +239,6 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
           filter,
           timetableResult,
         );
-        const headsign = filter.type === 'route-headsign' ? filter.headsign : undefined;
-        const serviceDate = getServiceDay(dateTime);
 
         if (logger.isEnabled('debug')) {
           logger.debug(

--- a/src/hooks/use-timetable.ts
+++ b/src/hooks/use-timetable.ts
@@ -183,7 +183,6 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
       params: OpenStopTimetableParams,
       filter: TimetableFilter,
     ): Promise<TimetableOpenOutcome> => {
-
       const { dateTime, stopId } = params;
 
       const requestId = requestIdRef.current + 1;

--- a/src/hooks/use-timetable.ts
+++ b/src/hooks/use-timetable.ts
@@ -42,6 +42,14 @@ export interface UseTimetableReturn {
   openRouteHeadsignTimetable: (
     params: OpenRouteHeadsignTimetableParams,
   ) => Promise<TimetableOpenOutcome>;
+  /**
+   * Change the datetime of the currently displayed timetable while
+   * preserving the current stop and filter (stop / route-headsign).
+   * Replaces the in-place data; the dialog is not closed.
+   *
+   * No-op (returns `{ status: 'error' }`) when no timetable is open.
+   */
+  changeDateTime: (dateTime: Date) => Promise<TimetableOpenOutcome>;
   closeTimetable: () => void;
 }
 
@@ -126,6 +134,7 @@ function buildTimetableEntries(
 }
 
 function formatTimetableDebugMessage(params: {
+  dateTime: Date;
   filter: TimetableFilter;
   stopId: string;
   entriesCount: number;
@@ -137,7 +146,7 @@ function formatTimetableDebugMessage(params: {
     routeSuffix = ` ${params.filter.routeId} "${params.filter.headsign}"`;
   }
 
-  return `timetable(${params.filter.type}): ${params.stopId}${routeSuffix} → entries=${params.entriesCount} omitted.nonBoardable=${params.omittedNonBoardable} total=${params.totalEntries}`;
+  return `timetable(${params.filter.type}): ${params.dateTime.toISOString()} ${params.stopId}${routeSuffix} → entries=${params.entriesCount} omitted.nonBoardable=${params.omittedNonBoardable} total=${params.totalEntries}`;
 }
 
 function formatUnknownError(error: unknown) {
@@ -153,9 +162,15 @@ function formatUnknownError(error: unknown) {
   };
 }
 
+interface CurrentRequest {
+  filter: TimetableFilter;
+  stopId: string;
+}
+
 export function useTimetable(repo: TransitRepository): UseTimetableReturn {
   const [timetableData, setTimetableData] = useState<TimetableData | null>(null);
   const requestIdRef = useRef(0);
+  const currentRequestRef = useRef<CurrentRequest | null>(null);
 
   const openTimetable = useCallback(
     async (
@@ -219,6 +234,7 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
           logger.debug(
             formatTimetableDebugMessage({
               filter,
+              dateTime,
               stopId,
               entriesCount: entries.length,
               omittedNonBoardable: omitted.nonBoardable,
@@ -232,6 +248,7 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
           stop: meta.stop,
           routes,
           headsign,
+          viewingDateTime: dateTime,
           serviceDate: getServiceDay(dateTime),
           timetableEntries: entries,
           omitted,
@@ -241,6 +258,7 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
           }),
           agencies: meta.agencies,
         });
+        currentRequestRef.current = { filter, stopId };
 
         return { status: 'opened' };
       } catch (error: unknown) {
@@ -274,8 +292,20 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
     [openTimetable],
   );
 
+  const changeDateTime = useCallback(
+    (dateTime: Date): Promise<TimetableOpenOutcome> => {
+      const current = currentRequestRef.current;
+      if (!current) {
+        return Promise.resolve({ status: 'error' });
+      }
+      return openTimetable({ dateTime, stopId: current.stopId }, current.filter);
+    },
+    [openTimetable],
+  );
+
   const closeTimetable = useCallback(() => {
     requestIdRef.current += 1;
+    currentRequestRef.current = null;
     setTimetableData(null);
   }, []);
 
@@ -283,6 +313,7 @@ export function useTimetable(repo: TransitRepository): UseTimetableReturn {
     timetableData,
     openStopTimetable,
     openRouteHeadsignTimetable,
+    changeDateTime,
     closeTimetable,
   };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -153,6 +153,12 @@
       "noDropOff": "No drop-off",
       "arriving": "Arr"
     },
+    "dateNav": {
+      "previousDay": "Previous day",
+      "nextDay": "Next day",
+      "now": "Now",
+      "datePickerLabel": "Date and time to view"
+    },
     "grid": {
       "row": {
         "hour": "{{hour}}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -153,7 +153,7 @@
       "noDropOff": "No drop-off",
       "arriving": "Arr"
     },
-    "dateNav": {
+    "dateTimeNav": {
       "previousDay": "Previous day",
       "nextDay": "Next day",
       "now": "Now",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -153,6 +153,12 @@
       "noDropOff": "降×",
       "arriving": "着"
     },
+    "dateNav": {
+      "previousDay": "前日",
+      "nextDay": "翌日",
+      "now": "現在",
+      "datePickerLabel": "表示する日時"
+    },
     "grid": {
       "row": {
         "hour": "{{hour}}時",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -153,7 +153,7 @@
       "noDropOff": "降×",
       "arriving": "着"
     },
-    "dateNav": {
+    "dateTimeNav": {
       "previousDay": "前日",
       "nextDay": "翌日",
       "now": "現在",

--- a/src/types/app/timetable.ts
+++ b/src/types/app/timetable.ts
@@ -7,6 +7,12 @@ export interface TimetableData {
   stop: Stop;
   routes: Route[];
   headsign?: string;
+  /**
+   * Datetime requested when this timetable was opened or re-opened.
+   * Used by the dialog to render the date picker value and to decide
+   * whether the current-hour highlight should be active.
+   */
+  viewingDateTime: Date;
   serviceDate: Date;
   timetableEntries: TimetableEntry[];
   omitted: TimetableOmitted;

--- a/src/types/app/timetable.ts
+++ b/src/types/app/timetable.ts
@@ -8,11 +8,11 @@ export interface TimetableData {
   routes: Route[];
   headsign?: string;
   /**
-   * Datetime requested when this timetable was opened or re-opened.
-   * Used by the dialog to render the date picker value and to decide
-   * whether the current-hour highlight should be active.
+   * The point in time that this timetable is "as of" -- i.e. the datetime
+   * the timetable data is generated against. Carries the time-of-day axis
+   * that `serviceDate` does not.
    */
-  viewingDateTime: Date;
+  referenceDateTime: Date;
   serviceDate: Date;
   timetableEntries: TimetableEntry[];
   omitted: TimetableOmitted;

--- a/src/utils/__tests__/datetime.test.ts
+++ b/src/utils/__tests__/datetime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatDateParts, toDatetimeLocalValue } from '../datetime';
+import { formatDateParts } from '../datetime';
 
 const TZ = 'Asia/Tokyo';
 
@@ -93,15 +93,5 @@ describe('formatDateParts', () => {
     const en = formatDateParts(WED_0915_UTC, 'en', TZ, { showYear: true });
     expect(ja.dateText).toBe('2026年3月4日');
     expect(en.dateText).toBe('Mar 4, 2026');
-  });
-});
-
-describe('toDatetimeLocalValue', () => {
-  it('returns ISO-like local datetime string', () => {
-    expect(toDatetimeLocalValue(new Date(2026, 2, 4, 9, 5))).toBe('2026-03-04T09:05');
-  });
-
-  it('pads month, day, hours and minutes', () => {
-    expect(toDatetimeLocalValue(new Date(2026, 0, 3, 1, 2))).toBe('2026-01-03T01:02');
   });
 });

--- a/src/utils/__tests__/html-date-time.test.ts
+++ b/src/utils/__tests__/html-date-time.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { toDatetimeLocalInputValue } from '../html-date-time';
+
+describe('toDatetimeLocalInputValue', () => {
+  it('returns ISO-like local datetime string', () => {
+    expect(toDatetimeLocalInputValue(new Date(2026, 2, 4, 9, 5))).toBe('2026-03-04T09:05');
+  });
+
+  it('pads month, day, hours and minutes to 2 digits', () => {
+    expect(toDatetimeLocalInputValue(new Date(2026, 0, 3, 1, 2))).toBe('2026-01-03T01:02');
+  });
+
+  it('keeps 4-digit year as is', () => {
+    expect(toDatetimeLocalInputValue(new Date(2026, 11, 31, 23, 59))).toBe('2026-12-31T23:59');
+  });
+
+  it('pads 1-digit year to 4 digits', () => {
+    // Note: `new Date(yyyy, ...)` treats 0..99 as 1900 + yyyy, so use setFullYear.
+    const d = new Date(2026, 0, 1);
+    d.setFullYear(1, 4, 30);
+    d.setHours(13, 57, 0, 0);
+    expect(toDatetimeLocalInputValue(d)).toBe('0001-05-30T13:57');
+  });
+
+  it('pads 2-digit year to 4 digits', () => {
+    const d = new Date(2026, 0, 1);
+    d.setFullYear(99, 5, 15);
+    d.setHours(8, 30, 0, 0);
+    expect(toDatetimeLocalInputValue(d)).toBe('0099-06-15T08:30');
+  });
+
+  it('pads 3-digit year to 4 digits', () => {
+    const d = new Date(2026, 0, 1);
+    d.setFullYear(999, 0, 1);
+    d.setHours(0, 0, 0, 0);
+    expect(toDatetimeLocalInputValue(d)).toBe('0999-01-01T00:00');
+  });
+
+  it('does not truncate years with more than 4 digits', () => {
+    const d = new Date(2026, 0, 1);
+    d.setFullYear(12345, 0, 1);
+    d.setHours(0, 0, 0, 0);
+    expect(toDatetimeLocalInputValue(d)).toBe('12345-01-01T00:00');
+  });
+
+  it('handles all single-digit fields together', () => {
+    const d = new Date(2026, 0, 1);
+    d.setFullYear(5, 2, 4);
+    d.setHours(6, 7, 0, 0);
+    expect(toDatetimeLocalInputValue(d)).toBe('0005-03-04T06:07');
+  });
+
+  it('handles end-of-year boundary 23:59', () => {
+    expect(toDatetimeLocalInputValue(new Date(2026, 11, 31, 23, 59))).toBe('2026-12-31T23:59');
+  });
+
+  it('handles start-of-year boundary 00:00', () => {
+    expect(toDatetimeLocalInputValue(new Date(2026, 0, 1, 0, 0))).toBe('2026-01-01T00:00');
+  });
+});

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -99,24 +99,3 @@ export function formatDateParts(
 
   return result;
 }
-
-/**
- * Convert a Date to an `<input type="datetime-local">` value string.
- *
- * @param date - The date to convert.
- * @returns ISO-like local datetime string (`"YYYY-MM-DDTHH:mm"`).
- *
- * @example
- * ```ts
- * toDatetimeLocalValue(new Date("2026-03-04T09:05:00"))
- * // => "2026-03-04T09:05"
- * ```
- */
-export function toDatetimeLocalValue(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  const h = String(date.getHours()).padStart(2, '0');
-  const min = String(date.getMinutes()).padStart(2, '0');
-  return `${y}-${m}-${d}T${h}:${min}`;
-}

--- a/src/utils/html-date-time.ts
+++ b/src/utils/html-date-time.ts
@@ -1,0 +1,35 @@
+/**
+ * Utilities for the HTML date/time string formats described in MDN
+ * "Using date and time formats in HTML":
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Date_and_time_formats
+ *
+ * The formats covered here are used by:
+ * - `<input type="date" | "datetime-local" | "month" | "time" | "week">`
+ * - `<ins>` / `<del>` `datetime` attribute
+ */
+
+/**
+ * Convert a Date to an `<input type="datetime-local">` value string.
+ *
+ * The HTML spec requires the year to be at least 4 digits, so
+ * 1-3 digit years are zero-padded. Months, days, hours and minutes
+ * are zero-padded to 2 digits. Seconds and milliseconds are omitted
+ * because the default `step` of `datetime-local` is minute-precision.
+ *
+ * @param date - The date to convert.
+ * @returns datetime-local value string (`"YYYY-MM-DDTHH:mm"`).
+ *
+ * @example
+ * ```ts
+ * toDatetimeLocalInputValue(new Date("2026-03-04T09:05:00"))
+ * // => "2026-03-04T09:05"
+ * ```
+ */
+export function toDatetimeLocalInputValue(date: Date): string {
+  const yyyy = String(date.getFullYear()).padStart(4, '0');
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  const hh = String(date.getHours()).padStart(2, '0');
+  const min = String(date.getMinutes()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}T${hh}:${min}`;
+}


### PR DESCRIPTION
## Summary

Add a date navigation row to `TimetableDialog` so users can browse the timetable for any service day without closing the dialog (prev / next / `<input type="datetime-local">` picker / now), and isolate the underlying `useTimetable` state in a new `TimetableContainer` so that picker operations stop re-rendering the entire app tree.

### What you can do now

- In the dialog header, jump to the previous / next service day, type or scroll any datetime in the picker, or hit the **Now** button to return to the realtime wall clock.
- Picker typing debounces fetch at 1000ms (1 keystroke does not equal 1 fetch), so `yyyymmdd` style direct typing is finally usable.
- Year / month / day spinners are clamped to mount-time ±1 year via the input's `min` / `max` (= browser-level spinner constraint).

### Why it feels much faster

`useTimetable` is no longer owned by `App`. It lives in a new `TimetableContainer` (`src/components/timetable/timetable-container.tsx`) that internally renders `TimetableDialog`. Picker changes update state inside the container and no longer re-render the rest of the app (StopBrowser / NearbyStops / TimetableStats / StopsSummary, etc.). On mobile, the picker now feels instant and the new grid paints without competing with unrelated work. Follow-up audit for other containers tracked in #265.

### Highlights by commit

- `feat(timetable-dialog): add date navigation (prev/next/picker/now)` — the navigation row itself + i18n.
- `chore(use-timetable): include service day in debug log` — visibility for the new flow.
- `refactor(use-timetable): extract resolveDisplayedHeadsign helper` — small cleanup that paid off in later commits.
- `refactor(timetable-dialog): extract DateTimeNavigation sub-component` — keeps `TimetableDialog` focused on the grid surface.
- `refactor(timetable-dialog): adopt referenceDateTime for highlight basis` — moves hour highlighting to `data.referenceDateTime` so picker / label / highlight always agree.
- `feat(timetable-dialog): polish datetime picker UX with debounce and bounds` — local state + 1000ms debounce + `min`/`max` + 4-digit year zero-padding bugfix.
- `refactor(timetable-dialog): drop unused time prop and debug log` — `time` was no longer consulted; removing it ends the 15-second re-render cycle.
- `refactor(dialog): align datetime-local input validation between picker dialogs` — `TimeSettingDialog` also gets `min`/`max` and an Invalid-Date guard.
- `refactor(stops-summary): extract StopsSummary into its own module` — rename `NearbyStopsSummary` -> `StopsSummary`, rename `getNearbyStopsSummaryText` -> `buildStopsSummaryText`.
- `refactor(timetable): introduce TimetableContainer to localize timetable state` — the perf payoff.

### Notable bug fix

`toDatetimeLocalInputValue` previously emitted year unpadded, so editing the picker year through 1-3 digits produced invalid `value` strings (e.g. `1-05-30T13:57`). Browsers then blanked the picker UI mid-edit. Year is now zero-padded to 4 digits, so both `DateTimeNavigation` and `TimeSettingDialog` survive edits through low-digit years.

### Out of scope

- Container Pattern audit for other App-level state owners (`useTripInspection`, `useAppDialogs`, `useStopsForBounds`, `useGlobalFilter`, `useUserSettings`, realtime clock) — tracked in #265.
- TimeSettingDialog rich-validation tooltip / UI feedback for `:invalid` — intentionally not added; the explicit submit button makes silent rejection clearer than a red border with no explanation.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm test` (4242 tests pass)
- [x] `npm run build`
- [x] Manual verification on dev server (port 5175): prev / next / now / direct typing of year via picker / mount-time ±1 year bounds enforced by spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)