### PR TITLE
feat(marker): show platform_code on stop popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ### Added
 
+- Stop marker popup: GTFS `platform_code` を amber chip (`PlatformCodeLabel`) で stop 名の隣に表示するようにした (stop 検索結果行と同じ UI 表現)。 standard tooltip / lightweight (Canvas) popup の双方に反映。 `platform_code` 未設定の stop は表示変化なし。
 - TimetableDialog: 表示中の時刻表を別日時で見直せる datetime navigation 行を追加 (前日 / 翌日 / `<input type="datetime-local">` / 現在ボタン)。 picker の編集は 1000ms debounce で fetch をまとめ、 直接 typing 中も中間状態で再 fetch が走らないようにした。
 - TimetableDialog: datetime picker のスピナー操作範囲を mount 時刻 ± 1 年でクランプ (`<input type="datetime-local">` の `min` / `max` 属性で picker UI 側から制約)。 direct typing で範囲外の値が入力された場合は JS 側では弾かず、 そのまま fetch して「該当データなし (= 空時刻表)」 を表示する (黙って無視するよりも空表示で「データがない」 と伝わる方が UX 上わかりやすいため)。 NaN (`new Date(invalid)`) だけは `Number.isNaN` チェックで弾く。
 

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -1,4 +1,15 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { ChevronLeft, ChevronRight, Clock } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { BoardabilityFilter } from '@/components/filter/boardability-filter';
+import { OriginFilter } from '@/components/filter/origin-filter';
 import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
+import { TimetableGrid } from '@/components/timetable/timetable-grid';
+import { TimetableHeader } from '@/components/timetable/timetable-header';
+import { TimetableHeadsignFilter } from '@/components/timetable/timetable-headsign-filter';
+import { TimetableMetadata } from '@/components/timetable/timetable-metadata';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -11,10 +22,11 @@ import { VerboseTimetableSummary } from '@/components/verbose/verbose-timetable-
 import { DEFAULT_TIMEZONE, resolveAgencyLang } from '@/config/transit-defaults';
 import { findRouteDirectionForHeadsign } from '@/domain/transit/find-route-direction-for-headsign';
 import { getEffectiveHeadsign } from '@/domain/transit/get-effective-headsign';
+import { getRouteHeadsignKey } from '@/domain/transit/get-route-headsign-key';
+import { hasUnknownDestination } from '@/domain/transit/has-unknown-destination';
 import { getSelectedHeadsignDisplayName } from '@/domain/transit/name-resolver/get-headsign-display-names';
 import { getRouteDisplayNames } from '@/domain/transit/name-resolver/get-route-display-names';
 import { getStopDisplayNames } from '@/domain/transit/name-resolver/get-stop-display-names';
-import { hasUnknownDestination } from '@/domain/transit/has-unknown-destination';
 import { getServiceDayMinutes } from '@/domain/transit/service-day';
 import { applyStopEventAttributeToggles } from '@/domain/transit/timetable-filter';
 import type { TimetableEntryStats } from '@/domain/transit/timetable-stats';
@@ -27,19 +39,8 @@ import type { TimetableData } from '@/types/app/timetable';
 import type { Agency } from '@/types/app/transit';
 import type { TimetableEntry, TripInspectionTarget } from '@/types/app/transit-composed';
 import { formatDateParts } from '@/utils/datetime';
-import { toDatetimeLocalInputValue } from '@/utils/html-date-time';
 import { DAY_COLOR_CATEGORY_CLASSES } from '@/utils/day-of-week';
-import { ChevronLeft, ChevronRight, Clock } from 'lucide-react';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { getRouteHeadsignKey } from '../../domain/transit/get-route-headsign-key';
-import { BoardabilityFilter } from '../filter/boardability-filter';
-import { OriginFilter } from '../filter/origin-filter';
-import { TimetableGrid } from '../timetable/timetable-grid';
-import { TimetableHeader } from '../timetable/timetable-header';
-import { TimetableHeadsignFilter } from '../timetable/timetable-headsign-filter';
-import { TimetableMetadata } from '../timetable/timetable-metadata';
-import { ButtonGroup } from '../ui/button-group';
+import { toDatetimeLocalInputValue } from '@/utils/html-date-time';
 
 interface TimetableDialogProps {
   /** Pass null when the dialog should be closed. */
@@ -200,41 +201,39 @@ function DateTimeNavigation({ viewingDateTime, onChangeDateTime }: DateTimeNavig
 
   return (
     <div className="flex flex-wrap items-center justify-center gap-1.5">
-      <ButtonGroup>
-        <Button
-          variant="outline"
-          size="icon-xs"
-          onClick={handlePrevDay}
-          aria-label={t('timetable.dateTimeNav.previousDay')}
-        >
-          <ChevronLeft className="size-4" />
-        </Button>
-        <input
-          type="datetime-local"
-          value={editingValue}
-          onChange={handlePickerChange}
-          min={inputBounds.minString}
-          max={inputBounds.maxString}
-          aria-label={t('timetable.dateTimeNav.datePickerLabel')}
-          className="border-input bg-background h-6 rounded-md border px-2 text-xs leading-none"
-        />
-        <Button
-          variant="outline"
-          size="icon-xs"
-          onClick={handleResetToNow}
-          aria-label={t('timetable.dateTimeNav.now')}
-        >
-          <Clock className="size-4" />
-        </Button>
-        <Button
-          variant="outline"
-          size="icon-xs"
-          onClick={handleNextDay}
-          aria-label={t('timetable.dateTimeNav.nextDay')}
-        >
-          <ChevronRight className="size-4" />
-        </Button>
-      </ButtonGroup>
+      <Button
+        variant="outline"
+        size="icon-xs"
+        onClick={handlePrevDay}
+        aria-label={t('timetable.dateTimeNav.previousDay')}
+      >
+        <ChevronLeft className="size-4" />
+      </Button>
+      <input
+        type="datetime-local"
+        value={editingValue}
+        onChange={handlePickerChange}
+        min={inputBounds.minString}
+        max={inputBounds.maxString}
+        aria-label={t('timetable.dateTimeNav.datePickerLabel')}
+        className="border-input bg-background h-6 rounded-md border px-2 text-xs leading-none"
+      />
+      <Button
+        variant="outline"
+        size="icon-xs"
+        onClick={handleResetToNow}
+        aria-label={t('timetable.dateTimeNav.now')}
+      >
+        <Clock className="size-4" />
+      </Button>
+      <Button
+        variant="outline"
+        size="icon-xs"
+        onClick={handleNextDay}
+        aria-label={t('timetable.dateTimeNav.nextDay')}
+      >
+        <ChevronRight className="size-4" />
+      </Button>
     </div>
   );
 }

--- a/src/components/marker/stop-marker-summary.tsx
+++ b/src/components/marker/stop-marker-summary.tsx
@@ -12,6 +12,7 @@ import { routeTypesEmoji } from '../../utils/route-type-emoji';
 import { IdBadge } from '../badge/id-badge';
 import { RelativeTime } from '../relative-time';
 import { TripInfo } from '../trip-info';
+import { PlatformCodeLabel } from '../stop/platform-code-label';
 
 interface StopMarkerSummaryProps {
   stop: Stop;
@@ -63,6 +64,7 @@ export function StopMarkerSummary({
         <span>
           {routeTypesEmoji(routeTypes)} {stopNames.name}
         </span>
+        {stop.platform_code && <PlatformCodeLabel code={stop.platform_code} size="xs" />}
         {agencies.length > 0 &&
           agencies.map((a) => (
             <AgencyBadge

--- a/src/components/marker/stop-marker-summary.tsx
+++ b/src/components/marker/stop-marker-summary.tsx
@@ -64,7 +64,7 @@ export function StopMarkerSummary({
         <span>
           {routeTypesEmoji(routeTypes)} {stopNames.name}
         </span>
-        {stop.platform_code && <PlatformCodeLabel code={stop.platform_code} size="xs" />}
+        {stop.platform_code && <PlatformCodeLabel code={stop.platform_code} size="xs" className="font-normal" />}
         {agencies.length > 0 &&
           agencies.map((a) => (
             <AgencyBadge

--- a/src/components/marker/stop-marker-summary.tsx
+++ b/src/components/marker/stop-marker-summary.tsx
@@ -64,7 +64,14 @@ export function StopMarkerSummary({
         <span>
           {routeTypesEmoji(routeTypes)} {stopNames.name}
         </span>
-        {stop.platform_code && <PlatformCodeLabel code={stop.platform_code} size="xs" className="font-normal" />}
+        {stop.platform_code && (
+          <PlatformCodeLabel
+            //
+            code={stop.platform_code}
+            size="xs"
+            className="font-normal"
+          />
+        )}
         {agencies.length > 0 &&
           agencies.map((a) => (
             <AgencyBadge


### PR DESCRIPTION
## Summary

- Render `PlatformCodeLabel` next to the stop name in `StopMarkerSummary`, shared by the standard tooltip and the lightweight (Canvas) popup.
- Mirrors the existing pattern in `src/components/search/stop-search-result-item.tsx` (amber chip, falsy-guarded, `size="xs"` since the marker context is more compact than the search row's `"sm"`).
- Data layer already carries `platform_code` end-to-end (GTFS extract -> `pc` short key -> `merge-sources-v2` -> `Stop.platform_code`); this PR is display-only.

## Test plan

- [x] `tsc --noEmit` passes.
- [x] ESLint / Prettier pass.
- [x] Verified in browser: stop popup shows the platform chip when `platform_code` is present and renders unchanged when it is absent.