### PR TITLE
feat(data-source-settings): show operating-period enablement state

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Transit explorer without destination — discover where you can go from here
 - 📦 任意のデータを選択して利用
 - ⌨️ キーボードショートカット (help:?)
 
-
 ## Documentation
 
 - [PRD.md](./PRD.md) -- プロダクト要件、ユーザー体験、機能要件

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -219,8 +219,8 @@ vi.mock('../components/dialog/info-dialog', () => ({
   },
 }));
 
-vi.mock('../components/dialog/data-source-settings-dialog', () => ({
-  DataSourceSettingsDialog: (props: unknown) => {
+vi.mock('../components/datasource/data-source-settings-container', () => ({
+  DataSourceSettingsContainer: (props: unknown) => {
     mockDataSourceSettingsDialog(props);
     return null;
   },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -86,7 +86,7 @@ import {
 
 // components
 import { AppLayout } from './components/app-layout';
-import { DataSourceSettingsDialog } from './components/dialog/data-source-settings-dialog';
+import { DataSourceSettingsContainer } from './components/datasource/data-source-settings-container';
 import { InfoDialog } from './components/dialog/info-dialog';
 import { ShortcutHelpDialog } from './components/dialog/shortcut-help-dialog';
 import { StopSearchDialog } from './components/dialog/stop-search-dialog';
@@ -998,9 +998,10 @@ export default function App() {
         onOpenChange={setInfoDialogOpen}
         onOpenDataSourceSettings={openDataSourceSettingsDialog}
       />
-      <DataSourceSettingsDialog
+      <DataSourceSettingsContainer
         open={dataSourceSettingsDialogOpen}
         onOpenChange={setDataSourceSettingsDialogOpen}
+        referenceDateTime={dateTime}
       />
       <ShortcutHelpDialog open={shortcutHelpOpen} onOpenChange={setShortcutHelpOpen} />
       <TripInspectionContainer

--- a/src/components/badge/metric-badge-tone-scale.ts
+++ b/src/components/badge/metric-badge-tone-scale.ts
@@ -85,6 +85,57 @@ export const FIVE_LEVEL_METRIC_BADGE_TONE_SCALE: ReadonlyArray<MetricBadgeTone> 
   },
 ];
 
+/** Accents for {@link ENABLEMENT_BADGE_TONE_SCALE}, as literals so the scale needs
+ * no new theme token. */
+const ENABLED_TONE_ACCENT = 'oklch(0.64 0.18 145)'; // green
+const DISABLED_TONE_ACCENT = 'oklch(0.72 0.18 58)'; // amber (the project's orange accent)
+const UNKNOWN_TONE_ACCENT = 'oklch(0.62 0 0)'; // neutral gray
+
+/** Indices into {@link ENABLEMENT_BADGE_TONE_SCALE}. */
+export const ENABLEMENT_TONE_INDEX = {
+  enabled: 0,
+  disabled: 1,
+  unknown: 2,
+} as const;
+
+/**
+ * Generic three-state tone set for badges that convey a lifecycle /
+ * availability state rather than an intensity level:
+ *
+ *   - `enabled` (index 0)  -- green
+ *   - `disabled` (index 1) -- amber
+ *   - `unknown` (index 2)  -- neutral gray
+ *
+ * The states are distinguished by the icon color, text color, and frame only
+ * -- the background stays the theme default, so background color is not used
+ * to convey the state. Each accent is mixed into the base tokens, so the
+ * colors adapt to the theme without a new token. Index via
+ * {@link ENABLEMENT_TONE_INDEX}.
+ */
+export const ENABLEMENT_BADGE_TONE_SCALE: ReadonlyArray<MetricBadgeTone> = [
+  {
+    iconBg: `color-mix(in oklab, ${ENABLED_TONE_ACCENT} 12%, var(--background))`,
+    iconFg: `color-mix(in oklab, ${ENABLED_TONE_ACCENT} 85%, var(--foreground))`,
+    textBg: 'var(--background)',
+    textFg: `color-mix(in oklab, ${ENABLED_TONE_ACCENT} 70%, var(--foreground))`,
+    frameColor: `color-mix(in oklab, ${ENABLED_TONE_ACCENT} 55%, var(--border))`,
+  },
+  {
+    iconBg: `color-mix(in oklab, ${DISABLED_TONE_ACCENT} 12%, var(--background))`,
+    iconFg: `color-mix(in oklab, ${DISABLED_TONE_ACCENT} 85%, var(--foreground))`,
+    textBg: 'var(--background)',
+    textFg: `color-mix(in oklab, ${DISABLED_TONE_ACCENT} 70%, var(--foreground))`,
+    frameColor: `color-mix(in oklab, ${DISABLED_TONE_ACCENT} 55%, var(--border))`,
+  },
+  {
+    iconBg: `color-mix(in oklab, ${UNKNOWN_TONE_ACCENT} 12%, var(--background))`,
+    iconFg: `color-mix(in oklab, ${UNKNOWN_TONE_ACCENT} 85%, var(--foreground))`,
+    textBg: 'var(--background)',
+    textFg: `color-mix(in oklab, ${UNKNOWN_TONE_ACCENT} 70%, var(--foreground))`,
+    frameColor: `color-mix(in oklab, ${UNKNOWN_TONE_ACCENT} 55%, var(--border))`,
+  },
+];
+
 export const RED_METRIC_BADGE_TONE_SCALE =
   createSingleHueMetricBadgeToneScale('oklch(0.62 0.2 24)');
 export const ORANGE_METRIC_BADGE_TONE_SCALE =

--- a/src/components/badge/metric-level-badge.stories.tsx
+++ b/src/components/badge/metric-level-badge.stories.tsx
@@ -6,6 +6,8 @@ import type { BaseLabelSize } from '../label/base-label';
 import {
   AQUA_METRIC_BADGE_TONE_SCALE,
   BLUE_METRIC_BADGE_TONE_SCALE,
+  ENABLEMENT_BADGE_TONE_SCALE,
+  ENABLEMENT_TONE_INDEX,
   FIVE_LEVEL_METRIC_BADGE_TONE_SCALE,
   GOLD_METRIC_BADGE_TONE_SCALE,
   GRAY_METRIC_BADGE_TONE_SCALE,
@@ -480,6 +482,41 @@ export const ToneScaleComparison: Story = {
       </div>
     </div>
   ),
+};
+
+// --- Enablement tone (3-state, not a 0-5 intensity level) ---
+
+/**
+ * The generic `ENABLEMENT_BADGE_TONE_SCALE` (enabled / disabled / unknown).
+ * Unlike the scales above, its index is a semantic state (see
+ * `ENABLEMENT_TONE_INDEX`), not an intensity level. The operating-period badge
+ * uses it; its `unknown` state is gated out of the dialog, so this story is
+ * the only place the `unknown` tone is visible.
+ */
+export const EnablementToneComparison: Story = {
+  args: {
+    iconName: 'CalendarDays',
+    text: 'Enablement',
+    size: 'xs',
+    ariaLabel: 'Operating period',
+  },
+  render: (args) => {
+    const states: ReadonlyArray<{ label: string; level: number }> = [
+      { label: 'enabled', level: ENABLEMENT_TONE_INDEX.enabled },
+      { label: 'disabled', level: ENABLEMENT_TONE_INDEX.disabled },
+      { label: 'unknown', level: ENABLEMENT_TONE_INDEX.unknown },
+    ];
+    return (
+      <div className="flex flex-col gap-2">
+        {states.map((state) => (
+          <div key={state.label} className="flex items-center gap-2">
+            <span className="w-24 text-xs text-gray-500">{state.label}</span>
+            <Wrapper {...args} level={state.level} badgeToneScale={ENABLEMENT_BADGE_TONE_SCALE} />
+          </div>
+        ))}
+      </div>
+    );
+  },
 };
 
 // --- Kitchen sink ---

--- a/src/components/datasource/__tests__/data-source-group-summary-2.test.tsx
+++ b/src/components/datasource/__tests__/data-source-group-summary-2.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ENABLEMENT_BADGE_TONE_SCALE,
+  ENABLEMENT_TONE_INDEX,
+} from '../../badge/metric-badge-tone-scale';
+import type { DataSourceGroupInfo } from '../../../types/app/data-source-group-info';
+import { DataSourceGroupSummary2 } from '../data-source-group-summary-2';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts) {
+        const firstStringOpt = Object.values(opts).find((value): value is string => {
+          return typeof value === 'string';
+        });
+        if (firstStringOpt !== undefined) {
+          return `${key} [${firstStringOpt}]`;
+        }
+      }
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+function makeGroupInfo(
+  operatingDates: { first: string | null; last: string | null } | null,
+): DataSourceGroupInfo {
+  return {
+    groupId: 'test-group',
+    infos: [],
+    size: null,
+    translationLanguages: null,
+    boardingStopsCount: null,
+    maxTripsPerDay: null,
+    operatingDates,
+    routeTypeCounts: null,
+    routeShapesCount: null,
+  };
+}
+
+function getOperatingDatesBadge(): HTMLElement {
+  return screen.getByLabelText('dataSourceSettings.operatingDates.aria [20260101-20260131]');
+}
+
+function expectBadgeFrameColor(expectedFrameColor: string): void {
+  expect(getOperatingDatesBadge().getAttribute('style')).toContain(
+    `border-color: ${expectedFrameColor};`,
+  );
+}
+
+describe('DataSourceGroupSummary2 operating-period badge', () => {
+  it('uses the unknown tone when the reference date is omitted', () => {
+    render(
+      <DataSourceGroupSummary2
+        groupInfo={makeGroupInfo({ first: '20260101', last: '20260131' })}
+      />,
+    );
+
+    expectBadgeFrameColor(ENABLEMENT_BADGE_TONE_SCALE[ENABLEMENT_TONE_INDEX.unknown].frameColor);
+  });
+
+  it('uses the enabled tone when the reference date is within the operating period', () => {
+    render(
+      <DataSourceGroupSummary2
+        groupInfo={makeGroupInfo({ first: '20260101', last: '20260131' })}
+        referenceDateKey="20260115"
+      />,
+    );
+
+    expectBadgeFrameColor(ENABLEMENT_BADGE_TONE_SCALE[ENABLEMENT_TONE_INDEX.enabled].frameColor);
+  });
+
+  it('uses the disabled tone when the reference date is after the operating period', () => {
+    render(
+      <DataSourceGroupSummary2
+        groupInfo={makeGroupInfo({ first: '20260101', last: '20260131' })}
+        referenceDateKey="20260201"
+      />,
+    );
+
+    expectBadgeFrameColor(ENABLEMENT_BADGE_TONE_SCALE[ENABLEMENT_TONE_INDEX.disabled].frameColor);
+  });
+
+  it('uses the disabled tone when the reference date is before the operating period', () => {
+    render(
+      <DataSourceGroupSummary2
+        groupInfo={makeGroupInfo({ first: '20260101', last: '20260131' })}
+        referenceDateKey="20251201"
+      />,
+    );
+
+    expectBadgeFrameColor(ENABLEMENT_BADGE_TONE_SCALE[ENABLEMENT_TONE_INDEX.disabled].frameColor);
+  });
+
+  it('omits the operating-period badge when operating dates are absent', () => {
+    render(<DataSourceGroupSummary2 groupInfo={makeGroupInfo(null)} referenceDateKey="20260115" />);
+
+    expect(
+      screen.queryByLabelText(/dataSourceSettings\.operatingDates\.aria/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('omits the operating-period badge when only one bound is present', () => {
+    render(
+      <DataSourceGroupSummary2
+        groupInfo={makeGroupInfo({ first: null, last: '20260131' })}
+        referenceDateKey="20260115"
+      />,
+    );
+
+    expect(
+      screen.queryByLabelText(/dataSourceSettings\.operatingDates\.aria/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/datasource/data-source-group-item.tsx
+++ b/src/components/datasource/data-source-group-item.tsx
@@ -58,8 +58,8 @@ interface DataSourceGroupItemProps {
   /**
    * Effective "today" as a `YYYYMMDD` key, forwarded to the summary so the
    * operating-period badge can reflect whether the data has expired.
-   * Optional: when omitted (e.g. in isolated stories) the period status is
-   * not evaluated.
+   * Optional: when omitted (e.g. in isolated stories) the period cannot be
+   * evaluated and the badge falls back to the neutral `unknown` tone.
    */
   referenceDateKey?: string;
   checked: boolean;

--- a/src/components/datasource/data-source-group-item.tsx
+++ b/src/components/datasource/data-source-group-item.tsx
@@ -55,6 +55,13 @@ interface DataSourceGroupItemProps {
   countryEmoji: string;
   loadStatus: GroupLoadStatus;
   groupInfo: DataSourceGroupInfo | null;
+  /**
+   * Effective "today" as a `YYYYMMDD` key, forwarded to the summary so the
+   * operating-period badge can reflect whether the data has expired.
+   * Optional: when omitted (e.g. in isolated stories) the period status is
+   * not evaluated.
+   */
+  referenceDateKey?: string;
   checked: boolean;
   disabled: boolean;
   onCheckedChange: (next: boolean) => void;
@@ -66,6 +73,7 @@ export function DataSourceGroupItem({
   countryEmoji,
   loadStatus,
   groupInfo,
+  referenceDateKey,
   checked,
   disabled,
   onCheckedChange,
@@ -104,7 +112,7 @@ export function DataSourceGroupItem({
           )}
         </div>
         {/* <DataSourceGroupSummary groupInfo={groupInfo} /> */}
-        <DataSourceGroupSummary2 groupInfo={groupInfo} />
+        <DataSourceGroupSummary2 groupInfo={groupInfo} referenceDateKey={referenceDateKey} />
         <PartialFraction loadStatus={loadStatus} />
         <FailureList loadStatus={loadStatus} />
       </div>

--- a/src/components/datasource/data-source-group-summary-2.stories.tsx
+++ b/src/components/datasource/data-source-group-summary-2.stories.tsx
@@ -125,15 +125,13 @@ export const AllFiveStars: Story = {
 };
 
 /**
- * Operating-period badge across its period states. The operating range is
- * fixed at `20260101-20260131`; only the reference date varies to produce
- * `inPeriod` / `expired` / `beforePeriod`. The last row has no operating-date
- * data (`hasOperatingPeriod === false`), so the badge is omitted.
- *
- * Note: today the badge text / presence is identical for the first three rows
- * (the period status is computed but does not yet change the badge
- * appearance). This story is the harness for that upcoming visual treatment
- * and documents the conditions.
+ * Operating-period badge across its states. The operating range is fixed at
+ * `20260101-20260131`; the reference date varies to produce `inPeriod`
+ * (green, `CalendarRange`), `expired` (amber, `CalendarX`), and `beforePeriod`
+ * (amber, `CalendarX`). The fourth row omits the reference date, so the period
+ * cannot be evaluated and the badge falls back to the neutral `unknown` tone.
+ * The last row has no operating-date data (`hasOperatingPeriod === false`), so
+ * the badge is omitted entirely.
  */
 export const OperatingPeriodComparison: Story = {
   render: () => {
@@ -150,11 +148,12 @@ export const OperatingPeriodComparison: Story = {
     const scenarios: ReadonlyArray<{
       label: string;
       args: WrapperArgs;
-      referenceDateKey: string;
+      referenceDateKey?: string;
     }> = [
       { label: 'inPeriod (ref 20260115)', args: base, referenceDateKey: '20260115' },
       { label: 'expired (ref 20260201)', args: base, referenceDateKey: '20260201' },
       { label: 'beforePeriod (ref 20251201)', args: base, referenceDateKey: '20251201' },
+      { label: 'unknown (no reference date)', args: base },
       {
         label: 'no operating dates (hasOperatingPeriod false)',
         args: { ...base, showOperatingDates: false },

--- a/src/components/datasource/data-source-group-summary-2.stories.tsx
+++ b/src/components/datasource/data-source-group-summary-2.stories.tsx
@@ -124,6 +124,62 @@ export const AllFiveStars: Story = {
   },
 };
 
+/**
+ * Operating-period badge across its period states. The operating range is
+ * fixed at `20260101-20260131`; only the reference date varies to produce
+ * `inPeriod` / `expired` / `beforePeriod`. The last row has no operating-date
+ * data (`hasOperatingPeriod === false`), so the badge is omitted.
+ *
+ * Note: today the badge text / presence is identical for the first three rows
+ * (the period status is computed but does not yet change the badge
+ * appearance). This story is the harness for that upcoming visual treatment
+ * and documents the conditions.
+ */
+export const OperatingPeriodComparison: Story = {
+  render: () => {
+    const base: WrapperArgs = {
+      groupInfoNull: false,
+      sizeBytes: 3_400_000,
+      languageCount: 2,
+      routeCount: 24,
+      boardingStopsCount: 1500,
+      maxTripsPerDay: 8000,
+      routeShapesCount: 48,
+      showOperatingDates: true,
+    };
+    const scenarios: ReadonlyArray<{
+      label: string;
+      args: WrapperArgs;
+      referenceDateKey: string;
+    }> = [
+      { label: 'inPeriod (ref 20260115)', args: base, referenceDateKey: '20260115' },
+      { label: 'expired (ref 20260201)', args: base, referenceDateKey: '20260201' },
+      { label: 'beforePeriod (ref 20251201)', args: base, referenceDateKey: '20251201' },
+      {
+        label: 'no operating dates (hasOperatingPeriod false)',
+        args: { ...base, showOperatingDates: false },
+        referenceDateKey: '20260115',
+      },
+    ];
+    return (
+      <div className="flex flex-col gap-2">
+        {scenarios.map((scenario) => (
+          <div key={scenario.label} className="bg-background rounded border p-3">
+            <div className="flex items-baseline justify-between">
+              <span className="text-sm font-medium">京王バス 🚍 🇯🇵</span>
+              <span className="text-[10px] text-gray-400">{scenario.label}</span>
+            </div>
+            <DataSourceGroupSummary2
+              groupInfo={buildGroupInfo(scenario.args)}
+              referenceDateKey={scenario.referenceDateKey}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  },
+};
+
 // --- Threshold sweep ---
 
 /**

--- a/src/components/datasource/data-source-group-summary-2.tsx
+++ b/src/components/datasource/data-source-group-summary-2.tsx
@@ -1,23 +1,24 @@
 import {
   CalendarDays,
   CalendarRange,
+  CalendarX,
   Globe,
   HardDrive,
   Route,
   Signpost,
   Spline,
 } from 'lucide-react';
-import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getDataPeriodStatus } from '../../domain/datasource/data-period-status';
 import { toTranslationCoverageLevel } from '../../domain/datasource/translation-coverage-level';
-import { createLogger } from '../../lib/logger';
 import type { DataSourceGroupInfo } from '../../types/app/data-source-group-info';
 import { formatBytesForDisplay } from '../../utils/format-bytes';
 import { toMetricLevel } from '../../utils/to-metric-level';
+import {
+  ENABLEMENT_TONE_INDEX,
+  ENABLEMENT_BADGE_TONE_SCALE,
+} from '../badge/metric-badge-tone-scale';
 import { MetricLevelBadge } from '../badge/metric-level-badge';
-
-const logger = createLogger('DataSourceGroupSummary2');
 
 /**
  * 5-level threshold buckets calibrated against actual catalog data
@@ -66,6 +67,49 @@ const MAX_TRIPS_THRESHOLDS: ReadonlyArray<number> = [0, 100, 500, 3000, 8000];
 const ROUTE_SHAPES_THRESHOLDS: ReadonlyArray<number> = [0, 2, 10, 25, 100];
 
 /**
+ * Operating-period badge for {@link DataSourceGroupSummary2}.
+ *
+ * Render-only: the parent owns the "has operating dates" gate and only renders
+ * this when both bounds are present, so this component always renders the
+ * badge. It shows the operating-date range (`first-last`) and, via
+ * {@link getDataPeriodStatus}, tints the badge (frame + icon) when the range
+ * is out of the operating period (expired or not-yet-started) relative to the
+ * effective "today" (`referenceDateKey`).
+ */
+function OperatingPeriodBadge({
+  first,
+  last,
+  referenceDateKey,
+}: {
+  first: string;
+  last: string;
+  referenceDateKey: string | undefined;
+}) {
+  const { t } = useTranslation();
+
+  const operatingDatesText = `${first}-${last}`;
+  const periodStatus =
+    referenceDateKey !== undefined ? getDataPeriodStatus({ first, last }, referenceDateKey) : null;
+  // Out of the operating range (expired or not-yet-started) -> the amber
+  // "disabled" tone (index 1). inPeriod / unknown reference -> the green
+  // "enabled" tone (index 0).
+  const isOutOfPeriod = periodStatus === 'expired' || periodStatus === 'beforePeriod';
+
+  return (
+    <MetricLevelBadge
+      size="xs"
+      icon={isOutOfPeriod ? <CalendarX /> : <CalendarRange />}
+      text={operatingDatesText}
+      level={isOutOfPeriod ? ENABLEMENT_TONE_INDEX.disabled : ENABLEMENT_TONE_INDEX.enabled}
+      badgeToneScale={ENABLEMENT_BADGE_TONE_SCALE}
+      aria-label={t('dataSourceSettings.operatingDates.aria', {
+        range: operatingDatesText,
+      })}
+    />
+  );
+}
+
+/**
  * Color-scale variant of {@link DataSourceGroupSummary}. Same props,
  * same metric set, but each value is displayed in a `MetricLevelBadge`
  * whose tone is chosen from a discrete color scale based on the
@@ -84,40 +128,23 @@ export function DataSourceGroupSummary2({
 }) {
   const { i18n, t } = useTranslation();
 
-  // Classify the operating period against the effective "today". This does
-  // not yet alter the rendered badge — it is computed and debug-logged so
-  // the wiring can be verified before the visual treatment is added.
-  const periodStatus =
-    groupInfo !== null && referenceDateKey !== undefined
-      ? getDataPeriodStatus(groupInfo.operatingDates, referenceDateKey)
-      : null;
-  const groupId = groupInfo?.groupId ?? null;
-  const operatingFirst = groupInfo?.operatingDates?.first ?? null;
-  const operatingLast = groupInfo?.operatingDates?.last ?? null;
-  useEffect(() => {
-    if (periodStatus === null) {
-      return;
-    }
-    logger.debug(
-      `period status [${groupId ?? '?'}] ${operatingFirst ?? '?'}-${operatingLast ?? '?'} @ ${referenceDateKey ?? '?'} -> ${periodStatus}`,
-    );
-  }, [groupId, operatingFirst, operatingLast, referenceDateKey, periodStatus]);
-
   if (groupInfo === null) {
     return null;
   }
-  const operatingDatesText =
-    groupInfo.operatingDates === null ||
-    groupInfo.operatingDates.first === null ||
-    groupInfo.operatingDates.last === null
-      ? null
-      : `${groupInfo.operatingDates.first}-${groupInfo.operatingDates.last}`;
+  // The catalog emits operating dates as a first/last pair (or the whole
+  // object absent), so a one-sided range cannot occur. Narrow to a non-null
+  // pair so the render-only OperatingPeriodBadge receives non-null bounds.
+  const { operatingDates } = groupInfo;
+  const operatingPeriod =
+    operatingDates !== null && operatingDates.first !== null && operatingDates.last !== null
+      ? { first: operatingDates.first, last: operatingDates.last }
+      : null;
   const routesCount =
     groupInfo.routeTypeCounts === null || Object.keys(groupInfo.routeTypeCounts).length === 0
       ? null
       : Object.values(groupInfo.routeTypeCounts).reduce((sum, count) => sum + count, 0);
   const hasAnyMetric =
-    operatingDatesText !== null ||
+    operatingPeriod !== null ||
     groupInfo.size !== null ||
     groupInfo.translationLanguages !== null ||
     routesCount !== null ||
@@ -201,15 +228,11 @@ export function DataSourceGroupSummary2({
       )}
 
       {/* Operating period */}
-      {operatingDatesText !== null && (
-        <MetricLevelBadge
-          size="xs"
-          icon={<CalendarRange />}
-          text={operatingDatesText}
-          level={0}
-          aria-label={t('dataSourceSettings.operatingDates.aria', {
-            range: operatingDatesText,
-          })}
+      {operatingPeriod !== null && (
+        <OperatingPeriodBadge
+          first={operatingPeriod.first}
+          last={operatingPeriod.last}
+          referenceDateKey={referenceDateKey}
         />
       )}
     </div>

--- a/src/components/datasource/data-source-group-summary-2.tsx
+++ b/src/components/datasource/data-source-group-summary-2.tsx
@@ -151,9 +151,9 @@ export function DataSourceGroupSummary2({
   if (groupInfo === null) {
     return null;
   }
-  // The catalog emits operating dates as a first/last pair (or the whole
-  // object absent), so a one-sided range cannot occur. Narrow to a non-null
-  // pair so the render-only OperatingPeriodBadge receives non-null bounds.
+  // Show the operating-period badge only when both bounds are known; a
+  // one-sided range yields no badge. Narrow to a non-null pair so the
+  // render-only OperatingPeriodBadge receives non-null bounds.
   const { operatingDates } = groupInfo;
   const operatingPeriod =
     operatingDates !== null && operatingDates.first !== null && operatingDates.last !== null

--- a/src/components/datasource/data-source-group-summary-2.tsx
+++ b/src/components/datasource/data-source-group-summary-2.tsx
@@ -7,12 +7,17 @@ import {
   Signpost,
   Spline,
 } from 'lucide-react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getDataPeriodStatus } from '../../domain/datasource/data-period-status';
 import { toTranslationCoverageLevel } from '../../domain/datasource/translation-coverage-level';
+import { createLogger } from '../../lib/logger';
 import type { DataSourceGroupInfo } from '../../types/app/data-source-group-info';
 import { formatBytesForDisplay } from '../../utils/format-bytes';
 import { toMetricLevel } from '../../utils/to-metric-level';
 import { MetricLevelBadge } from '../badge/metric-level-badge';
+
+const logger = createLogger('DataSourceGroupSummary2');
 
 /**
  * 5-level threshold buckets calibrated against actual catalog data
@@ -70,8 +75,34 @@ const ROUTE_SHAPES_THRESHOLDS: ReadonlyArray<number> = [0, 2, 10, 25, 100];
  * Aria labels keep the raw numbers (or formatted size) so screen
  * readers still receive precise values.
  */
-export function DataSourceGroupSummary2({ groupInfo }: { groupInfo: DataSourceGroupInfo | null }) {
+export function DataSourceGroupSummary2({
+  groupInfo,
+  referenceDateKey,
+}: {
+  groupInfo: DataSourceGroupInfo | null;
+  referenceDateKey?: string;
+}) {
   const { i18n, t } = useTranslation();
+
+  // Classify the operating period against the effective "today". This does
+  // not yet alter the rendered badge — it is computed and debug-logged so
+  // the wiring can be verified before the visual treatment is added.
+  const periodStatus =
+    groupInfo !== null && referenceDateKey !== undefined
+      ? getDataPeriodStatus(groupInfo.operatingDates, referenceDateKey)
+      : null;
+  const groupId = groupInfo?.groupId ?? null;
+  const operatingFirst = groupInfo?.operatingDates?.first ?? null;
+  const operatingLast = groupInfo?.operatingDates?.last ?? null;
+  useEffect(() => {
+    if (periodStatus === null) {
+      return;
+    }
+    logger.debug(
+      `period status [${groupId ?? '?'}] ${operatingFirst ?? '?'}-${operatingLast ?? '?'} @ ${referenceDateKey ?? '?'} -> ${periodStatus}`,
+    );
+  }, [groupId, operatingFirst, operatingLast, referenceDateKey, periodStatus]);
+
   if (groupInfo === null) {
     return null;
   }

--- a/src/components/datasource/data-source-group-summary-2.tsx
+++ b/src/components/datasource/data-source-group-summary-2.tsx
@@ -9,7 +9,10 @@ import {
   Spline,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { getDataPeriodStatus } from '../../domain/datasource/data-period-status';
+import {
+  getDataPeriodStatus,
+  type DataPeriodStatus,
+} from '../../domain/datasource/data-period-status';
 import { toTranslationCoverageLevel } from '../../domain/datasource/translation-coverage-level';
 import type { DataSourceGroupInfo } from '../../types/app/data-source-group-info';
 import { formatBytesForDisplay } from '../../utils/format-bytes';
@@ -67,6 +70,23 @@ const MAX_TRIPS_THRESHOLDS: ReadonlyArray<number> = [0, 100, 500, 3000, 8000];
 const ROUTE_SHAPES_THRESHOLDS: ReadonlyArray<number> = [0, 2, 10, 25, 100];
 
 /**
+ * Map an operating-period status to its {@link ENABLEMENT_TONE_INDEX}. A
+ * missing reference date (`null`) or `indeterminate` maps to `unknown`, so the
+ * badge is not shown as `enabled` when the period cannot be evaluated.
+ */
+function enablementToneIndexForPeriodStatus(periodStatus: DataPeriodStatus | null): number {
+  switch (periodStatus) {
+    case 'expired':
+    case 'beforePeriod':
+      return ENABLEMENT_TONE_INDEX.disabled;
+    case 'inPeriod':
+      return ENABLEMENT_TONE_INDEX.enabled;
+    default:
+      return ENABLEMENT_TONE_INDEX.unknown;
+  }
+}
+
+/**
  * Operating-period badge for {@link DataSourceGroupSummary2}.
  *
  * Render-only: the parent owns the "has operating dates" gate and only renders
@@ -90,9 +110,9 @@ function OperatingPeriodBadge({
   const operatingDatesText = `${first}-${last}`;
   const periodStatus =
     referenceDateKey !== undefined ? getDataPeriodStatus({ first, last }, referenceDateKey) : null;
-  // Out of the operating range (expired or not-yet-started) -> the amber
-  // "disabled" tone (index 1). inPeriod / unknown reference -> the green
-  // "enabled" tone (index 0).
+  // Out of the operating range (expired or not-yet-started) gets the CalendarX
+  // icon; in-period / unknown keeps CalendarRange. The tone is chosen by
+  // {@link enablementToneIndexForPeriodStatus}.
   const isOutOfPeriod = periodStatus === 'expired' || periodStatus === 'beforePeriod';
 
   return (
@@ -100,7 +120,7 @@ function OperatingPeriodBadge({
       size="xs"
       icon={isOutOfPeriod ? <CalendarX /> : <CalendarRange />}
       text={operatingDatesText}
-      level={isOutOfPeriod ? ENABLEMENT_TONE_INDEX.disabled : ENABLEMENT_TONE_INDEX.enabled}
+      level={enablementToneIndexForPeriodStatus(periodStatus)}
       badgeToneScale={ENABLEMENT_BADGE_TONE_SCALE}
       aria-label={t('dataSourceSettings.operatingDates.aria', {
         range: operatingDatesText,

--- a/src/components/datasource/data-source-settings-container.tsx
+++ b/src/components/datasource/data-source-settings-container.tsx
@@ -10,16 +10,7 @@ import { DataSourceSettingsDialog } from '../dialog/data-source-settings-dialog'
 
 interface DataSourceSettingsContainerProps {
   open: boolean;
-  /**
-   * The app-wide effective "now", owned by `App`'s single `useDateTime`
-   * instance and forwarded here (mirroring how `TripInspectionContainer`
-   * receives `relativeTimeNow`). The container reduces it to a `YYYYMMDD` key
-   * whose value is stable across the 15s tick, which keeps the period
-   * classification (and its effect) from changing each tick. It does NOT, on
-   * its own, stop the container/dialog from re-rendering on the tick -- they
-   * are unmemoized, so the tick still re-renders this subtree. Cutting those
-   * re-renders off is a separate memoization step (see Issue 265).
-   */
+  /** The effective "now", used to classify each group's operating period. */
   referenceDateTime: Date;
   onOpenChange: (open: boolean) => void;
 }
@@ -58,10 +49,8 @@ export function DataSourceSettingsContainer({
 
   const groupInfoById = useDataSourceGroupInfo(visibleGroups);
 
-  // A YYYYMMDD key changes once per day, so the *value* passed downstream is
-  // stable across the app's 15s tick even though `referenceDateTime` is a new
-  // object each tick. This suppresses the period-status effect re-firing; it
-  // does not stop the unmemoized container/dialog from re-rendering on the tick.
+  // A YYYYMMDD key changes once per day, so the value passed downstream stays
+  // stable even though `referenceDateTime` updates with the app clock.
   const referenceDateKey = useMemo(() => formatDateKey(referenceDateTime), [referenceDateTime]);
 
   return (

--- a/src/components/datasource/data-source-settings-container.tsx
+++ b/src/components/datasource/data-source-settings-container.tsx
@@ -1,0 +1,82 @@
+import { useMemo } from 'react';
+import settings from '../../config/data-source-settings';
+import { computeDialogDisplay } from '../../domain/datasource/dialog-display';
+import { formatDateKey } from '../../domain/transit/calendar-utils';
+import { useDataSourceGroupInfo } from '../../hooks/use-data-source-group-info';
+import { useIsForcedSourcesMode } from '../../hooks/use-is-forced-sources-mode';
+import { useSourceLoadStatus } from '../../hooks/use-source-load-status';
+import { useUserDataSourceSettings } from '../../hooks/use-user-data-source-settings';
+import { DataSourceSettingsDialog } from '../dialog/data-source-settings-dialog';
+
+interface DataSourceSettingsContainerProps {
+  open: boolean;
+  /**
+   * The app-wide effective "now", owned by `App`'s single `useDateTime`
+   * instance and forwarded here (mirroring how `TripInspectionContainer`
+   * receives `relativeTimeNow`). The container reduces it to a `YYYYMMDD` key
+   * whose value is stable across the 15s tick, which keeps the period
+   * classification (and its effect) from changing each tick. It does NOT, on
+   * its own, stop the container/dialog from re-rendering on the tick -- they
+   * are unmemoized, so the tick still re-renders this subtree. Cutting those
+   * re-renders off is a separate memoization step (see Issue 265).
+   */
+  referenceDateTime: Date;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Owns the data-source settings dialog's stateful hooks
+ * (`useSourceLoadStatus`, `useIsForcedSourcesMode`,
+ * `useUserDataSourceSettings`, `useDataSourceGroupInfo`) and the
+ * dialog-display derivation, then renders the presentational
+ * {@link DataSourceSettingsDialog}.
+ *
+ * The effective clock is not owned here: `App` stays its single source of
+ * truth and passes it in as `referenceDateTime` (see that prop for how it is
+ * used).
+ */
+export function DataSourceSettingsContainer({
+  open,
+  referenceDateTime,
+  onOpenChange,
+}: DataSourceSettingsContainerProps) {
+  const loadStatusByPrefix = useSourceLoadStatus();
+  const isForcedSourcesMode = useIsForcedSourcesMode();
+  const { enabledGroupIds, setGroupEnabled, setGroupsEnabled, resetToDefaults } =
+    useUserDataSourceSettings();
+
+  // Normalize the two operating modes (forced / normal) into one shape so
+  // the view never branches on `isForcedSourcesMode`. Returns the visible
+  // groups + the Set used for both per-row Switch state and per-section
+  // enabled counts.
+  const { visibleGroups, effectiveEnabledIds } = computeDialogDisplay(
+    settings,
+    loadStatusByPrefix,
+    isForcedSourcesMode,
+    enabledGroupIds,
+  );
+
+  const groupInfoById = useDataSourceGroupInfo(visibleGroups);
+
+  // A YYYYMMDD key changes once per day, so the *value* passed downstream is
+  // stable across the app's 15s tick even though `referenceDateTime` is a new
+  // object each tick. This suppresses the period-status effect re-firing; it
+  // does not stop the unmemoized container/dialog from re-rendering on the tick.
+  const referenceDateKey = useMemo(() => formatDateKey(referenceDateTime), [referenceDateTime]);
+
+  return (
+    <DataSourceSettingsDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      loadStatusByPrefix={loadStatusByPrefix}
+      visibleGroups={visibleGroups}
+      effectiveEnabledIds={effectiveEnabledIds}
+      isForcedSourcesMode={isForcedSourcesMode}
+      groupInfoById={groupInfoById}
+      referenceDateKey={referenceDateKey}
+      setGroupEnabled={setGroupEnabled}
+      setGroupsEnabled={setGroupsEnabled}
+      resetToDefaults={resetToDefaults}
+    />
+  );
+}

--- a/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
+++ b/src/components/dialog/__tests__/data-source-settings-dialog.test.tsx
@@ -11,7 +11,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import type { DataSourceCatalogBundle } from '@contracts/data/transit-v2-catalog-json';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { DataSourceSettingsDialog } from '../data-source-settings-dialog';
+import { DataSourceSettingsContainer } from '../../datasource/data-source-settings-container';
 import settings from '../../../config/data-source-settings';
 import { getDefaultEnabledIds } from '../../../domain/datasource/data-source-selection';
 import type { SourceLoadState } from '../../../domain/datasource/source-load-state';
@@ -101,6 +101,11 @@ vi.mock('../../../domain/datasource/dialog-display', async () => {
 const noopOnOpenChange = (): void => {
   // intentionally empty for tests that don't care about close
 };
+
+// Fixed reference time passed to the container; these tests assert on the
+// dialog's load/selection rendering, not on operating-period status, so the
+// exact value is irrelevant.
+const testDateTime = new Date('2026-06-01T12:00:00Z');
 
 const emptyLoadStatus: SourceLoadState = new Map();
 
@@ -224,7 +229,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
       effectiveEnabledIds: new Set(['demo-group']),
     });
 
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
 
     const demoRow = findGroupRow('Demo Group');
 
@@ -233,7 +244,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
   });
 
   it('shows the development notice Alert, not the forced-mode Alert', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     expect(screen.getByText('dataSourceSettings.developmentNotice.title')).toBeInTheDocument();
     expect(screen.queryByText('dataSourceSettings.forcedMode.title')).not.toBeInTheDocument();
   });
@@ -253,14 +270,26 @@ describe('DataSourceSettingsDialog — normal mode', () => {
       effectiveEnabledIds: new Set(['other-test']),
     });
 
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
 
     expect(screen.getByText('dataSourceSettings.section.other')).toBeInTheDocument();
     expect(findGroupRow('Other Test')).toBeInTheDocument();
   });
 
   it('enables the Reset to defaults button', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const resetButton = screen.getByRole('button', {
       name: 'dataSourceSettings.resetToDefaults',
     });
@@ -268,7 +297,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
   });
 
   it('enables the Restart button', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const restartButton = screen.getByRole('button', {
       name: 'dataSourceSettings.restart.aria',
     });
@@ -283,7 +318,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
     vi.stubGlobal('location', { ...window.location, reload: reloadSpy });
 
     try {
-      render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+      render(
+        <DataSourceSettingsContainer
+          open
+          onOpenChange={noopOnOpenChange}
+          referenceDateTime={testDateTime}
+        />,
+      );
       const restartButton = screen.getByRole('button', {
         name: 'dataSourceSettings.restart.aria',
       });
@@ -305,7 +346,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
       setGroupsEnabled: mockSetGroupsEnabled,
       resetToDefaults: mockResetToDefaults,
     });
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const toeiBusRow = findGroupRow('Toei Bus');
     const toeiBusSwitch = within(toeiBusRow).getByRole('switch');
     expect(toeiBusSwitch).toHaveAttribute('aria-checked', 'true');
@@ -316,7 +363,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
   });
 
   it('clicking a Switch calls setGroupEnabled with the matching group id', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const toeiBusRow = findGroupRow('Toei Bus');
     const toeiBusSwitch = within(toeiBusRow).getByRole('switch');
     // Initial state is `checked` (toei-bus is in defaults), so clicking
@@ -326,7 +379,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
   });
 
   it('clicking Reset to defaults calls resetToDefaults', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const resetButton = screen.getByRole('button', {
       name: 'dataSourceSettings.resetToDefaults',
     });
@@ -335,7 +394,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
   });
 
   it('clicking the "All on" bulk button calls setGroupsEnabled with the section group ids and true', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     // There is one "All on" button per section; pick any one of the Bus
     // section's by aria-label.
     const enableAllBus = screen.getByRole('button', {
@@ -352,7 +417,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
   });
 
   it('clicking the "All off" bulk button calls setGroupsEnabled with the section group ids and false', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const disableAllBus = screen.getByRole('button', {
       name: 'dataSourceSettings.bulkAction.disableAll.aria [dataSourceSettings.section.3]',
     });
@@ -364,7 +435,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
   });
 
   it('clicking the global "All on" button calls setGroupsEnabled with every visible group id and true', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const enableAllGlobal = screen.getByRole('button', {
       name: 'dataSourceSettings.bulkAction.enableAllGlobal.aria',
     });
@@ -381,7 +458,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
   });
 
   it('clicking the global "All off" button calls setGroupsEnabled with every visible group id and false', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const disableAllGlobal = screen.getByRole('button', {
       name: 'dataSourceSettings.bulkAction.disableAllGlobal.aria',
     });
@@ -403,7 +486,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
       setGroupsEnabled: mockSetGroupsEnabled,
       resetToDefaults: mockResetToDefaults,
     });
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const tokoRow = findGroupRow('Toei Transport');
     const tokoSwitch = within(tokoRow).getByRole('switch');
     expect(tokoSwitch).toHaveAttribute('aria-checked', 'false');
@@ -416,7 +505,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
         ['toaran', { status: 'failed', error: new Error('network down') }],
       ]),
     );
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     expect(screen.getAllByText('dataSourceSettings.partial.fraction').length).toBeGreaterThan(0);
   });
 
@@ -424,7 +519,13 @@ describe('DataSourceSettingsDialog — normal mode', () => {
     mockUseSourceLoadStatus.mockReturnValue(
       new Map([['toaran', { status: 'failed', error: new Error('network down') }]]),
     );
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     expect(screen.getAllByText(/toaran/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/network down/).length).toBeGreaterThan(0);
   });
@@ -443,7 +544,13 @@ describe('DataSourceSettingsDialog — forced-sources mode', () => {
   });
 
   it('shows the forced-mode Alert, not the development notice', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     expect(screen.getByText('dataSourceSettings.forcedMode.title')).toBeInTheDocument();
     expect(
       screen.queryByText('dataSourceSettings.developmentNotice.title'),
@@ -451,7 +558,13 @@ describe('DataSourceSettingsDialog — forced-sources mode', () => {
   });
 
   it('narrows visibility to groups with attempted prefixes', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     // toei-bus (1 section) and toko (4 sections — `routeTypes: [0,1,2,3]`)
     // share minkuru → both visible
     expect(getAllSwitchesFor('Toei Bus').length).toBeGreaterThan(0);
@@ -473,7 +586,13 @@ describe('DataSourceSettingsDialog — forced-sources mode', () => {
       setGroupsEnabled: mockSetGroupsEnabled,
       resetToDefaults: mockResetToDefaults,
     });
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     for (const sw of getAllSwitchesFor('Toei Bus')) {
       expect(sw).toHaveAttribute('aria-checked', 'true');
     }
@@ -483,7 +602,13 @@ describe('DataSourceSettingsDialog — forced-sources mode', () => {
   });
 
   it('disables every visible Switch', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     for (const sw of getAllSwitchesFor('Toei Bus')) {
       expect(sw).toBeDisabled();
     }
@@ -493,7 +618,13 @@ describe('DataSourceSettingsDialog — forced-sources mode', () => {
   });
 
   it('disables the Reset to defaults button', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const resetButton = screen.getByRole('button', {
       name: 'dataSourceSettings.resetToDefaults',
     });
@@ -501,7 +632,13 @@ describe('DataSourceSettingsDialog — forced-sources mode', () => {
   });
 
   it('disables the Restart button', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const restartButton = screen.getByRole('button', {
       name: 'dataSourceSettings.restart.aria',
     });
@@ -509,7 +646,13 @@ describe('DataSourceSettingsDialog — forced-sources mode', () => {
   });
 
   it('disables every bulk-action button', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     // Bus section is the one that gets shown in forced mode for this
     // setup (minkuru loaded). Both bulk buttons in that section must be
     // disabled.
@@ -524,7 +667,13 @@ describe('DataSourceSettingsDialog — forced-sources mode', () => {
   });
 
   it('disables the global all-on / all-off buttons', () => {
-    render(<DataSourceSettingsDialog open onOpenChange={noopOnOpenChange} />);
+    render(
+      <DataSourceSettingsContainer
+        open
+        onOpenChange={noopOnOpenChange}
+        referenceDateTime={testDateTime}
+      />,
+    );
     const enableAllGlobal = screen.getByRole('button', {
       name: 'dataSourceSettings.bulkAction.enableAllGlobal.aria',
     });

--- a/src/components/dialog/data-source-settings-dialog.tsx
+++ b/src/components/dialog/data-source-settings-dialog.tsx
@@ -12,12 +12,10 @@ import {
 } from '@/components/ui/dialog';
 import { InfoIcon, WrenchIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import settings from '../../config/data-source-settings';
 import {
   aggregateGroupLoadStatus,
   type GroupLoadStatus,
 } from '../../domain/datasource/aggregate-group-status';
-import { computeDialogDisplay } from '../../domain/datasource/dialog-display';
 import { getSourceGroupDisplayName } from '../../domain/datasource/get-source-group-display-name';
 import {
   ROUTE_TYPE_OTHER,
@@ -25,10 +23,7 @@ import {
   type RouteTypeSectionKey,
 } from '../../domain/datasource/route-type-priority';
 import { sortSourceGroupsForDisplay } from '../../domain/datasource/sort-source-groups';
-import { useDataSourceGroupInfo } from '../../hooks/use-data-source-group-info';
-import { useIsForcedSourcesMode } from '../../hooks/use-is-forced-sources-mode';
-import { useSourceLoadStatus } from '../../hooks/use-source-load-status';
-import { useUserDataSourceSettings } from '../../hooks/use-user-data-source-settings';
+import type { SourceLoadState } from '../../domain/datasource/source-load-state';
 import type { DataSourceGroupInfo } from '../../types/app/data-source-group-info';
 import type { SourceGroup } from '../../types/app/source-group';
 import { countriesFlagEmoji } from '../../utils/country-flag';
@@ -39,6 +34,33 @@ type NoticeVariant = 'forced' | 'development';
 interface DataSourceSettingsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Per-prefix load status, owned by the container. */
+  loadStatusByPrefix: SourceLoadState;
+  /** Groups to render, already filtered for the active operating mode. */
+  visibleGroups: readonly SourceGroup[];
+  /** Enabled-group Set driving per-row Switch state and per-section counts. */
+  effectiveEnabledIds: ReadonlySet<string>;
+  /** Whether the `?sources=` URL override is active (disables all toggles). */
+  isForcedSourcesMode: boolean;
+  /** Catalog / SourceMeta-derived summary per group id. */
+  groupInfoById: ReadonlyMap<string, DataSourceGroupInfo>;
+  /**
+   * Effective "today" as a `YYYYMMDD` key, used to classify each group's
+   * operating-period status. The value only changes at the day boundary, so
+   * the period classification and its debug-log effect stay stable across the
+   * app's 15s clock tick. NOTE: this stable value does NOT by itself stop this
+   * subtree from re-rendering on the tick -- the container and this view are
+   * not memoized, so they still re-render (running buildSections etc.) on
+   * every tick. Suppressing those re-renders is a separate memoization step
+   * (see Issue 265), not done here.
+   */
+  referenceDateKey: string;
+  /** Toggle a single group's enabled state. */
+  setGroupEnabled: (groupId: string, enabled: boolean) => void;
+  /** Toggle multiple groups' enabled state in one update. */
+  setGroupsEnabled: (groupIds: readonly string[], enabled: boolean) => void;
+  /** Clear the user preference and revert to config defaults. */
+  resetToDefaults: () => void;
 }
 
 interface GroupRow {
@@ -84,7 +106,7 @@ interface Section {
 
 function buildGroupRow(
   group: SourceGroup,
-  loadStatusByPrefix: ReturnType<typeof useSourceLoadStatus>,
+  loadStatusByPrefix: SourceLoadState,
   groupInfoById: ReadonlyMap<string, DataSourceGroupInfo>,
   lang: string,
 ): GroupRow {
@@ -129,7 +151,7 @@ function sectionEmoji(key: RouteTypeSectionKey): string {
  */
 function buildSections(
   groups: readonly SourceGroup[],
-  loadStatusByPrefix: ReturnType<typeof useSourceLoadStatus>,
+  loadStatusByPrefix: SourceLoadState,
   groupInfoById: ReadonlyMap<string, DataSourceGroupInfo>,
   lang: string,
   t: (key: string) => string,
@@ -179,7 +201,7 @@ interface DistinctGroupCounts {
  */
 function countDistinctGroupStatuses(
   groups: readonly SourceGroup[],
-  loadStatusByPrefix: ReturnType<typeof useSourceLoadStatus>,
+  loadStatusByPrefix: SourceLoadState,
 ): DistinctGroupCounts {
   const counts: DistinctGroupCounts = {
     loaded: 0,
@@ -226,8 +248,10 @@ function DialogNotice({ variant }: { variant: NoticeVariant }) {
 }
 
 /**
- * Modal dialog listing every configured source group with its current load
- * status.
+ * Presentational modal dialog listing every configured source group with its
+ * current load status. All state (load status, user preference, forced mode,
+ * group info) and the dialog-display derivation are owned by
+ * {@link DataSourceSettingsDialogContainer} and passed in as props.
  *
  * Layout: one section per GTFS route_type (in {@link ROUTE_TYPE_PRIORITY}
  * order). A group is listed in every section whose route_type it covers,
@@ -236,42 +260,23 @@ function DialogNotice({ variant }: { variant: NoticeVariant }) {
  * aggregated status is the same in every section because it is derived
  * from `prefixes`, not from the section's route_type.
  *
- * Groups where `SourceGroup.systemEnabledByDefault === false` are
- * app-level intentional disables and are hidden from the user — except
- * when their data has actually been loaded via the `?sources=all` debug
- * override. The effective visibility rule is therefore:
- *
- *     systemEnabledByDefault === true  ∪  any prefix is in the load-status map
- *
- * so `?sources=all` (which loads every group including the disabled
- * ones) reveals those groups in the dialog, while default and
- * normal-URL flows continue to hide them.
- *
  * Named with "Settings" in anticipation of Phase N, when users will be
  * able to toggle individual sources on/off here.
- *
- * @param open - Whether the dialog is open.
- * @param onOpenChange - Called when the open state changes.
  */
-export function DataSourceSettingsDialog({ open, onOpenChange }: DataSourceSettingsDialogProps) {
+export function DataSourceSettingsDialog({
+  open,
+  onOpenChange,
+  loadStatusByPrefix,
+  visibleGroups,
+  effectiveEnabledIds,
+  isForcedSourcesMode,
+  groupInfoById,
+  referenceDateKey,
+  setGroupEnabled,
+  setGroupsEnabled,
+  resetToDefaults,
+}: DataSourceSettingsDialogProps) {
   const { t, i18n } = useTranslation();
-  const loadStatusByPrefix = useSourceLoadStatus();
-  const isForcedSourcesMode = useIsForcedSourcesMode();
-  const { enabledGroupIds, setGroupEnabled, setGroupsEnabled, resetToDefaults } =
-    useUserDataSourceSettings();
-
-  // Normalize the two operating modes (forced / normal) into one shape
-  // so the body below never branches on `isForcedSourcesMode`. The
-  // pure-function call returns the visible groups + the Set used for
-  // both per-row Switch state and per-section enabled counts.
-  const { visibleGroups, effectiveEnabledIds } = computeDialogDisplay(
-    settings,
-    loadStatusByPrefix,
-    isForcedSourcesMode,
-    enabledGroupIds,
-  );
-
-  const groupInfoById = useDataSourceGroupInfo(visibleGroups);
 
   const sections = buildSections(
     visibleGroups,
@@ -380,6 +385,7 @@ export function DataSourceSettingsDialog({ open, onOpenChange }: DataSourceSetti
                       countryEmoji={row.countryEmoji}
                       loadStatus={row.loadStatus}
                       groupInfo={row.groupInfo}
+                      referenceDateKey={referenceDateKey}
                       checked={effectiveEnabledIds.has(row.groupId)}
                       disabled={isForcedSourcesMode}
                       onCheckedChange={(next) => {

--- a/src/components/dialog/data-source-settings-dialog.tsx
+++ b/src/components/dialog/data-source-settings-dialog.tsx
@@ -46,13 +46,7 @@ interface DataSourceSettingsDialogProps {
   groupInfoById: ReadonlyMap<string, DataSourceGroupInfo>;
   /**
    * Effective "today" as a `YYYYMMDD` key, used to classify each group's
-   * operating-period status. The value only changes at the day boundary, so
-   * the period classification and its debug-log effect stay stable across the
-   * app's 15s clock tick. NOTE: this stable value does NOT by itself stop this
-   * subtree from re-rendering on the tick -- the container and this view are
-   * not memoized, so they still re-render (running buildSections etc.) on
-   * every tick. Suppressing those re-renders is a separate memoization step
-   * (see Issue 265), not done here.
+   * operating-period status.
    */
   referenceDateKey: string;
   /** Toggle a single group's enabled state. */
@@ -251,7 +245,7 @@ function DialogNotice({ variant }: { variant: NoticeVariant }) {
  * Presentational modal dialog listing every configured source group with its
  * current load status. All state (load status, user preference, forced mode,
  * group info) and the dialog-display derivation are owned by
- * {@link DataSourceSettingsDialogContainer} and passed in as props.
+ * {@link DataSourceSettingsContainer} and passed in as props.
  *
  * Layout: one section per GTFS route_type (in {@link ROUTE_TYPE_PRIORITY}
  * order). A group is listed in every section whose route_type it covers,

--- a/src/domain/datasource/__tests__/data-period-status.test.ts
+++ b/src/domain/datasource/__tests__/data-period-status.test.ts
@@ -44,13 +44,21 @@ describe('getDataPeriodStatus', () => {
     );
   });
 
-  it('evaluates expiry when only the last bound is known', () => {
-    expect(getDataPeriodStatus({ first: null, last: '20261231' }, '20270101')).toBe('expired');
-    expect(getDataPeriodStatus({ first: null, last: '20261231' }, '20260601')).toBe('inPeriod');
+  it('returns indeterminate when only the last bound is known', () => {
+    expect(getDataPeriodStatus({ first: null, last: '20261231' }, '20270101')).toBe(
+      'indeterminate',
+    );
+    expect(getDataPeriodStatus({ first: null, last: '20261231' }, '20260601')).toBe(
+      'indeterminate',
+    );
   });
 
-  it('evaluates the lower bound when only the first bound is known', () => {
-    expect(getDataPeriodStatus({ first: '20260101', last: null }, '20251231')).toBe('beforePeriod');
-    expect(getDataPeriodStatus({ first: '20260101', last: null }, '20260601')).toBe('inPeriod');
+  it('returns indeterminate when only the first bound is known', () => {
+    expect(getDataPeriodStatus({ first: '20260101', last: null }, '20251231')).toBe(
+      'indeterminate',
+    );
+    expect(getDataPeriodStatus({ first: '20260101', last: null }, '20260601')).toBe(
+      'indeterminate',
+    );
   });
 });

--- a/src/domain/datasource/__tests__/data-period-status.test.ts
+++ b/src/domain/datasource/__tests__/data-period-status.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { getDataPeriodStatus } from '../data-period-status';
+
+describe('getDataPeriodStatus', () => {
+  it('returns indeterminate when operatingDates is null', () => {
+    expect(getDataPeriodStatus(null, '20260601')).toBe('indeterminate');
+  });
+
+  it('returns indeterminate when both bounds are null', () => {
+    expect(getDataPeriodStatus({ first: null, last: null }, '20260601')).toBe('indeterminate');
+  });
+
+  it('returns indeterminate when the reference date key is empty', () => {
+    expect(getDataPeriodStatus({ first: '20260101', last: '20261231' }, '')).toBe('indeterminate');
+  });
+
+  it('returns inPeriod when the reference date is within the span', () => {
+    expect(getDataPeriodStatus({ first: '20260101', last: '20261231' }, '20260601')).toBe(
+      'inPeriod',
+    );
+  });
+
+  it('treats the first day as inPeriod (inclusive lower bound)', () => {
+    expect(getDataPeriodStatus({ first: '20260101', last: '20261231' }, '20260101')).toBe(
+      'inPeriod',
+    );
+  });
+
+  it('treats the last day as inPeriod (inclusive upper bound)', () => {
+    expect(getDataPeriodStatus({ first: '20260101', last: '20261231' }, '20261231')).toBe(
+      'inPeriod',
+    );
+  });
+
+  it('returns expired when the reference date is after the last day', () => {
+    expect(getDataPeriodStatus({ first: '20260101', last: '20261231' }, '20270101')).toBe(
+      'expired',
+    );
+  });
+
+  it('returns beforePeriod when the reference date is before the first day', () => {
+    expect(getDataPeriodStatus({ first: '20260101', last: '20261231' }, '20251231')).toBe(
+      'beforePeriod',
+    );
+  });
+
+  it('evaluates expiry when only the last bound is known', () => {
+    expect(getDataPeriodStatus({ first: null, last: '20261231' }, '20270101')).toBe('expired');
+    expect(getDataPeriodStatus({ first: null, last: '20261231' }, '20260601')).toBe('inPeriod');
+  });
+
+  it('evaluates the lower bound when only the first bound is known', () => {
+    expect(getDataPeriodStatus({ first: '20260101', last: null }, '20251231')).toBe('beforePeriod');
+    expect(getDataPeriodStatus({ first: '20260101', last: null }, '20260601')).toBe('inPeriod');
+  });
+});

--- a/src/domain/datasource/data-period-status.ts
+++ b/src/domain/datasource/data-period-status.ts
@@ -1,0 +1,53 @@
+/**
+ * Lifecycle status of a data source's operating-date span relative to a
+ * reference date ("today").
+ *
+ * - `inPeriod` — the reference date falls within the known bound(s).
+ * - `expired` — the reference date is after the latest operating date.
+ * - `beforePeriod` — the reference date is before the earliest operating date.
+ * - `indeterminate` — no operating-date data to evaluate against.
+ */
+export type DataPeriodStatus = 'inPeriod' | 'expired' | 'beforePeriod' | 'indeterminate';
+
+/**
+ * Classify a data source's operating-date span against a reference date.
+ *
+ * `operatingDates` carries the earliest (`first`) and latest (`last`)
+ * service dates derived from the catalog (trip-backed min/max), each as a
+ * `YYYYMMDD` key or `null` when that bound is unknown. `referenceDateKey`
+ * is the effective "today" as a `YYYYMMDD` key (see `formatDateKey`),
+ * which honours the app's `?time=` override.
+ *
+ * Both bounds are inclusive: a reference date equal to `first` or `last`
+ * is still `inPeriod`. Because `YYYYMMDD` keys are fixed-width, a plain
+ * string comparison orders them chronologically, so no date parsing is
+ * needed.
+ *
+ * Returns `indeterminate` when there is nothing to evaluate: the input is
+ * `null`, both bounds are `null`, or `referenceDateKey` is empty. A
+ * single known bound is still evaluated (e.g. only `last` known yields
+ * `expired` once the reference date passes it, otherwise `inPeriod`).
+ *
+ * @param operatingDates - Earliest / latest operating dates, or `null`.
+ * @param referenceDateKey - Effective "today" as a `YYYYMMDD` key.
+ * @returns The period status relative to the reference date.
+ */
+export function getDataPeriodStatus(
+  operatingDates: { first: string | null; last: string | null } | null,
+  referenceDateKey: string,
+): DataPeriodStatus {
+  if (operatingDates === null || referenceDateKey === '') {
+    return 'indeterminate';
+  }
+  const { first, last } = operatingDates;
+  if (first === null && last === null) {
+    return 'indeterminate';
+  }
+  if (last !== null && referenceDateKey > last) {
+    return 'expired';
+  }
+  if (first !== null && referenceDateKey < first) {
+    return 'beforePeriod';
+  }
+  return 'inPeriod';
+}

--- a/src/domain/datasource/data-period-status.ts
+++ b/src/domain/datasource/data-period-status.ts
@@ -2,10 +2,11 @@
  * Lifecycle status of a data source's operating-date span relative to a
  * reference date ("today").
  *
- * - `inPeriod` — the reference date falls within the known bound(s).
+ * - `inPeriod` — the reference date falls within the operating range.
  * - `expired` — the reference date is after the latest operating date.
  * - `beforePeriod` — the reference date is before the earliest operating date.
- * - `indeterminate` — no operating-date data to evaluate against.
+ * - `indeterminate` — operating dates are missing or incomplete (either bound
+ *   absent), or there is no reference date.
  */
 export type DataPeriodStatus = 'inPeriod' | 'expired' | 'beforePeriod' | 'indeterminate';
 
@@ -23,10 +24,12 @@ export type DataPeriodStatus = 'inPeriod' | 'expired' | 'beforePeriod' | 'indete
  * string comparison orders them chronologically, so no date parsing is
  * needed.
  *
- * Returns `indeterminate` when there is nothing to evaluate: the input is
- * `null`, both bounds are `null`, or `referenceDateKey` is empty. A
- * single known bound is still evaluated (e.g. only `last` known yields
- * `expired` once the reference date passes it, otherwise `inPeriod`).
+ * Both bounds are required: returns `indeterminate` when the input is `null`,
+ * either bound is `null`, or `referenceDateKey` is empty. The catalog always
+ * emits operating dates as a first/last pair (a one-sided range cannot
+ * occur), and deciding `inPeriod` (after the start and before the end) needs
+ * both ends, so a single known bound is treated as `indeterminate` rather
+ * than guessed.
  *
  * @param operatingDates - Earliest / latest operating dates, or `null`.
  * @param referenceDateKey - Effective "today" as a `YYYYMMDD` key.
@@ -40,13 +43,13 @@ export function getDataPeriodStatus(
     return 'indeterminate';
   }
   const { first, last } = operatingDates;
-  if (first === null && last === null) {
+  if (first === null || last === null) {
     return 'indeterminate';
   }
-  if (last !== null && referenceDateKey > last) {
+  if (referenceDateKey > last) {
     return 'expired';
   }
-  if (first !== null && referenceDateKey < first) {
+  if (referenceDateKey < first) {
     return 'beforePeriod';
   }
   return 'inPeriod';

--- a/src/domain/datasource/data-period-status.ts
+++ b/src/domain/datasource/data-period-status.ts
@@ -25,11 +25,9 @@ export type DataPeriodStatus = 'inPeriod' | 'expired' | 'beforePeriod' | 'indete
  * needed.
  *
  * Both bounds are required: returns `indeterminate` when the input is `null`,
- * either bound is `null`, or `referenceDateKey` is empty. The catalog always
- * emits operating dates as a first/last pair (a one-sided range cannot
- * occur), and deciding `inPeriod` (after the start and before the end) needs
- * both ends, so a single known bound is treated as `indeterminate` rather
- * than guessed.
+ * either bound is `null`, or `referenceDateKey` is empty. Deciding `inPeriod`
+ * (after the start and before the end) needs both ends, so a single known
+ * bound is treated as `indeterminate` rather than guessed.
  *
  * @param operatingDates - Earliest / latest operating dates, or `null`.
  * @param referenceDateKey - Effective "today" as a `YYYYMMDD` key.


### PR DESCRIPTION
## Summary

Surfaces each data source's operating-period status in the Data Source Settings dialog. The operating-period badge is now coloured by lifecycle state:

- **In period** -> green (`CalendarRange`)
- **Expired / not-yet-started** -> amber (`CalendarX`)
- **No operating-date data** -> badge hidden

States are distinguished by icon, text, and frame colour; the background stays the theme default, so background colour is not used to convey the state.

## Changes

- **Domain**: add `getDataPeriodStatus(operatingDates, referenceDateKey)` returning `inPeriod` / `expired` / `beforePeriod` / `indeterminate`. Both bounds are required -- a single bound yields `indeterminate`, matching the catalog's first/last-pair output (the pipeline never emits a one-sided range). Pure function with tests.
- **Tone scale**: add a generic `ENABLEMENT_BADGE_TONE_SCALE` (`enabled` / `disabled` / `unknown`) plus `ENABLEMENT_TONE_INDEX` to `metric-badge-tone-scale.ts`. Accents are literal `oklch` values mixed into base tokens, so no new theme token is introduced.
- **Container Pattern**: `DataSourceSettingsContainer` owns the dialog's stateful hooks and receives the app-wide clock as `referenceDateTime` (single source of truth in `App`), reducing it to a per-day-stable `referenceDateKey`. `DataSourceSettingsDialog` is now a presentational view.
- **Badge**: extract a render-only `OperatingPeriodBadge`; the parent gates it on the presence of both operating-date bounds (so `indeterminate` stays hidden).
- **Story**: add `OperatingPeriodComparison` covering the states.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run test` (relevant suites), `npm run build` all pass.
- Verified visually in Storybook (`DataSource/DataSourceGroupSummary2` -> `OperatingPeriodComparison`).

## Notes / follow-ups

- Render-cost (Issue #265 family): the dialog subtree is not memoised, so it still re-renders on the app's 15s clock tick. The `referenceDateKey` is per-day-stable (the period effect/classification do not change on the tick), but cutting the re-renders would require memoising the view -- a separate step, intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)