### PR TITLE
fix(data-source-settings): key operating period by GTFS service day

### DIFF
--- a/src/components/datasource/data-source-settings-container.tsx
+++ b/src/components/datasource/data-source-settings-container.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from 'react';
 import settings from '../../config/data-source-settings';
 import { computeDialogDisplay } from '../../domain/datasource/dialog-display';
-import { formatDateKey } from '../../domain/transit/calendar-utils';
-import { getServiceDay } from '../../domain/transit/service-day';
+import { getServiceDayKey } from '../../domain/transit/service-day';
 import { useDataSourceGroupInfo } from '../../hooks/use-data-source-group-info';
 import { useIsForcedSourcesMode } from '../../hooks/use-is-forced-sources-mode';
 import { useSourceLoadStatus } from '../../hooks/use-source-load-status';
@@ -50,16 +49,12 @@ export function DataSourceSettingsContainer({
 
   const groupInfoById = useDataSourceGroupInfo(visibleGroups);
 
-  // Normalize to the GTFS service day (03:00 boundary) before keying, matching
-  // how the app derives "today" elsewhere (App's serviceDayKey). This keeps the
-  // operating-period classification correct between 00:00-02:59, when the
-  // service day is still the previous calendar day. The YYYYMMDD key changes
-  // once per day, so the value passed downstream stays stable across the app
-  // clock updates.
-  const referenceDateKey = useMemo(
-    () => formatDateKey(getServiceDay(referenceDateTime)),
-    [referenceDateTime],
-  );
+  // Key by the GTFS service day (03:00 boundary), matching how the app derives
+  // "today" elsewhere. This keeps the operating-period classification correct
+  // between 00:00-02:59, when the service day is still the previous calendar
+  // day. The YYYYMMDD key changes once per day, so the value passed downstream
+  // stays stable across the app clock updates.
+  const referenceDateKey = useMemo(() => getServiceDayKey(referenceDateTime), [referenceDateTime]);
 
   return (
     <DataSourceSettingsDialog

--- a/src/components/datasource/data-source-settings-container.tsx
+++ b/src/components/datasource/data-source-settings-container.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import settings from '../../config/data-source-settings';
 import { computeDialogDisplay } from '../../domain/datasource/dialog-display';
 import { formatDateKey } from '../../domain/transit/calendar-utils';
+import { getServiceDay } from '../../domain/transit/service-day';
 import { useDataSourceGroupInfo } from '../../hooks/use-data-source-group-info';
 import { useIsForcedSourcesMode } from '../../hooks/use-is-forced-sources-mode';
 import { useSourceLoadStatus } from '../../hooks/use-source-load-status';
@@ -49,9 +50,16 @@ export function DataSourceSettingsContainer({
 
   const groupInfoById = useDataSourceGroupInfo(visibleGroups);
 
-  // A YYYYMMDD key changes once per day, so the value passed downstream stays
-  // stable even though `referenceDateTime` updates with the app clock.
-  const referenceDateKey = useMemo(() => formatDateKey(referenceDateTime), [referenceDateTime]);
+  // Normalize to the GTFS service day (03:00 boundary) before keying, matching
+  // how the app derives "today" elsewhere (App's serviceDayKey). This keeps the
+  // operating-period classification correct between 00:00-02:59, when the
+  // service day is still the previous calendar day. The YYYYMMDD key changes
+  // once per day, so the value passed downstream stays stable across the app
+  // clock updates.
+  const referenceDateKey = useMemo(
+    () => formatDateKey(getServiceDay(referenceDateTime)),
+    [referenceDateTime],
+  );
 
   return (
     <DataSourceSettingsDialog

--- a/src/domain/transit/__tests__/service-day.test.ts
+++ b/src/domain/transit/__tests__/service-day.test.ts
@@ -6,6 +6,10 @@ import {
   getServiceDayMinutes,
 } from '../service-day';
 
+function makeLocalDate(day: number, hour: number, minute = 0): Date {
+  return new Date(2026, 2, day, hour, minute, 0, 0);
+}
+
 describe('SERVICE_DAY_BOUNDARY_HOUR', () => {
   it('is 3 (03:00)', () => {
     expect(SERVICE_DAY_BOUNDARY_HOUR).toBe(3);
@@ -14,7 +18,7 @@ describe('SERVICE_DAY_BOUNDARY_HOUR', () => {
 
 describe('getServiceDay', () => {
   it('returns same calendar day at 04:00', () => {
-    const now = new Date('2026-03-11T04:00:00');
+    const now = makeLocalDate(11, 4);
     const result = getServiceDay(now);
     expect(result.getFullYear()).toBe(2026);
     expect(result.getMonth()).toBe(2); // March = 2
@@ -24,45 +28,45 @@ describe('getServiceDay', () => {
   });
 
   it('returns same calendar day at 03:00 (boundary)', () => {
-    const now = new Date('2026-03-11T03:00:00');
+    const now = makeLocalDate(11, 3);
     const result = getServiceDay(now);
     expect(result.getDate()).toBe(11);
   });
 
   it('returns previous calendar day at 02:59', () => {
-    const now = new Date('2026-03-11T02:59:00');
+    const now = makeLocalDate(11, 2, 59);
     const result = getServiceDay(now);
     expect(result.getDate()).toBe(10);
     expect(result.getHours()).toBe(0);
   });
 
   it('returns previous calendar day at 00:00 (midnight)', () => {
-    const now = new Date('2026-03-11T00:00:00');
+    const now = makeLocalDate(11, 0);
     const result = getServiceDay(now);
     expect(result.getDate()).toBe(10);
   });
 
   it('returns previous calendar day at 01:30', () => {
-    const now = new Date('2026-03-11T01:30:00');
+    const now = makeLocalDate(11, 1, 30);
     const result = getServiceDay(now);
     expect(result.getDate()).toBe(10);
   });
 
   it('handles month boundary (March 1 at 01:00 → Feb 28)', () => {
-    const now = new Date('2026-03-01T01:00:00');
+    const now = makeLocalDate(1, 1);
     const result = getServiceDay(now);
     expect(result.getMonth()).toBe(1); // February
     expect(result.getDate()).toBe(28);
   });
 
   it('returns same day at 14:00 (normal daytime)', () => {
-    const now = new Date('2026-03-11T14:00:00');
+    const now = makeLocalDate(11, 14);
     const result = getServiceDay(now);
     expect(result.getDate()).toBe(11);
   });
 
   it('returns same day at 23:59', () => {
-    const now = new Date('2026-03-11T23:59:00');
+    const now = makeLocalDate(11, 23, 59);
     const result = getServiceDay(now);
     expect(result.getDate()).toBe(11);
   });
@@ -86,35 +90,35 @@ describe('getServiceDayKey', () => {
 
 describe('getServiceDayMinutes', () => {
   it('returns standard minutes at 10:00', () => {
-    const now = new Date('2026-03-11T10:00:00');
+    const now = makeLocalDate(11, 10);
     expect(getServiceDayMinutes(now)).toBe(600);
   });
 
   it('returns standard minutes at 03:00 (boundary)', () => {
-    const now = new Date('2026-03-11T03:00:00');
+    const now = makeLocalDate(11, 3);
     expect(getServiceDayMinutes(now)).toBe(180);
   });
 
   it('returns overnight minutes at 00:00 (midnight)', () => {
-    const now = new Date('2026-03-11T00:00:00');
+    const now = makeLocalDate(11, 0);
     // 00:00 → (0 + 24) * 60 = 1440
     expect(getServiceDayMinutes(now)).toBe(1440);
   });
 
   it('returns overnight minutes at 01:30', () => {
-    const now = new Date('2026-03-11T01:30:00');
+    const now = makeLocalDate(11, 1, 30);
     // 01:30 → (1 + 24) * 60 + 30 = 1530
     expect(getServiceDayMinutes(now)).toBe(1530);
   });
 
   it('returns overnight minutes at 02:59', () => {
-    const now = new Date('2026-03-11T02:59:00');
+    const now = makeLocalDate(11, 2, 59);
     // 02:59 → (2 + 24) * 60 + 59 = 1619
     expect(getServiceDayMinutes(now)).toBe(1619);
   });
 
   it('returns standard minutes at 23:59', () => {
-    const now = new Date('2026-03-11T23:59:00');
+    const now = makeLocalDate(11, 23, 59);
     expect(getServiceDayMinutes(now)).toBe(1439);
   });
 });

--- a/src/domain/transit/__tests__/service-day.test.ts
+++ b/src/domain/transit/__tests__/service-day.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { SERVICE_DAY_BOUNDARY_HOUR, getServiceDay, getServiceDayMinutes } from '../service-day';
+import {
+  SERVICE_DAY_BOUNDARY_HOUR,
+  getServiceDay,
+  getServiceDayKey,
+  getServiceDayMinutes,
+} from '../service-day';
 
 describe('SERVICE_DAY_BOUNDARY_HOUR', () => {
   it('is 3 (03:00)', () => {
@@ -60,6 +65,22 @@ describe('getServiceDay', () => {
     const now = new Date('2026-03-11T23:59:00');
     const result = getServiceDay(now);
     expect(result.getDate()).toBe(11);
+  });
+});
+
+describe('getServiceDayKey', () => {
+  // Dates are built from local components (year, monthIndex, day, hour) so the
+  // assertions do not depend on the test runner's time zone: getServiceDay
+  // reads local hours and formatDateKey reads local Y/M/D.
+  it('keys the same calendar day at or after the boundary', () => {
+    expect(getServiceDayKey(new Date(2026, 2, 11, 3, 0))).toBe('20260311');
+    expect(getServiceDayKey(new Date(2026, 2, 11, 4, 0))).toBe('20260311');
+    expect(getServiceDayKey(new Date(2026, 2, 11, 10, 0))).toBe('20260311');
+  });
+
+  it('keys the previous calendar day before the boundary', () => {
+    expect(getServiceDayKey(new Date(2026, 2, 11, 0, 0))).toBe('20260310');
+    expect(getServiceDayKey(new Date(2026, 2, 11, 2, 59))).toBe('20260310');
   });
 });
 

--- a/src/domain/transit/service-day.ts
+++ b/src/domain/transit/service-day.ts
@@ -14,6 +14,8 @@
  * getServiceDay(new Date('2026-03-11T04:00:00')) // → 2026-03-11T00:00:00
  */
 
+import { formatDateKey } from './calendar-utils';
+
 /**
  * Hour at which the GTFS service day changes.
  *
@@ -40,6 +42,21 @@ export function getServiceDay(now: Date): Date {
   }
   result.setHours(0, 0, 0, 0);
   return result;
+}
+
+/**
+ * The GTFS service day for a given real-world time, as a `YYYYMMDD` key.
+ *
+ * Convenience for callers that only need the day key (not the `Date`);
+ * equivalent to `formatDateKey(getServiceDay(now))`. Use this wherever the
+ * "current service day" is compared as a key so the
+ * {@link SERVICE_DAY_BOUNDARY_HOUR} boundary is applied consistently.
+ *
+ * @param now - The real-world current time.
+ * @returns The service day as a `YYYYMMDD` key.
+ */
+export function getServiceDayKey(now: Date): string {
+  return formatDateKey(getServiceDay(now));
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #270 (review feedback). The operating-period badge keyed its reference date with the raw calendar date (`formatDateKey(referenceDateTime)`), but the rest of the app normalizes "today" via `getServiceDay` (03:00 service-day boundary, see `App`'s `serviceDayKey`).

Between **00:00-02:59** the service day is still the previous calendar day, so the calendar-date key misclassified the operating-period status (e.g. a source whose last operating date is today would read as `expired` at 01:00, even though the current service day is still that day).

## Changes

- Add a reusable `getServiceDayKey(now)` helper in `domain/transit/service-day.ts` (`formatDateKey(getServiceDay(now))`), so the "current service day as a key" rule is applied consistently.
- `DataSourceSettingsContainer` now derives `referenceDateKey` via `getServiceDayKey(referenceDateTime)` instead of the raw calendar date.
- Add unit tests for `getServiceDayKey` around the 03:00 boundary. The dates are built from **local components** (`new Date(2026, 2, 11, h, m)`) so the assertions do not depend on the runner's time zone.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build` pass.
- `service-day` suite (17 tests) passes under `TZ=UTC`, `America/Los_Angeles`, `Asia/Tokyo`, `Asia/Kolkata` (+5:30), and `Pacific/Chatham` (DST / 45-min offset) — confirming no time-zone dependence.

Refs: #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)