### PR TITLE
fix(stops): refresh nearby stops and radius label on perf-mode toggle

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -188,7 +188,7 @@ export default function App() {
     clearFocusRef.current();
   }, []);
 
-  const { inBoundStops, radiusStops, mapCenter, hasNearbyLoaded, handleBoundsChanged } =
+  const { inBoundStops, radiusStops, radius, mapCenter, hasNearbyLoaded, handleBoundsChanged } =
     useStopsForBounds({
       repo,
       perfProfile,
@@ -956,7 +956,14 @@ export default function App() {
             selectedStopId,
             isNearbyLoading,
             hasNearbyLoaded,
-            dataConfig: perfProfile.data,
+            // Radius that the displayed `stopTimes` were collected
+            // within. Use the radius from the committed fetch, not the
+            // live perfProfile, so the "Xm" radius label and the stop
+            // count update together on a perf-mode toggle (the re-fetch
+            // commits both at once). Falls back to the active profile
+            // before the first commit, while the summary still shows the
+            // loading placeholder.
+            stopsRadius: radius ?? perfProfile.data.stops.nearbyRadius,
             time: dateTime,
             mapCenter,
             infoLevel: settings.infoLevel,

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
 import type { LatLng } from '../types/app/map';
-import type { DataConfig } from '../config/perf-profiles';
 import type { InfoLevel } from '../types/app/settings';
 import type { TimetableEntriesState } from '../types/app/transit';
 import type { GlobalFilter } from '../types/app/global-filter';
@@ -29,7 +28,13 @@ export interface BottomSheetProps {
   selectedStopId: string | null;
   isNearbyLoading: boolean;
   hasNearbyLoaded: boolean;
-  dataConfig: DataConfig;
+  /**
+   * Radius (metres) within which the displayed `stopTimes` were
+   * collected, shown in the summary's "Xm / Xkm 圏内" label. Sourced
+   * from the committed fetch (not the live perf profile) so the label
+   * and the stop count change together on a perf-mode toggle.
+   */
+  stopsRadius: number;
   time: Date;
   mapCenter: LatLng | null;
   infoLevel: InfoLevel;
@@ -82,7 +87,7 @@ export function BottomSheet({
   selectedStopId,
   isNearbyLoading: _isNearbyLoading,
   hasNearbyLoaded,
-  dataConfig,
+  stopsRadius,
   time: now,
   mapCenter,
   infoLevel,
@@ -167,7 +172,7 @@ export function BottomSheet({
         timetableEntriesStateByStopId={timetableEntriesStateByStopId}
         selectedStopId={selectedStopId}
         hasNearbyLoaded={hasNearbyLoaded}
-        dataConfig={dataConfig}
+        stopsRadius={stopsRadius}
         now={now}
         mapCenter={mapCenter}
         infoLevel={infoLevel}

--- a/src/components/stop-browser-header.stories.tsx
+++ b/src/components/stop-browser-header.stories.tsx
@@ -24,7 +24,7 @@ import { StopBrowserHeader } from './stop-browser-header';
 
 // --- Shared defaults ---
 
-const defaultDataConfig = PERF_PROFILES.normal.data;
+const defaultStopsRadius = PERF_PROFILES.normal.data.stops.nearbyRadius;
 const selectView = (id: string) => STOP_TIMES_VIEWS.find((v) => v.id === id);
 const defaultSelectedView = selectView(DEFAULT_VIEW_ID);
 const defaultCounts = { total: 12, nonEmpty: 7, originCount: 3, boardableCount: 5 };
@@ -50,7 +50,7 @@ const meta = {
     counts: defaultCounts,
     nearbyStopsCounts: defaultCounts,
     filteredNearbyStopsCounts: defaultFilteredNearbyStopsCounts,
-    dataConfig: defaultDataConfig,
+    stopsRadius: defaultStopsRadius,
     dataLangs: ['ja'],
     omitEmptyStops: false,
     isOmitEmptyStopsForced: false,
@@ -286,7 +286,7 @@ const kitchenSinkArgs = {
   counts: { total: 42, nonEmpty: 28, originCount: 6, boardableCount: 15 },
   nearbyStopsCounts: { total: 42, nonEmpty: 28, originCount: 6, boardableCount: 15 },
   filteredNearbyStopsCounts: { total: 21, nonEmpty: 21, originCount: 6, boardableCount: 15 },
-  dataConfig: defaultDataConfig,
+  stopsRadius: defaultStopsRadius,
   dataLangs: ['ja'],
   omitEmptyStops: true,
   viewId: 'route-headsign',

--- a/src/components/stop-browser-header.tsx
+++ b/src/components/stop-browser-header.tsx
@@ -1,4 +1,3 @@
-import type { DataConfig } from '../config/perf-profiles';
 import type { InfoLevel } from '../types/app/settings';
 import type { Agency } from '../types/app/transit';
 import type { StopTimeViewMeta } from '../types/app/transit-composed';
@@ -31,7 +30,8 @@ interface StopBrowserHeaderProps {
   /** App-filtered counts before BottomSheet-local filters. */
   filteredNearbyStopsCounts: StopsCounts;
   counts: StopsCounts;
-  dataConfig: DataConfig;
+  /** Radius (metres) within which the displayed stops were collected, shown in {@link StopsSummary}. */
+  stopsRadius: number;
   dataLangs: readonly string[];
   omitEmptyStops: boolean;
   isOmitEmptyStopsForced: boolean;
@@ -59,7 +59,7 @@ export function StopBrowserHeader({
   nearbyStopsCounts,
   filteredNearbyStopsCounts,
   counts,
-  dataConfig,
+  stopsRadius,
   dataLangs,
   omitEmptyStops,
   isOmitEmptyStopsForced,
@@ -120,7 +120,7 @@ export function StopBrowserHeader({
         hasLoaded={hasNearbyLoaded}
         totalCount={nearbyStopsCounts}
         filteredCount={counts.total}
-        nearbyRadius={dataConfig.stops.nearbyRadius}
+        nearbyRadius={stopsRadius}
         omitEmptyStops={omitEmptyStops}
         infoLevel={infoLevel}
       />

--- a/src/components/stop-browser.tsx
+++ b/src/components/stop-browser.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { LatLng } from '../types/app/map';
-import type { DataConfig } from '../config/perf-profiles';
 import type { InfoLevel } from '../types/app/settings';
 import type { Agency, AppRouteTypeValue, TimetableEntriesState } from '../types/app/transit';
 import type { GlobalFilter } from '../types/app/global-filter';
@@ -50,7 +49,8 @@ export interface StopBrowserProps {
   timetableEntriesStateByStopId: ReadonlyMap<string, TimetableEntriesState>;
   selectedStopId: string | null;
   hasNearbyLoaded: boolean;
-  dataConfig: DataConfig;
+  /** Radius (metres) within which the displayed stops were collected; shown in the header summary. */
+  stopsRadius: number;
   now: Date;
   mapCenter: LatLng | null;
   infoLevel: InfoLevel;
@@ -94,7 +94,7 @@ export function StopBrowser({
   timetableEntriesStateByStopId,
   selectedStopId,
   hasNearbyLoaded,
-  dataConfig,
+  stopsRadius,
   now,
   mapCenter,
   infoLevel,
@@ -211,7 +211,7 @@ export function StopBrowser({
         nearbyStopsCounts={nearbyStopsCounts}
         filteredNearbyStopsCounts={filteredNearbyStopsCounts}
         counts={trimmedStopTimesCounts}
-        dataConfig={dataConfig}
+        stopsRadius={stopsRadius}
         dataLangs={dataLangs}
         omitEmptyStops={omitEmptyStops}
         isOmitEmptyStopsForced={isOmitEmptyStopsForced}

--- a/src/components/stop-panel.tsx
+++ b/src/components/stop-panel.tsx
@@ -21,7 +21,7 @@ export function StopPanel({
   timetableEntriesStateByStopId,
   selectedStopId,
   hasNearbyLoaded,
-  dataConfig,
+  stopsRadius,
   time: now,
   mapCenter,
   infoLevel,
@@ -44,7 +44,7 @@ export function StopPanel({
         timetableEntriesStateByStopId={timetableEntriesStateByStopId}
         selectedStopId={selectedStopId}
         hasNearbyLoaded={hasNearbyLoaded}
-        dataConfig={dataConfig}
+        stopsRadius={stopsRadius}
         now={now}
         mapCenter={mapCenter}
         infoLevel={infoLevel}

--- a/src/hooks/__tests__/use-stops-for-bounds.test.ts
+++ b/src/hooks/__tests__/use-stops-for-bounds.test.ts
@@ -527,12 +527,20 @@ describe('useStopsForBounds', () => {
       await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
     });
     expect(result.current.radiusStops).toEqual([liteStop]);
+    expect(result.current.radius).toBe(PERF_PROFILES.lite.data.stops.nearbyRadius);
 
     // Toggle the perf profile WITHOUT a new bounds event (= the user
     // tapped the perf-mode button). The hook must re-fetch against the
     // last viewport with the new profile's radius / maxResults instead
     // of waiting for the next pan.
     rerender({ perfProfile: PERF_PROFILES.normal });
+
+    // Before the re-fetch commits, the committed radius must still
+    // reflect the displayed (lite) stops -- otherwise the radius label
+    // would change ahead of the stop count.
+    expect(result.current.radiusStops).toEqual([liteStop]);
+    expect(result.current.radius).toBe(PERF_PROFILES.lite.data.stops.nearbyRadius);
+
     await act(async () => {
       await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
     });
@@ -542,6 +550,8 @@ describe('useStopsForBounds', () => {
     expect(repo.getStopsNearby).toHaveBeenLastCalledWith(CENTER_A, nearbyRadius, maxResults);
     expect(result.current.radiusStops).toEqual([normalStop]);
     expect(result.current.inBoundStops).toEqual([normalStop]);
+    // Radius and stops commit together: the label now matches the new stops.
+    expect(result.current.radius).toBe(nearbyRadius);
   });
 
   it('treats a half-failed response as success on the succeeding side and empty on the failing side', async () => {

--- a/src/hooks/__tests__/use-stops-for-bounds.test.ts
+++ b/src/hooks/__tests__/use-stops-for-bounds.test.ts
@@ -494,6 +494,56 @@ describe('useStopsForBounds', () => {
     expect(onStopsCommitted).not.toHaveBeenCalled();
   });
 
+  it('re-fetches against the last viewport when the perf profile changes (perf-mode toggle)', async () => {
+    const liteStop = makeStopMeta('lite-stop');
+    const normalStop = makeStopMeta('normal-stop');
+
+    const getStopsInBounds = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, data: [liteStop], truncated: false })
+      .mockResolvedValue({ success: true, data: [normalStop], truncated: false });
+    const getStopsNearby = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, data: [liteStop], truncated: false })
+      .mockResolvedValue({ success: true, data: [normalStop], truncated: false });
+
+    const repo = makeRepo({ getStopsInBounds, getStopsNearby });
+
+    const { result, rerender } = renderHook(
+      ({ perfProfile }) =>
+        useStopsForBounds({
+          repo,
+          perfProfile,
+          debounceMs: TEST_DEBOUNCE_MS,
+        }),
+      { initialProps: { perfProfile: PERF_PROFILES.lite } },
+    );
+
+    // Initial viewport fetch under the `lite` profile.
+    act(() => {
+      result.current.handleBoundsChanged(BOUNDS_A, CENTER_A);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+    expect(result.current.radiusStops).toEqual([liteStop]);
+
+    // Toggle the perf profile WITHOUT a new bounds event (= the user
+    // tapped the perf-mode button). The hook must re-fetch against the
+    // last viewport with the new profile's radius / maxResults instead
+    // of waiting for the next pan.
+    rerender({ perfProfile: PERF_PROFILES.normal });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TEST_DEBOUNCE_MS);
+    });
+
+    const { nearbyRadius, maxResults } = PERF_PROFILES.normal.data.stops;
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(repo.getStopsNearby).toHaveBeenLastCalledWith(CENTER_A, nearbyRadius, maxResults);
+    expect(result.current.radiusStops).toEqual([normalStop]);
+    expect(result.current.inBoundStops).toEqual([normalStop]);
+  });
+
   it('treats a half-failed response as success on the succeeding side and empty on the failing side', async () => {
     const stop = makeStopMeta('present');
     const repoInBoundsFails = makeRepo({

--- a/src/hooks/use-stops-for-bounds.ts
+++ b/src/hooks/use-stops-for-bounds.ts
@@ -81,6 +81,10 @@ export interface UseStopsForBoundsReturn {
  *    successor's fetch is even issued is still classified as stale.
  * 4. `onStopsCommitted` callback that fires only after the latest
  *    fetch has been committed (used by the caller to clear focus)
+ * 5. re-fetch against the last viewport when `repo` / `perfProfile`
+ *    changes, so a perf-mode toggle (which changes `nearbyRadius` /
+ *    `maxResults`) refreshes the visible stop set immediately instead
+ *    of waiting for the next pan
  *
  * The latest-only guard is about state correctness, not cancellation:
  * the underlying repository call still completes its I/O / CPU work,
@@ -99,6 +103,12 @@ export function useStopsForBounds(params: UseStopsForBoundsParams): UseStopsForB
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const latestRequestIdRef = useRef(0);
 
+  // Remember the most recent viewport so a repo / perfProfile change
+  // can re-fetch against it without waiting for the next pan. Updated
+  // on every `handleBoundsChanged`; consumed by the re-fetch effect
+  // below.
+  const lastViewportRef = useRef<{ bounds: Bounds; center: LatLng } | null>(null);
+
   // Hold the latest `onStopsCommitted` in a ref so `handleBoundsChanged`
   // does not need to list it as a dep. Without this, the callback
   // identity churn at the call site (typical for inline arrows or
@@ -109,19 +119,20 @@ export function useStopsForBounds(params: UseStopsForBoundsParams): UseStopsForB
     onStopsCommittedRef.current = onStopsCommitted;
   }, [onStopsCommitted]);
 
-  const handleBoundsChanged = useCallback(
+  // Core fetch dispatch: bump the request id, (re)arm the debounce
+  // timer, and commit the result only if it is still the latest. Shared
+  // by `handleBoundsChanged` (viewport changes) and the re-fetch effect
+  // below (repo / perfProfile changes), so both paths go through the
+  // same latest-only guard. Reads `nearbyRadius` / `maxResults` from
+  // the current `perfProfile` via deps, so a re-dispatch after a
+  // perf-mode toggle uses the new values.
+  const dispatchFetch = useCallback(
     (bounds: Bounds, center: LatLng) => {
-      // Update `mapCenter` synchronously so per-stop distance displays
-      // and any other map-anchored UI follow the pan without waiting
-      // for the debounced fetch. The fetch result is allowed to be
-      // late; the visible map center is not.
-      setMapCenter(center);
-      // Bump the request id at the moment a new viewport arrives, not
-      // when its debounced fetch is dispatched. Otherwise an old
-      // in-flight response that lands between a new bounds event and
-      // its yet-to-be-issued fetch would still see itself as `latest`
-      // and overwrite the fresher state. The newly bumped id is the
-      // one the upcoming fetch will own.
+      // Bump the request id at the moment a fetch is dispatched, not
+      // when its debounced timer fires. Otherwise an old in-flight
+      // response that lands between this call and its yet-to-be-issued
+      // fetch would still see itself as `latest` and overwrite the
+      // fresher state. The newly bumped id is the one this fetch owns.
       const requestId = ++latestRequestIdRef.current;
       clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = setTimeout(() => {
@@ -170,20 +181,42 @@ export function useStopsForBounds(params: UseStopsForBoundsParams): UseStopsForB
     [repo, perfProfile, debounceMs],
   );
 
-  // Invalidate any in-flight request and clear the pending debounce
-  // when the upstream data source or perf profile changes. Without
-  // this, a response that started under the old `repo` / `perfProfile`
-  // would still pass the latest-request guard (its id is the most
-  // recent one ever issued) and overwrite state that should reflect
-  // the new source.
+  const handleBoundsChanged = useCallback(
+    (bounds: Bounds, center: LatLng) => {
+      // Update `mapCenter` synchronously so per-stop distance displays
+      // and any other map-anchored UI follow the pan without waiting
+      // for the debounced fetch. The fetch result is allowed to be
+      // late; the visible map center is not.
+      setMapCenter(center);
+      // Record the viewport so the re-fetch effect can refresh against
+      // it when the repo / perfProfile changes.
+      lastViewportRef.current = { bounds, center };
+      dispatchFetch(bounds, center);
+    },
+    [dispatchFetch],
+  );
+
+  // Re-fetch against the last known viewport when the data source or
+  // perf profile changes. A perf-mode toggle changes `nearbyRadius` /
+  // `maxResults`, so the visible stop set must refresh immediately
+  // rather than waiting for the next pan -- otherwise the radius label
+  // (derived synchronously from `perfProfile`) updates while the stop
+  // list stays stale. `dispatchFetch` also bumps the request id, so any
+  // in-flight fetch issued under the old repo / profile is invalidated
+  // and cannot overwrite the fresh result.
   //
-  // Bumping `latestRequestIdRef` here is safe even on the very first
-  // render: no fetch has been dispatched yet, so there is no id to
-  // collide with.
+  // The effect keys on `dispatchFetch`, whose identity changes exactly
+  // when `repo` / `perfProfile` / `debounceMs` change. On the very
+  // first render there is no viewport yet (no pan has happened), so
+  // there is nothing to re-fetch; the initial fetch is driven by the
+  // caller's first `handleBoundsChanged`.
   useEffect(() => {
-    ++latestRequestIdRef.current;
-    clearTimeout(debounceTimerRef.current);
-  }, [repo, perfProfile]);
+    const lastViewport = lastViewportRef.current;
+    if (lastViewport === null) {
+      return;
+    }
+    dispatchFetch(lastViewport.bounds, lastViewport.center);
+  }, [dispatchFetch]);
 
   // Cancel any pending debounce on unmount so the timeout cannot fire
   // a fetch after the consumer has gone away. The request-id guard

--- a/src/hooks/use-stops-for-bounds.ts
+++ b/src/hooks/use-stops-for-bounds.ts
@@ -48,6 +48,16 @@ export interface UseStopsForBoundsReturn {
   /** Stops within `nearbyRadius` of the current map center. */
   radiusStops: StopWithMeta[];
   /**
+   * The radius (metres) that the current `radiusStops` lie within, or
+   * `null` before the first committed fetch. This is the `perfProfile`
+   * `nearbyRadius` captured at commit time and set in the same state
+   * update as `radiusStops`, so after a `perfProfile` change it lags the
+   * live profile until the re-fetch commits. A consumer pairing a radius
+   * with the stop count should read this rather than the live
+   * `perfProfile`, so the label and count never disagree.
+   */
+  radius: number | null;
+  /**
    * Latest map center, updated immediately on every bounds-changed
    * event (not debounced).
    */
@@ -97,6 +107,7 @@ export function useStopsForBounds(params: UseStopsForBoundsParams): UseStopsForB
 
   const [inBoundStops, setInBoundStops] = useState<StopWithMeta[]>([]);
   const [radiusStops, setRadiusStops] = useState<StopWithMeta[]>([]);
+  const [radius, setRadius] = useState<number | null>(null);
   const [mapCenter, setMapCenter] = useState<LatLng | null>(null);
   const [hasNearbyLoaded, setHasNearbyLoaded] = useState(false);
 
@@ -173,6 +184,10 @@ export function useStopsForBounds(params: UseStopsForBoundsParams): UseStopsForB
           );
           setInBoundStops(inBounds);
           setRadiusStops(nearby);
+          // Commit the radius that these stops lie within in the same
+          // update, so a label reading `radius` flips together with the
+          // stop count rather than ahead of it.
+          setRadius(nearbyRadius);
           setHasNearbyLoaded(true);
           onStopsCommittedRef.current?.();
         });
@@ -228,5 +243,12 @@ export function useStopsForBounds(params: UseStopsForBoundsParams): UseStopsForB
     };
   }, []);
 
-  return { inBoundStops, radiusStops, mapCenter, hasNearbyLoaded, handleBoundsChanged };
+  return {
+    inBoundStops,
+    radiusStops,
+    radius,
+    mapCenter,
+    hasNearbyLoaded,
+    handleBoundsChanged,
+  };
 }


### PR DESCRIPTION
## Summary

Fixes the map-overlay **perf-mode toggle** so that the nearby-stop list and its radius label stay correct after a toggle. Two related regressions/defects around `useStopsForBounds`:

1. **Toggling perf mode did not re-fetch stops.** The radius label changed (e.g. `1km圏内` -> `500m圏内`) but the actual stop list stayed stale until the next pan, so label and data disagreed.
2. **Even once re-fetching, the radius label led the stop count.** The label read the live `perfProfile` while the count came from the committed fetch, so the `Xm 圏内` text flipped ~300ms (the debounce) before the count caught up.

Closes #274.

## Root cause

1. Regression from `8145da98` (extract `useStopsForBounds`). The old re-fetch path was implicit: a perf-mode change altered `perfProfile` -> changed `handleBoundsChanged`'s identity -> re-fired `MapView`'s `onBoundsChanged` effect -> re-fetch. The extracted hook added an invalidation effect that, because React runs child effects before parent effects, cleared the just-armed debounce timer (and bumped the request id) right after `MapView` re-dispatched, cancelling the re-fetch.
2. The radius label was sourced from the live `perfProfile.data.stops.nearbyRadius` (synchronous), while the count came from the committed `radiusStops` (async, debounced).

## Changes

- **`fix(stops): re-fetch nearby stops on perf-mode toggle`** — `useStopsForBounds` is now self-contained: it records the last viewport and re-dispatches the fetch through the shared request-id guard when `repo` / `perfProfile` changes, instead of relying on `MapView` re-firing `onBoundsChanged`. The in-flight invalidation guarantee is preserved.
- **`fix(stops): keep radius label in sync with displayed stop count`** — `useStopsForBounds` commits the radius the stops lie within in the same state update (new `radius` return value), and the summary label is driven from it. The radius-only `dataConfig` prop threaded through `BottomSheet` / `StopPanel` / `StopBrowser` / `StopBrowserHeader` is replaced by an explicit `stopsRadius` prop. No loading state is introduced.

## Verification

- typecheck / lint / prettier / build: pass
- tests: full suite green; new regression tests in `use-stops-for-bounds.test.ts` cover (a) re-fetch against the last viewport on a perf-profile change and (b) `radius` committing atomically with `radiusStops`
- Manual (Chrome DevTools): toggling perf mode now re-fetches, and high-frequency sampling shows the radius label and stop count transition together with no intermediate "new range + old count" state (e.g. `3カ所 / 1km圏内` -> `2カ所 / 500m圏内`, `2カ所 / 500m圏内` -> `10カ所 / 2km圏内`).

## Follow-up (out of scope)

Renaming the misleading time-basis props (`BottomSheetProps.time` -> `referenceTime`, and the project-wide `now` prop convention) is deferred to a separate refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
