### PR TITLE
refactor: clarify time-related prop names (virtualNow / relativeTimeNow)

### DIFF
--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -364,10 +364,10 @@ describe('App anchor error toast', () => {
       handleToggleAnchorByStopId: vi.fn(),
     });
     mockUseDateTime.mockReturnValue({
-      dateTime: new Date('2026-03-28T12:00:00Z'),
-      isCustomTime: false,
-      resetToNow: vi.fn(),
-      setCustomTime: vi.fn(),
+      virtualNow: new Date('2026-03-28T12:00:00Z'),
+      isVirtualNowPinned: false,
+      pinVirtualNow: vi.fn(),
+      unpinVirtualNow: vi.fn(),
     });
     mockGetServiceDayMinutes.mockReturnValue(12 * 60);
     mockUseNearbyStopTimes.mockReturnValue({

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -113,7 +113,7 @@ export default function App() {
   const [anchorRepo] = useState(() => new LocalStorageAnchorRepository());
   const [stopSelectionRepo] = useState(() => new LocalStorageStopSelectionRepository());
   const { settings, updateSetting, updateSettings } = useUserSettings();
-  const { dateTime, isCustomTime, resetToNow, setCustomTime } = useDateTime();
+  const { virtualNow, isVirtualNowPinned, pinVirtualNow, unpinVirtualNow } = useDateTime();
   const isWebStorageReady = useWebStorageAvailability('local');
 
   // Sync i18next language with user setting.
@@ -314,7 +314,7 @@ export default function App() {
 
   const { stopTimes: nearbyStopTimes, isNearbyLoading } = useNearbyStopTimes(
     radiusStops,
-    dateTime,
+    virtualNow,
     repo,
   );
 
@@ -510,7 +510,7 @@ export default function App() {
       }
       const [depsResult, rtResult] = await Promise.all([
         // No limit: stop-time stats and verbose display need all entries.
-        repo.getUpcomingTimetableEntries(stopId, dateTime),
+        repo.getUpcomingTimetableEntries(stopId, virtualNow),
         repo.getRouteTypesForStop(stopId),
       ]);
       const stopTimes = depsResult.success ? depsResult.data : [];
@@ -527,7 +527,7 @@ export default function App() {
         routes: meta.routes,
       };
     },
-    [repo, dateTime, inBoundStops, radiusStops],
+    [repo, virtualNow, inBoundStops, radiusStops],
   );
 
   const handleShowTimetable = useCallback(
@@ -536,11 +536,11 @@ export default function App() {
       if (!open) {
         return;
       }
-      void open({ stopId, routeId, headsign, dateTime }).then((status) => {
+      void open({ stopId, routeId, headsign, dateTime: virtualNow }).then((status) => {
         showOpenOutcomeToast(getTimetableOpenOutcomeMessage(status.status), t);
       });
     },
-    [dateTime, t],
+    [virtualNow, t],
   );
 
   const handleShowStopTimetable = useCallback(
@@ -549,11 +549,11 @@ export default function App() {
       if (!open) {
         return;
       }
-      void open({ stopId, dateTime }).then((status) => {
+      void open({ stopId, dateTime: virtualNow }).then((status) => {
         showOpenOutcomeToast(getTimetableOpenOutcomeMessage(status.status), t);
       });
     },
-    [dateTime, t],
+    [virtualNow, t],
   );
 
   // Thin launch wrappers over the imperative handle exposed by
@@ -562,9 +562,9 @@ export default function App() {
   // current time (captured at click time so it never goes stale).
   const handleOpenTripInspectionByStopId = useCallback(
     (stopId: string) => {
-      tripInspectionRef.current?.openByStopId({ stopId, referenceDateTime: dateTime });
+      tripInspectionRef.current?.openByStopId({ stopId, referenceDateTime: virtualNow });
     },
-    [dateTime],
+    [virtualNow],
   );
 
   const handleInspectTrip = useCallback((target: TripInspectionTarget) => {
@@ -685,7 +685,7 @@ export default function App() {
   // `deriveFilteredNearbyStops`; MapView reads the filtered result
   // (`stopTimes`) rather than `globalFilter` itself.
   const { showOriginOnly, showBoardableOnly, effectiveOmitEmptyStops, globalFilter } =
-    useGlobalFilter(dateTime);
+    useGlobalFilter(virtualNow);
 
   // --- Settings handlers ---
 
@@ -758,11 +758,11 @@ export default function App() {
     [settings.visibleRouteShapes],
   );
 
-  // Derive service day from dateTime. serviceDay itself recomputes every
+  // Derive service day from virtualNow. serviceDay itself recomputes every
   // 15-second tick (new Date), but serviceDayKey (string) only changes at
   // the 03:00 boundary. resolveRouteFreq depends on serviceDayKey, so
   // shapes re-render is skipped for the vast majority of ticks.
-  const serviceDay = useMemo(() => getServiceDay(dateTime), [dateTime]);
+  const serviceDay = useMemo(() => getServiceDay(virtualNow), [virtualNow]);
   const serviceDayKey = formatDateKey(serviceDay);
   const stableServiceDay = useMemo(() => {
     // `serviceDayKey` is `YYYYMMDD` (no separators) per `formatDateKey`,
@@ -881,7 +881,7 @@ export default function App() {
             renderMode={settings.renderMode}
             infoLevel={settings.infoLevel}
             dataLang={langChain}
-            time={dateTime}
+            time={virtualNow}
             onBoundsChanged={handleBoundsChanged}
             onStopSelected={handleSelectStop}
             onFetchStopTimes={handleFetchStopTimes}
@@ -943,10 +943,10 @@ export default function App() {
             }
             lookupAnchorStopMeta={lookupAnchorStopMeta}
             lookupHistoryStopMeta={lookupHistoryStopMeta}
-            time={dateTime}
-            isCustomTime={isCustomTime}
-            onResetToNow={resetToNow}
-            onCustomTimeSet={setCustomTime}
+            time={virtualNow}
+            isCustomTime={isVirtualNowPinned}
+            onResetToNow={unpinVirtualNow}
+            onCustomTimeSet={pinVirtualNow}
           />
         </MapViewContainer>
         <AppLayout
@@ -964,7 +964,7 @@ export default function App() {
             // before the first commit, while the summary still shows the
             // loading placeholder.
             stopsRadius: radius ?? perfProfile.data.stops.nearbyRadius,
-            time: dateTime,
+            time: virtualNow,
             mapCenter,
             infoLevel: settings.infoLevel,
             dataLangs: langChain,
@@ -1008,13 +1008,13 @@ export default function App() {
       <DataSourceSettingsContainer
         open={dataSourceSettingsDialogOpen}
         onOpenChange={setDataSourceSettingsDialogOpen}
-        referenceDateTime={dateTime}
+        referenceDateTime={virtualNow}
       />
       <ShortcutHelpDialog open={shortcutHelpOpen} onOpenChange={setShortcutHelpOpen} />
       <TripInspectionContainer
         ref={tripInspectionRef}
         repo={repo}
-        relativeTimeNow={dateTime}
+        relativeTimeNow={virtualNow}
         infoLevel={settings.infoLevel}
         dataLangs={langChain}
         onSelectStopById={handleSelectStopFromTripInspection}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -881,7 +881,7 @@ export default function App() {
             renderMode={settings.renderMode}
             infoLevel={settings.infoLevel}
             dataLang={langChain}
-            time={virtualNow}
+            relativeTimeNow={virtualNow}
             onBoundsChanged={handleBoundsChanged}
             onStopSelected={handleSelectStop}
             onFetchStopTimes={handleFetchStopTimes}
@@ -943,7 +943,7 @@ export default function App() {
             }
             lookupAnchorStopMeta={lookupAnchorStopMeta}
             lookupHistoryStopMeta={lookupHistoryStopMeta}
-            time={virtualNow}
+            virtualNow={virtualNow}
             isCustomTime={isVirtualNowPinned}
             onResetToNow={unpinVirtualNow}
             onCustomTimeSet={pinVirtualNow}
@@ -964,7 +964,7 @@ export default function App() {
             // before the first commit, while the summary still shows the
             // loading placeholder.
             stopsRadius: radius ?? perfProfile.data.stops.nearbyRadius,
-            time: virtualNow,
+            relativeTimeNow: virtualNow,
             mapCenter,
             infoLevel: settings.infoLevel,
             dataLangs: langChain,

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -35,7 +35,12 @@ export interface BottomSheetProps {
    * and the stop count change together on a perf-mode toggle.
    */
   stopsRadius: number;
-  time: Date;
+  /**
+   * The "now" for relative departure times ("in N min"). Usually the real
+   * clock, but the user can pin it (time picker / `?time=`); when pinned
+   * the countdown stops.
+   */
+  relativeTimeNow: Date;
   mapCenter: LatLng | null;
   infoLevel: InfoLevel;
   /** Display language chain for translated GTFS/ODPT data names. */
@@ -88,7 +93,7 @@ export function BottomSheet({
   isNearbyLoading: _isNearbyLoading,
   hasNearbyLoaded,
   stopsRadius,
-  time: now,
+  relativeTimeNow: now,
   mapCenter,
   infoLevel,
   dataLangs,

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -90,10 +90,13 @@ export function BottomSheet({
   stopTimes,
   timetableEntriesStateByStopId,
   selectedStopId,
+  // Intentionally unused (`_` prefix): by current spec the stop list does
+  // not render a re-fetch loading state. Kept rather than removed -- it is
+  // a meaningful loading-state signal that may be surfaced later.
   isNearbyLoading: _isNearbyLoading,
   hasNearbyLoaded,
   stopsRadius,
-  relativeTimeNow: now,
+  relativeTimeNow,
   mapCenter,
   infoLevel,
   dataLangs,
@@ -178,7 +181,7 @@ export function BottomSheet({
         selectedStopId={selectedStopId}
         hasNearbyLoaded={hasNearbyLoaded}
         stopsRadius={stopsRadius}
-        now={now}
+        now={relativeTimeNow}
         mapCenter={mapCenter}
         infoLevel={infoLevel}
         dataLangs={dataLangs}

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -90,10 +90,7 @@ export function BottomSheet({
   stopTimes,
   timetableEntriesStateByStopId,
   selectedStopId,
-  // Intentionally unused (`_` prefix): by current spec the stop list does
-  // not render a re-fetch loading state. Kept rather than removed -- it is
-  // a meaningful loading-state signal that may be surfaced later.
-  isNearbyLoading: _isNearbyLoading,
+  isNearbyLoading,
   hasNearbyLoaded,
   stopsRadius,
   relativeTimeNow,
@@ -179,6 +176,7 @@ export function BottomSheet({
         stopTimes={stopTimes}
         timetableEntriesStateByStopId={timetableEntriesStateByStopId}
         selectedStopId={selectedStopId}
+        isNearbyLoading={isNearbyLoading}
         hasNearbyLoaded={hasNearbyLoaded}
         stopsRadius={stopsRadius}
         now={relativeTimeNow}

--- a/src/components/map/map-overlay.tsx
+++ b/src/components/map/map-overlay.tsx
@@ -81,8 +81,8 @@ interface MapOverlayProps {
   lookupAnchorStopMeta: (stopId: string) => StopWithMeta | null;
   lookupHistoryStopMeta: (stopId: string) => StopWithMeta | null;
   tileIndex: number | null;
-  /** Currently displayed time (from `useDateTime`). */
-  time: Date;
+  /** The app's virtual "now" shown in the time-control bar (live clock, or a pinned custom time). */
+  virtualNow: Date;
   /** True when the displayed time is user-pinned (not "now"). */
   isCustomTime: boolean;
   /** Reset the displayed time back to the live "now" clock. */
@@ -137,7 +137,7 @@ export function MapOverlay({
   lookupAnchorStopMeta,
   lookupHistoryStopMeta,
   tileIndex,
-  time,
+  virtualNow,
   isCustomTime,
   onResetToNow,
   onCustomTimeSet,
@@ -185,7 +185,7 @@ export function MapOverlay({
       <StopControlPanel infoLevel={infoLevel} onSearchClick={onSearchClick} />
       <InfoPanel infoLevel={infoLevel} onInfoClick={onInfoClick} />
       <TimeControls
-        time={time}
+        time={virtualNow}
         isCustomTime={isCustomTime}
         onResetToNow={onResetToNow}
         onCustomTimeSet={onCustomTimeSet}

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -308,7 +308,7 @@ export function MapView({
   renderMode,
   infoLevel,
   dataLang,
-  relativeTimeNow: now,
+  relativeTimeNow,
   onBoundsChanged,
   onStopSelected,
   onFetchStopTimes,
@@ -611,7 +611,7 @@ export function MapView({
           agenciesMap={agenciesMap}
           showTooltip={true}
           // showTooltip={false}
-          time={now}
+          time={relativeTimeNow}
           infoLevel={infoLevel}
           dataLang={dataLang}
           renderMode={nearbyRenderMode}
@@ -642,7 +642,7 @@ export function MapView({
             routeTypeMap={routeStopsRouteTypeMap}
             showTooltip={true}
             stopTimes={timetableEntriesMap}
-            time={now}
+            time={relativeTimeNow}
             renderMode={nearbyRenderMode}
             infoLevel={infoLevel}
             dataLang={dataLang}
@@ -660,7 +660,7 @@ export function MapView({
           stops={filteredNearbyStops}
           routeTypeMap={routeTypeMap}
           agenciesMap={agenciesMap}
-          now={now}
+          now={relativeTimeNow}
           infoLevel={infoLevel}
           dataLang={dataLang}
           renderMode={nearbyRenderMode}

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -235,7 +235,12 @@ export interface MapViewProps {
   infoLevel: InfoLevel;
   /** Display language chain for translated GTFS/ODPT data names. */
   dataLang: readonly string[];
-  time: Date;
+  /**
+   * The "now" for relative departure times ("in N min"). Usually the real
+   * clock, but the user can pin it (time picker / `?time=`); when pinned
+   * the countdown stops.
+   */
+  relativeTimeNow: Date;
   onBoundsChanged: (bounds: Bounds, center: LatLng) => void;
   onStopSelected: (stop: Stop) => void;
   onFetchStopTimes: (stopId: string) => Promise<StopWithContext | null>;
@@ -303,7 +308,7 @@ export function MapView({
   renderMode,
   infoLevel,
   dataLang,
-  time: now,
+  relativeTimeNow: now,
   onBoundsChanged,
   onStopSelected,
   onFetchStopTimes,

--- a/src/components/stop-browser.tsx
+++ b/src/components/stop-browser.tsx
@@ -48,6 +48,7 @@ export interface StopBrowserProps {
    */
   timetableEntriesStateByStopId: ReadonlyMap<string, TimetableEntriesState>;
   selectedStopId: string | null;
+  isNearbyLoading: boolean;
   hasNearbyLoaded: boolean;
   /** Radius (metres) within which the displayed stops were collected; shown in the header summary. */
   stopsRadius: number;
@@ -93,6 +94,11 @@ export function StopBrowser({
   stopTimes,
   timetableEntriesStateByStopId,
   selectedStopId,
+  // Intentionally unused (`_` prefix): by current spec the stop list does
+  // not render a re-fetch loading state. Kept rather than removed -- it is
+  // a meaningful loading-state signal that may be surfaced later. Held here
+  // (the shared StopBrowser) so both BottomSheet and StopPanel forward it.
+  isNearbyLoading: _isNearbyLoading,
   hasNearbyLoaded,
   stopsRadius,
   now,

--- a/src/components/stop-browser.tsx
+++ b/src/components/stop-browser.tsx
@@ -52,6 +52,11 @@ export interface StopBrowserProps {
   hasNearbyLoaded: boolean;
   /** Radius (metres) within which the displayed stops were collected; shown in the header summary. */
   stopsRadius: number;
+  /**
+   * Reference "now" for relative departure times (the surface's
+   * `relativeTimeNow`, forwarded under the rendering-subtree's `now`
+   * convention); pinnable, so the countdown freezes when pinned.
+   */
   now: Date;
   mapCenter: LatLng | null;
   infoLevel: InfoLevel;

--- a/src/components/stop-panel.tsx
+++ b/src/components/stop-panel.tsx
@@ -22,7 +22,7 @@ export function StopPanel({
   selectedStopId,
   hasNearbyLoaded,
   stopsRadius,
-  relativeTimeNow: now,
+  relativeTimeNow,
   mapCenter,
   infoLevel,
   dataLangs,
@@ -45,7 +45,7 @@ export function StopPanel({
         selectedStopId={selectedStopId}
         hasNearbyLoaded={hasNearbyLoaded}
         stopsRadius={stopsRadius}
-        now={now}
+        now={relativeTimeNow}
         mapCenter={mapCenter}
         infoLevel={infoLevel}
         dataLangs={dataLangs}

--- a/src/components/stop-panel.tsx
+++ b/src/components/stop-panel.tsx
@@ -20,6 +20,7 @@ export function StopPanel({
   stopTimes,
   timetableEntriesStateByStopId,
   selectedStopId,
+  isNearbyLoading,
   hasNearbyLoaded,
   stopsRadius,
   relativeTimeNow,
@@ -43,6 +44,7 @@ export function StopPanel({
         stopTimes={stopTimes}
         timetableEntriesStateByStopId={timetableEntriesStateByStopId}
         selectedStopId={selectedStopId}
+        isNearbyLoading={isNearbyLoading}
         hasNearbyLoaded={hasNearbyLoaded}
         stopsRadius={stopsRadius}
         now={relativeTimeNow}

--- a/src/components/stop-panel.tsx
+++ b/src/components/stop-panel.tsx
@@ -22,7 +22,7 @@ export function StopPanel({
   selectedStopId,
   hasNearbyLoaded,
   stopsRadius,
-  time: now,
+  relativeTimeNow: now,
   mapCenter,
   infoLevel,
   dataLangs,

--- a/src/hooks/__tests__/use-date-time.test.ts
+++ b/src/hooks/__tests__/use-date-time.test.ts
@@ -15,19 +15,19 @@ describe('useDateTime', () => {
     const before = new Date();
     const { result } = renderHook(() => useDateTime());
 
-    expect(result.current.isCustomTime).toBe(false);
-    expect(result.current.dateTime.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(result.current.isVirtualNowPinned).toBe(false);
+    expect(result.current.virtualNow.getTime()).toBeGreaterThanOrEqual(before.getTime());
   });
 
-  it('updates dateTime every 15 seconds in real-time mode', () => {
+  it('updates virtualNow every 15 seconds in real-time mode', () => {
     const { result } = renderHook(() => useDateTime());
-    const initial = result.current.dateTime.getTime();
+    const initial = result.current.virtualNow.getTime();
 
     act(() => {
       vi.advanceTimersByTime(15_000);
     });
 
-    expect(result.current.dateTime.getTime()).toBeGreaterThan(initial);
+    expect(result.current.virtualNow.getTime()).toBeGreaterThan(initial);
   });
 
   it('switches to custom time mode', () => {
@@ -35,11 +35,11 @@ describe('useDateTime', () => {
     const custom = new Date('2025-01-01T12:00:00');
 
     act(() => {
-      result.current.setCustomTime(custom);
+      result.current.pinVirtualNow(custom);
     });
 
-    expect(result.current.isCustomTime).toBe(true);
-    expect(result.current.dateTime).toBe(custom);
+    expect(result.current.isVirtualNowPinned).toBe(true);
+    expect(result.current.virtualNow).toBe(custom);
   });
 
   it('stops interval updates in custom time mode', () => {
@@ -47,61 +47,61 @@ describe('useDateTime', () => {
     const custom = new Date('2025-01-01T12:00:00');
 
     act(() => {
-      result.current.setCustomTime(custom);
+      result.current.pinVirtualNow(custom);
     });
 
     act(() => {
       vi.advanceTimersByTime(30_000);
     });
 
-    // dateTime should still be the custom time, not updated
-    expect(result.current.dateTime).toBe(custom);
+    // virtualNow should still be the custom time, not updated
+    expect(result.current.virtualNow).toBe(custom);
   });
 
   it('resets to real-time mode', () => {
     const { result } = renderHook(() => useDateTime());
 
     act(() => {
-      result.current.setCustomTime(new Date('2025-01-01T12:00:00'));
+      result.current.pinVirtualNow(new Date('2025-01-01T12:00:00'));
     });
-    expect(result.current.isCustomTime).toBe(true);
+    expect(result.current.isVirtualNowPinned).toBe(true);
 
     act(() => {
-      result.current.resetToNow();
+      result.current.unpinVirtualNow();
     });
 
-    expect(result.current.isCustomTime).toBe(false);
+    expect(result.current.isVirtualNowPinned).toBe(false);
   });
 
   it('resumes interval after reset to now', () => {
     const { result } = renderHook(() => useDateTime());
 
     act(() => {
-      result.current.setCustomTime(new Date('2025-01-01T12:00:00'));
+      result.current.pinVirtualNow(new Date('2025-01-01T12:00:00'));
     });
 
     act(() => {
-      result.current.resetToNow();
+      result.current.unpinVirtualNow();
     });
 
-    const afterReset = result.current.dateTime.getTime();
+    const afterReset = result.current.virtualNow.getTime();
 
     act(() => {
       vi.advanceTimersByTime(15_000);
     });
 
-    expect(result.current.dateTime.getTime()).toBeGreaterThan(afterReset);
+    expect(result.current.virtualNow.getTime()).toBeGreaterThan(afterReset);
   });
 
-  it('does not update dateTime before 15 seconds', () => {
+  it('does not update virtualNow before 15 seconds', () => {
     const { result } = renderHook(() => useDateTime());
-    const initial = result.current.dateTime.getTime();
+    const initial = result.current.virtualNow.getTime();
 
     act(() => {
       vi.advanceTimersByTime(14_999);
     });
 
-    expect(result.current.dateTime.getTime()).toBe(initial);
+    expect(result.current.virtualNow.getTime()).toBe(initial);
   });
 
   it('replaces a previous custom time with a new one', () => {
@@ -110,31 +110,31 @@ describe('useDateTime', () => {
     const second = new Date('2025-06-15T18:30:00');
 
     act(() => {
-      result.current.setCustomTime(first);
+      result.current.pinVirtualNow(first);
     });
-    expect(result.current.dateTime).toBe(first);
+    expect(result.current.virtualNow).toBe(first);
 
     act(() => {
-      result.current.setCustomTime(second);
+      result.current.pinVirtualNow(second);
     });
-    expect(result.current.dateTime).toBe(second);
-    expect(result.current.isCustomTime).toBe(true);
+    expect(result.current.virtualNow).toBe(second);
+    expect(result.current.isVirtualNowPinned).toBe(true);
   });
 
-  it('resetToNow returns a fresh Date, not the old custom time', () => {
+  it('unpinVirtualNow returns a fresh Date, not the old custom time', () => {
     const { result } = renderHook(() => useDateTime());
     const oldCustom = new Date('2000-01-01T00:00:00');
 
     act(() => {
-      result.current.setCustomTime(oldCustom);
+      result.current.pinVirtualNow(oldCustom);
     });
 
     act(() => {
-      result.current.resetToNow();
+      result.current.unpinVirtualNow();
     });
 
     // The reset time should be much later than the old custom time
-    expect(result.current.dateTime.getTime()).toBeGreaterThan(oldCustom.getTime());
+    expect(result.current.virtualNow.getTime()).toBeGreaterThan(oldCustom.getTime());
   });
 
   it('cleans up interval on unmount', () => {

--- a/src/hooks/use-date-time.ts
+++ b/src/hooks/use-date-time.ts
@@ -9,14 +9,14 @@ const NOW_UPDATE_INTERVAL_MS = 15_000;
  * Return type for the useDateTime hook.
  */
 export interface UseDateTimeReturn {
-  /** The effective date/time (custom or real-time). */
-  dateTime: Date;
-  /** Whether a custom time is active. */
-  isCustomTime: boolean;
-  /** Reset to real-time mode. */
-  resetToNow: () => void;
-  /** Set a custom time (switches to manual mode). */
-  setCustomTime: (date: Date) => void;
+  /** The app's virtual "now": the live clock (updates every 15s) or a pinned custom time. */
+  virtualNow: Date;
+  /** Whether `virtualNow` is pinned to a custom time (true) or tracking the live clock (false). */
+  isVirtualNowPinned: boolean;
+  /** Pin `virtualNow` to a specific instant (switches off live tracking). */
+  pinVirtualNow: (date: Date) => void;
+  /** Release the pin and resume tracking the live clock. */
+  unpinVirtualNow: () => void;
 }
 
 /**
@@ -38,8 +38,8 @@ export function useDateTime(): UseDateTimeReturn {
     return param;
   });
 
-  const isCustomTime = customTime !== null;
-  const dateTime = customTime ?? now;
+  const isVirtualNowPinned = customTime !== null;
+  const virtualNow = customTime ?? now;
 
   // Auto-update `now` every 15 seconds in real-time mode
   useEffect(() => {
@@ -52,16 +52,16 @@ export function useDateTime(): UseDateTimeReturn {
     return () => clearInterval(id);
   }, [customTime]);
 
-  const resetToNow = useCallback(() => {
+  const unpinVirtualNow = useCallback(() => {
     logger.info('Reset to real-time mode');
     setCustomTimeState(null);
     setNow(new Date());
   }, []);
 
-  const setCustomTime = useCallback((date: Date) => {
+  const pinVirtualNow = useCallback((date: Date) => {
     logger.info(`Custom time set: ${date.toISOString()}`);
     setCustomTimeState(date);
   }, []);
 
-  return { dateTime, isCustomTime, resetToNow, setCustomTime };
+  return { virtualNow, isVirtualNowPinned, pinVirtualNow, unpinVirtualNow };
 }


### PR DESCRIPTION
## Summary

Clarify time-related prop names so the same value reads consistently from its source in `useDateTime` down to where it is consumed. Naming and docs only -- no behavior change.

The core idea: one source-of-truth value (the app's virtual "now") fans out under purpose-specific names.

- **Source** (`useDateTime`): `virtualNow` -- the app's virtual "now" (the live clock that updates every 15s, or a pinned custom time).
- **Relative-time role** (app-facing surfaces): `relativeTimeNow` -- the reference "now" for relative departure times ("in N min").
- **Rendering subtree**: keeps the established `now` convention; the `relativeTimeNow -> now` seam sits at the shell -> content boundary and is documented.

## Changes

- `useDateTime` / `UseDateTimeReturn`: rename the 4 members for clarity, scoped with `virtualNow` so they stay unambiguous if the hook gains other time state. Hook / interface names kept general on purpose.
  - `dateTime` -> `virtualNow`
  - `isCustomTime` -> `isVirtualNowPinned`
  - `setCustomTime` -> `pinVirtualNow`
  - `resetToNow` -> `unpinVirtualNow`
- App-boundary `time` props named by purpose:
  - `MapView.time` / `BottomSheet.time` -> `relativeTimeNow` (relative departure-time basis)
  - `MapOverlay.time` -> `virtualNow` (shown as-is in the time-control bar)
- `MapView` / `BottomSheet` / `StopPanel`: use `relativeTimeNow` directly instead of aliasing back to a local `now`.
- `isNearbyLoading`: routed through the shared `StopBrowser` (used by both `BottomSheet` and `StopPanel`) and documented as intentionally unused -- by current spec the stop list does not render a re-fetch loading state, but the signal is kept as meaningful state.
- `StopBrowserProps.now`: documented as the `relativeTimeNow` seam (the rendering subtree's `now` convention is intentionally left as-is).

## Out of scope (deliberately left)

- The deep `now` convention across the rendering subtree (StopGrid / NearbyStop / StopTimeItem / RelativeTime / markers / trip views) -- self-evident in those dedicated relative-time renderers; broad churn for low gain.
- The picker chain's `isCustomTime` / `onCustomTimeSet` / `onResetToNow` vocabulary -- "custom time" reads naturally in the time-setting UI; treated as a valid local vocabulary bridged in `app.tsx`.
- `nearbyStopsCounts` / `filteredNearbyStopsCounts`, `dataLangs`/`dataLang`, `stopTimes` (intentional project vocabulary).

## Verification

typecheck / lint / prettier / build all pass; full test suite green (309 files, 4295 tests). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
