### PR TITLE
feat(transit-display): departures/arrivals split-flap board view

### DIFF
--- a/pipeline/scripts/dev/dev-lib/__tests__/v2-data-summary.test.ts
+++ b/pipeline/scripts/dev/dev-lib/__tests__/v2-data-summary.test.ts
@@ -493,6 +493,13 @@ describe('routes summary', () => {
 describe('trip patterns summary', () => {
   it('captures count, direction_id split, and trip/stop headsign coverage', () => {
     const bundle = createDataBundle({
+      routes: {
+        v: 2,
+        data: [
+          { v: 2, i: 'src:r1', s: 'B1', l: 'Bus Route', t: 3, c: '', tc: '', ai: 'src:a1' },
+          { v: 2, i: 'src:r2', s: 'R1', l: 'Rail Route', t: 2, c: '', tc: '', ai: 'src:a1' },
+        ],
+      },
       tripPatterns: {
         v: 2,
         data: {
@@ -509,7 +516,7 @@ describe('trip patterns summary', () => {
           // direction_id omitted, trip headsign + a mix of sh / no-sh stops.
           'src:p3': {
             v: 2,
-            r: 'src:r1',
+            r: 'src:r2',
             h: 'Loop',
             stops: [{ id: 'src:s1' }, { id: 'src:s2', sh: 'Loop branch' }],
           },
@@ -517,7 +524,7 @@ describe('trip patterns summary', () => {
           // (the keio-bus convention).
           'src:p4': {
             v: 2,
-            r: 'src:r1',
+            r: 'src:r2',
             h: '',
             stops: [{ id: 'src:s1', sh: 'Terminal' }],
           },
@@ -540,6 +547,12 @@ describe('trip patterns summary', () => {
     expect(stats.tripPatterns.withTripHeadsignCount).toBe(3);
     // p1, p3, p4 have at least one stop carrying sh; p2 has none.
     expect(stats.tripPatterns.withStopHeadsignCount).toBe(3);
+    expect(stats.tripPatterns.routeTypeCounts).toEqual({ '2': 1, '3': 1 });
+    expect(stats.tripPatterns.patternRouteTypeCounts).toEqual({ '2': 2, '3': 2 });
+    expect(stats.tripPatterns.directionCountsByRouteType).toEqual({
+      '2': { direction0Count: 0, direction1Count: 0, directionNoneCount: 2 },
+      '3': { direction0Count: 1, direction1Count: 1, directionNoneCount: 0 },
+    });
   });
 
   it('returns zero counts for an empty tripPatterns record', () => {
@@ -555,11 +568,14 @@ describe('trip patterns summary', () => {
     expect(stats.tripPatterns.direction0Count).toBe(0);
     expect(stats.tripPatterns.direction1Count).toBe(0);
     expect(stats.tripPatterns.directionNoneCount).toBe(0);
+    expect(stats.tripPatterns.routeTypeCounts).toEqual({ '3': 1 });
+    expect(stats.tripPatterns.patternRouteTypeCounts).toEqual({});
+    expect(stats.tripPatterns.directionCountsByRouteType).toEqual({});
     expect(stats.tripPatterns.withTripHeadsignCount).toBe(0);
     expect(stats.tripPatterns.withStopHeadsignCount).toBe(0);
   });
 
-  it('renders a single Summary table with every facet column', () => {
+  it('renders Summary and direction analysis with route-type facets', () => {
     const stats = analyzeV2DataVolume({
       prefix: 'src',
       nameEn: 'Src Transit',
@@ -569,13 +585,16 @@ describe('trip patterns summary', () => {
     });
     const body = V2_DATA_VOLUME_SECTIONS['trip-patterns'].render([stats]);
     expect(body).toContain('### Summary');
+    expect(body).toContain('routeTypes');
+    expect(body).toContain('patternsByType');
     expect(body).toContain('directionCounts');
+    expect(body).toContain('directionByType');
+    expect(body).toContain('bus:');
+    expect(body).toContain('bus(0:');
     expect(body).toContain('withTripHeadsign');
     expect(body).toContain('withStopHeadsign');
     // directionCounts breakdown string keeps all three keys.
     expect(body).toContain('none:');
-    // Flat section — no detail sub-sections.
-    expect(body).not.toContain('### Direction');
     expect(body).not.toContain('### Headsign');
   });
 });

--- a/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
@@ -292,6 +292,7 @@ export type V2DataVolumeSectionName =
   | 'routes'
   | 'stops'
   | 'trip-patterns'
+  | 'directions'
   | 'i18n-coverage'
   | 'periods'
   | 'file-sizes'
@@ -1087,6 +1088,190 @@ function formatDirectionCounts(s: TripPatternsSummary): string {
   return `0:${s.direction0Count}, 1:${s.direction1Count}, none:${s.directionNoneCount}`;
 }
 
+type DirectionMode =
+  | 'no-patterns'
+  | '0-only'
+  | '1-only'
+  | 'none-only'
+  | '0+1'
+  | '0+none'
+  | '1+none'
+  | '0+1+none';
+
+const DIRECTION_MODE_ORDER: readonly DirectionMode[] = [
+  '0-only',
+  '1-only',
+  'none-only',
+  '0+1',
+  '0+none',
+  '1+none',
+  '0+1+none',
+  'no-patterns',
+];
+
+function classifyDirectionMode(summary: TripPatternsSummary): DirectionMode {
+  const has0 = summary.direction0Count > 0;
+  const has1 = summary.direction1Count > 0;
+  const hasNone = summary.directionNoneCount > 0;
+  if (!has0 && !has1 && !hasNone) {
+    return 'no-patterns';
+  }
+  if (has0 && !has1 && !hasNone) {
+    return '0-only';
+  }
+  if (!has0 && has1 && !hasNone) {
+    return '1-only';
+  }
+  if (!has0 && !has1 && hasNone) {
+    return 'none-only';
+  }
+  if (has0 && has1 && !hasNone) {
+    return '0+1';
+  }
+  if (has0 && !has1 && hasNone) {
+    return '0+none';
+  }
+  if (!has0 && has1 && hasNone) {
+    return '1+none';
+  }
+  return '0+1+none';
+}
+
+function formatDirectionModeCounts(counts: Record<DirectionMode, number>): string {
+  return DIRECTION_MODE_ORDER.map((mode) => `${mode}:${counts[mode]}`).join(', ');
+}
+
+function isDirectionCompleteMode(mode: DirectionMode): boolean {
+  return mode === '0-only' || mode === '1-only' || mode === '0+1';
+}
+
+function isDirectionMixedWithNoneMode(mode: DirectionMode): boolean {
+  return mode === '0+none' || mode === '1+none' || mode === '0+1+none';
+}
+
+interface DirectionAnalysisRow {
+  nameEn: string;
+  prefix: string;
+  mode: DirectionMode;
+  count: number;
+  directionCounts: string;
+}
+
+function renderDirectionModeSubsection(mode: DirectionMode, rows: DirectionAnalysisRow[]): string {
+  const header = ['source', 'prefix', 'count', 'directionCounts'];
+  const modeRows = rows.filter((row) => row.mode === mode);
+  const totalPatterns = modeRows.reduce((acc, row) => acc + row.count, 0);
+  if (modeRows.length === 0) {
+    return [`### Mode: ${mode}`, '', 'sources=0, tripPatterns=0', '', '-'].join('\n');
+  }
+  const tableRows: string[][] = modeRows.map((row) => [
+    row.nameEn,
+    row.prefix,
+    String(row.count),
+    row.directionCounts,
+  ]);
+  tableRows.push(['totals', '', String(totalPatterns), '-']);
+  return [
+    `### Mode: ${mode}`,
+    '',
+    `sources=${modeRows.length}, tripPatterns=${totalPatterns}`,
+    '',
+    renderTable(header, tableRows, header.length),
+  ].join('\n');
+}
+
+/**
+ * Render source-level direction_id completeness / mixture analysis.
+ *
+ * Unlike `trip-patterns`, which reports pattern counts, this section
+ * classifies the whole source by which `dir` states appear. That makes
+ * incomplete direction modeling visible at a glance: complete sources
+ * have only 0/1 values, ODPT-like sources are `none-only`, and mixed
+ * sources contain both explicit and omitted direction_id values.
+ */
+function formatDirectionsSectionBody(results: V2DataVolumeStats[]): string {
+  const modeCounts: Record<DirectionMode, number> = {
+    '0-only': 0,
+    '1-only': 0,
+    'none-only': 0,
+    '0+1': 0,
+    '0+none': 0,
+    '1+none': 0,
+    '0+1+none': 0,
+    'no-patterns': 0,
+  };
+  let completeSources = 0;
+  let noneOnlySources = 0;
+  let mixedWithNoneSources = 0;
+
+  const header = ['source', 'prefix', 'mode', 'count', 'directionCounts'];
+  const analysisRows: DirectionAnalysisRow[] = results.map((result) => {
+    const mode = classifyDirectionMode(result.tripPatterns);
+    modeCounts[mode] += 1;
+    if (isDirectionCompleteMode(mode)) {
+      completeSources += 1;
+    }
+    if (mode === 'none-only') {
+      noneOnlySources += 1;
+    }
+    if (isDirectionMixedWithNoneMode(mode)) {
+      mixedWithNoneSources += 1;
+    }
+    return {
+      nameEn: result.nameEn,
+      prefix: result.prefix,
+      mode,
+      count: result.tripPatterns.count,
+      directionCounts: formatDirectionCounts(result.tripPatterns),
+    };
+  });
+  const rows: string[][] = analysisRows.map((row) => [
+    row.nameEn,
+    row.prefix,
+    row.mode,
+    String(row.count),
+    row.directionCounts,
+  ]);
+
+  const totalPatterns = results.reduce((acc, result) => acc + result.tripPatterns.count, 0);
+  const totalDirection0 = results.reduce(
+    (acc, result) => acc + result.tripPatterns.direction0Count,
+    0,
+  );
+  const totalDirection1 = results.reduce(
+    (acc, result) => acc + result.tripPatterns.direction1Count,
+    0,
+  );
+  const totalDirectionNone = results.reduce(
+    (acc, result) => acc + result.tripPatterns.directionNoneCount,
+    0,
+  );
+  const totalsDirectionCounts = `0:${totalDirection0}, 1:${totalDirection1}, none:${totalDirectionNone}`;
+  rows.push([
+    'totals',
+    '',
+    formatDirectionModeCounts(modeCounts),
+    String(totalPatterns),
+    totalsDirectionCounts,
+  ]);
+
+  return [
+    '### Totals',
+    '',
+    `sources=${results.length}, completeSources=${completeSources}, noneOnlySources=${noneOnlySources}, mixedWithNoneSources=${mixedWithNoneSources}`,
+    `sourceModes=${formatDirectionModeCounts(modeCounts)}`,
+    '',
+    '### Summary',
+    '',
+    renderTable(header, rows, header.length),
+    '',
+    ...DIRECTION_MODE_ORDER.flatMap((mode) => [
+      renderDirectionModeSubsection(mode, analysisRows),
+      '',
+    ]).slice(0, -1),
+  ].join('\n');
+}
+
 /**
  * Render the `trip-patterns` section as a single Summary table.
  *
@@ -1491,6 +1676,13 @@ export const V2_DATA_VOLUME_SECTIONS = {
       'Trip pattern inventory (Athenai abstraction: unique route + headsign + direction + stop-sequence combination). Single Summary table. `directionCounts` is the direction_id 0/1/none split (ODPT sources omit direction_id so they read as all-none); `withTripHeadsign` / `withStopHeadsign` count patterns carrying a trip-level (`h`) / stop-level (`stops[].sh`) headsign, revealing the source headsign convention.',
     render: formatTripPatternsSectionBody,
   },
+  directions: {
+    name: 'directions',
+    title: 'DataBundle directions (data.json)',
+    description:
+      'Source-level direction_id completeness analysis based on TripPatternJson.dir. Classifies each source as 0-only / 1-only / none-only / 0+1 / mixed-with-none variants, then repeats the rows in per-mode sub-sections so omitted or partially omitted direction_id feeds are easy to scan.',
+    render: formatDirectionsSectionBody,
+  },
   'i18n-coverage': {
     name: 'i18n-coverage',
     title: 'DataBundle i18n-coverage (data.json)',
@@ -1521,6 +1713,7 @@ export const V2_DATA_VOLUME_SECTION_NAMES: readonly V2DataVolumeSectionName[] = 
   'routes',
   'stops',
   'trip-patterns',
+  'directions',
   'i18n-coverage',
   // Composite sections within DataBundle (combine multiple keys) —
   // synthesis / interpretation comes last.

--- a/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
@@ -201,12 +201,28 @@ export interface RoutesSummary {
  * The two together reveal a source's headsign convention: some
  * sources populate only `h`, some (e.g. keio-bus) leave `h` blank
  * and rely entirely on `sh`, and some populate both.
+ *
+ * `routeTypeCounts` counts the source's route inventory by GTFS
+ * `route_type`, while `patternRouteTypeCounts` counts trip patterns
+ * by the route_type of their referenced route. Comparing these helps
+ * inspect whether direction_id usage differs by mode (rail / bus / etc.)
+ * without leaving the trip-patterns section.
  */
 export interface TripPatternsSummary {
   count: number;
   direction0Count: number;
   direction1Count: number;
   directionNoneCount: number;
+  routeTypeCounts: Record<string, number>;
+  patternRouteTypeCounts: Record<string, number>;
+  directionCountsByRouteType: Record<
+    string,
+    {
+      direction0Count: number;
+      direction1Count: number;
+      directionNoneCount: number;
+    }
+  >;
   withTripHeadsignCount: number;
   withStopHeadsignCount: number;
 }
@@ -507,18 +523,37 @@ function buildRoutesSummary(bundle: DataBundle): RoutesSummary {
  */
 function buildTripPatternsSummary(bundle: DataBundle): TripPatternsSummary {
   const patterns = Object.values(bundle.tripPatterns.data);
+  const routeTypesByRouteId = new Map<string, string>();
+  const routeTypeCounts: Record<string, number> = {};
+  for (const route of bundle.routes.data) {
+    const routeType = String(route.t);
+    routeTypesByRouteId.set(route.i, routeType);
+    routeTypeCounts[routeType] = (routeTypeCounts[routeType] ?? 0) + 1;
+  }
+  const patternRouteTypeCounts: Record<string, number> = {};
+  const directionCountsByRouteType: TripPatternsSummary['directionCountsByRouteType'] = {};
   let direction0Count = 0;
   let direction1Count = 0;
   let directionNoneCount = 0;
   let withTripHeadsignCount = 0;
   let withStopHeadsignCount = 0;
   for (const pattern of patterns) {
+    const routeType = routeTypesByRouteId.get(pattern.r) ?? 'missing-route';
+    patternRouteTypeCounts[routeType] = (patternRouteTypeCounts[routeType] ?? 0) + 1;
+    const directionByType = (directionCountsByRouteType[routeType] ??= {
+      direction0Count: 0,
+      direction1Count: 0,
+      directionNoneCount: 0,
+    });
     if (pattern.dir === 0) {
       direction0Count += 1;
+      directionByType.direction0Count += 1;
     } else if (pattern.dir === 1) {
       direction1Count += 1;
+      directionByType.direction1Count += 1;
     } else {
       directionNoneCount += 1;
+      directionByType.directionNoneCount += 1;
     }
     if (pattern.h !== '') {
       withTripHeadsignCount += 1;
@@ -534,6 +569,9 @@ function buildTripPatternsSummary(bundle: DataBundle): TripPatternsSummary {
     direction0Count,
     direction1Count,
     directionNoneCount,
+    routeTypeCounts,
+    patternRouteTypeCounts,
+    directionCountsByRouteType,
     withTripHeadsignCount,
     withStopHeadsignCount,
   };
@@ -1087,6 +1125,29 @@ function formatDirectionCounts(s: TripPatternsSummary): string {
   return `0:${s.direction0Count}, 1:${s.direction1Count}, none:${s.directionNoneCount}`;
 }
 
+function formatDirectionBreakdown(counts: {
+  direction0Count: number;
+  direction1Count: number;
+  directionNoneCount: number;
+}): string {
+  return `0:${counts.direction0Count}, 1:${counts.direction1Count}, none:${counts.directionNoneCount}`;
+}
+
+function formatDirectionCountsByRouteType(s: TripPatternsSummary): string {
+  const entries = Object.entries(s.directionCountsByRouteType).sort(([left], [right]) =>
+    compareRouteTypeKeys(left, right),
+  );
+  if (entries.length === 0) {
+    return '-';
+  }
+  return entries
+    .map(
+      ([routeType, counts]) =>
+        `${formatRouteTypeLabel(routeType)}(${formatDirectionBreakdown(counts)})`,
+    )
+    .join(', ');
+}
+
 type DirectionMode =
   | 'no-patterns'
   | '0-only'
@@ -1153,11 +1214,13 @@ interface DirectionAnalysisRow {
   prefix: string;
   mode: DirectionMode;
   count: number;
+  routeTypes: string;
   directionCounts: string;
+  directionByType: string;
 }
 
 function renderDirectionModeSubsection(mode: DirectionMode, rows: DirectionAnalysisRow[]): string {
-  const header = ['source', 'prefix', 'count', 'directionCounts'];
+  const header = ['source', 'prefix', 'count', 'routeTypes', 'directionCounts', 'directionByType'];
   const modeRows = rows.filter((row) => row.mode === mode);
   const totalPatterns = modeRows.reduce((acc, row) => acc + row.count, 0);
   if (modeRows.length === 0) {
@@ -1167,9 +1230,11 @@ function renderDirectionModeSubsection(mode: DirectionMode, rows: DirectionAnaly
     row.nameEn,
     row.prefix,
     String(row.count),
+    row.routeTypes,
     row.directionCounts,
+    row.directionByType,
   ]);
-  tableRows.push(['totals', '', String(totalPatterns), '-']);
+  tableRows.push(['totals', '', String(totalPatterns), '-', '-', '-']);
   return [
     `### Direction mode: ${mode}`,
     '',
@@ -1203,7 +1268,15 @@ function formatTripPatternDirectionSubsections(results: V2DataVolumeStats[]): st
   let noneOnlySources = 0;
   let mixedWithNoneSources = 0;
 
-  const header = ['source', 'prefix', 'mode', 'count', 'directionCounts'];
+  const header = [
+    'source',
+    'prefix',
+    'mode',
+    'count',
+    'routeTypes',
+    'directionCounts',
+    'directionByType',
+  ];
   const analysisRows: DirectionAnalysisRow[] = results.map((result) => {
     const mode = classifyDirectionMode(result.tripPatterns);
     modeCounts[mode] += 1;
@@ -1221,7 +1294,9 @@ function formatTripPatternDirectionSubsections(results: V2DataVolumeStats[]): st
       prefix: result.prefix,
       mode,
       count: result.tripPatterns.count,
+      routeTypes: formatTypeCounts(result.tripPatterns.routeTypeCounts),
       directionCounts: formatDirectionCounts(result.tripPatterns),
+      directionByType: formatDirectionCountsByRouteType(result.tripPatterns),
     };
   });
   const rows: string[][] = analysisRows.map((row) => [
@@ -1229,7 +1304,9 @@ function formatTripPatternDirectionSubsections(results: V2DataVolumeStats[]): st
     row.prefix,
     row.mode,
     String(row.count),
+    row.routeTypes,
     row.directionCounts,
+    row.directionByType,
   ]);
 
   const totalPatterns = results.reduce((acc, result) => acc + result.tripPatterns.count, 0);
@@ -1251,7 +1328,9 @@ function formatTripPatternDirectionSubsections(results: V2DataVolumeStats[]): st
     '',
     formatDirectionModeCounts(modeCounts),
     String(totalPatterns),
+    '-',
     totalsDirectionCounts,
+    '-',
   ]);
 
   return [
@@ -1298,12 +1377,26 @@ function formatTripPatternsSectionBody(results: V2DataVolumeStats[]): string {
     0,
   );
   const totalsDirectionCounts = `0:${totalDirection0}, 1:${totalDirection1}, none:${totalDirectionNone}`;
+  const aggregatedRouteTypes: Record<string, number> = {};
+  const aggregatedPatternRouteTypes: Record<string, number> = {};
+  const aggregateCounts = (target: Record<string, number>, source: Record<string, number>) => {
+    for (const [key, count] of Object.entries(source)) {
+      target[key] = (target[key] ?? 0) + count;
+    }
+  };
+  for (const r of results) {
+    aggregateCounts(aggregatedRouteTypes, r.tripPatterns.routeTypeCounts);
+    aggregateCounts(aggregatedPatternRouteTypes, r.tripPatterns.patternRouteTypeCounts);
+  }
 
   const header = [
     'source',
     'prefix',
     'count',
+    'routeTypes',
+    'patternsByType',
     'directionCounts',
+    'directionByType',
     'withTripHeadsign',
     'withStopHeadsign',
   ];
@@ -1311,7 +1404,10 @@ function formatTripPatternsSectionBody(results: V2DataVolumeStats[]): string {
     r.nameEn,
     r.prefix,
     String(r.tripPatterns.count),
+    formatTypeCounts(r.tripPatterns.routeTypeCounts),
+    formatTypeCounts(r.tripPatterns.patternRouteTypeCounts),
     formatDirectionCounts(r.tripPatterns),
+    formatDirectionCountsByRouteType(r.tripPatterns),
     String(r.tripPatterns.withTripHeadsignCount),
     String(r.tripPatterns.withStopHeadsignCount),
   ]);
@@ -1319,7 +1415,10 @@ function formatTripPatternsSectionBody(results: V2DataVolumeStats[]): string {
     'totals',
     '',
     String(totalPatterns),
+    formatTypeCounts(aggregatedRouteTypes),
+    formatTypeCounts(aggregatedPatternRouteTypes),
     totalsDirectionCounts,
+    '-',
     String(totalWithTripHeadsign),
     String(totalWithStopHeadsign),
   ]);
@@ -1358,15 +1457,37 @@ const ROUTE_TYPE_LABELS: Record<string, string> = {
   '12': 'monorail',
 };
 
+function compareRouteTypeKeys(left: string, right: string): number {
+  const leftNumber = Number(left);
+  const rightNumber = Number(right);
+  const leftIsNumeric = Number.isFinite(leftNumber);
+  const rightIsNumeric = Number.isFinite(rightNumber);
+  if (leftIsNumeric && rightIsNumeric) {
+    return leftNumber - rightNumber;
+  }
+  if (leftIsNumeric) {
+    return -1;
+  }
+  if (rightIsNumeric) {
+    return 1;
+  }
+  return left.localeCompare(right);
+}
+
+function formatRouteTypeLabel(value: string): string {
+  return ROUTE_TYPE_LABELS[value] ?? value;
+}
+
 function formatTypeCounts(counts: Record<string, number>): string {
-  const entries = Object.entries(counts).sort(([left], [right]) => Number(left) - Number(right));
+  const entries = Object.entries(counts).sort(([left], [right]) =>
+    compareRouteTypeKeys(left, right),
+  );
   if (entries.length === 0) {
     return '-';
   }
   return entries
     .map(([value, count]) => {
-      const label = ROUTE_TYPE_LABELS[value];
-      return label === undefined ? `${value}:${count}` : `${label}:${count}`;
+      return `${formatRouteTypeLabel(value)}:${count}`;
     })
     .join(', ');
 }

--- a/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
+++ b/pipeline/scripts/dev/dev-lib/v2-data-summary.ts
@@ -292,7 +292,6 @@ export type V2DataVolumeSectionName =
   | 'routes'
   | 'stops'
   | 'trip-patterns'
-  | 'directions'
   | 'i18n-coverage'
   | 'periods'
   | 'file-sizes'
@@ -1162,7 +1161,7 @@ function renderDirectionModeSubsection(mode: DirectionMode, rows: DirectionAnaly
   const modeRows = rows.filter((row) => row.mode === mode);
   const totalPatterns = modeRows.reduce((acc, row) => acc + row.count, 0);
   if (modeRows.length === 0) {
-    return [`### Mode: ${mode}`, '', 'sources=0, tripPatterns=0', '', '-'].join('\n');
+    return [`### Direction mode: ${mode}`, '', 'sources=0, tripPatterns=0', '', '-'].join('\n');
   }
   const tableRows: string[][] = modeRows.map((row) => [
     row.nameEn,
@@ -1172,7 +1171,7 @@ function renderDirectionModeSubsection(mode: DirectionMode, rows: DirectionAnaly
   ]);
   tableRows.push(['totals', '', String(totalPatterns), '-']);
   return [
-    `### Mode: ${mode}`,
+    `### Direction mode: ${mode}`,
     '',
     `sources=${modeRows.length}, tripPatterns=${totalPatterns}`,
     '',
@@ -1181,7 +1180,7 @@ function renderDirectionModeSubsection(mode: DirectionMode, rows: DirectionAnaly
 }
 
 /**
- * Render source-level direction_id completeness / mixture analysis.
+ * Render trip-pattern direction_id completeness / mixture subsections.
  *
  * Unlike `trip-patterns`, which reports pattern counts, this section
  * classifies the whole source by which `dir` states appear. That makes
@@ -1189,7 +1188,7 @@ function renderDirectionModeSubsection(mode: DirectionMode, rows: DirectionAnaly
  * have only 0/1 values, ODPT-like sources are `none-only`, and mixed
  * sources contain both explicit and omitted direction_id values.
  */
-function formatDirectionsSectionBody(results: V2DataVolumeStats[]): string {
+function formatTripPatternDirectionSubsections(results: V2DataVolumeStats[]): string {
   const modeCounts: Record<DirectionMode, number> = {
     '0-only': 0,
     '1-only': 0,
@@ -1256,12 +1255,12 @@ function formatDirectionsSectionBody(results: V2DataVolumeStats[]): string {
   ]);
 
   return [
-    '### Totals',
+    '### Direction analysis',
     '',
     `sources=${results.length}, completeSources=${completeSources}, noneOnlySources=${noneOnlySources}, mixedWithNoneSources=${mixedWithNoneSources}`,
     `sourceModes=${formatDirectionModeCounts(modeCounts)}`,
     '',
-    '### Summary',
+    '### Direction summary',
     '',
     renderTable(header, rows, header.length),
     '',
@@ -1278,11 +1277,12 @@ function formatDirectionsSectionBody(results: V2DataVolumeStats[]): string {
  * `TripPatternJson` carries little summarisable data — just the
  * direction_id split and the two headsign-level presence counts.
  * That is four data columns, which fits one table comfortably, so
- * the section stays flat (Totals → Summary) rather than adopting the
- * sub-section structure that pays off only for facet-rich sections
- * (routes, stops). The route / stop-sequence facets are left out:
- * distinct route count duplicates the routes section, and per-pattern
- * stop counts are distribution-style analysis (see `analyze-*`).
+ * the inventory table stays flat. Direction completeness is included
+ * as follow-up subsections because it is still a TripPatternJson facet,
+ * just easier to scan by source-level mode. The route / stop-sequence
+ * facets are left out: distinct route count duplicates the routes
+ * section, and per-pattern stop counts are distribution-style analysis
+ * (see `analyze-*`).
  */
 function formatTripPatternsSectionBody(results: V2DataVolumeStats[]): string {
   const totalPatterns = results.reduce((acc, r) => acc + r.tripPatterns.count, 0);
@@ -1333,6 +1333,8 @@ function formatTripPatternsSectionBody(results: V2DataVolumeStats[]): string {
     '',
     // directionCounts is a wide text column → all columns left-aligned.
     renderTable(header, rows, header.length),
+    '',
+    formatTripPatternDirectionSubsections(results),
   ].join('\n');
 }
 
@@ -1673,15 +1675,8 @@ export const V2_DATA_VOLUME_SECTIONS = {
     name: 'trip-patterns',
     title: 'DataBundle trip patterns (data.json)',
     description:
-      'Trip pattern inventory (Athenai abstraction: unique route + headsign + direction + stop-sequence combination). Single Summary table. `directionCounts` is the direction_id 0/1/none split (ODPT sources omit direction_id so they read as all-none); `withTripHeadsign` / `withStopHeadsign` count patterns carrying a trip-level (`h`) / stop-level (`stops[].sh`) headsign, revealing the source headsign convention.',
+      'Trip pattern inventory (Athenai abstraction: unique route + headsign + direction + stop-sequence combination). Summary table plus direction analysis subsections. `directionCounts` is the direction_id 0/1/none split (ODPT sources omit direction_id so they read as all-none); `withTripHeadsign` / `withStopHeadsign` count patterns carrying a trip-level (`h`) / stop-level (`stops[].sh`) headsign, revealing the source headsign convention.',
     render: formatTripPatternsSectionBody,
-  },
-  directions: {
-    name: 'directions',
-    title: 'DataBundle directions (data.json)',
-    description:
-      'Source-level direction_id completeness analysis based on TripPatternJson.dir. Classifies each source as 0-only / 1-only / none-only / 0+1 / mixed-with-none variants, then repeats the rows in per-mode sub-sections so omitted or partially omitted direction_id feeds are easy to scan.',
-    render: formatDirectionsSectionBody,
   },
   'i18n-coverage': {
     name: 'i18n-coverage',
@@ -1713,7 +1708,6 @@ export const V2_DATA_VOLUME_SECTION_NAMES: readonly V2DataVolumeSectionName[] = 
   'routes',
   'stops',
   'trip-patterns',
-  'directions',
   'i18n-coverage',
   // Composite sections within DataBundle (combine multiple keys) —
   // synthesis / interpretation comes last.

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,6 +1,11 @@
 import { vi } from 'vitest';
 import type { Stop, Route, AppRouteTypeValue } from '../types/app/transit';
-import type { StopWithMeta, StopWithContext } from '../types/app/transit-composed';
+import type {
+  StopWithMeta,
+  StopWithContext,
+  ContextualTimetableEntry,
+  StopServiceType,
+} from '../types/app/transit-composed';
 import type { TransitRepository } from '../repositories/transit-repository';
 
 /**
@@ -87,6 +92,61 @@ export function makeStopWithContext(
     stopServiceState: 'boardable',
     agencies: [],
     routes,
+  };
+}
+
+/**
+ * Creates a minimal ContextualTimetableEntry for testing.
+ *
+ * The unit-test counterpart of the Storybook `createEntry` fixture: a single
+ * standalone entry whose schedule, direction, boarding, and pattern-position
+ * fields can be overridden independently. Use this instead of reaching into
+ * `src/stories/fixtures.ts` (Storybook-only) from unit tests.
+ *
+ * @param overrides - Partial fields to override the defaults
+ * @returns A ContextualTimetableEntry with sensible defaults
+ */
+export function makeContextualEntry(
+  overrides: Partial<{
+    route: Route;
+    departureMinutes: number;
+    arrivalMinutes: number;
+    headsign: string;
+    direction: 0 | 1;
+    pickupType: StopServiceType;
+    dropOffType: StopServiceType;
+    stopIndex: number;
+    totalStops: number;
+    isTerminal: boolean;
+    isOrigin: boolean;
+    serviceDate: Date;
+  }> = {},
+): ContextualTimetableEntry {
+  const departureMinutes = overrides.departureMinutes ?? 480; // 08:00
+  const route = overrides.route ?? makeRoute('test');
+  const headsign = overrides.headsign ?? 'Test';
+  return {
+    tripLocator: { patternId: `${route.route_id}__${headsign}`, serviceId: 'test', tripIndex: 0 },
+    schedule: {
+      departureMinutes,
+      arrivalMinutes: overrides.arrivalMinutes ?? departureMinutes,
+    },
+    routeDirection: {
+      route,
+      tripHeadsign: { name: headsign, names: {} },
+      direction: overrides.direction,
+    },
+    boarding: {
+      pickupType: overrides.pickupType ?? 0,
+      dropOffType: overrides.dropOffType ?? 0,
+    },
+    patternPosition: {
+      stopIndex: overrides.stopIndex ?? 0,
+      totalStops: overrides.totalStops ?? 1,
+      isTerminal: overrides.isTerminal ?? false,
+      isOrigin: overrides.isOrigin ?? false,
+    },
+    serviceDate: overrides.serviceDate ?? new Date('2026-01-01'),
   };
 }
 

--- a/src/components/app-layout.test.tsx
+++ b/src/components/app-layout.test.tsx
@@ -62,10 +62,10 @@ function makeLayoutProps(): AppLayoutInputProps {
 const expectedInjectedStopBrowserState = {
   stopBrowserState: {
     viewId: DEFAULT_VIEW_ID,
-    hiddenRouteTypes: new Set(),
-    hiddenAgencyIds: new Set(),
+    hiddenRouteTypes: new Set<number>(),
+    hiddenAgencyIds: new Set<string>(),
   },
-  onStopBrowserStateChange: expect.any(Function),
+  onStopBrowserStateChange: expect.any(Function) as LayoutProps['onStopBrowserStateChange'],
 };
 
 function renderAppLayout(props: AppLayoutInputProps) {

--- a/src/components/app-layout.test.tsx
+++ b/src/components/app-layout.test.tsx
@@ -2,6 +2,13 @@ import { render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppLayout } from './app-layout';
 import type { LayoutProps } from './layout-props';
+import { DEFAULT_VIEW_ID } from '../domain/transit/stop-time-views';
+
+/**
+ * Props App passes to AppLayout: every {@link LayoutProps} field except the
+ * shared StopBrowser state, which AppLayout owns and injects itself.
+ */
+type AppLayoutInputProps = Omit<LayoutProps, 'stopBrowserState' | 'onStopBrowserStateChange'>;
 
 const { mockUseLayoutMode, mockMapBottomSheetLayout, mockMultiPaneLayout } = vi.hoisted(() => ({
   mockUseLayoutMode: vi.fn(),
@@ -33,7 +40,7 @@ vi.mock('./multi-pane-layout', () => ({
  * Distinct sentinel values per field so a forwarding regression — a
  * dropped, renamed, or swapped prop — fails the prop-equality assertion.
  */
-function makeLayoutProps(): LayoutProps {
+function makeLayoutProps(): AppLayoutInputProps {
   return {
     bottomSheetProps: {
       sentinel: 'bottomSheetProps',
@@ -48,7 +55,20 @@ function makeLayoutProps(): LayoutProps {
   };
 }
 
-function renderAppLayout(props: LayoutProps) {
+/**
+ * The shared StopBrowser state AppLayout injects: the initial value from its
+ * own `useState`, plus the updater (asserted as any function).
+ */
+const expectedInjectedStopBrowserState = {
+  stopBrowserState: {
+    viewId: DEFAULT_VIEW_ID,
+    hiddenRouteTypes: new Set(),
+    hiddenAgencyIds: new Set(),
+  },
+  onStopBrowserStateChange: expect.any(Function),
+};
+
+function renderAppLayout(props: AppLayoutInputProps) {
   render(
     <AppLayout
       bottomSheetProps={props.bottomSheetProps}
@@ -80,17 +100,23 @@ describe('AppLayout', () => {
     expect(mockMapBottomSheetLayout).not.toHaveBeenCalled();
   });
 
-  it('forwards every LayoutProps field to MapBottomSheetLayout in simple mode', () => {
+  it('forwards received props and injects shared StopBrowser state to MapBottomSheetLayout in simple mode', () => {
     mockUseLayoutMode.mockReturnValue('simple');
     const props = makeLayoutProps();
     renderAppLayout(props);
-    expect(mockMapBottomSheetLayout.mock.lastCall?.[0]).toEqual(props);
+    expect(mockMapBottomSheetLayout.mock.lastCall?.[0]).toEqual({
+      ...props,
+      ...expectedInjectedStopBrowserState,
+    });
   });
 
-  it('forwards every LayoutProps field to MultiPaneLayout in multi-pane mode', () => {
+  it('forwards received props and injects shared StopBrowser state to MultiPaneLayout in multi-pane mode', () => {
     mockUseLayoutMode.mockReturnValue('multi-pane');
     const props = makeLayoutProps();
     renderAppLayout(props);
-    expect(mockMultiPaneLayout.mock.lastCall?.[0]).toEqual(props);
+    expect(mockMultiPaneLayout.mock.lastCall?.[0]).toEqual({
+      ...props,
+      ...expectedInjectedStopBrowserState,
+    });
   });
 });

--- a/src/components/app-layout.tsx
+++ b/src/components/app-layout.tsx
@@ -1,9 +1,13 @@
-import { useEffect, useRef } from 'react';
-import { MapBottomSheetLayout } from './map-bottom-sheet-layout';
-import { MultiPaneLayout } from './multi-pane-layout';
-import type { LayoutProps } from './layout-props';
-import { useLayoutMode } from '../hooks/use-layout-mode';
-import { createLogger } from '../lib/logger';
+import { useEffect, useRef, useState } from 'react';
+
+import { DEFAULT_VIEW_ID } from '@/domain/transit/stop-time-views';
+import { useLayoutMode } from '@/hooks/use-layout-mode';
+import { createLogger } from '@/lib/logger';
+import type { StopBrowserSharedState } from '@/types/app/stop-browser';
+
+import type { LayoutProps } from '@/components/layout-props';
+import { MapBottomSheetLayout } from '@/components/map-bottom-sheet-layout';
+import { MultiPaneLayout } from '@/components/multi-pane-layout';
 
 const logger = createLogger('AppLayout');
 
@@ -26,9 +30,17 @@ export function AppLayout({
   globalFilter,
   nearbyStopsCounts,
   filteredNearbyStopsCounts,
-}: LayoutProps) {
+}: Omit<LayoutProps, 'stopBrowserState' | 'onStopBrowserStateChange'>) {
   const layoutMode = useLayoutMode();
   const Layout = layoutMode === 'multi-pane' ? MultiPaneLayout : MapBottomSheetLayout;
+
+  // StopBrowser state shared across layout surfaces, held above the layout swap
+  // so it survives switching between the multi-pane and bottom-sheet surfaces.
+  const [stopBrowserState, setStopBrowserState] = useState<StopBrowserSharedState>(() => ({
+    viewId: DEFAULT_VIEW_ID,
+    hiddenRouteTypes: new Set(),
+    hiddenAgencyIds: new Set(),
+  }));
 
   // Log actual mode switches only. The ref holds the previous value so
   // the initial mount is skipped — a switch triggers a remount of the
@@ -47,6 +59,8 @@ export function AppLayout({
       globalFilter={globalFilter}
       nearbyStopsCounts={nearbyStopsCounts}
       filteredNearbyStopsCounts={filteredNearbyStopsCounts}
+      stopBrowserState={stopBrowserState}
+      onStopBrowserStateChange={setStopBrowserState}
     />
   );
 }

--- a/src/components/bottom-sheet.tsx
+++ b/src/components/bottom-sheet.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import type { LatLng } from '../types/app/map';
 import type { InfoLevel } from '../types/app/settings';
 import type { TimetableEntriesState } from '../types/app/transit';
 import type { GlobalFilter } from '../types/app/global-filter';
 import type { StopsCounts } from '../types/app/stop';
+import type { StopBrowserSharedState } from '../types/app/stop-browser';
 import type { StopWithContext, TripInspectionTarget } from '../types/app/transit-composed';
 import { cn } from '../lib/utils';
 import { StopBrowser } from './stop-browser';
@@ -70,6 +71,10 @@ export interface BottomSheetProps {
   onOpenTripInspectionByStopId?: (stopId: string) => void;
   /** Optional callback for inspecting one concrete trip. */
   onInspectTrip?: (target: TripInspectionTarget) => void;
+  /** Shared StopBrowser state owned by AppLayout (survives layout-mode swaps). */
+  stopBrowserState: StopBrowserSharedState;
+  /** Updater for {@link stopBrowserState} (accepts a value or an updater fn). */
+  onStopBrowserStateChange: Dispatch<SetStateAction<StopBrowserSharedState>>;
   /** Collapsed-state height class applied to the sheet root. */
   collapsedHeightClassName?: string;
   /** Expanded-state height class applied to the sheet root. */
@@ -107,6 +112,8 @@ export function BottomSheet({
   onToggleAnchor,
   onOpenTripInspectionByStopId,
   onInspectTrip,
+  stopBrowserState,
+  onStopBrowserStateChange,
   collapsedHeightClassName = 'h-[40dvh]',
   expandedHeightClassName = 'h-[70dvh]',
   expanded: expandedProp,
@@ -193,6 +200,8 @@ export function BottomSheet({
         onToggleAnchor={onToggleAnchor}
         onOpenTripInspectionByStopId={onOpenTripInspectionByStopId}
         onInspectTrip={onInspectTrip}
+        stopBrowserState={stopBrowserState}
+        onStopBrowserStateChange={onStopBrowserStateChange}
       />
     </div>
   );

--- a/src/components/layout-props.ts
+++ b/src/components/layout-props.ts
@@ -1,6 +1,8 @@
+import type { Dispatch, SetStateAction } from 'react';
 import type { BottomSheetProps } from './bottom-sheet';
 import type { GlobalFilter } from '../types/app/global-filter';
 import type { StopsCounts } from '../types/app/stop';
+import type { StopBrowserSharedState } from '../types/app/stop-browser';
 
 /**
  * Shared props for a top-level overlay layout component.
@@ -20,6 +22,8 @@ export interface LayoutProps {
     | 'globalFilter'
     | 'nearbyStopsCounts'
     | 'filteredNearbyStopsCounts'
+    | 'stopBrowserState'
+    | 'onStopBrowserStateChange'
   >;
   /**
    * App-wide filter state shared with the active stop-browser surface —
@@ -37,4 +41,13 @@ export interface LayoutProps {
   nearbyStopsCounts: StopsCounts;
   /** Post-`globalFilter`, pre-BottomSheet-local-filter counts from `app.tsx`. */
   filteredNearbyStopsCounts: StopsCounts;
+  /**
+   * StopBrowser state shared across surfaces, owned by `AppLayout` (held above
+   * the layout swap so the view tab and surface-local filters survive switching
+   * surfaces). Forwarded to the active surface alongside the App-owned
+   * `globalFilter`.
+   */
+  stopBrowserState: StopBrowserSharedState;
+  /** Updater for {@link stopBrowserState} (accepts a value or an updater fn). */
+  onStopBrowserStateChange: Dispatch<SetStateAction<StopBrowserSharedState>>;
 }

--- a/src/components/map-bottom-sheet-layout.tsx
+++ b/src/components/map-bottom-sheet-layout.tsx
@@ -23,6 +23,8 @@ export function MapBottomSheetLayout({
   globalFilter,
   nearbyStopsCounts,
   filteredNearbyStopsCounts,
+  stopBrowserState,
+  onStopBrowserStateChange,
 }: LayoutProps) {
   const setMapSlot = useSetMapSlotElement();
   return (
@@ -37,6 +39,8 @@ export function MapBottomSheetLayout({
         globalFilter={globalFilter}
         nearbyStopsCounts={nearbyStopsCounts}
         filteredNearbyStopsCounts={filteredNearbyStopsCounts}
+        stopBrowserState={stopBrowserState}
+        onStopBrowserStateChange={onStopBrowserStateChange}
       />
     </>
   );

--- a/src/components/multi-pane-layout.test.tsx
+++ b/src/components/multi-pane-layout.test.tsx
@@ -55,6 +55,8 @@ function makeLayoutProps(): LayoutProps {
     globalFilter: {} as unknown as LayoutProps['globalFilter'],
     nearbyStopsCounts: {} as unknown as LayoutProps['nearbyStopsCounts'],
     filteredNearbyStopsCounts: {} as unknown as LayoutProps['filteredNearbyStopsCounts'],
+    stopBrowserState: {} as unknown as LayoutProps['stopBrowserState'],
+    onStopBrowserStateChange: () => {},
   };
 }
 
@@ -69,6 +71,8 @@ function renderMultiPaneLayout() {
         globalFilter={props.globalFilter}
         nearbyStopsCounts={props.nearbyStopsCounts}
         filteredNearbyStopsCounts={props.filteredNearbyStopsCounts}
+        stopBrowserState={props.stopBrowserState}
+        onStopBrowserStateChange={props.onStopBrowserStateChange}
       />
     </MapSlotProvider>,
   );

--- a/src/components/multi-pane-layout.tsx
+++ b/src/components/multi-pane-layout.tsx
@@ -43,6 +43,8 @@ export function MultiPaneLayout({
   globalFilter,
   nearbyStopsCounts,
   filteredNearbyStopsCounts,
+  stopBrowserState,
+  onStopBrowserStateChange,
 }: LayoutProps) {
   const orientation = useMultiPaneOrientation();
   const mapPaneSize = MULTI_PANE_MAP_PANE_SIZE[orientation];
@@ -58,6 +60,8 @@ export function MultiPaneLayout({
         globalFilter={globalFilter}
         nearbyStopsCounts={nearbyStopsCounts}
         filteredNearbyStopsCounts={filteredNearbyStopsCounts}
+        stopBrowserState={stopBrowserState}
+        onStopBrowserStateChange={onStopBrowserStateChange}
       />
     </ResizablePanel>
   );

--- a/src/components/stop-browser.stories.tsx
+++ b/src/components/stop-browser.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 import { computeStopsCounts } from '../domain/transit/compute-stops-counts';
+import { DEFAULT_VIEW_ID } from '../domain/transit/stop-time-views';
 import {
   agencyOretetsu,
   agencyTobus,
@@ -154,6 +155,12 @@ const meta = {
     onToggleAnchor: fn(),
     onOpenTripInspectionByStopId: fn(),
     onInspectTrip: fn(),
+    stopBrowserState: {
+      viewId: DEFAULT_VIEW_ID,
+      hiddenRouteTypes: new Set<number>(),
+      hiddenAgencyIds: new Set<string>(),
+    },
+    onStopBrowserStateChange: fn(),
   },
   argTypes: {
     infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },

--- a/src/components/stop-browser.tsx
+++ b/src/components/stop-browser.tsx
@@ -195,6 +195,11 @@ export function StopBrowser({
     if (!contentRef.current) {
       return;
     }
+    // The transit-display (board) view is not stop-oriented, so leave its scroll
+    // position alone -- do not jump to the selected stop or reset to the top.
+    if (viewId === 'transit-display') {
+      return;
+    }
     if (selectedStopId) {
       const el = contentRef.current.querySelector(`[data-stop-id="${selectedStopId}"]`);
       if (el) {
@@ -203,7 +208,7 @@ export function StopBrowser({
       }
     }
     contentRef.current.scrollTop = 0;
-  }, [selectedStopId, stopIdsKey]);
+  }, [selectedStopId, stopIdsKey, viewId]);
 
   const headerSize = resolveContainerDisplaySize(rootRect?.width ?? 0);
 

--- a/src/components/stop-browser.tsx
+++ b/src/components/stop-browser.tsx
@@ -195,11 +195,15 @@ export function StopBrowser({
     if (!contentRef.current) {
       return;
     }
-    // The transit-display (board) view is not stop-oriented, so leave its scroll
-    // position alone -- do not jump to the selected stop or reset to the top.
+
     if (viewId === 'transit-display') {
+      // The transit-display (board) view is not stop-oriented: the same stop id can
+      // appear in multiple rows (one stop shows up across several boards), so a stop
+      // cannot be targeted for scrolling. Leave its scroll position alone -- do not
+      // jump to the selected stop or reset to the top.
       return;
     }
+
     if (selectedStopId) {
       const el = contentRef.current.querySelector(`[data-stop-id="${selectedStopId}"]`);
       if (el) {

--- a/src/components/stop-browser.tsx
+++ b/src/components/stop-browser.tsx
@@ -1,20 +1,25 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
 
 import { collectPresentAgencies } from '../domain/transit/collect-present-agencies';
 import { collectPresentRouteTypes } from '../domain/transit/collect-present-route-types';
 import { computeStopsCounts } from '../domain/transit/compute-stops-counts';
 import { ROUTE_TYPE_DISPLAY_ORDER } from '../domain/transit/route-type-display-order';
-import {
-  DEFAULT_VIEW_ID,
-  STOP_TIMES_VIEWS,
-  type StopTimeViewId,
-} from '../domain/transit/stop-time-views';
+import { STOP_TIMES_VIEWS, type StopTimeViewId } from '../domain/transit/stop-time-views';
 import { filterByAgency, filterByRouteType } from '../domain/transit/timetable-filter';
 import { useElementRect } from '../hooks/use-element-rect';
 import type { GlobalFilter } from '../types/app/global-filter';
 import type { LatLng } from '../types/app/map';
 import type { InfoLevel } from '../types/app/settings';
 import type { StopsCounts } from '../types/app/stop';
+import type { StopBrowserSharedState } from '../types/app/stop-browser';
 import type { Agency, TimetableEntriesState } from '../types/app/transit';
 import type { StopWithContext, TripInspectionTarget } from '../types/app/transit-composed';
 import { resolveContainerDisplaySize } from './shared/display-size';
@@ -71,6 +76,15 @@ export interface StopBrowserProps {
   onOpenTripInspectionByStopId?: (stopId: string) => void;
   /** Optional callback for inspecting one concrete trip. */
   onInspectTrip?: (target: TripInspectionTarget) => void;
+  /**
+   * Shared StopBrowser state owned by `AppLayout`. Replaces what used to be
+   * StopBrowser-local `useState` (view tab + surface-local filters) so it
+   * survives a layout-mode swap. The field setters below are derived from
+   * {@link onStopBrowserStateChange}.
+   */
+  stopBrowserState: StopBrowserSharedState;
+  /** Updater for {@link stopBrowserState} (accepts a value or an updater fn). */
+  onStopBrowserStateChange: Dispatch<SetStateAction<StopBrowserSharedState>>;
 }
 
 /**
@@ -108,6 +122,8 @@ export function StopBrowser({
   onToggleAnchor,
   onOpenTripInspectionByStopId,
   onInspectTrip,
+  stopBrowserState,
+  onStopBrowserStateChange,
 }: StopBrowserProps) {
   const {
     showOriginOnly,
@@ -120,9 +136,30 @@ export function StopBrowser({
   } = globalFilter;
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null);
   const rootRect = useElementRect(rootElement);
-  const [viewId, setViewId] = useState<StopTimeViewId>(DEFAULT_VIEW_ID);
-  const [hiddenRouteTypes, setHiddenRouteTypes] = useState<Set<number>>(() => new Set());
-  const [hiddenAgencyIds, setHiddenAgencyIds] = useState<Set<string>>(() => new Set());
+  // View tab + surface-local filters are owned by AppLayout (shared across layout
+  // surfaces); derive field setters from the single shared-state updater so the
+  // rest of this component keeps using plain per-field setters.
+  const { viewId, hiddenRouteTypes, hiddenAgencyIds } = stopBrowserState;
+  const setViewId = useCallback(
+    (next: StopTimeViewId) => onStopBrowserStateChange((prev) => ({ ...prev, viewId: next })),
+    [onStopBrowserStateChange],
+  );
+  const setHiddenRouteTypes = useCallback(
+    (action: SetStateAction<Set<number>>) =>
+      onStopBrowserStateChange((prev) => ({
+        ...prev,
+        hiddenRouteTypes: typeof action === 'function' ? action(prev.hiddenRouteTypes) : action,
+      })),
+    [onStopBrowserStateChange],
+  );
+  const setHiddenAgencyIds = useCallback(
+    (action: SetStateAction<Set<string>>) =>
+      onStopBrowserStateChange((prev) => ({
+        ...prev,
+        hiddenAgencyIds: typeof action === 'function' ? action(prev.hiddenAgencyIds) : action,
+      })),
+    [onStopBrowserStateChange],
+  );
   const selectedView = STOP_TIMES_VIEWS.find((v) => v.id === viewId);
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -134,29 +171,35 @@ export function StopBrowser({
 
   const presentAgencies = useMemo(() => collectPresentAgencies(stopTimes), [stopTimes]);
 
-  const toggleRouteType = useCallback((rt: number) => {
-    setHiddenRouteTypes((prev) => {
-      const next = new Set(prev);
-      if (next.has(rt)) {
-        next.delete(rt);
-      } else {
-        next.add(rt);
-      }
-      return next;
-    });
-  }, []);
+  const toggleRouteType = useCallback(
+    (rt: number) => {
+      setHiddenRouteTypes((prev) => {
+        const next = new Set(prev);
+        if (next.has(rt)) {
+          next.delete(rt);
+        } else {
+          next.add(rt);
+        }
+        return next;
+      });
+    },
+    [setHiddenRouteTypes],
+  );
 
-  const toggleAgency = useCallback((agency: Agency) => {
-    setHiddenAgencyIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(agency.agency_id)) {
-        next.delete(agency.agency_id);
-      } else {
-        next.add(agency.agency_id);
-      }
-      return next;
-    });
-  }, []);
+  const toggleAgency = useCallback(
+    (agency: Agency) => {
+      setHiddenAgencyIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(agency.agency_id)) {
+          next.delete(agency.agency_id);
+        } else {
+          next.add(agency.agency_id);
+        }
+        return next;
+      });
+    },
+    [setHiddenAgencyIds],
+  );
 
   // App-wide origin / boardable filters and the empty-stop omission
   // policy are already applied upstream in `app.tsx`. Here we apply only

--- a/src/components/stop-panel.tsx
+++ b/src/components/stop-panel.tsx
@@ -37,6 +37,8 @@ export function StopPanel({
   onToggleAnchor,
   onOpenTripInspectionByStopId,
   onInspectTrip,
+  stopBrowserState,
+  onStopBrowserStateChange,
 }: StopPanelProps) {
   return (
     <div className="z-1000 flex h-full w-full flex-col overflow-hidden bg-white py-2 dark:bg-gray-900">
@@ -61,6 +63,8 @@ export function StopPanel({
         onToggleAnchor={onToggleAnchor}
         onOpenTripInspectionByStopId={onOpenTripInspectionByStopId}
         onInspectTrip={onInspectTrip}
+        stopBrowserState={stopBrowserState}
+        onStopBrowserStateChange={onStopBrowserStateChange}
       />
     </div>
   );

--- a/src/components/transit-display/transit-display-entry.stories.tsx
+++ b/src/components/transit-display/transit-display-entry.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
-import type { TransitDisplayEntryData } from '../../domain/transit/transit-info-display/build-transit-display-data';
+import type { TransitDisplayDatumForUi } from '../../domain/transit/transit-info-display/build-transit-display-data';
 import {
   agencyTobus,
   baseStop,
@@ -45,15 +45,15 @@ function makeStopContext(stopId: string, routeTypes: AppRouteTypeValue[]): StopW
 }
 
 /**
- * Build a {@link TransitDisplayEntryData} for stories.
+ * Build a {@link TransitDisplayDatumForUi} for stories.
  *
- * `TransitDisplayEntryData` is the presentational output of `buildTransitDisplayEntryData`,
+ * `TransitDisplayDatumForUi` is the presentational output of `buildTransitDisplayDatumForUi`,
  * so stories construct it directly rather than running the builder.
  *
  * @param overrides - Flat override knobs for the defaults.
  * @returns A complete row with realistic default values.
  */
-function makeRow(overrides: MakeRowOverrides = {}): TransitDisplayEntryData {
+function makeRow(overrides: MakeRowOverrides = {}): TransitDisplayDatumForUi {
   const stopId = overrides.stopId ?? 'stop-001';
   const departureMinutes = overrides.departureMinutes ?? 870; // 14:30
   const serviceDate = overrides.serviceDate ?? storyServiceDate;
@@ -95,7 +95,7 @@ const meta = {
   title: 'TransitDisplay/TransitDisplayEntry',
   component: TransitDisplayEntry,
   args: {
-    data: makeRow(),
+    dataWithMeta: makeRow(),
     infoLevel: 'normal' as const,
     size: 'md' as const,
     hasMultiRoutes: false,
@@ -104,7 +104,7 @@ const meta = {
     onInspectTrip: fn(),
   },
   argTypes: {
-    data: { control: 'object' },
+    dataWithMeta: { control: 'object' },
     infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
     size: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
     hasMultiRoutes: { control: 'boolean' },
@@ -135,14 +135,14 @@ export const Default: Story = {};
 /** Empty headsign falls back to the `-` placeholder in the second line. */
 export const EmptyHeadsign: Story = {
   args: {
-    data: makeRow({ headsign: '' }),
+    dataWithMeta: makeRow({ headsign: '' }),
   },
 };
 
 /** Long stop name, route name, and headsign all exercise truncation. */
 export const LongText: Story = {
   args: {
-    data: makeRow({
+    dataWithMeta: makeRow({
       stopName: '東京都立産業技術研究センター前',
       routeName: '北大01',
       headsign: '北大路バスターミナル・下鴨神社・出町柳駅',
@@ -154,7 +154,7 @@ export const LongText: Story = {
 /** Single-character headsign — minimum-length rendering. */
 export const ShortHeadsign: Story = {
   args: {
-    data: makeRow({ routeName: 'TX', headsign: 'X', timeText: '14:30' }),
+    dataWithMeta: makeRow({ routeName: 'TX', headsign: 'X', timeText: '14:30' }),
   },
 };
 
@@ -199,7 +199,7 @@ export const SizeComparison: Story = {
         {rows.map(({ size, data }) => (
           <TransitDisplayEntry
             key={data.key}
-            data={data}
+            dataWithMeta={data}
             infoLevel={args.infoLevel}
             size={size}
             hasMultiRoutes={args.hasMultiRoutes}
@@ -215,7 +215,7 @@ export const SizeComparison: Story = {
 
 // --- Kitchen sink ---
 
-const kitchenSinkRows: TransitDisplayEntryData[] = [
+const kitchenSinkRows: TransitDisplayDatumForUi[] = [
   makeRow({
     key: 'k1',
     timeText: '14:30',
@@ -315,7 +315,7 @@ export const KitchenSink: Story = {
       {kitchenSinkRows.map((row) => (
         <TransitDisplayEntry
           key={row.key}
-          data={row}
+          dataWithMeta={row}
           infoLevel={args.infoLevel}
           size={args.size}
           hasMultiRoutes={args.hasMultiRoutes}

--- a/src/components/transit-display/transit-display-entry.stories.tsx
+++ b/src/components/transit-display/transit-display-entry.stories.tsx
@@ -26,8 +26,6 @@ interface MakeRowOverrides {
   agencyName?: string;
   headsign?: string;
   timeText?: string;
-  isArrival?: boolean;
-  isPickupUnavailable?: boolean;
   departureMinutes?: number;
   arrivalMinutes?: number;
   serviceDate?: Date;
@@ -75,7 +73,6 @@ function makeRow(overrides: MakeRowOverrides = {}): TransitDisplayEntryData {
     agencyName: overrides.agencyName ?? '都バス',
     headsign: overrides.headsign ?? '大塚駅前',
     timeText: overrides.timeText ?? '9:30',
-    isArrival: overrides.isArrival ?? false,
     attributes: overrides.attributes ?? {
       isTerminal: true,
       isOrigin: true,
@@ -225,7 +222,13 @@ const kitchenSinkRows: TransitDisplayEntryData[] = [
     departureMinutes: 870,
     routeName: '都02',
     headsign: '大塚駅前',
-    isArrival: false,
+    // origin
+    attributes: {
+      isTerminal: false,
+      isOrigin: true,
+      isPickupUnavailable: false,
+      isDropOffUnavailable: false,
+    },
   }),
   makeRow({
     key: 'k2',
@@ -234,7 +237,13 @@ const kitchenSinkRows: TransitDisplayEntryData[] = [
     stopName: '東京都立産業技術研究センター前',
     routeName: '北大01',
     headsign: '北大路バスターミナル・下鴨神社・出町柳駅',
-    isArrival: true,
+    // terminal
+    attributes: {
+      isTerminal: true,
+      isOrigin: false,
+      isPickupUnavailable: false,
+      isDropOffUnavailable: false,
+    },
   }),
   makeRow({
     key: 'k3',
@@ -242,7 +251,13 @@ const kitchenSinkRows: TransitDisplayEntryData[] = [
     departureMinutes: 875,
     routeName: 'TX',
     headsign: 'X',
-    isArrival: false,
+    // pickup unavailable
+    attributes: {
+      isTerminal: false,
+      isOrigin: false,
+      isPickupUnavailable: true,
+      isDropOffUnavailable: false,
+    },
   }),
   makeRow({
     key: 'k4',
@@ -250,7 +265,13 @@ const kitchenSinkRows: TransitDisplayEntryData[] = [
     departureMinutes: 880,
     routeName: '荒川線',
     headsign: '',
-    isArrival: true,
+    // drop-off unavailable
+    attributes: {
+      isTerminal: false,
+      isOrigin: false,
+      isPickupUnavailable: false,
+      isDropOffUnavailable: true,
+    },
   }),
   makeRow({
     key: 'k5',
@@ -259,14 +280,34 @@ const kitchenSinkRows: TransitDisplayEntryData[] = [
     stopName: '三ノ輪橋',
     routeName: '都08',
     headsign: '日暮里駅',
-    isArrival: false,
+    // all attributes set (maximum content)
+    attributes: {
+      isTerminal: true,
+      isOrigin: true,
+      isPickupUnavailable: true,
+      isDropOffUnavailable: true,
+    },
+  }),
+  makeRow({
+    key: 'k6',
+    timeText: '14:45',
+    departureMinutes: 885,
+    routeName: '反96',
+    headsign: '五反田駅',
+    // no attributes set (plain row, no labels)
+    attributes: {
+      isTerminal: false,
+      isOrigin: false,
+      isPickupUnavailable: false,
+      isDropOffUnavailable: false,
+    },
   }),
 ];
 
 /**
- * A realistic terminal board: multiple rows mixing arrivals and
- * departures, with short and long stop names, route names, and
- * headsigns rendered in timeline order.
+ * Maximum-content rows: short and long stop / route / headsign text, with each
+ * attribute label exercised across the rows (origin, terminal, pickup
+ * unavailable, drop-off unavailable, all combined, and none).
  */
 export const KitchenSink: Story = {
   render: (args) => (

--- a/src/components/transit-display/transit-display-entry.stories.tsx
+++ b/src/components/transit-display/transit-display-entry.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
-import type { TransitDisplayDatumForUi } from '../../domain/transit/transit-info-display/build-transit-display-data';
+import type { TransitDisplayDatumForUi } from '../../domain/transit/transit-info-display/build-transit-display-data-for-ui';
 import {
   agencyTobus,
   baseStop,

--- a/src/components/transit-display/transit-display.stories.tsx
+++ b/src/components/transit-display/transit-display.stories.tsx
@@ -12,7 +12,7 @@ import {
   storyNow,
   storyServiceDate,
 } from '../../stories/fixtures';
-import type { AppRouteTypeValue } from '../../types/app/transit';
+import type { AppRouteTypeValue, TimetableEntryAttributes } from '../../types/app/transit';
 import type { StopWithContext } from '../../types/app/transit-composed';
 import { routeTypesEmoji } from '../../utils/route-type-emoji';
 import { TransitDisplay } from './transit-displays';
@@ -28,8 +28,7 @@ interface MakeEntryOverrides {
   agencyName?: string;
   headsign?: string;
   timeText?: string;
-  isArrival?: boolean;
-  isPickupUnavailable?: boolean;
+  attributes?: TimetableEntryAttributes;
 }
 
 /** Build a minimal {@link StopWithContext} for a row's `stop.context`. */
@@ -68,11 +67,10 @@ function makeEntry(overrides: MakeEntryOverrides = {}): TransitDisplayEntryData 
     agencyName: overrides.agencyName ?? '都バス',
     headsign: overrides.headsign ?? '大塚駅前',
     timeText: overrides.timeText ?? '14:30',
-    isArrival: overrides.isArrival ?? false,
-    attributes: {
-      isTerminal: overrides.isArrival ?? false,
+    attributes: overrides.attributes ?? {
+      isTerminal: false,
       isOrigin: false,
-      isPickupUnavailable: overrides.isPickupUnavailable ?? false,
+      isPickupUnavailable: false,
       isDropOffUnavailable: false,
     },
     arrivalMinutes: 870,
@@ -93,7 +91,14 @@ function makeDisplay(
   data: readonly TransitDisplayEntryData[] = departureRows,
 ): TransitDisplayData {
   return {
-    meta: { category: 'departures', routeTypes: [3], max: 12, radius: 100, ...metaOverrides },
+    meta: {
+      category: 'departures',
+      routeTypes: [3],
+      directions: ['none'],
+      max: 12,
+      radius: 100,
+      ...metaOverrides,
+    },
     data,
   };
 }
@@ -122,14 +127,24 @@ const arrivalRows: TransitDisplayEntryData[] = [
     timeText: '14:31',
     routeName: '都02',
     headsign: '錦糸町駅前',
-    isArrival: true,
+    attributes: {
+      isTerminal: true,
+      isOrigin: false,
+      isPickupUnavailable: false,
+      isDropOffUnavailable: false,
+    },
   }),
   makeEntry({
     key: 'a2',
     timeText: '14:35',
     routeName: '錦27',
     headsign: '錦糸町駅前',
-    isArrival: true,
+    attributes: {
+      isTerminal: true,
+      isOrigin: false,
+      isPickupUnavailable: false,
+      isDropOffUnavailable: false,
+    },
   }),
 ];
 

--- a/src/components/transit-display/transit-display.stories.tsx
+++ b/src/components/transit-display/transit-display.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 import type {
-  TransitDisplayData,
+  TransitDisplayDataWithMetaData,
   TransitDisplayEntryData,
 } from '../../domain/transit/transit-info-display/build-transit-display-data';
 import {
@@ -85,11 +85,11 @@ function makeEntry(overrides: MakeEntryOverrides = {}): TransitDisplayEntryData 
   };
 }
 
-/** Assemble a {@link TransitDisplayData} from meta overrides and rows. */
+/** Assemble a {@link TransitDisplayDataWithMetaData} from meta overrides and rows. */
 function makeDisplay(
-  metaOverrides: Partial<TransitDisplayData['meta']> = {},
+  metaOverrides: Partial<TransitDisplayDataWithMetaData['meta']> = {},
   data: readonly TransitDisplayEntryData[] = departureRows,
-): TransitDisplayData {
+): TransitDisplayDataWithMetaData {
   return {
     meta: {
       category: 'departures',

--- a/src/components/transit-display/transit-display.stories.tsx
+++ b/src/components/transit-display/transit-display.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 import type {
-  TransitDisplayDataWithMetaData,
-  TransitDisplayEntryData,
+  TransitDisplayDataWithMetaDataForUi,
+  TransitDisplayDatumForUi,
 } from '../../domain/transit/transit-info-display/build-transit-display-data';
 import {
   agencyTobus,
@@ -44,11 +44,11 @@ function makeStopContext(stopId: string, routeType: AppRouteTypeValue): StopWith
 }
 
 /**
- * Build a {@link TransitDisplayEntryData} for stories. The entry data is the
- * presentational output of `buildTransitDisplayEntryData`, so stories construct
+ * Build a {@link TransitDisplayDatumForUi} for stories. The entry data is the
+ * presentational output of `buildTransitDisplayDatumForUi`, so stories construct
  * it directly rather than running the builder.
  */
-function makeEntry(overrides: MakeEntryOverrides = {}): TransitDisplayEntryData {
+function makeEntry(overrides: MakeEntryOverrides = {}): TransitDisplayDatumForUi {
   const key = overrides.key ?? 'story-entry';
   const routeType = overrides.routeType ?? 3;
   const stopId = `stop-${key}`;
@@ -85,11 +85,11 @@ function makeEntry(overrides: MakeEntryOverrides = {}): TransitDisplayEntryData 
   };
 }
 
-/** Assemble a {@link TransitDisplayDataWithMetaData} from meta overrides and rows. */
+/** Assemble a {@link TransitDisplayDataWithMetaDataForUi} from meta overrides and rows. */
 function makeDisplay(
-  metaOverrides: Partial<TransitDisplayDataWithMetaData['meta']> = {},
-  data: readonly TransitDisplayEntryData[] = departureRows,
-): TransitDisplayDataWithMetaData {
+  metaOverrides: Partial<TransitDisplayDataWithMetaDataForUi['meta']> = {},
+  data: readonly TransitDisplayDatumForUi[] = departureRows,
+): TransitDisplayDataWithMetaDataForUi {
   return {
     meta: {
       category: 'departures',
@@ -103,7 +103,7 @@ function makeDisplay(
   };
 }
 
-const departureRows: TransitDisplayEntryData[] = [
+const departureRows: TransitDisplayDatumForUi[] = [
   makeEntry({ key: 'd1', timeText: '14:30', routeName: '都02', headsign: '大塚駅前' }),
   makeEntry({
     key: 'd2',
@@ -121,7 +121,7 @@ const departureRows: TransitDisplayEntryData[] = [
   }),
 ];
 
-const arrivalRows: TransitDisplayEntryData[] = [
+const arrivalRows: TransitDisplayDatumForUi[] = [
   makeEntry({
     key: 'a1',
     timeText: '14:31',
@@ -148,7 +148,7 @@ const arrivalRows: TransitDisplayEntryData[] = [
   }),
 ];
 
-const trainRows: TransitDisplayEntryData[] = [
+const trainRows: TransitDisplayDatumForUi[] = [
   makeEntry({
     key: 't1',
     routeType: 2,
@@ -175,7 +175,7 @@ const meta = {
   title: 'TransitDisplay/TransitDisplay',
   component: TransitDisplay,
   args: {
-    display: makeDisplay(),
+    dataWithMeta: makeDisplay(),
     emptyMessage: 'Hidden by filter',
     now: storyNow,
     mapCenter: storyMapCenter,
@@ -185,7 +185,7 @@ const meta = {
     onInspectTrip: fn(),
   },
   argTypes: {
-    display: { control: 'object' },
+    dataWithMeta: { control: 'object' },
     infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
     size: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
   },
@@ -212,14 +212,14 @@ export const Default: Story = {};
 /** Arrival board: right arrow + ARRIVALS, sorted/shown by arrival time. */
 export const ArrivalBoard: Story = {
   args: {
-    display: makeDisplay({ category: 'arrivals' }, arrivalRows),
+    dataWithMeta: makeDisplay({ category: 'arrivals' }, arrivalRows),
   },
 };
 
 /** Rail board: the header mode emoji follows the board's route type. */
 export const TrainDeparture: Story = {
   args: {
-    display: makeDisplay({ routeTypes: [2] }, trainRows),
+    dataWithMeta: makeDisplay({ routeTypes: [2] }, trainRows),
   },
 };
 
@@ -230,7 +230,7 @@ export const SizeComparison: Story = {
       {(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
         <TransitDisplay
           key={size}
-          display={args.display}
+          dataWithMeta={args.dataWithMeta}
           emptyMessage={args.emptyMessage}
           now={args.now}
           mapCenter={args.mapCenter}
@@ -249,13 +249,13 @@ export const SizeComparison: Story = {
 /** No entries: the body shows the empty fallback message. */
 export const Empty: Story = {
   args: {
-    display: makeDisplay({}, []),
+    dataWithMeta: makeDisplay({}, []),
   },
 };
 
 // --- Kitchen sink ---
 
-const kitchenSinkRows: TransitDisplayEntryData[] = [
+const kitchenSinkRows: TransitDisplayDatumForUi[] = [
   makeEntry({ key: 'k1', timeText: '14:30', routeName: '都02', headsign: '大塚駅前' }),
   makeEntry({
     key: 'k2',
@@ -276,7 +276,7 @@ const kitchenSinkRows: TransitDisplayEntryData[] = [
  */
 export const KitchenSink: Story = {
   args: {
-    display: makeDisplay({}, kitchenSinkRows),
+    dataWithMeta: makeDisplay({}, kitchenSinkRows),
     infoLevel: 'verbose' as const,
   },
 };

--- a/src/components/transit-display/transit-display.stories.tsx
+++ b/src/components/transit-display/transit-display.stories.tsx
@@ -3,7 +3,7 @@ import { fn } from 'storybook/test';
 import type {
   TransitDisplayDataWithMetaDataForUi,
   TransitDisplayDatumForUi,
-} from '../../domain/transit/transit-info-display/build-transit-display-data';
+} from '../../domain/transit/transit-info-display/build-transit-display-data-for-ui';
 import {
   agencyTobus,
   baseStop,

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -66,7 +66,7 @@ export function TransitDisplaysContainer({
   const stopIdsKey = useMemo(() => stopTimes.map((swc) => swc.stop.stop_id).join(','), [stopTimes]);
   const scrollFade = useScrollFades(contentRef, stopIdsKey);
 
-  const displays = useMemo(() => {
+  const transitDisplayData = useMemo(() => {
     const maxEntries = transitDisplayMaxEntriesFor(infoLevel);
 
     // Per-mode direction policy is composed here rather than inside the builder:
@@ -99,7 +99,7 @@ export function TransitDisplaysContainer({
     >
       {scrollFade.showTop && <ScrollFadeEdge position="top" />}
       <TransitDisplays
-        dataWithMeta={displays}
+        dataWithMeta={transitDisplayData}
         dataLangs={dataLangs}
         emptyMessage={t('stop.timetable.allFilteredOut')}
         now={now}

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -14,9 +14,26 @@ import { TransitDisplays } from '@/components/transit-display/transit-displays';
 import {
   buildTransitDisplayDataSet,
   NEARBY_RADIUS_M,
+  sortTransitDisplayDataForUi,
   transitDisplayMaxEntriesFor,
-  type TransitDisplayRouteGrouping,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
+import { ROUTE_TYPE_DISPLAY_ORDER } from '@/domain/transit/route-type-display-order';
+import type { AppRouteTypeValue } from '@/types/app/transit';
+
+/**
+ * Route types whose boards are NOT split by direction: bus, trolleybus, and
+ * ferry. Their `direction_id` is route-local / arbitrary, and at a shared stop
+ * many routes converge (ferries especially fan out hub-and-spoke across several
+ * pontoons), so a per-direction split would mix unrelated routes; the headsign
+ * carries the destination instead. Everything else (rail / subway / tram /
+ * monorail / ...) is split, where a line's direction is the meaningful axis.
+ */
+const NO_SPLIT_ROUTE_TYPES: readonly AppRouteTypeValue[] = [3, 11, 4];
+
+/** Every other route type is split by direction, kept in display order. */
+const DIRECTION_SPLIT_ROUTE_TYPES: readonly AppRouteTypeValue[] = ROUTE_TYPE_DISPLAY_ORDER.filter(
+  (routeType) => !NO_SPLIT_ROUTE_TYPES.includes(routeType),
+);
 
 export interface TransitDisplaysContainerProps {
   stopTimes: StopWithContext[];
@@ -49,40 +66,38 @@ export function TransitDisplaysContainer({
   const stopIdsKey = useMemo(() => stopTimes.map((swc) => swc.stop.stop_id).join(','), [stopTimes]);
   const scrollFade = useScrollFades(contentRef, stopIdsKey);
 
-  const displays = useMemo(
-    () => {
-      // Under development: trying out routeGrouping variants here. Keep the
-      // commented-out alternatives below -- do not delete them.
+  const displays = useMemo(() => {
+    const maxEntries = transitDisplayMaxEntriesFor(infoLevel);
 
-      const transitDisplayRouteGrouping: TransitDisplayRouteGrouping = {
-        // kind: 'none',
-        kind: 'route',
-      };
-      // const transitDisplayRouteGrouping: TransitDisplayRouteGrouping = {
-      //   kind: 'custom',
-      //   groups: [
-      //     [...ROUTE_TYPE_DISPLAY_ORDER], // as none
-      //     ...ROUTE_TYPE_DISPLAY_ORDER.map((t) => [t]), // as route
-      //     // ...(Object.values(ROUTE_TYPE_CATEGORY_GROUPS) as AppRouteTypeValue[][]), // as route type category
-      //   ],
-      // };
-
-      // Direction split (under development): a single toggle that splits every
-      // route type. Per-mode behavior (e.g. split trains but not buses) would be
-      // composed from multiple buildTransitDisplayDataSet calls with different
-      // routeGrouping, not a per-mode rule inside the builder.
-      const transitDisplaySplitByDirection = true;
-      // const transitDisplaySplitByDirection = false;
-
-      return buildTransitDisplayDataSet(stopTimes, dataLangs, NEARBY_RADIUS_M, {
-        maxEntries: transitDisplayMaxEntriesFor(infoLevel),
-        routeGrouping: transitDisplayRouteGrouping,
-        splitByDirection: transitDisplaySplitByDirection,
-      });
-    },
-    ///
-    [stopTimes, dataLangs, infoLevel],
-  );
+    // Per-mode direction policy is composed here rather than inside the builder:
+    // NO_SPLIT_ROUTE_TYPES keep both directions on one board, everything else
+    // splits by direction. The builder takes a single splitByDirection flag, so
+    // this is two calls (each scoped to its route types via a custom grouping).
+    // The concatenated result is then re-ordered into the canonical UI order by
+    // sortTransitDisplayDataForUi, so the board order is correct regardless of
+    // which modes share a stop (the raw concat is not in display order).
+    const directionUnsplitDisplays = buildTransitDisplayDataSet(
+      stopTimes,
+      dataLangs,
+      NEARBY_RADIUS_M,
+      {
+        maxEntries,
+        routeGrouping: { kind: 'custom', groups: NO_SPLIT_ROUTE_TYPES.map((t) => [t]) },
+        splitByDirection: false,
+      },
+    );
+    const directionSplitDisplays = buildTransitDisplayDataSet(
+      stopTimes,
+      dataLangs,
+      NEARBY_RADIUS_M,
+      {
+        maxEntries,
+        routeGrouping: { kind: 'custom', groups: DIRECTION_SPLIT_ROUTE_TYPES.map((t) => [t]) },
+        splitByDirection: true,
+      },
+    );
+    return sortTransitDisplayDataForUi([...directionUnsplitDisplays, ...directionSplitDisplays]);
+  }, [stopTimes, dataLangs, infoLevel]);
 
   return (
     <div

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -14,8 +14,8 @@ import { TransitDisplays } from '@/components/transit-display/transit-displays';
 import {
   buildTransitDisplayDataSet,
   NEARBY_RADIUS_M,
-  sortTransitDisplayDataForUi,
-  toTransitDisplayData,
+  sortTransitDisplayDataWithMetaDataForUi,
+  toTransitDisplayDataWithMetaData,
   transitDisplayMaxEntriesFor,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
 import { ROUTE_TYPE_DISPLAY_ORDER } from '@/domain/transit/route-type-display-order';
@@ -75,9 +75,9 @@ export function TransitDisplaysContainer({
     // splits by direction. The builder takes a single splitByDirection flag, so
     // this is two calls (each scoped to its route types via a custom grouping).
     // buildTransitDisplayDataSet returns structural boards; presentation (name /
-    // time resolution into UI data) is done here via toTransitDisplayData. The
-    // concatenated result is then re-ordered into the canonical UI order by
-    // sortTransitDisplayDataForUi, so the board order is correct regardless of
+    // time resolution into UI data) is done here via toTransitDisplayDataWithMetaData.
+    // The concatenated result is then re-ordered into the canonical UI order by
+    // sortTransitDisplayDataWithMetaDataForUi, so the board order is correct regardless of
     // which modes share a stop (the raw concat is not in display order).
     const directionUnsplitBoards = buildTransitDisplayDataSet(stopTimes, NEARBY_RADIUS_M, {
       maxEntries,
@@ -90,9 +90,9 @@ export function TransitDisplaysContainer({
       splitByDirection: true,
     });
     const dataForUi = [...directionUnsplitBoards, ...directionSplitBoards].map((board) =>
-      toTransitDisplayData(board, dataLangs, NEARBY_RADIUS_M, maxEntries),
+      toTransitDisplayDataWithMetaData(board, dataLangs, NEARBY_RADIUS_M, maxEntries),
     );
-    return sortTransitDisplayDataForUi(dataForUi);
+    return sortTransitDisplayDataWithMetaDataForUi(dataForUi);
   }, [stopTimes, dataLangs, infoLevel]);
 
   return (

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -49,27 +49,40 @@ export function TransitDisplaysContainer({
   const stopIdsKey = useMemo(() => stopTimes.map((swc) => swc.stop.stop_id).join(','), [stopTimes]);
   const scrollFade = useScrollFades(contentRef, stopIdsKey);
 
-  const displays = useMemo(() => {
-    // Under development: trying out routeGrouping variants here. Keep the
-    // commented-out alternatives below -- do not delete them.
+  const displays = useMemo(
+    () => {
+      // Under development: trying out routeGrouping variants here. Keep the
+      // commented-out alternatives below -- do not delete them.
 
-    const transitDisplayRouteGrouping: TransitDisplayRouteGrouping = {
-      // kind: 'none',
-      kind: 'route',
-    };
-    // const transitDisplayRouteGrouping: TransitDisplayRouteGrouping = {
-    //   kind: 'custom',
-    //   groups: [
-    //     [...ROUTE_TYPE_DISPLAY_ORDER], // as none
-    //     ...ROUTE_TYPE_DISPLAY_ORDER.map((t) => [t]), // as route
-    //     // ...(Object.values(ROUTE_TYPE_CATEGORY_GROUPS) as AppRouteTypeValue[][]), // as route type category
-    //   ],
-    // };
-    return buildTransitDisplayDataSet(stopTimes, dataLangs, NEARBY_RADIUS_M, {
-      maxEntries: transitDisplayMaxEntriesFor(infoLevel),
-      routeGrouping: transitDisplayRouteGrouping,
-    });
-  }, [stopTimes, dataLangs, infoLevel]);
+      const transitDisplayRouteGrouping: TransitDisplayRouteGrouping = {
+        // kind: 'none',
+        kind: 'route',
+      };
+      // const transitDisplayRouteGrouping: TransitDisplayRouteGrouping = {
+      //   kind: 'custom',
+      //   groups: [
+      //     [...ROUTE_TYPE_DISPLAY_ORDER], // as none
+      //     ...ROUTE_TYPE_DISPLAY_ORDER.map((t) => [t]), // as route
+      //     // ...(Object.values(ROUTE_TYPE_CATEGORY_GROUPS) as AppRouteTypeValue[][]), // as route type category
+      //   ],
+      // };
+
+      // Direction split (under development): a single toggle that splits every
+      // route type. Per-mode behavior (e.g. split trains but not buses) would be
+      // composed from multiple buildTransitDisplayDataSet calls with different
+      // routeGrouping, not a per-mode rule inside the builder.
+      const transitDisplaySplitByDirection = true;
+      // const transitDisplaySplitByDirection = false;
+
+      return buildTransitDisplayDataSet(stopTimes, dataLangs, NEARBY_RADIUS_M, {
+        maxEntries: transitDisplayMaxEntriesFor(infoLevel),
+        routeGrouping: transitDisplayRouteGrouping,
+        splitByDirection: transitDisplaySplitByDirection,
+      });
+    },
+    ///
+    [stopTimes, dataLangs, infoLevel],
+  );
 
   return (
     <div

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -15,6 +15,7 @@ import {
   buildTransitDisplayDataSet,
   NEARBY_RADIUS_M,
   sortTransitDisplayDataForUi,
+  toTransitDisplayData,
   transitDisplayMaxEntriesFor,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
 import { ROUTE_TYPE_DISPLAY_ORDER } from '@/domain/transit/route-type-display-order';
@@ -73,30 +74,25 @@ export function TransitDisplaysContainer({
     // NO_SPLIT_ROUTE_TYPES keep both directions on one board, everything else
     // splits by direction. The builder takes a single splitByDirection flag, so
     // this is two calls (each scoped to its route types via a custom grouping).
-    // The concatenated result is then re-ordered into the canonical UI order by
+    // buildTransitDisplayDataSet returns structural boards; presentation (name /
+    // time resolution into UI data) is done here via toTransitDisplayData. The
+    // concatenated result is then re-ordered into the canonical UI order by
     // sortTransitDisplayDataForUi, so the board order is correct regardless of
     // which modes share a stop (the raw concat is not in display order).
-    const directionUnsplitDisplays = buildTransitDisplayDataSet(
-      stopTimes,
-      dataLangs,
-      NEARBY_RADIUS_M,
-      {
-        maxEntries,
-        routeGrouping: { kind: 'custom', groups: NO_SPLIT_ROUTE_TYPES.map((t) => [t]) },
-        splitByDirection: false,
-      },
+    const directionUnsplitBoards = buildTransitDisplayDataSet(stopTimes, NEARBY_RADIUS_M, {
+      maxEntries,
+      routeGrouping: { kind: 'custom', groups: NO_SPLIT_ROUTE_TYPES.map((t) => [t]) },
+      splitByDirection: false,
+    });
+    const directionSplitBoards = buildTransitDisplayDataSet(stopTimes, NEARBY_RADIUS_M, {
+      maxEntries,
+      routeGrouping: { kind: 'custom', groups: DIRECTION_SPLIT_ROUTE_TYPES.map((t) => [t]) },
+      splitByDirection: true,
+    });
+    const dataForUi = [...directionUnsplitBoards, ...directionSplitBoards].map((board) =>
+      toTransitDisplayData(board, dataLangs, NEARBY_RADIUS_M, maxEntries),
     );
-    const directionSplitDisplays = buildTransitDisplayDataSet(
-      stopTimes,
-      dataLangs,
-      NEARBY_RADIUS_M,
-      {
-        maxEntries,
-        routeGrouping: { kind: 'custom', groups: DIRECTION_SPLIT_ROUTE_TYPES.map((t) => [t]) },
-        splitByDirection: true,
-      },
-    );
-    return sortTransitDisplayDataForUi([...directionUnsplitDisplays, ...directionSplitDisplays]);
+    return sortTransitDisplayDataForUi(dataForUi);
   }, [stopTimes, dataLangs, infoLevel]);
 
   return (

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -102,7 +102,7 @@ export function TransitDisplaysContainer({
     >
       {scrollFade.showTop && <ScrollFadeEdge position="top" />}
       <TransitDisplays
-        displays={displays}
+        dataWithMeta={displays}
         dataLangs={dataLangs}
         emptyMessage={t('stop.timetable.allFilteredOut')}
         now={now}

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -14,7 +14,7 @@ import { TransitDisplays } from '@/components/transit-display/transit-displays';
 import {
   buildTransitDisplayDataSet,
   NEARBY_RADIUS_M,
-  sortTransitDisplayDataWithMetaData_RAWForUi,
+  sortTransitDisplayDataWithMetaData,
   transitDisplayMaxEntriesFor,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
 import { ROUTE_TYPE_DISPLAY_ORDER } from '@/domain/transit/route-type-display-order';
@@ -75,7 +75,7 @@ export function TransitDisplaysContainer({
     // this is two calls (each scoped to its route types via a custom grouping).
     // buildTransitDisplayDataSet attaches each display's meta but leaves rows raw.
     // The concatenated result is re-ordered into the canonical UI order by
-    // sortTransitDisplayDataWithMetaData_RAWForUi (so the order is correct
+    // sortTransitDisplayDataWithMetaData (so the order is correct
     // regardless of which modes share a stop -- the raw concat is not in display
     // order). Rows stay raw here; TransitDisplays resolves them into UI data.
     const directionUnsplitRaw = buildTransitDisplayDataSet(stopTimes, NEARBY_RADIUS_M, {
@@ -88,10 +88,7 @@ export function TransitDisplaysContainer({
       routeGrouping: { kind: 'custom', groups: DIRECTION_SPLIT_ROUTE_TYPES.map((t) => [t]) },
       splitByDirection: true,
     });
-    return sortTransitDisplayDataWithMetaData_RAWForUi([
-      ...directionUnsplitRaw,
-      ...directionSplitRaw,
-    ]);
+    return sortTransitDisplayDataWithMetaData([...directionUnsplitRaw, ...directionSplitRaw]);
   }, [stopTimes, infoLevel]);
 
   return (

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -14,8 +14,7 @@ import { TransitDisplays } from '@/components/transit-display/transit-displays';
 import {
   buildTransitDisplayDataSet,
   NEARBY_RADIUS_M,
-  sortTransitDisplayDataWithMetaDataForUi,
-  toTransitDisplayDataWithMetaData,
+  sortTransitDisplayDataWithMetaData_RAWForUi,
   transitDisplayMaxEntriesFor,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
 import { ROUTE_TYPE_DISPLAY_ORDER } from '@/domain/transit/route-type-display-order';
@@ -74,26 +73,26 @@ export function TransitDisplaysContainer({
     // NO_SPLIT_ROUTE_TYPES keep both directions on one board, everything else
     // splits by direction. The builder takes a single splitByDirection flag, so
     // this is two calls (each scoped to its route types via a custom grouping).
-    // buildTransitDisplayDataSet returns structural boards; presentation (name /
-    // time resolution into UI data) is done here via toTransitDisplayDataWithMetaData.
-    // The concatenated result is then re-ordered into the canonical UI order by
-    // sortTransitDisplayDataWithMetaDataForUi, so the board order is correct regardless of
-    // which modes share a stop (the raw concat is not in display order).
-    const directionUnsplitBoards = buildTransitDisplayDataSet(stopTimes, NEARBY_RADIUS_M, {
+    // buildTransitDisplayDataSet attaches each display's meta but leaves rows raw.
+    // The concatenated result is re-ordered into the canonical UI order by
+    // sortTransitDisplayDataWithMetaData_RAWForUi (so the order is correct
+    // regardless of which modes share a stop -- the raw concat is not in display
+    // order). Rows stay raw here; TransitDisplays resolves them into UI data.
+    const directionUnsplitRaw = buildTransitDisplayDataSet(stopTimes, NEARBY_RADIUS_M, {
       maxEntries,
       routeGrouping: { kind: 'custom', groups: NO_SPLIT_ROUTE_TYPES.map((t) => [t]) },
       splitByDirection: false,
     });
-    const directionSplitBoards = buildTransitDisplayDataSet(stopTimes, NEARBY_RADIUS_M, {
+    const directionSplitRaw = buildTransitDisplayDataSet(stopTimes, NEARBY_RADIUS_M, {
       maxEntries,
       routeGrouping: { kind: 'custom', groups: DIRECTION_SPLIT_ROUTE_TYPES.map((t) => [t]) },
       splitByDirection: true,
     });
-    const dataForUi = [...directionUnsplitBoards, ...directionSplitBoards].map((board) =>
-      toTransitDisplayDataWithMetaData(board, dataLangs, NEARBY_RADIUS_M, maxEntries),
-    );
-    return sortTransitDisplayDataWithMetaDataForUi(dataForUi);
-  }, [stopTimes, dataLangs, infoLevel]);
+    return sortTransitDisplayDataWithMetaData_RAWForUi([
+      ...directionUnsplitRaw,
+      ...directionSplitRaw,
+    ]);
+  }, [stopTimes, infoLevel]);
 
   return (
     <div
@@ -104,6 +103,7 @@ export function TransitDisplaysContainer({
       {scrollFade.showTop && <ScrollFadeEdge position="top" />}
       <TransitDisplays
         displays={displays}
+        dataLangs={dataLangs}
         emptyMessage={t('stop.timetable.allFilteredOut')}
         now={now}
         mapCenter={mapCenter}

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -308,11 +308,10 @@ export function TransitDisplayEntry({
   const showRouteTypeOfStop = infoLevelFlag.isVerboseEnabled;
 
   return (
-    // `data-stop-id` lets the stop browser's scroll-to-selected effect find this
-    // row (it queries `[data-stop-id=...]`); without it, selecting a stop in this
-    // view fails the lookup and resets the scroll to the top.
+    // No `data-stop-id` here: the same stop id can appear in several rows across
+    // boards, so it cannot identify a single row -- and the stop browser skips its
+    // scroll-to-selected effect for this view anyway.
     <li
-      data-stop-id={data.stop.id}
       className={cn(
         'cursor-pointer border-b border-neutral-800 px-3 py-2 text-neutral-100 last:border-b-0 hover:bg-neutral-800/95',
         ROW_TEXT_CLASS_BY_SIZE[size],

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -14,7 +14,7 @@ import {
   buildTransitDisplayDatumForUi,
   type TransitDisplayCategory,
   type TransitDisplayDataWithMetaDataForUi,
-  type TransitDisplayDataWithMetaData_RAW,
+  type TransitDisplayDataWithMetaData,
   type TransitDisplayDatumForUi,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
 import { getBearingDeg } from '@/domain/transit/distance';
@@ -106,7 +106,7 @@ const HEADSIGN_WIDTH_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
 
 export interface TransitDisplaysProps {
   /** Raw displays (meta + unresolved board); rows are resolved here for rendering. */
-  dataWithMeta: readonly TransitDisplayDataWithMetaData_RAW[];
+  dataWithMeta: readonly TransitDisplayDataWithMetaData[];
   /** Display language chain passed to {@link buildTransitDisplayDatumForUi} for row resolution. */
   dataLangs: readonly string[];
   emptyMessage: string;
@@ -132,7 +132,7 @@ const DEFAULT_CATEGORIES: Record<TransitDisplayCategory, boolean> = {
 };
 
 /**
- * Resolves each {@link TransitDisplayDataWithMetaData_RAW} into UI rows (via
+ * Resolves each {@link TransitDisplayDataWithMetaData} into UI rows (via
  * {@link buildTransitDisplayDatumForUi} -- this is the only consumer that needs
  * them) and renders it as its own stacked board, with a filter bar on top for
  * choosing which categories (departures / arrivals) to show. The filter is

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -127,7 +127,7 @@ export interface TransitDisplaysProps {
  */
 const FILTERABLE_CATEGORIES: readonly TransitDisplayCategory[] = ['departures', 'arrivals'];
 
-/** All categories shown by default (no board hidden until the user toggles one off). */
+/** Default category visibility: departures shown, arrivals hidden until toggled on. */
 const DEFAULT_CATEGORIES: Record<TransitDisplayCategory, boolean> = {
   departures: true,
   arrivals: false,
@@ -584,8 +584,8 @@ export function TransitDisplayEntry({
             attributes={dataWithMeta.attributes}
             showDisplayTerminal={true}
             showDisplayOrigin={true}
-            showDisplayPickupUnavailable={infoLevelFlag.isVerboseEnabled ? true : false}
-            showDisplayDropOffUnavailable={infoLevelFlag.isVerboseEnabled ? true : false}
+            showDisplayPickupUnavailable={infoLevelFlag.isVerboseEnabled}
+            showDisplayDropOffUnavailable={infoLevelFlag.isVerboseEnabled}
           />
         </span>
 

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -11,11 +11,11 @@ import { TimetableEntryAttributesLabels } from '@/components/label/timetable-ent
 import type { ExtendedDisplaySize } from '@/components/shared/display-size';
 import { Button } from '@/components/ui/button';
 import {
-  buildTransitDisplayEntryData,
+  buildTransitDisplayDatumForUi,
   type TransitDisplayCategory,
-  type TransitDisplayDataWithMetaData,
+  type TransitDisplayDataWithMetaDataForUi,
   type TransitDisplayDataWithMetaData_RAW,
-  type TransitDisplayEntryData,
+  type TransitDisplayDatumForUi,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
 import { getBearingDeg } from '@/domain/transit/distance';
 import { routeTypesEmoji } from '@/utils/route-type-emoji';
@@ -106,8 +106,8 @@ const HEADSIGN_WIDTH_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
 
 export interface TransitDisplaysProps {
   /** Raw displays (meta + unresolved board); rows are resolved here for rendering. */
-  displays: readonly TransitDisplayDataWithMetaData_RAW[];
-  /** Display language chain passed to {@link buildTransitDisplayEntryData} for row resolution. */
+  dataWithMeta: readonly TransitDisplayDataWithMetaData_RAW[];
+  /** Display language chain passed to {@link buildTransitDisplayDatumForUi} for row resolution. */
   dataLangs: readonly string[];
   emptyMessage: string;
   now: Date;
@@ -133,14 +133,14 @@ const DEFAULT_CATEGORIES: Record<TransitDisplayCategory, boolean> = {
 
 /**
  * Resolves each {@link TransitDisplayDataWithMetaData_RAW} into UI rows (via
- * {@link buildTransitDisplayEntryData} -- this is the only consumer that needs
+ * {@link buildTransitDisplayDatumForUi} -- this is the only consumer that needs
  * them) and renders it as its own stacked board, with a filter bar on top for
  * choosing which categories (departures / arrivals) to show. The filter is
  * presentation-only local state: it narrows the rendered displays, it does not
  * change how they are built or fetched.
  */
 export function TransitDisplays({
-  displays,
+  dataWithMeta,
   dataLangs,
   emptyMessage,
   now,
@@ -156,21 +156,21 @@ export function TransitDisplays({
   // Resolve every raw display's rows into UI data here -- TransitDisplays is the
   // only consumer that needs the resolved rows. Resolve all up front, then let
   // the category filter below narrow the already-resolved list.
-  const resolvedDisplays = useMemo<readonly TransitDisplayDataWithMetaData[]>(
+  const resolvedDataWithMeta = useMemo<readonly TransitDisplayDataWithMetaDataForUi[]>(
     () =>
-      displays.map((raw) => ({
-        meta: raw.meta,
-        data: buildTransitDisplayEntryData(raw.data.data, dataLangs, raw.data.category),
+      dataWithMeta.map((datum) => ({
+        meta: datum.meta,
+        data: buildTransitDisplayDatumForUi(datum.data.data, dataLangs, datum.data.category),
       })),
-    [displays, dataLangs],
+    [dataWithMeta, dataLangs],
   );
 
   // Only offer toggles for categories that actually have a board, so the bar
   // mirrors what is on screen rather than always showing both.
   const presentCategories = FILTERABLE_CATEGORIES.filter((category) =>
-    resolvedDisplays.some((display) => display.meta.category === category),
+    resolvedDataWithMeta.some((display) => display.meta.category === category),
   );
-  const visibleDisplays = resolvedDisplays.filter(
+  const visibleData = resolvedDataWithMeta.filter(
     (display) => shownCategories[display.meta.category],
   );
 
@@ -188,14 +188,14 @@ export function TransitDisplays({
           onToggleCategory={toggleCategory}
         />
       )}
-      {visibleDisplays.map((display, index) => (
+      {visibleData.map((dataWithMeta, index) => (
         // Key from the board's identity (category + its route types), with the
         // map index as a disambiguator: a `custom` route grouping can collapse
         // two groups to the same present route types, so identity alone is not
         // guaranteed unique.
         <TransitDisplay
-          key={`${display.meta.category}__${display.meta.routeTypes.join('-')}__${index}`}
-          display={display}
+          key={`${dataWithMeta.meta.category}__${dataWithMeta.meta.routeTypes.join('-')}__${index}`}
+          dataWithMeta={dataWithMeta}
           emptyMessage={emptyMessage}
           now={now}
           mapCenter={mapCenter}
@@ -315,7 +315,7 @@ function TransitDisplayCategoryFilter({
 }
 
 export interface TransitDisplayProps {
-  display: TransitDisplayDataWithMetaData;
+  dataWithMeta: TransitDisplayDataWithMetaDataForUi;
   emptyMessage: string;
   now: Date;
   mapCenter: LatLng | null;
@@ -339,7 +339,7 @@ export interface TransitDisplayProps {
  * above the rows, or an empty fallback when the board has no entries.
  */
 export function TransitDisplay({
-  display,
+  dataWithMeta,
   emptyMessage,
   mapCenter,
   infoLevel,
@@ -353,11 +353,11 @@ export function TransitDisplay({
   // route type and basis are structured meta; the UI composes the localized text.
   // The board's title carries the departure/arrival distinction, so rows do not
   // repeat it: each row shows a single time (the board's basis) without a label.
-  const isArrivalBoard = display.meta.category === 'arrivals';
-  const routeTypeIcon = routeTypesEmoji(display.meta.routeTypes);
+  const isArrivalBoard = dataWithMeta.meta.category === 'arrivals';
+  const routeTypeIcon = routeTypesEmoji(dataWithMeta.meta.routeTypes);
   const title = t(isArrivalBoard ? 'transitDisplay.arrivals' : 'transitDisplay.departures');
   // A board that mixes route types: rows then show their own trip route-type emoji.
-  const hasMultiRoutes = display.meta.routeTypes.length >= 2;
+  const hasMultiRoutes = dataWithMeta.meta.routeTypes.length >= 2;
 
   // for debug
   // if (display.meta.category === 'arrivals') {
@@ -387,8 +387,9 @@ export function TransitDisplay({
         {infoLevelFlag.isVerboseEnabled && (
           <div className="flex items-baseline gap-3">
             <p className="m-0 ml-auto w-full min-w-0 text-right text-xs text-amber-200/80">
-              [{display.meta.category} / rt {display.meta.routeTypes.join(',')} / dir{' '}
-              {display.meta.directions.join(',')} (max:{display.meta.max},{display.meta.radius}m)]
+              [{dataWithMeta.meta.category} / rt {dataWithMeta.meta.routeTypes.join(',')} / dir{' '}
+              {dataWithMeta.meta.directions.join(',')} (max:{dataWithMeta.meta.max},
+              {dataWithMeta.meta.radius}m)]
             </p>
           </div>
         )}
@@ -424,22 +425,22 @@ export function TransitDisplay({
               ROW_TEXT_CLASS_BY_SIZE[size],
             )}
           >
-            {display.meta.radius}m
+            {dataWithMeta.meta.radius}m
           </p>
         </div>
       </div>
       {/* Body: the rows (or the empty fallback). */}
       <div className="bg-neutral-950 p-0">
-        {display.data.length === 0 ? (
+        {dataWithMeta.data.length === 0 ? (
           <p className="m-0 px-1 py-2 text-xs tracking-[0.08em] text-amber-100/55">
             {emptyMessage}
           </p>
         ) : (
           <ul className="m-0 list-none p-0">
-            {display.data.map((row) => (
+            {dataWithMeta.data.map((row) => (
               <TransitDisplayEntry
                 key={row.key}
-                data={row}
+                dataWithMeta={row}
                 mapCenter={mapCenter}
                 infoLevel={infoLevel}
                 size={size}
@@ -504,7 +505,7 @@ function TimeInfo({
 }
 
 export interface TransitDisplayEntryProps {
-  data: TransitDisplayEntryData;
+  dataWithMeta: TransitDisplayDatumForUi;
   mapCenter: LatLng | null;
   infoLevel: InfoLevel;
   /** Display size; drives the row text size. */
@@ -521,7 +522,7 @@ export interface TransitDisplayEntryProps {
 
 /** A single departure-board row (one stop event). */
 export function TransitDisplayEntry({
-  data,
+  dataWithMeta,
   mapCenter,
   infoLevel,
   size,
@@ -533,8 +534,9 @@ export function TransitDisplayEntry({
 
   // Distance is baked on the row (query-time); bearing is computed live from the
   // current map center so the direction arrow tracks panning, like StopInfo.
-  const distanceRounded = data.stop.distance != null ? Math.round(data.stop.distance) : null;
-  const bearing = mapCenter ? getBearingDeg(mapCenter, data.stop.context.stop) : null;
+  const distanceRounded =
+    dataWithMeta.stop.distance != null ? Math.round(dataWithMeta.stop.distance) : null;
+  const bearing = mapCenter ? getBearingDeg(mapCenter, dataWithMeta.stop.context.stop) : null;
 
   const showRouteTypeOfEntry = infoLevelFlag.isVerboseEnabled || hasMultiRoutes;
   // const showRouteTypeOfStop = infoLevelFlag.isVerboseEnabled || data.stop.context.routeTypes.length >= 2;
@@ -550,15 +552,15 @@ export function TransitDisplayEntry({
         ROW_TEXT_CLASS_BY_SIZE[size],
         BOARD_PANEL_BG,
       )}
-      onClick={() => onStopSelected(data.stop.id)}
+      onClick={() => onStopSelected(dataWithMeta.stop.id)}
     >
       {/* Single-line departure-board row: time, mode, route, agency, destination, stop, platform. */}
       <div className="flex items-center gap-2 whitespace-nowrap">
         {/* Local TimeInfo: shows timeText; tap selects the stop + opens inspection. */}
         <TimeInfo
-          timeText={data.timeText}
-          stopId={data.stop.id}
-          inspectTarget={data.inspectionTarget}
+          timeText={dataWithMeta.timeText}
+          stopId={dataWithMeta.stop.id}
+          inspectTarget={dataWithMeta.inspectionTarget}
           className={ROW_TEXT_CLASS_BY_SIZE[size]}
           onStopSelected={onStopSelected}
           onInspectTrip={onInspectTrip}
@@ -566,18 +568,18 @@ export function TransitDisplayEntry({
 
         {showRouteTypeOfEntry && (
           // Route type emoji for the trip
-          <span aria-hidden>{data.routeTypeEmoji}</span>
+          <span aria-hidden>{dataWithMeta.routeTypeEmoji}</span>
         )}
 
         {/* Headsign (destination) + attribute labels: headsign fills the column and
             truncates, pushing the labels to the right edge. */}
         <span className={cn('flex items-center gap-1', HEADSIGN_WIDTH_CLASS_BY_SIZE[size])}>
-          <span className="min-w-0 flex-1 truncate">{data.headsign || '-'}</span>
+          <span className="min-w-0 flex-1 truncate">{dataWithMeta.headsign || '-'}</span>
           {/* Attribute labels (terminal / origin / no-pickup / no-drop-off). Shows the
             no-boarding marker so a service that cannot be boarded here is not silent. */}
           <TimetableEntryAttributesLabels
             size={TIMETABLE_ENTRY_ATTRIBUTES_LABELS_SIZE_BY_SIZE[size]}
-            attributes={data.attributes}
+            attributes={dataWithMeta.attributes}
             showDisplayTerminal={true}
             showDisplayOrigin={true}
             showDisplayPickupUnavailable={infoLevelFlag.isVerboseEnabled ? true : false}
@@ -587,27 +589,27 @@ export function TransitDisplayEntry({
 
         {/* Route name */}
         <span className="min-w-[6ch] flex-1 truncate text-left text-amber-100">
-          {data.routeName}
+          {dataWithMeta.routeName}
         </span>
 
         {/* Operating agency */}
         <span className="min-w-[6ch] flex-1 truncate text-left text-neutral-400">
-          {data.agencyName}
+          {dataWithMeta.agencyName}
         </span>
 
         {/* Stop: stop-level mode emojis + stop name + platform code. */}
         {showRouteTypeOfStop && (
           // Stop-level mode emojis
-          <span aria-hidden>{data.stop.routeTypesEmoji}</span>
+          <span aria-hidden>{dataWithMeta.stop.routeTypesEmoji}</span>
         )}
 
         {/* Stop info kept together as one group (stop name, platform code, and
             distance / direction) so the stop's details are not split across the row. */}
         <span className="flex min-w-0 flex-1 items-center gap-1">
-          <span className="min-w-0 truncate">{data.stop.name}</span>
-          {data.stop.platformCode !== undefined && (
+          <span className="min-w-0 truncate">{dataWithMeta.stop.name}</span>
+          {dataWithMeta.stop.platformCode !== undefined && (
             <span className="shrink-0 bg-neutral-800 px-1 text-amber-100">
-              {data.stop.platformCode}
+              {dataWithMeta.stop.platformCode}
             </span>
           )}
           {/* Distance + direction to the stop (same DistanceBadge as StopInfo). */}

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -362,7 +362,7 @@ export function TransitDisplay({
   const hasMultiRoutes = dataWithMeta.meta.routeTypes.length >= 2;
 
   // for debug
-  // if (display.meta.category === 'arrivals') {
+  // if (dataWithMeta.meta.category === 'arrivals') {
   //   return null;
   // }
 

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { ArrowRight, ArrowUp } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -11,8 +11,10 @@ import { TimetableEntryAttributesLabels } from '@/components/label/timetable-ent
 import type { ExtendedDisplaySize } from '@/components/shared/display-size';
 import { Button } from '@/components/ui/button';
 import {
+  buildTransitDisplayEntryData,
   type TransitDisplayCategory,
   type TransitDisplayDataWithMetaData,
+  type TransitDisplayDataWithMetaData_RAW,
   type TransitDisplayEntryData,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
 import { getBearingDeg } from '@/domain/transit/distance';
@@ -103,7 +105,10 @@ const HEADSIGN_WIDTH_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
 };
 
 export interface TransitDisplaysProps {
-  displays: readonly TransitDisplayDataWithMetaData[];
+  /** Raw displays (meta + unresolved board); rows are resolved here for rendering. */
+  displays: readonly TransitDisplayDataWithMetaData_RAW[];
+  /** Display language chain passed to {@link buildTransitDisplayEntryData} for row resolution. */
+  dataLangs: readonly string[];
   emptyMessage: string;
   now: Date;
   mapCenter: LatLng | null;
@@ -127,13 +132,16 @@ const DEFAULT_CATEGORIES: Record<TransitDisplayCategory, boolean> = {
 };
 
 /**
- * Renders every {@link TransitDisplayDataWithMetaData} as its own stacked board, with a
- * filter bar on top for choosing which categories (departures / arrivals) to
- * show. The filter is presentation-only local state: it narrows the rendered
- * `displays`, it does not change how they are built or fetched.
+ * Resolves each {@link TransitDisplayDataWithMetaData_RAW} into UI rows (via
+ * {@link buildTransitDisplayEntryData} -- this is the only consumer that needs
+ * them) and renders it as its own stacked board, with a filter bar on top for
+ * choosing which categories (departures / arrivals) to show. The filter is
+ * presentation-only local state: it narrows the rendered displays, it does not
+ * change how they are built or fetched.
  */
 export function TransitDisplays({
   displays,
+  dataLangs,
   emptyMessage,
   now,
   mapCenter,
@@ -145,12 +153,26 @@ export function TransitDisplays({
   const [shownCategories, setShownCategories] =
     useState<Record<TransitDisplayCategory, boolean>>(DEFAULT_CATEGORIES);
 
+  // Resolve every raw display's rows into UI data here -- TransitDisplays is the
+  // only consumer that needs the resolved rows. Resolve all up front, then let
+  // the category filter below narrow the already-resolved list.
+  const resolvedDisplays = useMemo<readonly TransitDisplayDataWithMetaData[]>(
+    () =>
+      displays.map((raw) => ({
+        meta: raw.meta,
+        data: buildTransitDisplayEntryData(raw.data.data, dataLangs, raw.data.category),
+      })),
+    [displays, dataLangs],
+  );
+
   // Only offer toggles for categories that actually have a board, so the bar
   // mirrors what is on screen rather than always showing both.
   const presentCategories = FILTERABLE_CATEGORIES.filter((category) =>
-    displays.some((display) => display.meta.category === category),
+    resolvedDisplays.some((display) => display.meta.category === category),
   );
-  const visibleDisplays = displays.filter((display) => shownCategories[display.meta.category]);
+  const visibleDisplays = resolvedDisplays.filter(
+    (display) => shownCategories[display.meta.category],
+  );
 
   const toggleCategory = (category: TransitDisplayCategory) => {
     setShownCategories((prev) => ({ ...prev, [category]: !prev[category] }));

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { ArrowRight, ArrowUp } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -7,7 +9,9 @@ import type { TripInspectionTarget } from '@/types/app/transit-composed';
 import { DistanceBadge } from '@/components/badge/distance-badge';
 import { TimetableEntryAttributesLabels } from '@/components/label/timetable-entry-attributes-labels';
 import type { ExtendedDisplaySize } from '@/components/shared/display-size';
+import { Button } from '@/components/ui/button';
 import {
+  type TransitDisplayCategory,
   type TransitDisplayData,
   type TransitDisplayEntryData,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
@@ -35,6 +39,69 @@ const BOARD_FRAME_COLOR = 'border-zinc-400 dark:border-zinc-700';
  */
 const BOARD_PANEL_BG = 'bg-neutral-800 dark:bg-neutral-900';
 
+/**
+ * Title text size per display size, one step larger than the rows so headings
+ * (the board title and the filter toggles) read above the data rows.
+ */
+const TITLE_TEXT_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
+  xs: 'text-[10px]',
+  sm: 'text-xs',
+  md: 'text-base',
+  lg: 'text-4xl',
+  xl: 'text-6xl',
+};
+
+/**
+ * Title icon size class per display size; tracks {@link TITLE_TEXT_CLASS_BY_SIZE}.
+ * A `size-*` class (not the lucide `size` prop) is required so the icon overrides
+ * the ui/button base rule `[&_svg:not([class*='size-'])]:size-4`, which otherwise
+ * pins button icons to 16px regardless of the prop.
+ */
+const TITLE_ICON_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
+  xs: 'size-2.5', // 10px
+  sm: 'size-3', // 12px
+  md: 'size-4', // 16px
+  lg: 'size-9', // 36px
+  xl: 'size-15', // 60px
+};
+
+/** Row text size per display size; the larger the container, the larger the rows. */
+const ROW_TEXT_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
+  xs: 'text-[8px]',
+  sm: 'text-[10px]',
+  md: 'text-xs',
+  lg: 'text-lg',
+  xl: 'text-2xl',
+};
+
+const TIMETABLE_ENTRY_ATTRIBUTES_LABELS_SIZE_BY_SIZE: Record<
+  ExtendedDisplaySize,
+  ExtendedDisplaySize
+> = {
+  xs: 'xs',
+  sm: 'xs',
+  md: 'xs',
+  lg: 'sm',
+  xl: 'md',
+};
+
+const DISTANCE_BADGE_SIZE_BY_SIZE: Record<ExtendedDisplaySize, ExtendedDisplaySize> = {
+  xs: 'xs',
+  sm: 'xs',
+  md: 'xs',
+  lg: 'lg',
+  xl: 'xl',
+};
+
+/** Headsign column width per display size (fixed: max == min so the column is stable). */
+const HEADSIGN_WIDTH_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
+  xs: 'max-w-[10ch] min-w-[10ch]',
+  sm: 'max-w-[12ch] min-w-[12ch]',
+  md: 'max-w-[18ch] min-w-[18ch]',
+  lg: 'max-w-[32ch] min-w-[32ch]',
+  xl: 'max-w-[32ch] min-w-[32ch]',
+};
+
 export interface TransitDisplaysProps {
   displays: readonly TransitDisplayData[];
   emptyMessage: string;
@@ -46,7 +113,25 @@ export interface TransitDisplaysProps {
   onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
-/** Renders every {@link TransitDisplayData} as its own stacked board. */
+/**
+ * Filter axis: which categories (departures / arrivals) the boards can be
+ * narrowed to, in board order. The only filter axis for now -- route type and
+ * direction are not user-selectable here.
+ */
+const FILTERABLE_CATEGORIES: readonly TransitDisplayCategory[] = ['departures', 'arrivals'];
+
+/** All categories shown by default (no board hidden until the user toggles one off). */
+const ALL_CATEGORIES_SHOWN: Record<TransitDisplayCategory, boolean> = {
+  departures: true,
+  arrivals: true,
+};
+
+/**
+ * Renders every {@link TransitDisplayData} as its own stacked board, with a
+ * filter bar on top for choosing which categories (departures / arrivals) to
+ * show. The filter is presentation-only local state: it narrows the rendered
+ * `displays`, it does not change how they are built or fetched.
+ */
 export function TransitDisplays({
   displays,
   emptyMessage,
@@ -57,9 +142,31 @@ export function TransitDisplays({
   onStopSelected,
   onInspectTrip,
 }: TransitDisplaysProps) {
+  const [shownCategories, setShownCategories] =
+    useState<Record<TransitDisplayCategory, boolean>>(ALL_CATEGORIES_SHOWN);
+
+  // Only offer toggles for categories that actually have a board, so the bar
+  // mirrors what is on screen rather than always showing both.
+  const presentCategories = FILTERABLE_CATEGORIES.filter((category) =>
+    displays.some((display) => display.meta.category === category),
+  );
+  const visibleDisplays = displays.filter((display) => shownCategories[display.meta.category]);
+
+  const toggleCategory = (category: TransitDisplayCategory) => {
+    setShownCategories((prev) => ({ ...prev, [category]: !prev[category] }));
+  };
+
   return (
     <div className="font-dotgothic16 px-4 pb-0">
-      {displays.map((display, index) => (
+      {presentCategories.length > 0 && (
+        <TransitDisplayCategoryFilter
+          categories={presentCategories}
+          shownCategories={shownCategories}
+          size={size}
+          onToggleCategory={toggleCategory}
+        />
+      )}
+      {visibleDisplays.map((display, index) => (
         // Key from the board's identity (category + its route types), with the
         // map index as a disambiguator: a `custom` route grouping can collapse
         // two groups to the same present route types, so identity alone is not
@@ -76,6 +183,86 @@ export function TransitDisplays({
           onInspectTrip={onInspectTrip}
         />
       ))}
+    </div>
+  );
+}
+
+interface TransitDisplayCategoryFilterProps {
+  /** Categories that have a board, in board order; one toggle is rendered per entry. */
+  categories: readonly TransitDisplayCategory[];
+  /** Current shown / hidden state per category. */
+  shownCategories: Record<TransitDisplayCategory, boolean>;
+  /** Display size; scales the toggle label text like the board rows. */
+  size: ExtendedDisplaySize;
+  onToggleCategory: (category: TransitDisplayCategory) => void;
+}
+
+/**
+ * Split-flap-styled filter bar: one flap toggle per category. Styled to match
+ * the boards (same frame and panel face, amber text) rather than the generic
+ * chip filter. A lit flap means the category is shown; a dimmed one means it is
+ * hidden.
+ */
+function TransitDisplayCategoryFilter({
+  categories,
+  shownCategories,
+  size,
+  onToggleCategory,
+}: TransitDisplayCategoryFilterProps) {
+  const { t } = useTranslation();
+  return (
+    <div
+      role="group"
+      aria-label={t('transitDisplay.filter.label')}
+      className={cn(
+        'mb-2 flex items-center gap-2 rounded-sm border-0 px-3 py-2',
+        // BOARD_FRAME_COLOR,
+        // BOARD_PANEL_BG,
+      )}
+    >
+      {categories.map((category) => {
+        const isShown = shownCategories[category];
+        const isArrival = category === 'arrivals';
+        return (
+          // Shared ui/button (ghost) reused for structure and focus handling,
+          // restyled to the split-flap palette: a lit flap means the category is
+          // shown, a dimmed one means it is hidden.
+          <Button
+            key={category}
+            variant="ghost"
+            size="sm"
+            onClick={() => onToggleCategory(category)}
+            className={cn(
+              // grow + basis-0 makes both buttons equal width so they fill the
+              // bar evenly (basis-0 avoids fighting the Button base `shrink-0`).
+              // min-w-0 lets the label truncate instead of overflowing on narrow screens.
+              // h-auto lets the button grow with the size-scaled label text.
+              'h-auto min-w-0 grow basis-0 rounded-sm border-2 py-1 font-bold tracking-[0.18em] uppercase',
+              TITLE_TEXT_CLASS_BY_SIZE[size],
+              isShown
+                ? 'border-amber-300/70 bg-neutral-800 text-amber-100 hover:bg-neutral-700 hover:text-amber-100 dark:hover:bg-neutral-700'
+                : 'border-neutral-700 bg-neutral-900 text-amber-100/30 hover:bg-neutral-800 hover:text-amber-100/60 dark:hover:bg-neutral-800',
+            )}
+          >
+            {isArrival ? (
+              <ArrowRight
+                strokeWidth={4}
+                aria-hidden
+                className={cn('shrink-0', TITLE_ICON_CLASS_BY_SIZE[size])}
+              />
+            ) : (
+              <ArrowUp
+                strokeWidth={4}
+                aria-hidden
+                className={cn('shrink-0', TITLE_ICON_CLASS_BY_SIZE[size])}
+              />
+            )}
+            <span className="truncate">
+              {t(isArrival ? 'transitDisplay.filter.arrivals' : 'transitDisplay.filter.departures')}
+            </span>
+          </Button>
+        );
+      })}
     </div>
   );
 }
@@ -161,17 +348,35 @@ export function TransitDisplay({
         <div className="flex items-baseline justify-between gap-3">
           {/* Title — board basis arrow (up = departures, right = arrivals) + mode + phrase.
               The arrow is decorative; the phrase already states departures/arrivals. */}
-          <h3 className="text-md flex min-w-0 items-center gap-4 font-bold tracking-[0.18em] text-amber-100 uppercase">
+          <h3
+            className={cn(
+              'flex min-w-0 items-center gap-4 font-bold tracking-[0.18em] text-amber-100 uppercase',
+              TITLE_TEXT_CLASS_BY_SIZE[size],
+            )}
+          >
             {isArrivalBoard ? (
-              <ArrowRight size={14} strokeWidth={4} aria-hidden className="shrink-0" />
+              <ArrowRight
+                strokeWidth={4}
+                aria-hidden
+                className={cn('shrink-0', TITLE_ICON_CLASS_BY_SIZE[size])}
+              />
             ) : (
-              <ArrowUp size={14} strokeWidth={4} aria-hidden className="shrink-0" />
+              <ArrowUp
+                strokeWidth={4}
+                aria-hidden
+                className={cn('shrink-0', TITLE_ICON_CLASS_BY_SIZE[size])}
+              />
             )}
             {routeTypeIcon}
             <span className="truncate">{title}</span>
           </h3>
           {/* Radius the board's stops were selected within (count is intentionally omitted). */}
-          <p className="m-0 shrink-0 text-[11px] tracking-[0.12em] whitespace-nowrap text-amber-200/80">
+          <p
+            className={cn(
+              'm-0 shrink-0 text-[11px] tracking-[0.12em] whitespace-nowrap text-amber-200/80',
+              ROW_TEXT_CLASS_BY_SIZE[size],
+            )}
+          >
             {display.meta.radius}m
           </p>
         </div>
@@ -266,43 +471,6 @@ export interface TransitDisplayEntryProps {
   onStopSelected: (stopId: string) => void;
   onInspectTrip?: (target: TripInspectionTarget) => void;
 }
-
-/** Row text size per display size; the larger the container, the larger the rows. */
-const ROW_TEXT_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
-  xs: 'text-[8px]',
-  sm: 'text-[10px]',
-  md: 'text-xs',
-  lg: 'text-lg',
-  xl: 'text-2xl',
-};
-
-const TIMETABLE_ENTRY_ATTRIBUTES_LABELS_SIZE_BY_SIZE: Record<
-  ExtendedDisplaySize,
-  ExtendedDisplaySize
-> = {
-  xs: 'xs',
-  sm: 'xs',
-  md: 'xs',
-  lg: 'sm',
-  xl: 'md',
-};
-
-const DISTANCE_BADGE_SIZE_BY_SIZE: Record<ExtendedDisplaySize, ExtendedDisplaySize> = {
-  xs: 'xs',
-  sm: 'xs',
-  md: 'xs',
-  lg: 'lg',
-  xl: 'xl',
-};
-
-/** Headsign column width per display size (fixed: max == min so the column is stable). */
-const HEADSIGN_WIDTH_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
-  xs: 'max-w-[10ch] min-w-[10ch]',
-  sm: 'max-w-[12ch] min-w-[12ch]',
-  md: 'max-w-[18ch] min-w-[18ch]',
-  lg: 'max-w-[32ch] min-w-[32ch]',
-  xl: 'max-w-[32ch] min-w-[32ch]',
-};
 
 /** A single departure-board row (one stop event). */
 export function TransitDisplayEntry({

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -121,9 +121,9 @@ export interface TransitDisplaysProps {
 const FILTERABLE_CATEGORIES: readonly TransitDisplayCategory[] = ['departures', 'arrivals'];
 
 /** All categories shown by default (no board hidden until the user toggles one off). */
-const ALL_CATEGORIES_SHOWN: Record<TransitDisplayCategory, boolean> = {
+const DEFAULT_CATEGORIES: Record<TransitDisplayCategory, boolean> = {
   departures: true,
-  arrivals: true,
+  arrivals: false,
 };
 
 /**
@@ -143,7 +143,7 @@ export function TransitDisplays({
   onInspectTrip,
 }: TransitDisplaysProps) {
   const [shownCategories, setShownCategories] =
-    useState<Record<TransitDisplayCategory, boolean>>(ALL_CATEGORIES_SHOWN);
+    useState<Record<TransitDisplayCategory, boolean>>(DEFAULT_CATEGORIES);
 
   // Only offer toggles for categories that actually have a board, so the bar
   // mirrors what is on screen rather than always showing both.
@@ -266,7 +266,7 @@ function TransitDisplayCategoryFilter({
               TITLE_TEXT_CLASS_BY_SIZE[size],
               isShown
                 ? 'border-amber-300/70 bg-neutral-800 text-amber-100 hover:bg-neutral-700 hover:text-amber-100 dark:hover:bg-neutral-700'
-                : 'border-neutral-700 bg-neutral-900 text-amber-100/30 hover:bg-neutral-800 hover:text-amber-100/60 dark:hover:bg-neutral-800',
+                : 'border-neutral-700 bg-neutral-900 text-neutral-600 hover:bg-neutral-800 hover:text-neutral-400 dark:hover:bg-neutral-800',
             )}
           >
             {isArrival ? (

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -12,7 +12,7 @@ import type { ExtendedDisplaySize } from '@/components/shared/display-size';
 import { Button } from '@/components/ui/button';
 import {
   type TransitDisplayCategory,
-  type TransitDisplayData,
+  type TransitDisplayDataWithMetaData,
   type TransitDisplayEntryData,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
 import { getBearingDeg } from '@/domain/transit/distance';
@@ -103,7 +103,7 @@ const HEADSIGN_WIDTH_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
 };
 
 export interface TransitDisplaysProps {
-  displays: readonly TransitDisplayData[];
+  displays: readonly TransitDisplayDataWithMetaData[];
   emptyMessage: string;
   now: Date;
   mapCenter: LatLng | null;
@@ -127,7 +127,7 @@ const DEFAULT_CATEGORIES: Record<TransitDisplayCategory, boolean> = {
 };
 
 /**
- * Renders every {@link TransitDisplayData} as its own stacked board, with a
+ * Renders every {@link TransitDisplayDataWithMetaData} as its own stacked board, with a
  * filter bar on top for choosing which categories (departures / arrivals) to
  * show. The filter is presentation-only local state: it narrows the rendered
  * `displays`, it does not change how they are built or fetched.
@@ -293,7 +293,7 @@ function TransitDisplayCategoryFilter({
 }
 
 export interface TransitDisplayProps {
-  display: TransitDisplayData;
+  display: TransitDisplayDataWithMetaData;
   emptyMessage: string;
   now: Date;
   mapCenter: LatLng | null;

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -113,6 +113,7 @@ export function TransitDisplay({
   onStopSelected,
   onInspectTrip,
 }: TransitDisplayProps) {
+  const infoLevelFlag = useInfoLevel(infoLevel);
   const { t } = useTranslation();
   // Airport-board-style title: mode emoji + departures/arrivals phrase. The
   // route type and basis are structured meta; the UI composes the localized text.
@@ -123,6 +124,12 @@ export function TransitDisplay({
   const title = t(isArrivalBoard ? 'transitDisplay.arrivals' : 'transitDisplay.departures');
   // A board that mixes route types: rows then show their own trip route-type emoji.
   const hasMultiRoutes = display.meta.routeTypes.length >= 2;
+
+  // for debug
+  // if (display.meta.category === 'arrivals') {
+  //   return null;
+  // }
+
   return (
     // Each board is framed like a classic airport signage panel: a thick,
     // square (no rounded corners) border makes the boundary between stacked
@@ -153,6 +160,13 @@ export function TransitDisplay({
           {routeTypeIcon}
           <span className="truncate">{title}</span>
         </h3>
+        {/* Board meta in brief: category, route type(s), direction(s), row cap, radius. */}
+        {infoLevelFlag.isVerboseEnabled && (
+          <p className="m-0 shrink-0 text-xs whitespace-nowrap text-amber-200/80">
+            [{display.meta.category} / rt {display.meta.routeTypes.join(',')} / dir{' '}
+            {display.meta.directions.join(',')} (max:{display.meta.max},{display.meta.radius}m)]
+          </p>
+        )}
         {/* Radius the board's stops were selected within (count is intentionally omitted). */}
         <p className="m-0 shrink-0 text-[11px] tracking-[0.12em] whitespace-nowrap text-amber-200/80">
           {display.meta.radius}m

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -11,12 +11,14 @@ import { TimetableEntryAttributesLabels } from '@/components/label/timetable-ent
 import type { ExtendedDisplaySize } from '@/components/shared/display-size';
 import { Button } from '@/components/ui/button';
 import {
-  buildTransitDisplayDatumForUi,
   type TransitDisplayCategory,
-  type TransitDisplayDataWithMetaDataForUi,
   type TransitDisplayDataWithMetaData,
-  type TransitDisplayDatumForUi,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
+import {
+  buildTransitDisplayDatumForUi,
+  type TransitDisplayDataWithMetaDataForUi,
+  type TransitDisplayDatumForUi,
+} from '@/domain/transit/transit-info-display/build-transit-display-data-for-ui';
 import { getBearingDeg } from '@/domain/transit/distance';
 import { routeTypesEmoji } from '@/utils/route-type-emoji';
 import type { InfoLevel } from '@/types/app/settings';

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -187,6 +187,29 @@ export function TransitDisplays({
   );
 }
 
+/**
+ * Filter toggle button box metrics (border width + padding) per display size, so
+ * the frame and inset scale with the size-scaled label. The buttons always
+ * contain an arrow svg, so horizontal padding uses `has-[>svg]:px-*` to override
+ * the ui/button size variant's own `has-[>svg]:px-3`; `py-*` sets the height feel.
+ * Border color is applied separately (the shown / hidden state classes).
+ */
+const FILTER_BUTTON_BOX_BY_SIZE: Record<ExtendedDisplaySize, string> = {
+  xs: 'border has-[>svg]:px-2 py-0.5',
+  sm: 'border-2 has-[>svg]:px-2.5 py-1',
+  md: 'border-4 has-[>svg]:px-3 py-1',
+  lg: 'border-8 has-[>svg]:px-5 py-2',
+  xl: 'border-12 has-[>svg]:px-8 py-4',
+};
+
+const FILTER_BOX_SIZE: Record<ExtendedDisplaySize, string> = {
+  xs: 'py-2 px-3 gap-2',
+  sm: 'py-2 px-3 gap-2.5',
+  md: 'py-2 px-3 gap-3',
+  lg: 'py-3 px-8 gap-8',
+  xl: 'py-4 px-12 gap-12',
+};
+
 interface TransitDisplayCategoryFilterProps {
   /** Categories that have a board, in board order; one toggle is rendered per entry. */
   categories: readonly TransitDisplayCategory[];
@@ -215,7 +238,8 @@ function TransitDisplayCategoryFilter({
       role="group"
       aria-label={t('transitDisplay.filter.label')}
       className={cn(
-        'mb-2 flex items-center gap-2 rounded-sm border-0 px-3 py-2',
+        'mb-2 flex items-center rounded-sm border-0',
+        FILTER_BOX_SIZE[size],
         // BOARD_FRAME_COLOR,
         // BOARD_PANEL_BG,
       )}
@@ -230,14 +254,15 @@ function TransitDisplayCategoryFilter({
           <Button
             key={category}
             variant="ghost"
-            size="sm"
+            size="default"
             onClick={() => onToggleCategory(category)}
             className={cn(
               // grow + basis-0 makes both buttons equal width so they fill the
               // bar evenly (basis-0 avoids fighting the Button base `shrink-0`).
               // min-w-0 lets the label truncate instead of overflowing on narrow screens.
               // h-auto lets the button grow with the size-scaled label text.
-              'h-auto min-w-0 grow basis-0 rounded-sm border-2 py-1 font-bold tracking-[0.18em] uppercase',
+              'h-auto min-w-0 grow basis-0 rounded-sm font-bold tracking-[0.18em] uppercase',
+              FILTER_BUTTON_BOX_BY_SIZE[size],
               TITLE_TEXT_CLASS_BY_SIZE[size],
               isShown
                 ? 'border-amber-300/70 bg-neutral-800 text-amber-100 hover:bg-neutral-700 hover:text-amber-100 dark:hover:bg-neutral-700'

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -558,8 +558,8 @@ export function TransitDisplayEntry({
             attributes={data.attributes}
             showDisplayTerminal={true}
             showDisplayOrigin={true}
-            showDisplayPickupUnavailable={true}
-            showDisplayDropOffUnavailable={true}
+            showDisplayPickupUnavailable={infoLevelFlag.isVerboseEnabled ? true : false}
+            showDisplayDropOffUnavailable={infoLevelFlag.isVerboseEnabled ? true : false}
           />
         </span>
 

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -144,33 +144,37 @@ export function TransitDisplay({
           with letter-spaced amber text, like a split-flap header. */}
       <div
         className={cn(
-          'flex items-baseline justify-between gap-3 border-b-8 px-3 py-2.5',
+          'flex flex-col gap-1 border-b-8 px-3 py-2.5',
           BOARD_PANEL_BG,
           BOARD_FRAME_COLOR,
         )}
       >
-        {/* Title — board basis arrow (up = departures, right = arrivals) + mode + phrase.
-            The arrow is decorative; the phrase already states departures/arrivals. */}
-        <h3 className="text-md flex min-w-0 items-center gap-4 font-bold tracking-[0.18em] text-amber-100 uppercase">
-          {isArrivalBoard ? (
-            <ArrowRight size={14} strokeWidth={4} aria-hidden className="shrink-0" />
-          ) : (
-            <ArrowUp size={14} strokeWidth={4} aria-hidden className="shrink-0" />
-          )}
-          {routeTypeIcon}
-          <span className="truncate">{title}</span>
-        </h3>
         {/* Board meta in brief: category, route type(s), direction(s), row cap, radius. */}
         {infoLevelFlag.isVerboseEnabled && (
-          <p className="m-0 shrink-0 text-xs whitespace-nowrap text-amber-200/80">
-            [{display.meta.category} / rt {display.meta.routeTypes.join(',')} / dir{' '}
-            {display.meta.directions.join(',')} (max:{display.meta.max},{display.meta.radius}m)]
-          </p>
+          <div className="flex items-baseline gap-3">
+            <p className="m-0 ml-auto w-full min-w-0 text-right text-xs text-amber-200/80">
+              [{display.meta.category} / rt {display.meta.routeTypes.join(',')} / dir{' '}
+              {display.meta.directions.join(',')} (max:{display.meta.max},{display.meta.radius}m)]
+            </p>
+          </div>
         )}
-        {/* Radius the board's stops were selected within (count is intentionally omitted). */}
-        <p className="m-0 shrink-0 text-[11px] tracking-[0.12em] whitespace-nowrap text-amber-200/80">
-          {display.meta.radius}m
-        </p>
+        <div className="flex items-baseline justify-between gap-3">
+          {/* Title — board basis arrow (up = departures, right = arrivals) + mode + phrase.
+              The arrow is decorative; the phrase already states departures/arrivals. */}
+          <h3 className="text-md flex min-w-0 items-center gap-4 font-bold tracking-[0.18em] text-amber-100 uppercase">
+            {isArrivalBoard ? (
+              <ArrowRight size={14} strokeWidth={4} aria-hidden className="shrink-0" />
+            ) : (
+              <ArrowUp size={14} strokeWidth={4} aria-hidden className="shrink-0" />
+            )}
+            {routeTypeIcon}
+            <span className="truncate">{title}</span>
+          </h3>
+          {/* Radius the board's stops were selected within (count is intentionally omitted). */}
+          <p className="m-0 shrink-0 text-[11px] tracking-[0.12em] whitespace-nowrap text-amber-200/80">
+            {display.meta.radius}m
+          </p>
+        </div>
       </div>
       {/* Body: the rows (or the empty fallback). */}
       <div className="bg-neutral-950 p-0">

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data-for-ui.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data-for-ui.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for build-transit-display-data-for-ui.ts.
+ *
+ * @vitest-environment node
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeContextualEntry, makeRoute, makeStop } from '../../../../__tests__/helpers';
+import type { AppRouteTypeValue, Agency, Route } from '../../../../types/app/transit';
+import type { StopWithContext, TripInspectionTarget } from '../../../../types/app/transit-composed';
+import { minutesToDate } from '../../calendar-utils';
+import { getAgencyDisplayNames } from '../../name-resolver/get-agency-display-name';
+import { getHeadsignDisplayNames } from '../../name-resolver/get-headsign-display-names';
+import { getRouteDisplayNames } from '../../name-resolver/get-route-display-names';
+import { getStopDisplayNames } from '../../name-resolver/get-stop-display-names';
+import { formatAbsoluteTime } from '../../time';
+import { getTimetableEntryAttributes } from '../../timetable-entry-attributes';
+import { buildTripInspectionTarget } from '../../trip-inspection-target';
+import { routeTypesEmoji } from '../../../../utils/route-type-emoji';
+import { buildTransitDisplayDatumForUi } from '../build-transit-display-data-for-ui';
+import type { TransitDisplayDatum } from '../build-transit-display-data';
+
+// Name resolution, emoji, attributes, and trip-inspection targeting are exercised
+// by their own suites; here they are mocked so the assertions pin only what
+// buildTransitDisplayDatumForUi itself does (field mapping, per-stop name cache,
+// category-dependent time, and key construction). Date utilities stay real.
+vi.mock('../../name-resolver/get-stop-display-names', () => ({ getStopDisplayNames: vi.fn() }));
+vi.mock('../../name-resolver/get-route-display-names', () => ({ getRouteDisplayNames: vi.fn() }));
+vi.mock('../../name-resolver/get-headsign-display-names', () => ({
+  getHeadsignDisplayNames: vi.fn(),
+}));
+vi.mock('../../name-resolver/get-agency-display-name', () => ({ getAgencyDisplayNames: vi.fn() }));
+vi.mock('../../timetable-entry-attributes', () => ({ getTimetableEntryAttributes: vi.fn() }));
+vi.mock('../../trip-inspection-target', () => ({ buildTripInspectionTarget: vi.fn() }));
+vi.mock('../../../../utils/route-type-emoji', () => ({ routeTypesEmoji: vi.fn() }));
+
+const MOCK_ATTRIBUTES = {
+  isTerminal: false,
+  isOrigin: false,
+  isPickupUnavailable: false,
+  isDropOffUnavailable: false,
+};
+const MOCK_INSPECTION_TARGET = { kind: 'mock-target' } as unknown as TripInspectionTarget;
+
+/** Minimal agency; only `agency_id` / `agency_lang` are read directly by the builder. */
+function makeAgency(id: string, lang = 'ja'): Agency {
+  return { agency_id: id, agency_lang: lang } as unknown as Agency;
+}
+
+/** A stop context with overridable agencies / routeTypes / distance. */
+function makeStopContext(
+  overrides: {
+    stopId?: string;
+    distance?: number;
+    routeTypes?: AppRouteTypeValue[];
+    agencies?: Agency[];
+    routes?: Route[];
+  } = {},
+): StopWithContext {
+  return {
+    stop: makeStop(overrides.stopId ?? 'stop-1'),
+    distance: overrides.distance ?? 120,
+    routeTypes: overrides.routeTypes ?? [3],
+    stopTimes: [],
+    stopServiceState: 'boardable',
+    agencies: overrides.agencies ?? [],
+    routes: overrides.routes ?? [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStopDisplayNames).mockImplementation(
+    (stop) => ({ name: `STOP:${stop.stop_id}` }) as ReturnType<typeof getStopDisplayNames>,
+  );
+  vi.mocked(getRouteDisplayNames).mockReturnValue({
+    resolved: { name: 'ROUTE' },
+  } as ReturnType<typeof getRouteDisplayNames>);
+  vi.mocked(getHeadsignDisplayNames).mockReturnValue({
+    resolved: { name: 'HEADSIGN' },
+  } as ReturnType<typeof getHeadsignDisplayNames>);
+  vi.mocked(getAgencyDisplayNames).mockReturnValue({
+    resolved: { name: 'AGENCY' },
+  } as ReturnType<typeof getAgencyDisplayNames>);
+  vi.mocked(getTimetableEntryAttributes).mockReturnValue(MOCK_ATTRIBUTES);
+  vi.mocked(buildTripInspectionTarget).mockReturnValue(MOCK_INSPECTION_TARGET);
+  vi.mocked(routeTypesEmoji).mockImplementation((routeTypes) => `emoji(${routeTypes.join(',')})`);
+});
+
+describe('buildTransitDisplayDatumForUi', () => {
+  it('returns an empty array for empty input', () => {
+    expect(buildTransitDisplayDatumForUi([], ['ja'], 'departures')).toEqual([]);
+  });
+
+  it('maps each datum to one UI row, in order', () => {
+    const datum: TransitDisplayDatum[] = [
+      { entry: makeContextualEntry({ departureMinutes: 480 }), stopWithContext: makeStopContext() },
+      { entry: makeContextualEntry({ departureMinutes: 540 }), stopWithContext: makeStopContext() },
+    ];
+
+    const rows = buildTransitDisplayDatumForUi(datum, ['ja'], 'departures');
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.departureMinutes)).toEqual([480, 540]);
+  });
+
+  it('fills row fields from the resolvers and the source entry', () => {
+    const route: Route = { ...makeRoute('r1', 3), agency_id: 'A1' };
+    const datum: TransitDisplayDatum[] = [
+      {
+        entry: makeContextualEntry({ route, departureMinutes: 480, arrivalMinutes: 510 }),
+        stopWithContext: makeStopContext({
+          stopId: 'stop-9',
+          distance: 250,
+          routeTypes: [3, 2],
+          agencies: [makeAgency('A1')],
+          routes: [route],
+        }),
+      },
+    ];
+
+    const [row] = buildTransitDisplayDatumForUi(datum, ['ja'], 'departures');
+
+    expect(row.routeName).toBe('ROUTE');
+    expect(row.headsign).toBe('HEADSIGN');
+    expect(row.agencyName).toBe('AGENCY');
+    expect(row.routeTypeEmoji).toBe('emoji(3)'); // trip-level: the route's own type
+    expect(row.stop).toEqual({
+      id: 'stop-9',
+      name: 'STOP:stop-9',
+      platformCode: undefined,
+      distance: 250,
+      routeTypesEmoji: 'emoji(3,2)', // stop-level: all the stop's route types
+      context: datum[0].stopWithContext,
+    });
+    // Passthrough fields.
+    expect(row.arrivalMinutes).toBe(510);
+    expect(row.departureMinutes).toBe(480);
+    expect(row.serviceDate).toEqual(new Date('2026-01-01'));
+    expect(row.attributes).toBe(MOCK_ATTRIBUTES);
+    expect(row.inspectionTarget).toBe(MOCK_INSPECTION_TARGET);
+  });
+
+  it("leaves agencyName empty when no stop agency matches the route's agency", () => {
+    const route: Route = { ...makeRoute('r1', 3), agency_id: 'A1' };
+    const datum: TransitDisplayDatum[] = [
+      {
+        // stop context carries no agencies -> no match for agency_id 'A1'
+        entry: makeContextualEntry({ route }),
+        stopWithContext: makeStopContext({ agencies: [] }),
+      },
+    ];
+
+    const [row] = buildTransitDisplayDatumForUi(datum, ['ja'], 'departures');
+
+    expect(row.agencyName).toBe('');
+    expect(getAgencyDisplayNames).not.toHaveBeenCalled();
+  });
+
+  it('uses the category time for timeText: departures -> departure, arrivals -> arrival', () => {
+    const serviceDate = new Date('2026-01-01');
+    const entry = makeContextualEntry({ departureMinutes: 480, arrivalMinutes: 510, serviceDate });
+    const datum: TransitDisplayDatum[] = [{ entry, stopWithContext: makeStopContext() }];
+
+    const [departuresRow] = buildTransitDisplayDatumForUi(datum, ['ja'], 'departures');
+    const [arrivalsRow] = buildTransitDisplayDatumForUi(datum, ['ja'], 'arrivals');
+
+    expect(departuresRow.timeText).toBe(formatAbsoluteTime(minutesToDate(serviceDate, 480)));
+    expect(arrivalsRow.timeText).toBe(formatAbsoluteTime(minutesToDate(serviceDate, 510)));
+    expect(departuresRow.timeText).not.toBe(arrivalsRow.timeText);
+  });
+
+  it('resolves each stop name at most once and shares it across that stop entries', () => {
+    const sharedStop = makeStopContext({ stopId: 'shared' });
+    const datum: TransitDisplayDatum[] = [
+      { entry: makeContextualEntry({ departureMinutes: 480 }), stopWithContext: sharedStop },
+      { entry: makeContextualEntry({ departureMinutes: 540 }), stopWithContext: sharedStop },
+    ];
+
+    const rows = buildTransitDisplayDatumForUi(datum, ['ja'], 'departures');
+
+    expect(rows.map((row) => row.stop.name)).toEqual(['STOP:shared', 'STOP:shared']);
+    // Per-stop cache: one resolution shared across both entries of the same stop.
+    expect(getStopDisplayNames).toHaveBeenCalledTimes(1);
+  });
+
+  it('builds distinct keys for the same trip on different service dates', () => {
+    const stopWithContext = makeStopContext({ stopId: 'k' });
+    const day1: TransitDisplayDatum = {
+      entry: makeContextualEntry({ serviceDate: new Date('2026-01-01') }),
+      stopWithContext,
+    };
+    const day2: TransitDisplayDatum = {
+      entry: makeContextualEntry({ serviceDate: new Date('2026-01-02') }),
+      stopWithContext,
+    };
+
+    const [row1] = buildTransitDisplayDatumForUi([day1], ['ja'], 'departures');
+    const [row2] = buildTransitDisplayDatumForUi([day2], ['ja'], 'departures');
+
+    expect(row1.key).not.toBe(row2.key);
+    // The key is a JSON tuple that embeds the stop_id, so it survives a literal
+    // separator collision between its parts.
+    expect(row1.key).toContain('k');
+  });
+});

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -4,27 +4,30 @@
  * @vitest-environment node
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  agencyTobus,
-  baseStop,
-  busRoute,
-  createEntry,
-  railRoute,
-  subwayRoute,
-} from '../../../../stories/fixtures';
+import { makeContextualEntry, makeRoute, makeStop } from '../../../../__tests__/helpers';
 import type { InfoLevel } from '../../../../types/app/settings';
 import type { Route, TimetableEntryAttributes } from '../../../../types/app/transit';
-import type { StopWithContext } from '../../../../types/app/transit-composed';
+import type {
+  ContextualTimetableEntry,
+  StopWithContext,
+} from '../../../../types/app/transit-composed';
 import { ROUTE_TYPE_DISPLAY_ORDER } from '../../route-type-display-order';
 import { getTimetableEntryAttributes } from '../../timetable-entry-attributes';
 import {
   categoryQualifies,
   clusterCandidatesByRouteType,
   filterStopsWithinRadius,
+  groupCandidatesIntoBoards,
+  sortAndCapBoards,
+  sortByCategory,
+  toTransitDisplayCandidates,
   transitDisplayMaxEntriesFor,
+  type TransitDisplayBoard,
   type TransitDisplayCandidate,
+  type TransitDisplayCategory,
+  type TransitDisplayCondition,
 } from '../build-transit-display-data';
 
 // categoryQualifies delegates origin/terminal determination to this domain
@@ -50,10 +53,14 @@ describe('transitDisplayMaxEntriesFor', () => {
   });
 });
 
+const busRoute = makeRoute('bus', 3); // route_type 3
+const railRoute = makeRoute('rail', 2); // route_type 2
+const subwayRoute = makeRoute('subway', 1); // route_type 1
+
 /** Minimal stop context; clustering only reads each candidate's route_type, not the stop. */
 const STUB_STOP: StopWithContext = {
-  stop: baseStop,
-  agencies: [agencyTobus],
+  stop: makeStop('stub'),
+  agencies: [],
   routes: [busRoute],
   routeTypes: [3],
   stopTimes: [],
@@ -62,13 +69,93 @@ const STUB_STOP: StopWithContext = {
 
 /** A candidate for a trip on the given route (route.route_type drives clustering). */
 function candidateOf(route: Route): TransitDisplayCandidate {
-  return { entry: createEntry({ route }), stopWithContext: STUB_STOP };
+  return { entry: makeContextualEntry({ route }), stopWithContext: STUB_STOP };
 }
+
+describe('sortByCategory', () => {
+  /** A candidate with explicit departure / arrival minutes (and optional service date). */
+  function candidateWithTimes(opts: {
+    dep: number;
+    arr?: number;
+    serviceDate?: Date;
+  }): TransitDisplayCandidate {
+    const entry = makeContextualEntry({
+      route: busRoute,
+      departureMinutes: opts.dep,
+      arrivalMinutes: opts.arr ?? opts.dep,
+      ...(opts.serviceDate ? { serviceDate: opts.serviceDate } : {}),
+    });
+    return { entry, stopWithContext: STUB_STOP };
+  }
+
+  it("'departures': orders earliest departure first", () => {
+    const result = sortByCategory(
+      [
+        candidateWithTimes({ dep: 900 }),
+        candidateWithTimes({ dep: 800 }),
+        candidateWithTimes({ dep: 850 }),
+      ],
+      'departures',
+    );
+    expect(result.map((c) => c.entry.schedule.departureMinutes)).toEqual([800, 850, 900]);
+  });
+
+  it("'arrivals': orders by arrival time, not departure time", () => {
+    const a = candidateWithTimes({ dep: 800, arr: 900 });
+    const b = candidateWithTimes({ dep: 850, arr: 810 });
+    // departures uses departureMinutes -> a (800) before b (850)
+    expect(
+      sortByCategory([a, b], 'departures').map((c) => c.entry.schedule.departureMinutes),
+    ).toEqual([800, 850]);
+    // arrivals uses arrivalMinutes -> b (810) before a (900)
+    expect(sortByCategory([a, b], 'arrivals').map((c) => c.entry.schedule.arrivalMinutes)).toEqual([
+      810, 900,
+    ]);
+  });
+
+  it('orders by service date then time (earlier date first even with a later time)', () => {
+    // makeContextualEntry defaults serviceDate to 2026-01-01.
+    const lateOnDay1 = candidateWithTimes({ dep: 1400 }); // 2026-01-01, 23:20
+    const earlyOnDay2 = candidateWithTimes({ dep: 100, serviceDate: new Date('2026-01-02') }); // next day, 01:40
+
+    expect(sortByCategory([earlyOnDay2, lateOnDay1], 'departures')).toEqual([
+      lateOnDay1,
+      earlyOnDay2,
+    ]);
+  });
+
+  it('compares by resolved wall-clock, so an overnight (>= 24:00) entry sorts past the next day', () => {
+    // The sort uses minutesToDate().getTime(), not a naive (serviceDate, minutes)
+    // ordering. A day-1 trip at 26:00 rolls over to day-2 02:00, so it must sort
+    // AFTER a day-2 trip at 01:00 -- the opposite of a naive date-then-minutes sort.
+    const overnightOnDay1 = candidateWithTimes({ dep: 1560 }); // 2026-01-01, 26:00 -> 01-02 02:00
+    const earlyOnDay2 = candidateWithTimes({ dep: 60, serviceDate: new Date('2026-01-02') }); // 01-02 01:00
+
+    expect(sortByCategory([overnightOnDay1, earlyOnDay2], 'departures')).toEqual([
+      earlyOnDay2,
+      overnightOnDay1,
+    ]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(sortByCategory([], 'departures')).toEqual([]);
+  });
+
+  it('does not mutate the input array', () => {
+    const c900 = candidateWithTimes({ dep: 900 });
+    const c800 = candidateWithTimes({ dep: 800 });
+    const input = [c900, c800];
+
+    sortByCategory(input, 'departures');
+
+    expect(input).toEqual([c900, c800]);
+  });
+});
 
 describe('categoryQualifies', () => {
   // The entry content is irrelevant: getTimetableEntryAttributes is mocked, so
   // only the flags it returns drive the result.
-  const ENTRY = createEntry({ route: busRoute });
+  const ENTRY = makeContextualEntry({ route: busRoute });
 
   /** Make the mocked getTimetableEntryAttributes return the given flags (rest false). */
   function withAttributes(flags: Partial<TimetableEntryAttributes>): void {
@@ -96,12 +183,35 @@ describe('categoryQualifies', () => {
     withAttributes({ isOrigin: false, isTerminal: true });
     expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
   });
+
+  it('a plain entry (no terminal/origin) qualifies for both categories', () => {
+    withAttributes({});
+
+    expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
+    expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
+  });
+
+  it('ignores boarding availability: pickup/drop-off unavailable does not disqualify', () => {
+    // Only terminal/origin gate qualification; boarding flags are irrelevant here.
+    withAttributes({ isPickupUnavailable: true, isDropOffUnavailable: true });
+
+    expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
+    expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
+  });
+
+  it('delegates terminal/origin determination to getTimetableEntryAttributes', () => {
+    withAttributes({});
+
+    categoryQualifies(ENTRY, 'departures');
+
+    expect(getTimetableEntryAttributes).toHaveBeenCalledWith(ENTRY);
+  });
 });
 
 describe('filterStopsWithinRadius', () => {
   /** A stop context at a given distance (metres), with a unique id for assertions. */
   function stopAtDistance(stopId: string, distance: number | undefined): StopWithContext {
-    return { ...STUB_STOP, stop: { ...baseStop, stop_id: stopId }, distance };
+    return { ...STUB_STOP, stop: makeStop(stopId), distance };
   }
 
   it('keeps stops within the radius and drops the ones beyond it', () => {
@@ -216,5 +326,282 @@ describe('clusterCandidatesByRouteType', () => {
 
     expect(clusters[0].routeTypes).toEqual([1]); // 2 dropped (not present)
     expect(clusters[0].candidates).toEqual([subway]);
+  });
+
+  it("'route': keeps the input order of candidates within a single type's cluster", () => {
+    const bus1 = candidateOf(busRoute); // 3
+    const bus2 = candidateOf(busRoute); // 3
+
+    const clusters = clusterCandidatesByRouteType([bus1, bus2], { kind: 'route' });
+
+    const busCluster = clusters.find((c) => c.routeTypes[0] === busRoute.route_type);
+    expect(busCluster?.candidates).toEqual([bus1, bus2]);
+  });
+
+  it("'route': returns the full display-order skeleton even with no candidates (all clusters empty)", () => {
+    const clusters = clusterCandidatesByRouteType([], { kind: 'route' });
+
+    // Structure is data-independent: one single-type cluster per display-order entry.
+    expect(clusters.map((c) => c.routeTypes)).toEqual(ROUTE_TYPE_DISPLAY_ORDER.map((t) => [t]));
+    expect(clusters.every((c) => c.candidates.length === 0)).toBe(true);
+  });
+
+  it("'none': returns a single empty cluster with no route types for no candidates", () => {
+    const clusters = clusterCandidatesByRouteType([], { kind: 'none' });
+
+    expect(clusters).toEqual([{ routeTypes: [], candidates: [] }]);
+  });
+
+  it("'custom': returns no clusters for an empty groups list", () => {
+    const bus = candidateOf(busRoute);
+
+    expect(clusterCandidatesByRouteType([bus], { kind: 'custom', groups: [] })).toEqual([]);
+  });
+});
+
+describe('groupCandidatesIntoBoards', () => {
+  // groupCandidatesIntoBoards routes through categoryQualifies ->
+  // getTimetableEntryAttributes (mocked at the top). Make the mock faithful for
+  // the only flags categoryQualifies reads, derived from the entry itself, so
+  // each candidate gets its own terminal/origin result.
+  beforeEach(() => {
+    vi.mocked(getTimetableEntryAttributes).mockImplementation((entry) => ({
+      isTerminal: entry.patternPosition.isTerminal,
+      isOrigin: entry.patternPosition.isOrigin,
+      isPickupUnavailable: false,
+      isDropOffUnavailable: false,
+    }));
+  });
+
+  /** A candidate with an explicit direction and terminal/origin position. */
+  function cand(
+    opts: { route?: Route; direction?: 0 | 1; isOrigin?: boolean; isTerminal?: boolean } = {},
+  ): TransitDisplayCandidate {
+    return {
+      entry: makeContextualEntry({
+        route: opts.route ?? busRoute,
+        direction: opts.direction,
+        isOrigin: opts.isOrigin,
+        isTerminal: opts.isTerminal,
+      }),
+      stopWithContext: STUB_STOP,
+    };
+  }
+
+  const notSplit: TransitDisplayCondition = {
+    maxEntries: 100,
+    routeGrouping: { kind: 'none' },
+    splitByDirection: false,
+  };
+  const split: TransitDisplayCondition = { ...notSplit, splitByDirection: true };
+
+  it('not split: produces a departures and an arrivals board per cluster', () => {
+    const a = cand({ direction: 0 });
+    const b = cand({ direction: 1 });
+
+    const boards = groupCandidatesIntoBoards([a, b], notSplit);
+
+    expect(boards).toHaveLength(2);
+    expect(boards.map((bd) => bd.category)).toEqual(['departures', 'arrivals']);
+    for (const bd of boards) {
+      expect(bd.routeTypes).toEqual([3]);
+      expect(bd.directions).toEqual([0, 1]); // present directions of the board's candidates
+      expect(bd.candidates).toEqual([a, b]);
+    }
+  });
+
+  it("not split: excludes terminal from departures and origin from arrivals, narrowing each board's directions", () => {
+    const plain0 = cand({ direction: 0 }); // qualifies both
+    const terminal1 = cand({ direction: 1, isTerminal: true }); // arrivals only
+
+    const boards = groupCandidatesIntoBoards([plain0, terminal1], notSplit);
+
+    const departures = boards.find((bd) => bd.category === 'departures');
+    const arrivals = boards.find((bd) => bd.category === 'arrivals');
+
+    expect(departures?.candidates).toEqual([plain0]); // terminal1 dropped
+    expect(departures?.directions).toEqual([0]); // direction 1 no longer present
+    expect(arrivals?.candidates).toEqual([plain0, terminal1]);
+    expect(arrivals?.directions).toEqual([0, 1]);
+  });
+
+  it('split: one board per present (direction, category); undefined maps to "none", absent buckets dropped', () => {
+    const noDir = cand({}); // direction undefined
+    const dir0 = cand({ direction: 0 });
+    // no direction 1 -> its buckets are empty and dropped
+
+    const boards = groupCandidatesIntoBoards([noDir, dir0], split);
+
+    expect(boards.map((bd) => ({ directions: bd.directions, category: bd.category }))).toEqual([
+      { directions: ['none'], category: 'departures' },
+      { directions: ['none'], category: 'arrivals' },
+      { directions: [0], category: 'departures' },
+      { directions: [0], category: 'arrivals' },
+    ]);
+    // each bucket keeps only its own direction's candidate
+    expect(boards[0].candidates).toEqual([noDir]);
+    expect(boards[2].candidates).toEqual([dir0]);
+  });
+
+  it('split: drops a board left empty after category qualification', () => {
+    const terminal0 = cand({ direction: 0, isTerminal: true }); // arrivals only
+
+    const boards = groupCandidatesIntoBoards([terminal0], split);
+
+    // direction-0 departures board is empty (terminal excluded) and dropped.
+    expect(boards).toHaveLength(1);
+    expect(boards[0].directions).toEqual([0]);
+    expect(boards[0].category).toBe('arrivals');
+    expect(boards[0].candidates).toEqual([terminal0]);
+  });
+
+  it('returns no boards for empty input', () => {
+    expect(groupCandidatesIntoBoards([], notSplit)).toEqual([]);
+    expect(groupCandidatesIntoBoards([], split)).toEqual([]);
+  });
+
+  it("respects the route grouping: 'route' yields per-route-type boards in display order", () => {
+    const bus = cand({ route: busRoute }); // 3
+    const subway = cand({ route: subwayRoute }); // 1
+
+    const boards = groupCandidatesIntoBoards([bus, subway], {
+      maxEntries: 100,
+      routeGrouping: { kind: 'route' },
+      splitByDirection: false,
+    });
+
+    // Empty route-type clusters are dropped; 3 precedes 1 in display order, and
+    // each surviving type yields a departures + arrivals board.
+    expect(boards.map((bd) => ({ routeTypes: bd.routeTypes, category: bd.category }))).toEqual([
+      { routeTypes: [3], category: 'departures' },
+      { routeTypes: [3], category: 'arrivals' },
+      { routeTypes: [1], category: 'departures' },
+      { routeTypes: [1], category: 'arrivals' },
+    ]);
+  });
+});
+
+describe('sortAndCapBoards', () => {
+  /** A candidate with explicit departure / arrival minutes. */
+  function candWithTimes(dep: number, arr: number = dep): TransitDisplayCandidate {
+    return {
+      entry: makeContextualEntry({ route: busRoute, departureMinutes: dep, arrivalMinutes: arr }),
+      stopWithContext: STUB_STOP,
+    };
+  }
+
+  /** A board carrying the given category and candidates (metadata is incidental). */
+  function boardOf(
+    category: TransitDisplayCategory,
+    candidates: TransitDisplayCandidate[],
+  ): TransitDisplayBoard {
+    return { routeTypes: [3], directions: ['none'], category, candidates };
+  }
+
+  it("sorts each board's candidates by its own category's time", () => {
+    const dep = boardOf('departures', [candWithTimes(900), candWithTimes(800), candWithTimes(850)]);
+    const arr = boardOf('arrivals', [candWithTimes(700, 900), candWithTimes(710, 810)]);
+
+    const [sortedDep, sortedArr] = sortAndCapBoards([dep, arr], 100);
+
+    expect(sortedDep.candidates.map((c) => c.entry.schedule.departureMinutes)).toEqual([
+      800, 850, 900,
+    ]);
+    // arrivals board sorts by arrivalMinutes (810 before 900), not departure time
+    expect(sortedArr.candidates.map((c) => c.entry.schedule.arrivalMinutes)).toEqual([810, 900]);
+  });
+
+  it('caps each board to maxEntries, keeping the earliest after sorting', () => {
+    const board = boardOf('departures', [
+      candWithTimes(900),
+      candWithTimes(800),
+      candWithTimes(850),
+      candWithTimes(700),
+    ]);
+
+    const [capped] = sortAndCapBoards([board], 2);
+
+    expect(capped.candidates.map((c) => c.entry.schedule.departureMinutes)).toEqual([700, 800]);
+  });
+
+  it('preserves board metadata (routeTypes, directions, category)', () => {
+    const board: TransitDisplayBoard = {
+      routeTypes: [2, 1],
+      directions: [0, 'none'],
+      category: 'departures',
+      candidates: [candWithTimes(800)],
+    };
+
+    const [result] = sortAndCapBoards([board], 100);
+
+    expect(result.routeTypes).toEqual([2, 1]);
+    expect(result.directions).toEqual([0, 'none']);
+    expect(result.category).toBe('departures');
+  });
+
+  it('does not mutate the input board candidates', () => {
+    const c900 = candWithTimes(900);
+    const c800 = candWithTimes(800);
+    const board = boardOf('departures', [c900, c800]);
+
+    sortAndCapBoards([board], 100);
+
+    expect(board.candidates).toEqual([c900, c800]);
+  });
+
+  it('returns an empty array for no boards', () => {
+    expect(sortAndCapBoards([], 100)).toEqual([]);
+  });
+
+  it('keeps an empty board empty', () => {
+    const [result] = sortAndCapBoards([boardOf('departures', [])], 100);
+
+    expect(result.candidates).toEqual([]);
+  });
+});
+
+describe('toTransitDisplayCandidates', () => {
+  /** A stop context carrying the given stopTimes (other fields are incidental). */
+  function stopWith(stopId: string, stopTimes: ContextualTimetableEntry[]): StopWithContext {
+    return { ...STUB_STOP, stop: makeStop(stopId), stopTimes };
+  }
+
+  it("flattens a stop's stopTimes into (entry, stopWithContext) pairs", () => {
+    const e0 = makeContextualEntry({ departureMinutes: 600 });
+    const e1 = makeContextualEntry({ departureMinutes: 700 });
+    const stop = stopWith('s1', [e0, e1]);
+
+    expect(toTransitDisplayCandidates([stop])).toEqual([
+      { entry: e0, stopWithContext: stop },
+      { entry: e1, stopWithContext: stop },
+    ]);
+  });
+
+  it('preserves stop order then stopTime order without reordering by time', () => {
+    const a0 = makeContextualEntry({ departureMinutes: 600 });
+    const a1 = makeContextualEntry({ departureMinutes: 610 });
+    const b0 = makeContextualEntry({ departureMinutes: 500 }); // earlier, but later stop
+    const stopA = stopWith('a', [a0, a1]);
+    const stopB = stopWith('b', [b0]);
+
+    const candidates = toTransitDisplayCandidates([stopA, stopB]);
+
+    // Declaration order is kept (b0 at 500 stays last); each entry keeps its source stop.
+    expect(candidates.map((c) => c.entry)).toEqual([a0, a1, b0]);
+    expect(candidates.map((c) => c.stopWithContext)).toEqual([stopA, stopA, stopB]);
+  });
+
+  it('contributes nothing for a stop with no stopTimes', () => {
+    const empty = stopWith('empty', []);
+    const e0 = makeContextualEntry({});
+    const withTimes = stopWith('s', [e0]);
+
+    expect(toTransitDisplayCandidates([empty, withTimes])).toEqual([
+      { entry: e0, stopWithContext: withTimes },
+    ]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(toTransitDisplayCandidates([])).toEqual([]);
   });
 });

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -8,7 +8,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { makeContextualEntry, makeRoute, makeStop } from '../../../../__tests__/helpers';
 import type { InfoLevel } from '../../../../types/app/settings';
-import type { Route, TimetableEntryAttributes } from '../../../../types/app/transit';
+import type {
+  AppRouteTypeValue,
+  Route,
+  TimetableEntryAttributes,
+} from '../../../../types/app/transit';
 import type {
   ContextualTimetableEntry,
   StopWithContext,
@@ -22,12 +26,14 @@ import {
   groupCandidatesIntoBoards,
   sortAndCapBoards,
   sortByCategory,
+  sortTransitDisplayDataForUi,
   toTransitDisplayCandidates,
   transitDisplayMaxEntriesFor,
   type TransitDisplayBoard,
   type TransitDisplayCandidate,
   type TransitDisplayCategory,
   type TransitDisplayCondition,
+  type TransitDisplayData,
 } from '../build-transit-display-data';
 
 // categoryQualifies delegates origin/terminal determination to this domain
@@ -624,5 +630,91 @@ describe('toTransitDisplayCandidates', () => {
 
   it('returns an empty array for empty input', () => {
     expect(toTransitDisplayCandidates([])).toEqual([]);
+  });
+});
+
+describe('sortTransitDisplayDataForUi', () => {
+  /** A display whose only meaningful fields for ordering are route type, category, direction. */
+  function display(
+    routeType: AppRouteTypeValue,
+    category: TransitDisplayCategory,
+    directions: readonly (0 | 1 | 'none')[] = ['none'],
+  ): TransitDisplayData {
+    return {
+      meta: { category, routeTypes: [routeType], directions, max: 10, radius: 100 },
+      data: [],
+    };
+  }
+
+  it('orders by route type in ROUTE_TYPE_DISPLAY_ORDER (ferry not hoisted)', () => {
+    // display order is [3, 11, 0, 2, 1, 12, 4, ...]: bus(3) < rail(2) < subway(1) < ferry(4)
+    const bus = display(3, 'departures');
+    const rail = display(2, 'departures');
+    const subway = display(1, 'departures');
+    const ferry = display(4, 'departures');
+
+    const sorted = sortTransitDisplayDataForUi([subway, ferry, rail, bus]);
+
+    expect(sorted.map((d) => d.meta.routeTypes[0])).toEqual([3, 2, 1, 4]);
+  });
+
+  it('within a route type, departures come before arrivals', () => {
+    const arr = display(2, 'arrivals');
+    const dep = display(2, 'departures');
+
+    expect(sortTransitDisplayDataForUi([arr, dep]).map((d) => d.meta.category)).toEqual([
+      'departures',
+      'arrivals',
+    ]);
+  });
+
+  it('within a category, orders by direction (none, 0, 1)', () => {
+    const d1 = display(2, 'departures', [1]);
+    const d0 = display(2, 'departures', [0]);
+    const dn = display(2, 'departures', ['none']);
+
+    expect(sortTransitDisplayDataForUi([d1, d0, dn]).map((d) => d.meta.directions[0])).toEqual([
+      'none',
+      0,
+      1,
+    ]);
+  });
+
+  it('applies the three levels together: route type -> category -> direction', () => {
+    const railArr0 = display(2, 'arrivals', [0]);
+    const busDep = display(3, 'departures', ['none']);
+    const railDep1 = display(2, 'departures', [1]);
+    const railDep0 = display(2, 'departures', [0]);
+    const busArr = display(3, 'arrivals', ['none']);
+
+    const sorted = sortTransitDisplayDataForUi([railArr0, busDep, railDep1, railDep0, busArr]);
+
+    expect(
+      sorted.map((d) => ({
+        rt: d.meta.routeTypes[0],
+        category: d.meta.category,
+        dir: d.meta.directions[0],
+      })),
+    ).toEqual([
+      { rt: 3, category: 'departures', dir: 'none' },
+      { rt: 3, category: 'arrivals', dir: 'none' },
+      { rt: 2, category: 'departures', dir: 0 },
+      { rt: 2, category: 'departures', dir: 1 },
+      { rt: 2, category: 'arrivals', dir: 0 },
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const a = display(2, 'departures');
+    const b = display(3, 'departures');
+    const input = [a, b];
+
+    sortTransitDisplayDataForUi(input);
+
+    expect(input).toEqual([a, b]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(sortTransitDisplayDataForUi([])).toEqual([]);
   });
 });

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -168,32 +168,52 @@ describe('categoryQualifies', () => {
     });
   }
 
-  it("'departures' reads isTerminal and ignores isOrigin", () => {
-    withAttributes({ isTerminal: true, isOrigin: true });
-    expect(categoryQualifies(ENTRY, 'departures')).toBe(false);
+  describe('departures', () => {
+    it('excludes terminal entries', () => {
+      withAttributes({ isTerminal: true });
+      expect(categoryQualifies(ENTRY, 'departures')).toBe(false);
+    });
 
-    withAttributes({ isTerminal: false, isOrigin: true });
-    expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
+    it('includes non-terminal entries and ignores isOrigin', () => {
+      withAttributes({ isTerminal: false, isOrigin: true });
+      expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
+    });
+
+    it('ignores isPickupUnavailable (still qualifies)', () => {
+      withAttributes({ isPickupUnavailable: true });
+      expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
+    });
+
+    it('ignores isDropOffUnavailable (still qualifies)', () => {
+      withAttributes({ isDropOffUnavailable: true });
+      expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
+    });
   });
 
-  it("'arrivals' reads isOrigin and ignores isTerminal", () => {
-    withAttributes({ isOrigin: true, isTerminal: true });
-    expect(categoryQualifies(ENTRY, 'arrivals')).toBe(false);
+  describe('arrivals', () => {
+    it('excludes origin entries', () => {
+      withAttributes({ isOrigin: true });
+      expect(categoryQualifies(ENTRY, 'arrivals')).toBe(false);
+    });
 
-    withAttributes({ isOrigin: false, isTerminal: true });
-    expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
+    it('includes non-origin entries and ignores isTerminal', () => {
+      withAttributes({ isOrigin: false, isTerminal: true });
+      expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
+    });
+
+    it('ignores isPickupUnavailable (still qualifies)', () => {
+      withAttributes({ isPickupUnavailable: true });
+      expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
+    });
+
+    it('ignores isDropOffUnavailable (still qualifies)', () => {
+      withAttributes({ isDropOffUnavailable: true });
+      expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
+    });
   });
 
   it('a plain entry (no terminal/origin) qualifies for both categories', () => {
     withAttributes({});
-
-    expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
-    expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
-  });
-
-  it('ignores boarding availability: pickup/drop-off unavailable does not disqualify', () => {
-    // Only terminal/origin gate qualification; boarding flags are irrelevant here.
-    withAttributes({ isPickupUnavailable: true, isDropOffUnavailable: true });
 
     expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
     expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -179,12 +179,12 @@ describe('categoryQualifies', () => {
       expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
     });
 
-    it('ignores isPickupUnavailable (still qualifies)', () => {
+    it('excludes un-boardable entries (isPickupUnavailable)', () => {
       withAttributes({ isPickupUnavailable: true });
-      expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
+      expect(categoryQualifies(ENTRY, 'departures')).toBe(false);
     });
 
-    it('ignores isDropOffUnavailable (still qualifies)', () => {
+    it('ignores isDropOffUnavailable (still qualifies, boarding is unaffected)', () => {
       withAttributes({ isDropOffUnavailable: true });
       expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
     });
@@ -201,14 +201,14 @@ describe('categoryQualifies', () => {
       expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
     });
 
-    it('ignores isPickupUnavailable (still qualifies)', () => {
+    it('ignores isPickupUnavailable (still qualifies, alighting is unaffected)', () => {
       withAttributes({ isPickupUnavailable: true });
       expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
     });
 
-    it('ignores isDropOffUnavailable (still qualifies)', () => {
+    it('excludes un-alightable entries (isDropOffUnavailable)', () => {
       withAttributes({ isDropOffUnavailable: true });
-      expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
+      expect(categoryQualifies(ENTRY, 'arrivals')).toBe(false);
     });
   });
 

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -20,6 +20,7 @@ import type { StopWithContext } from '../../../../types/app/transit-composed';
 import { ROUTE_TYPE_DISPLAY_ORDER } from '../../route-type-display-order';
 import {
   clusterCandidatesByRouteType,
+  filterStopsWithinRadius,
   transitDisplayMaxEntriesFor,
   type TransitDisplayCandidate,
 } from '../build-transit-display-data';
@@ -54,6 +55,59 @@ const STUB_STOP: StopWithContext = {
 function candidateOf(route: Route): TransitDisplayCandidate {
   return { entry: createEntry({ route }), stopWithContext: STUB_STOP };
 }
+
+describe('filterStopsWithinRadius', () => {
+  /** A stop context at a given distance (metres), with a unique id for assertions. */
+  function stopAtDistance(stopId: string, distance: number | undefined): StopWithContext {
+    return { ...STUB_STOP, stop: { ...baseStop, stop_id: stopId }, distance };
+  }
+
+  it('keeps stops within the radius and drops the ones beyond it', () => {
+    const near = stopAtDistance('near', 50);
+    const far = stopAtDistance('far', 150);
+
+    expect(filterStopsWithinRadius([near, far], 100)).toEqual([near]);
+  });
+
+  it('keeps a stop exactly at the radius (boundary is inclusive)', () => {
+    const onEdge = stopAtDistance('edge', 100);
+
+    expect(filterStopsWithinRadius([onEdge], 100)).toEqual([onEdge]);
+  });
+
+  it('keeps a stop at distance 0', () => {
+    const here = stopAtDistance('here', 0);
+
+    expect(filterStopsWithinRadius([here], 100)).toEqual([here]);
+  });
+
+  it('drops stops whose distance is undefined', () => {
+    const unknown = stopAtDistance('unknown', undefined);
+    const near = stopAtDistance('near', 10);
+
+    expect(filterStopsWithinRadius([unknown, near], 100)).toEqual([near]);
+  });
+
+  it('returns an empty array when no stop is within the radius', () => {
+    const far = stopAtDistance('far', 500);
+
+    expect(filterStopsWithinRadius([far], 100)).toEqual([]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(filterStopsWithinRadius([], 100)).toEqual([]);
+  });
+
+  it('preserves the input order of the surviving stops', () => {
+    const a = stopAtDistance('a', 10);
+    const b = stopAtDistance('b', 90);
+    const c = stopAtDistance('c', 40);
+
+    const result = filterStopsWithinRadius([a, b, c], 100);
+
+    expect(result.map((s) => s.stop.stop_id)).toEqual(['a', 'b', 'c']);
+  });
+});
 
 describe('clusterCandidatesByRouteType', () => {
   it("'route': one cluster per route type in display order, candidates placed by type", () => {

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -4,7 +4,7 @@
  * @vitest-environment node
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   agencyTobus,
@@ -15,15 +15,24 @@ import {
   subwayRoute,
 } from '../../../../stories/fixtures';
 import type { InfoLevel } from '../../../../types/app/settings';
-import type { Route } from '../../../../types/app/transit';
+import type { Route, TimetableEntryAttributes } from '../../../../types/app/transit';
 import type { StopWithContext } from '../../../../types/app/transit-composed';
 import { ROUTE_TYPE_DISPLAY_ORDER } from '../../route-type-display-order';
+import { getTimetableEntryAttributes } from '../../timetable-entry-attributes';
 import {
+  categoryQualifies,
   clusterCandidatesByRouteType,
   filterStopsWithinRadius,
   transitDisplayMaxEntriesFor,
   type TransitDisplayCandidate,
 } from '../build-transit-display-data';
+
+// categoryQualifies delegates origin/terminal determination to this domain
+// function (which may change over time), so the categoryQualifies unit tests
+// mock it to pin only categoryQualifies' own branching.
+vi.mock('../../timetable-entry-attributes', () => ({
+  getTimetableEntryAttributes: vi.fn(),
+}));
 
 describe('transitDisplayMaxEntriesFor', () => {
   it('returns the configured row cap for each info level', () => {
@@ -55,6 +64,39 @@ const STUB_STOP: StopWithContext = {
 function candidateOf(route: Route): TransitDisplayCandidate {
   return { entry: createEntry({ route }), stopWithContext: STUB_STOP };
 }
+
+describe('categoryQualifies', () => {
+  // The entry content is irrelevant: getTimetableEntryAttributes is mocked, so
+  // only the flags it returns drive the result.
+  const ENTRY = createEntry({ route: busRoute });
+
+  /** Make the mocked getTimetableEntryAttributes return the given flags (rest false). */
+  function withAttributes(flags: Partial<TimetableEntryAttributes>): void {
+    vi.mocked(getTimetableEntryAttributes).mockReturnValue({
+      isTerminal: false,
+      isOrigin: false,
+      isPickupUnavailable: false,
+      isDropOffUnavailable: false,
+      ...flags,
+    });
+  }
+
+  it("'departures' reads isTerminal and ignores isOrigin", () => {
+    withAttributes({ isTerminal: true, isOrigin: true });
+    expect(categoryQualifies(ENTRY, 'departures')).toBe(false);
+
+    withAttributes({ isTerminal: false, isOrigin: true });
+    expect(categoryQualifies(ENTRY, 'departures')).toBe(true);
+  });
+
+  it("'arrivals' reads isOrigin and ignores isTerminal", () => {
+    withAttributes({ isOrigin: true, isTerminal: true });
+    expect(categoryQualifies(ENTRY, 'arrivals')).toBe(false);
+
+    withAttributes({ isOrigin: false, isTerminal: true });
+    expect(categoryQualifies(ENTRY, 'arrivals')).toBe(true);
+  });
+});
 
 describe('filterStopsWithinRadius', () => {
   /** A stop context at a given distance (metres), with a unique id for assertions. */

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -26,14 +26,14 @@ import {
   groupCandidatesIntoBoards,
   sortAndCapTransitDisplayData,
   sortByCategory,
-  sortTransitDisplayDataWithMetaData_RAWForUi,
+  sortTransitDisplayDataWithMetaData,
   toTransitDisplayCandidates,
   transitDisplayMaxEntriesFor,
   type TransitDisplayData,
   type TransitDisplayCandidate,
   type TransitDisplayCategory,
   type TransitDisplayCondition,
-  type TransitDisplayDataWithMetaData_RAW,
+  type TransitDisplayDataWithMetaData,
 } from '../build-transit-display-data';
 
 // categoryQualifies delegates origin/terminal determination to this domain
@@ -631,13 +631,13 @@ describe('toTransitDisplayCandidates', () => {
   });
 });
 
-describe('sortTransitDisplayDataWithMetaData_RAWForUi', () => {
+describe('sortTransitDisplayDataWithMetaData', () => {
   /** A display whose only meaningful fields for ordering are route type, category, direction. */
   function display(
     routeType: AppRouteTypeValue,
     category: TransitDisplayCategory,
     directions: readonly (0 | 1 | 'none')[] = ['none'],
-  ): TransitDisplayDataWithMetaData_RAW {
+  ): TransitDisplayDataWithMetaData {
     return {
       meta: { category, routeTypes: [routeType], directions, max: 10, radius: 100 },
       data: { routeTypes: [routeType], directions, category, data: [] },
@@ -651,7 +651,7 @@ describe('sortTransitDisplayDataWithMetaData_RAWForUi', () => {
     const subway = display(1, 'departures');
     const ferry = display(4, 'departures');
 
-    const sorted = sortTransitDisplayDataWithMetaData_RAWForUi([subway, ferry, rail, bus]);
+    const sorted = sortTransitDisplayDataWithMetaData([subway, ferry, rail, bus]);
 
     expect(sorted.map((d) => d.meta.routeTypes[0])).toEqual([3, 2, 1, 4]);
   });
@@ -660,9 +660,10 @@ describe('sortTransitDisplayDataWithMetaData_RAWForUi', () => {
     const arr = display(2, 'arrivals');
     const dep = display(2, 'departures');
 
-    expect(
-      sortTransitDisplayDataWithMetaData_RAWForUi([arr, dep]).map((d) => d.meta.category),
-    ).toEqual(['departures', 'arrivals']);
+    expect(sortTransitDisplayDataWithMetaData([arr, dep]).map((d) => d.meta.category)).toEqual([
+      'departures',
+      'arrivals',
+    ]);
   });
 
   it('within a category, orders by direction (none, 0, 1)', () => {
@@ -671,7 +672,7 @@ describe('sortTransitDisplayDataWithMetaData_RAWForUi', () => {
     const dn = display(2, 'departures', ['none']);
 
     expect(
-      sortTransitDisplayDataWithMetaData_RAWForUi([d1, d0, dn]).map((d) => d.meta.directions[0]),
+      sortTransitDisplayDataWithMetaData([d1, d0, dn]).map((d) => d.meta.directions[0]),
     ).toEqual(['none', 0, 1]);
   });
 
@@ -682,7 +683,7 @@ describe('sortTransitDisplayDataWithMetaData_RAWForUi', () => {
     const railDep0 = display(2, 'departures', [0]);
     const busArr = display(3, 'arrivals', ['none']);
 
-    const sorted = sortTransitDisplayDataWithMetaData_RAWForUi([
+    const sorted = sortTransitDisplayDataWithMetaData([
       railArr0,
       busDep,
       railDep1,
@@ -710,12 +711,12 @@ describe('sortTransitDisplayDataWithMetaData_RAWForUi', () => {
     const b = display(3, 'departures');
     const input = [a, b];
 
-    sortTransitDisplayDataWithMetaData_RAWForUi(input);
+    sortTransitDisplayDataWithMetaData(input);
 
     expect(input).toEqual([a, b]);
   });
 
   it('returns an empty array for empty input', () => {
-    expect(sortTransitDisplayDataWithMetaData_RAWForUi([])).toEqual([]);
+    expect(sortTransitDisplayDataWithMetaData([])).toEqual([]);
   });
 });

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -26,14 +26,14 @@ import {
   groupCandidatesIntoBoards,
   sortAndCapTransitDisplayData,
   sortByCategory,
-  sortTransitDisplayDataWithMetaDataForUi,
+  sortTransitDisplayDataWithMetaData_RAWForUi,
   toTransitDisplayCandidates,
   transitDisplayMaxEntriesFor,
   type TransitDisplayData,
   type TransitDisplayCandidate,
   type TransitDisplayCategory,
   type TransitDisplayCondition,
-  type TransitDisplayDataWithMetaData,
+  type TransitDisplayDataWithMetaData_RAW,
 } from '../build-transit-display-data';
 
 // categoryQualifies delegates origin/terminal determination to this domain
@@ -631,16 +631,16 @@ describe('toTransitDisplayCandidates', () => {
   });
 });
 
-describe('sortTransitDisplayDataWithMetaDataForUi', () => {
+describe('sortTransitDisplayDataWithMetaData_RAWForUi', () => {
   /** A display whose only meaningful fields for ordering are route type, category, direction. */
   function display(
     routeType: AppRouteTypeValue,
     category: TransitDisplayCategory,
     directions: readonly (0 | 1 | 'none')[] = ['none'],
-  ): TransitDisplayDataWithMetaData {
+  ): TransitDisplayDataWithMetaData_RAW {
     return {
       meta: { category, routeTypes: [routeType], directions, max: 10, radius: 100 },
-      data: [],
+      data: { routeTypes: [routeType], directions, category, data: [] },
     };
   }
 
@@ -651,7 +651,7 @@ describe('sortTransitDisplayDataWithMetaDataForUi', () => {
     const subway = display(1, 'departures');
     const ferry = display(4, 'departures');
 
-    const sorted = sortTransitDisplayDataWithMetaDataForUi([subway, ferry, rail, bus]);
+    const sorted = sortTransitDisplayDataWithMetaData_RAWForUi([subway, ferry, rail, bus]);
 
     expect(sorted.map((d) => d.meta.routeTypes[0])).toEqual([3, 2, 1, 4]);
   });
@@ -660,9 +660,9 @@ describe('sortTransitDisplayDataWithMetaDataForUi', () => {
     const arr = display(2, 'arrivals');
     const dep = display(2, 'departures');
 
-    expect(sortTransitDisplayDataWithMetaDataForUi([arr, dep]).map((d) => d.meta.category)).toEqual(
-      ['departures', 'arrivals'],
-    );
+    expect(
+      sortTransitDisplayDataWithMetaData_RAWForUi([arr, dep]).map((d) => d.meta.category),
+    ).toEqual(['departures', 'arrivals']);
   });
 
   it('within a category, orders by direction (none, 0, 1)', () => {
@@ -671,7 +671,7 @@ describe('sortTransitDisplayDataWithMetaDataForUi', () => {
     const dn = display(2, 'departures', ['none']);
 
     expect(
-      sortTransitDisplayDataWithMetaDataForUi([d1, d0, dn]).map((d) => d.meta.directions[0]),
+      sortTransitDisplayDataWithMetaData_RAWForUi([d1, d0, dn]).map((d) => d.meta.directions[0]),
     ).toEqual(['none', 0, 1]);
   });
 
@@ -682,7 +682,7 @@ describe('sortTransitDisplayDataWithMetaDataForUi', () => {
     const railDep0 = display(2, 'departures', [0]);
     const busArr = display(3, 'arrivals', ['none']);
 
-    const sorted = sortTransitDisplayDataWithMetaDataForUi([
+    const sorted = sortTransitDisplayDataWithMetaData_RAWForUi([
       railArr0,
       busDep,
       railDep1,
@@ -710,12 +710,12 @@ describe('sortTransitDisplayDataWithMetaDataForUi', () => {
     const b = display(3, 'departures');
     const input = [a, b];
 
-    sortTransitDisplayDataWithMetaDataForUi(input);
+    sortTransitDisplayDataWithMetaData_RAWForUi(input);
 
     expect(input).toEqual([a, b]);
   });
 
   it('returns an empty array for empty input', () => {
-    expect(sortTransitDisplayDataWithMetaDataForUi([])).toEqual([]);
+    expect(sortTransitDisplayDataWithMetaData_RAWForUi([])).toEqual([]);
   });
 });

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -24,16 +24,16 @@ import {
   clusterCandidatesByRouteType,
   filterStopsWithinRadius,
   groupCandidatesIntoBoards,
-  sortAndCapBoards,
+  sortAndCapTransitDisplayData,
   sortByCategory,
-  sortTransitDisplayDataForUi,
+  sortTransitDisplayDataWithMetaDataForUi,
   toTransitDisplayCandidates,
   transitDisplayMaxEntriesFor,
-  type TransitDisplayBoard,
+  type TransitDisplayData,
   type TransitDisplayCandidate,
   type TransitDisplayCategory,
   type TransitDisplayCondition,
-  type TransitDisplayData,
+  type TransitDisplayDataWithMetaData,
 } from '../build-transit-display-data';
 
 // categoryQualifies delegates origin/terminal determination to this domain
@@ -432,7 +432,7 @@ describe('groupCandidatesIntoBoards', () => {
     for (const bd of boards) {
       expect(bd.routeTypes).toEqual([3]);
       expect(bd.directions).toEqual([0, 1]); // present directions of the board's candidates
-      expect(bd.candidates).toEqual([a, b]);
+      expect(bd.data).toEqual([a, b]);
     }
   });
 
@@ -445,9 +445,9 @@ describe('groupCandidatesIntoBoards', () => {
     const departures = boards.find((bd) => bd.category === 'departures');
     const arrivals = boards.find((bd) => bd.category === 'arrivals');
 
-    expect(departures?.candidates).toEqual([plain0]); // terminal1 dropped
+    expect(departures?.data).toEqual([plain0]); // terminal1 dropped
     expect(departures?.directions).toEqual([0]); // direction 1 no longer present
-    expect(arrivals?.candidates).toEqual([plain0, terminal1]);
+    expect(arrivals?.data).toEqual([plain0, terminal1]);
     expect(arrivals?.directions).toEqual([0, 1]);
   });
 
@@ -466,8 +466,8 @@ describe('groupCandidatesIntoBoards', () => {
       { directions: [0], category: 'arrivals' },
     ]);
     // each bucket keeps only its own direction's candidate
-    expect(boards[0].candidates).toEqual([noDir]); // none-departures
-    expect(boards[1].candidates).toEqual([dir0]); // 0-departures
+    expect(boards[0].data).toEqual([noDir]); // none-departures
+    expect(boards[1].data).toEqual([dir0]); // 0-departures
   });
 
   it('split: drops a board left empty after category qualification', () => {
@@ -479,7 +479,7 @@ describe('groupCandidatesIntoBoards', () => {
     expect(boards).toHaveLength(1);
     expect(boards[0].directions).toEqual([0]);
     expect(boards[0].category).toBe('arrivals');
-    expect(boards[0].candidates).toEqual([terminal0]);
+    expect(boards[0].data).toEqual([terminal0]);
   });
 
   it('returns no boards for empty input', () => {
@@ -508,7 +508,7 @@ describe('groupCandidatesIntoBoards', () => {
   });
 });
 
-describe('sortAndCapBoards', () => {
+describe('sortAndCapTransitDisplayData', () => {
   /** A candidate with explicit departure / arrival minutes. */
   function candWithTimes(dep: number, arr: number = dep): TransitDisplayCandidate {
     return {
@@ -521,21 +521,19 @@ describe('sortAndCapBoards', () => {
   function boardOf(
     category: TransitDisplayCategory,
     candidates: TransitDisplayCandidate[],
-  ): TransitDisplayBoard {
-    return { routeTypes: [3], directions: ['none'], category, candidates };
+  ): TransitDisplayData {
+    return { routeTypes: [3], directions: ['none'], category, data: candidates };
   }
 
   it("sorts each board's candidates by its own category's time", () => {
     const dep = boardOf('departures', [candWithTimes(900), candWithTimes(800), candWithTimes(850)]);
     const arr = boardOf('arrivals', [candWithTimes(700, 900), candWithTimes(710, 810)]);
 
-    const [sortedDep, sortedArr] = sortAndCapBoards([dep, arr], 100);
+    const [sortedDep, sortedArr] = sortAndCapTransitDisplayData([dep, arr], 100);
 
-    expect(sortedDep.candidates.map((c) => c.entry.schedule.departureMinutes)).toEqual([
-      800, 850, 900,
-    ]);
+    expect(sortedDep.data.map((c) => c.entry.schedule.departureMinutes)).toEqual([800, 850, 900]);
     // arrivals board sorts by arrivalMinutes (810 before 900), not departure time
-    expect(sortedArr.candidates.map((c) => c.entry.schedule.arrivalMinutes)).toEqual([810, 900]);
+    expect(sortedArr.data.map((c) => c.entry.schedule.arrivalMinutes)).toEqual([810, 900]);
   });
 
   it('caps each board to maxEntries, keeping the earliest after sorting', () => {
@@ -546,20 +544,20 @@ describe('sortAndCapBoards', () => {
       candWithTimes(700),
     ]);
 
-    const [capped] = sortAndCapBoards([board], 2);
+    const [capped] = sortAndCapTransitDisplayData([board], 2);
 
-    expect(capped.candidates.map((c) => c.entry.schedule.departureMinutes)).toEqual([700, 800]);
+    expect(capped.data.map((c) => c.entry.schedule.departureMinutes)).toEqual([700, 800]);
   });
 
   it('preserves board metadata (routeTypes, directions, category)', () => {
-    const board: TransitDisplayBoard = {
+    const board: TransitDisplayData = {
       routeTypes: [2, 1],
       directions: [0, 'none'],
       category: 'departures',
-      candidates: [candWithTimes(800)],
+      data: [candWithTimes(800)],
     };
 
-    const [result] = sortAndCapBoards([board], 100);
+    const [result] = sortAndCapTransitDisplayData([board], 100);
 
     expect(result.routeTypes).toEqual([2, 1]);
     expect(result.directions).toEqual([0, 'none']);
@@ -571,19 +569,19 @@ describe('sortAndCapBoards', () => {
     const c800 = candWithTimes(800);
     const board = boardOf('departures', [c900, c800]);
 
-    sortAndCapBoards([board], 100);
+    sortAndCapTransitDisplayData([board], 100);
 
-    expect(board.candidates).toEqual([c900, c800]);
+    expect(board.data).toEqual([c900, c800]);
   });
 
   it('returns an empty array for no boards', () => {
-    expect(sortAndCapBoards([], 100)).toEqual([]);
+    expect(sortAndCapTransitDisplayData([], 100)).toEqual([]);
   });
 
   it('keeps an empty board empty', () => {
-    const [result] = sortAndCapBoards([boardOf('departures', [])], 100);
+    const [result] = sortAndCapTransitDisplayData([boardOf('departures', [])], 100);
 
-    expect(result.candidates).toEqual([]);
+    expect(result.data).toEqual([]);
   });
 });
 
@@ -633,13 +631,13 @@ describe('toTransitDisplayCandidates', () => {
   });
 });
 
-describe('sortTransitDisplayDataForUi', () => {
+describe('sortTransitDisplayDataWithMetaDataForUi', () => {
   /** A display whose only meaningful fields for ordering are route type, category, direction. */
   function display(
     routeType: AppRouteTypeValue,
     category: TransitDisplayCategory,
     directions: readonly (0 | 1 | 'none')[] = ['none'],
-  ): TransitDisplayData {
+  ): TransitDisplayDataWithMetaData {
     return {
       meta: { category, routeTypes: [routeType], directions, max: 10, radius: 100 },
       data: [],
@@ -653,7 +651,7 @@ describe('sortTransitDisplayDataForUi', () => {
     const subway = display(1, 'departures');
     const ferry = display(4, 'departures');
 
-    const sorted = sortTransitDisplayDataForUi([subway, ferry, rail, bus]);
+    const sorted = sortTransitDisplayDataWithMetaDataForUi([subway, ferry, rail, bus]);
 
     expect(sorted.map((d) => d.meta.routeTypes[0])).toEqual([3, 2, 1, 4]);
   });
@@ -662,10 +660,9 @@ describe('sortTransitDisplayDataForUi', () => {
     const arr = display(2, 'arrivals');
     const dep = display(2, 'departures');
 
-    expect(sortTransitDisplayDataForUi([arr, dep]).map((d) => d.meta.category)).toEqual([
-      'departures',
-      'arrivals',
-    ]);
+    expect(sortTransitDisplayDataWithMetaDataForUi([arr, dep]).map((d) => d.meta.category)).toEqual(
+      ['departures', 'arrivals'],
+    );
   });
 
   it('within a category, orders by direction (none, 0, 1)', () => {
@@ -673,11 +670,9 @@ describe('sortTransitDisplayDataForUi', () => {
     const d0 = display(2, 'departures', [0]);
     const dn = display(2, 'departures', ['none']);
 
-    expect(sortTransitDisplayDataForUi([d1, d0, dn]).map((d) => d.meta.directions[0])).toEqual([
-      'none',
-      0,
-      1,
-    ]);
+    expect(
+      sortTransitDisplayDataWithMetaDataForUi([d1, d0, dn]).map((d) => d.meta.directions[0]),
+    ).toEqual(['none', 0, 1]);
   });
 
   it('applies the three levels together: route type -> category -> direction', () => {
@@ -687,7 +682,13 @@ describe('sortTransitDisplayDataForUi', () => {
     const railDep0 = display(2, 'departures', [0]);
     const busArr = display(3, 'arrivals', ['none']);
 
-    const sorted = sortTransitDisplayDataForUi([railArr0, busDep, railDep1, railDep0, busArr]);
+    const sorted = sortTransitDisplayDataWithMetaDataForUi([
+      railArr0,
+      busDep,
+      railDep1,
+      railDep0,
+      busArr,
+    ]);
 
     expect(
       sorted.map((d) => ({
@@ -709,12 +710,12 @@ describe('sortTransitDisplayDataForUi', () => {
     const b = display(3, 'departures');
     const input = [a, b];
 
-    sortTransitDisplayDataForUi(input);
+    sortTransitDisplayDataWithMetaDataForUi(input);
 
     expect(input).toEqual([a, b]);
   });
 
   it('returns an empty array for empty input', () => {
-    expect(sortTransitDisplayDataForUi([])).toEqual([]);
+    expect(sortTransitDisplayDataWithMetaDataForUi([])).toEqual([]);
   });
 });

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -452,15 +452,16 @@ describe('groupCandidatesIntoBoards', () => {
 
     const boards = groupCandidatesIntoBoards([noDir, dir0], split);
 
+    // Category-major: all departures (in direction order) before all arrivals.
     expect(boards.map((bd) => ({ directions: bd.directions, category: bd.category }))).toEqual([
       { directions: ['none'], category: 'departures' },
-      { directions: ['none'], category: 'arrivals' },
       { directions: [0], category: 'departures' },
+      { directions: ['none'], category: 'arrivals' },
       { directions: [0], category: 'arrivals' },
     ]);
     // each bucket keeps only its own direction's candidate
-    expect(boards[0].candidates).toEqual([noDir]);
-    expect(boards[2].candidates).toEqual([dir0]);
+    expect(boards[0].candidates).toEqual([noDir]); // none-departures
+    expect(boards[1].candidates).toEqual([dir0]); // 0-departures
   });
 
   it('split: drops a board left empty after category qualification', () => {

--- a/src/domain/transit/transit-info-display/build-transit-display-data-for-ui.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data-for-ui.ts
@@ -1,0 +1,169 @@
+/**
+ * UI presentation layer for transit displays: resolves a structural board's raw
+ * entries ({@link TransitDisplayDatum}) into display-name-resolved UI rows
+ * ({@link TransitDisplayDatumForUi}). Kept separate from build-transit-display-data.ts
+ * (the i18n-free structural builder) so the data layer stays free of
+ * presentation / name-resolution concerns; calling this is the UI's choice.
+ */
+import type { TimetableEntryAttributes } from '../../../types/app/transit';
+import type { StopWithContext, TripInspectionTarget } from '../../../types/app/transit-composed';
+import { routeTypesEmoji } from '../../../utils/route-type-emoji';
+import { formatDateKey, minutesToDate } from '../calendar-utils';
+import { getAgencyDisplayNames } from '../name-resolver/get-agency-display-name';
+import { getHeadsignDisplayNames } from '../name-resolver/get-headsign-display-names';
+import { getRouteDisplayNames } from '../name-resolver/get-route-display-names';
+import { getStopDisplayNames } from '../name-resolver/get-stop-display-names';
+import { getTimetableEntryAttributes } from '../timetable-entry-attributes';
+import { formatAbsoluteTime } from '../time';
+import { buildTripInspectionTarget } from '../trip-inspection-target';
+import {
+  categoryMinutes,
+  type TransitDisplayCategory,
+  type TransitDisplayDatum,
+  type TransitDisplayMeta,
+} from './build-transit-display-data';
+
+/**
+ * Stop-level fields of a {@link TransitDisplayDatumForUi}, grouped so consumers can
+ * tell stop context apart from the per-event (trip) fields.
+ */
+export interface TransitDisplayDatumForUiStop {
+  /** Stop ID (used for selection and row keys). */
+  id: string;
+  /** Resolved display name of the stop. */
+  name: string;
+  /** Platform code of the stop, when present. */
+  platformCode: string | undefined;
+  /** Distance in metres from the query centre point, when known. */
+  distance: number | undefined;
+  /** Mode emojis for all route_types served by the stop (stop-level). */
+  routeTypesEmoji: string;
+  /**
+   * Source stop context (shared reference) this event belongs to.
+   *
+   * Carried verbatim so row consumers can render stop-level presentation
+   * directly from the stop / agency / route metadata already resolved on
+   * the source context.
+   */
+  context: StopWithContext;
+}
+
+export interface TransitDisplayDatumForUi {
+  key: string;
+  /** Stop-level context for this event. */
+  stop: TransitDisplayDatumForUiStop;
+  /** Mode emoji for this event's route (trip-level: bus / train / etc.). */
+  routeTypeEmoji: string;
+  routeName: string;
+  /** Resolved display name of the agency operating this event's route. */
+  agencyName: string;
+  headsign: string;
+  /** Pre-formatted absolute display time (legacy presentation). */
+  timeText: string;
+  /** Boarding / drop-off availability and pattern-position flags for this event. */
+  attributes: TimetableEntryAttributes;
+  /** Service-day arrival minutes for `StopTimeTimeInfo` rendering. */
+  arrivalMinutes: number;
+  /** Service-day departure minutes for `StopTimeTimeInfo` rendering. */
+  departureMinutes: number;
+  /** Service date the stop event belongs to. */
+  serviceDate: Date;
+  /** Target used to open trip inspection for this stop event. */
+  inspectionTarget: TripInspectionTarget;
+}
+
+/**
+ * One resolved display, ready to render: its {@link TransitDisplayMeta} descriptor
+ * plus the UI rows. Produced by resolving a board's rows with
+ * {@link buildTransitDisplayDatumForUi} (e.g. in the UI container).
+ */
+export interface TransitDisplayDataWithMetaDataForUi {
+  /** Display descriptor (title + selection params). */
+  meta: TransitDisplayMeta;
+  /** The entry data this display renders. */
+  data: readonly TransitDisplayDatumForUi[];
+}
+
+export function buildTransitDisplayDatumForUi(
+  datum: readonly TransitDisplayDatum[],
+  preferredDisplayLangs: readonly string[],
+  category: TransitDisplayCategory,
+): TransitDisplayDatumForUi[] {
+  // Data-shaping half: resolve names and build the output objects for the
+  // already-selected entries.
+  // Stop names are per-stop, so resolve each at most once and share across the
+  // selected entries that belong to the same stop.
+  const stopNameCache = new Map<string, string>();
+  const resolveStopName = (stopWithContext: StopWithContext): string => {
+    const cached = stopNameCache.get(stopWithContext.stop.stop_id);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const agencyLangs = stopWithContext.agencies.map((agency) => agency.agency_lang);
+    const name = getStopDisplayNames(stopWithContext.stop, preferredDisplayLangs, agencyLangs).name;
+    stopNameCache.set(stopWithContext.stop.stop_id, name);
+    return name;
+  };
+
+  return datum.map(({ entry, stopWithContext }) => {
+    const agencyLangs = stopWithContext.agencies.map((agency) => agency.agency_lang);
+    const routeAgency = stopWithContext.agencies.find(
+      (agency) => agency.agency_id === entry.routeDirection.route.agency_id,
+    );
+    const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : agencyLangs;
+    const routeName = getRouteDisplayNames(
+      entry.routeDirection.route,
+      preferredDisplayLangs,
+      routeAgencyLangs,
+      'short',
+    ).resolved.name;
+    const headsign = getHeadsignDisplayNames(
+      entry.routeDirection,
+      preferredDisplayLangs,
+      routeAgencyLangs,
+      'stop',
+    ).resolved.name;
+    const agencyName = routeAgency
+      ? getAgencyDisplayNames(routeAgency, preferredDisplayLangs, routeAgencyLangs, 'short')
+          .resolved.name || routeAgency.agency_id
+      : '';
+    // Include the service date: TripLocator is per-service (not per-day), so the
+    // same (patternId, serviceId, tripIndex, stopIndex) can recur on different
+    // service dates within one board, which would collide as a React key.
+    // JSON.stringify (not a delimiter join) keeps the parts unambiguous: a
+    // patternId already embeds "__" (`${route_id}__${headsign}`), so a literal
+    // separator could let different tuples stringify to the same key.
+    const key = JSON.stringify([
+      stopWithContext.stop.stop_id,
+      formatDateKey(entry.serviceDate),
+      entry.tripLocator.patternId,
+      entry.tripLocator.serviceId,
+      entry.tripLocator.tripIndex,
+      entry.patternPosition.stopIndex,
+    ]);
+    const tripInspectionTarget = buildTripInspectionTarget(entry, entry.serviceDate);
+    return {
+      key,
+      stop: {
+        id: stopWithContext.stop.stop_id,
+        name: resolveStopName(stopWithContext),
+        platformCode: stopWithContext.stop.platform_code,
+        distance: stopWithContext.distance,
+        routeTypesEmoji: routeTypesEmoji(stopWithContext.routeTypes),
+        context: stopWithContext,
+      },
+      routeTypeEmoji: routeTypesEmoji([entry.routeDirection.route.route_type]),
+      routeName,
+      agencyName,
+      headsign,
+      timeText: formatAbsoluteTime(
+        minutesToDate(entry.serviceDate, categoryMinutes(entry, category)),
+      ),
+      attributes: getTimetableEntryAttributes(entry),
+      arrivalMinutes: entry.schedule.arrivalMinutes,
+      departureMinutes: entry.schedule.departureMinutes,
+      serviceDate: entry.serviceDate,
+      inspectionTarget: tripInspectionTarget,
+    };
+  });
+}

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -200,7 +200,7 @@ export function toTransitDisplayCandidates(
   );
 }
 
-/** 2.1 Route-type selector: keeps only candidates whose event runs on `routeType`. */
+/** Keeps only candidates whose event runs on `routeType`. */
 export function selectByRouteType(
   candidates: readonly TransitDisplayCandidate[],
   routeType: AppRouteTypeValue,
@@ -209,8 +209,8 @@ export function selectByRouteType(
 }
 
 /**
- * 2.2 Category selector: keeps only candidates that qualify for `category`'s
- * board (its category-specific logic; see {@link categoryQualifies}).
+ * Keeps only candidates that qualify for `category`'s board (its
+ * category-specific logic; see {@link categoryQualifies}).
  */
 export function selectByCategory(
   candidates: readonly TransitDisplayCandidate[],
@@ -220,8 +220,8 @@ export function selectByCategory(
 }
 
 /**
- * 3.1 Sort + cap: orders candidates earliest-first by the category's time and
- * returns at most `maxEntries` of them. Does not mutate the input.
+ * Orders candidates earliest-first by the category's time and returns at most
+ * `maxEntries` of them. Does not mutate the input.
  */
 export function sortAndCapByCategory(
   candidates: readonly TransitDisplayCandidate[],
@@ -330,9 +330,8 @@ const CATEGORIES: readonly TransitDisplayCategory[] = ['departures', 'arrivals']
 
 /**
  * One board's cell: which route type(s) and category it is, plus its candidates.
- * Plain candidates (not UI rows), so the same shape flows through selection (2),
- * sort + cap (3), and conversion (4) without those steps' concerns leaking into
- * each other.
+ * Plain candidates (not UI rows), so the same shape flows through grouping,
+ * sort + cap, and UI conversion without those concerns leaking into each other.
  */
 export interface TransitDisplayBoard {
   routeTypes: readonly AppRouteTypeValue[];
@@ -355,7 +354,7 @@ function presentRouteTypesInDisplayOrder(
 }
 
 /**
- * 2.1 Route-type clustering, per the grouping strategy:
+ * Clusters candidates by route type, per the grouping strategy:
  * - `route`: one cluster per route type (in `ROUTE_TYPE_DISPLAY_ORDER`)
  * - `none`: a single cluster of all candidates (its `routeTypes` are the present types)
  * - `custom`: one cluster per caller-supplied group, in the given order. Each
@@ -393,13 +392,13 @@ export function clusterCandidatesByRouteType(
 }
 
 /**
- * 2 Selector: clusters candidates into boards -- 2.1 route-type (per
- * `routeGrouping`) then 2.2 category -- yielding one board per non-empty cell,
- * in route-type display order x (departures, arrivals).
+ * Groups candidates into boards: clusters them by route type (per
+ * `routeGrouping`) then splits each cluster by category, yielding one board per
+ * non-empty cell, in route-type display order x (departures, arrivals).
  *
- * Selection only. No sort / cap (that is 3, {@link sortAndCapBoards}) and no UI
- * conversion (that is 4, {@link toTransitDisplayData}). Empty cells are dropped,
- * so the present route types fall out without a separate enumeration.
+ * Grouping only: it does not sort / cap ({@link sortAndCapBoards}) or resolve
+ * display names ({@link toTransitDisplayData}). Empty cells are dropped, so the
+ * present route types fall out without a separate enumeration.
  */
 export function groupCandidatesIntoBoards(
   candidates: readonly TransitDisplayCandidate[],
@@ -410,15 +409,15 @@ export function groupCandidatesIntoBoards(
       CATEGORIES.map((category) => ({
         routeTypes: cluster.routeTypes,
         category,
-        candidates: selectByCategory(cluster.candidates, category), // 2.2
+        candidates: selectByCategory(cluster.candidates, category), // split by category
       })),
     )
     .filter((board) => board.candidates.length > 0);
 }
 
 /**
- * 3 Sort + cap: orders each board's candidates earliest-first by its category's
- * time and caps to `maxEntries`. Operates per board; not the selector's concern.
+ * Orders each board's candidates earliest-first by its category's time and caps
+ * to `maxEntries`. Operates per board; the grouping is already done.
  */
 export function sortAndCapBoards(
   boards: readonly TransitDisplayBoard[],
@@ -431,7 +430,7 @@ export function sortAndCapBoards(
 }
 
 /**
- * 4 UI converter: turns one board into UI data -- assembles its `meta`
+ * Turns one board into UI data -- assembles its `meta`
  * descriptor (from the board cell + the `radiusMeters` / `maxEntries` scope) and
  * resolves display names for its candidates.
  */
@@ -453,9 +452,10 @@ export function toTransitDisplayData(
 }
 
 /**
- * Runs the board-building steps in sequence: 1 distance filter -> flatten ->
- * 2 select (route-type / category clustering) -> 3 sort + cap -> 4 UI convert.
- * Each step is single-purpose so the next one's concern does not leak into it.
+ * Runs the board-building steps in sequence: distance filter -> flatten ->
+ * group into boards (route-type / category clustering) -> sort + cap -> UI
+ * convert. Each step is single-purpose so the next one's concern does not leak
+ * into it.
  *
  * `radiusMeters` (the range stops are selected within; also each board's
  * `meta.radius`) and `condition` (the per-display selection condition) are both
@@ -468,15 +468,15 @@ export function buildTransitDisplayDataSet(
   radiusMeters: number,
   condition: TransitDisplayCondition,
 ): TransitDisplayData[] {
-  // 1 distance filter: stops within radiusMeters of the center
+  // distance filter: stops within radiusMeters of the center
   const nearbyStops = filterStopsWithinRadius(stops, radiusMeters);
   // flatten each stop's stopTimes into candidates
   const candidates = toTransitDisplayCandidates(nearbyStops);
-  // 2 cluster by route type, then category
+  // cluster by route type, then split by category, into boards
   const boards = groupCandidatesIntoBoards(candidates, condition.routeGrouping);
-  // 3 sort by time, cap each board
+  // sort by time, cap each board
   const cappedBoards = sortAndCapBoards(boards, condition.maxEntries);
-  // 4 resolve display names, build UI data
+  // resolve display names, build UI data
   return cappedBoards.map((board) =>
     toTransitDisplayData(board, preferredDisplayLangs, radiusMeters, condition.maxEntries),
   );

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -26,6 +26,8 @@ const MAX_ENTRIES_BY_INFO_LEVEL: Record<InfoLevel, number> = {
   normal: 10,
   detailed: 20,
   verbose: 20,
+  // detailed: 10,
+  // verbose: 10,
 };
 
 /** Resolves the per-board row cap for the given info level. */
@@ -176,7 +178,13 @@ function categoryMinutes(
   return category === 'arrivals' ? entry.schedule.arrivalMinutes : entry.schedule.departureMinutes;
 }
 
-/** Whether an entry belongs on the given category's board. */
+/**
+ * Whether an entry belongs on the given category's board, using signboard
+ * semantics specific to this Transit Board: a departures board lists trips you
+ * can board here (and that continue past here), an arrivals board lists trips you
+ * can alight here. Other views still show the data as-is; only this board applies
+ * the boardable / alightable rule.
+ */
 export function categoryQualifies(
   entry: ContextualTimetableEntry,
   category: TransitDisplayCategory,
@@ -185,9 +193,15 @@ export function categoryQualifies(
   const attributes = getTimetableEntryAttributes(entry);
 
   if (category === 'departures') {
-    return !attributes.isTerminal;
+    // A departures board lists trips you can actually leave on: not the terminal
+    // (the trip ends here) and boardable here (excludes boarding-prohibited stops
+    // such as the drop-off-only stop just before a terminus).
+    return !attributes.isTerminal && !attributes.isPickupUnavailable;
   }
-  return !attributes.isOrigin;
+  // An arrivals board lists trips you can alight from here: not the origin (the
+  // trip starts here) and drop-off allowed here (excludes pickup-only legs such
+  // as the boarding leg of a turn-around / boarding-swap stop).
+  return !attributes.isOrigin && !attributes.isDropOffUnavailable;
 }
 
 /**

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -161,19 +161,18 @@ function categoryMinutes(
   return category === 'arrivals' ? entry.schedule.arrivalMinutes : entry.schedule.departureMinutes;
 }
 
-/**
- * Whether an entry belongs on the given category's board. A departures board
- * excludes terminal arrivals (a terminal has no meaningful onward departure); an
- * arrivals board keeps every stop event (every event has a meaningful arrival).
- */
-function categoryQualifies(
+/** Whether an entry belongs on the given category's board. */
+export function categoryQualifies(
   entry: ContextualTimetableEntry,
   category: TransitDisplayCategory,
 ): boolean {
+  // [IMPORTANT] Use domain logic to determine the starting/ending point.
+  const attributes = getTimetableEntryAttributes(entry);
+
   if (category === 'departures') {
-    return !entry.patternPosition.isTerminal;
+    return !attributes.isTerminal;
   }
-  return true;
+  return !attributes.isOrigin;
 }
 
 /**
@@ -206,17 +205,6 @@ export function selectByRouteType(
   routeType: AppRouteTypeValue,
 ): TransitDisplayCandidate[] {
   return candidates.filter((c) => c.entry.routeDirection.route.route_type === routeType);
-}
-
-/**
- * Keeps only candidates that qualify for `category`'s board (its
- * category-specific logic; see {@link categoryQualifies}).
- */
-export function selectByCategory(
-  candidates: readonly TransitDisplayCandidate[],
-  category: TransitDisplayCategory,
-): TransitDisplayCandidate[] {
-  return candidates.filter((c) => categoryQualifies(c.entry, category));
 }
 
 /**
@@ -409,7 +397,8 @@ export function groupCandidatesIntoBoards(
       CATEGORIES.map((category) => ({
         routeTypes: cluster.routeTypes,
         category,
-        candidates: selectByCategory(cluster.candidates, category), // split by category
+        // keep only the candidates that qualify for this category's board
+        candidates: cluster.candidates.filter((c) => categoryQualifies(c.entry, category)),
       })),
     )
     .filter((board) => board.candidates.length > 0);

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -177,7 +177,7 @@ function categoryQualifies(
 }
 
 /**
- * 1.1 Distance filter: stops whose precomputed `distance` is within
+ * Distance filter: stops whose precomputed `distance` is within
  * `radiusMeters` of the query centre. `distance` is precomputed (metres), so no
  * coordinate maths is needed here.
  */
@@ -401,7 +401,7 @@ export function clusterCandidatesByRouteType(
  * conversion (that is 4, {@link toTransitDisplayData}). Empty cells are dropped,
  * so the present route types fall out without a separate enumeration.
  */
-export function selectTransitDisplayBoards(
+export function groupCandidatesIntoBoards(
   candidates: readonly TransitDisplayCandidate[],
   routeGrouping: TransitDisplayRouteGrouping,
 ): TransitDisplayBoard[] {
@@ -453,7 +453,7 @@ export function toTransitDisplayData(
 }
 
 /**
- * Runs the board-building steps in sequence: 1.1 distance filter -> flatten ->
+ * Runs the board-building steps in sequence: 1 distance filter -> flatten ->
  * 2 select (route-type / category clustering) -> 3 sort + cap -> 4 UI convert.
  * Each step is single-purpose so the next one's concern does not leak into it.
  *
@@ -468,11 +468,16 @@ export function buildTransitDisplayDataSet(
   radiusMeters: number,
   condition: TransitDisplayCondition,
 ): TransitDisplayData[] {
-  const nearbyStops = filterStopsWithinRadius(stops, radiusMeters); // 1.1
-  const candidates = toTransitDisplayCandidates(nearbyStops); // flatten once
-  const boards = selectTransitDisplayBoards(candidates, condition.routeGrouping); // 2
-  const cappedBoards = sortAndCapBoards(boards, condition.maxEntries); // 3
+  // 1 distance filter: stops within radiusMeters of the center
+  const nearbyStops = filterStopsWithinRadius(stops, radiusMeters);
+  // flatten each stop's stopTimes into candidates
+  const candidates = toTransitDisplayCandidates(nearbyStops);
+  // 2 cluster by route type, then category
+  const boards = groupCandidatesIntoBoards(candidates, condition.routeGrouping);
+  // 3 sort by time, cap each board
+  const cappedBoards = sortAndCapBoards(boards, condition.maxEntries);
+  // 4 resolve display names, build UI data
   return cappedBoards.map((board) =>
     toTransitDisplayData(board, preferredDisplayLangs, radiusMeters, condition.maxEntries),
-  ); // 4
+  );
 }

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -570,3 +570,32 @@ export function buildTransitDisplayDataSet(
     toTransitDisplayData(board, preferredDisplayLangs, radiusMeters, condition.maxEntries),
   );
 }
+
+/**
+ * UI ordering for the displays, independent of how they were built or merged
+ * (the container concatenates a no-split and a split call, so the raw order is
+ * not canonical). Three levels:
+ *   1. route type, by `ROUTE_TYPE_DISPLAY_ORDER`
+ *   2. within a route type: category, departures before arrivals
+ *   3. within a category: direction, in `DIRECTIONS` order (none, 0, 1)
+ *
+ * A full comparator (not a stable sort on one key), so reordering by route type
+ * can never disturb the departures/arrivals or direction order set up earlier.
+ */
+export function sortTransitDisplayDataForUi(
+  displays: readonly TransitDisplayData[],
+): TransitDisplayData[] {
+  const orderKey = (d: TransitDisplayData): [number, number, number] => {
+    const direction = d.meta.directions[0];
+    return [
+      ROUTE_TYPE_DISPLAY_ORDER.indexOf(d.meta.routeTypes[0]),
+      CATEGORIES.indexOf(d.meta.category),
+      DIRECTIONS.indexOf(direction === 'none' ? undefined : direction),
+    ];
+  };
+  return [...displays].sort((a, b) => {
+    const ka = orderKey(a);
+    const kb = orderKey(b);
+    return ka[0] - kb[0] || ka[1] - kb[1] || ka[2] - kb[2];
+  });
+}

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -38,7 +38,7 @@ export function transitDisplayMaxEntriesFor(infoLevel: InfoLevel): number {
  * Stop-level fields of a {@link TransitDisplayDatumForUi}, grouped so consumers can
  * tell stop context apart from the per-event (trip) fields.
  */
-export interface TransitDisplayEntryDataStop {
+export interface TransitDisplayDatumForUiStop {
   /** Stop ID (used for selection and row keys). */
   id: string;
   /** Resolved display name of the stop. */
@@ -62,7 +62,7 @@ export interface TransitDisplayEntryDataStop {
 export interface TransitDisplayDatumForUi {
   key: string;
   /** Stop-level context for this event. */
-  stop: TransitDisplayEntryDataStop;
+  stop: TransitDisplayDatumForUiStop;
   /** Mode emoji for this event's route (trip-level: bus / train / etc.). */
   routeTypeEmoji: string;
   routeName: string;
@@ -130,14 +130,13 @@ export interface TransitDisplayDataWithMetaDataForUi {
 }
 
 /**
- * PROVISIONAL NAME (`_RAW`, to be renamed). A display with its
- * {@link TransitDisplayMeta} descriptor attached but its rows NOT yet resolved:
- * `data` holds the structural board, so resolving it into UI rows (via
- * {@link buildTransitDisplayDatumForUi}) is the caller's choice. `meta` restates
- * the board's category / routeTypes /
- * directions and adds `max` / `radius`.
+ * A display with its {@link TransitDisplayMeta} descriptor attached but its rows
+ * NOT yet resolved: `data` holds the structural board, so resolving it into UI
+ * rows (via {@link buildTransitDisplayDatumForUi}) is the caller's choice. `meta`
+ * restates the board's category / routeTypes / directions and adds `max` /
+ * `radius`. The resolved counterpart is {@link TransitDisplayDataWithMetaDataForUi}.
  */
-export interface TransitDisplayDataWithMetaData_RAW {
+export interface TransitDisplayDataWithMetaData {
   /** Display descriptor (title + selection params). */
   meta: TransitDisplayMeta;
   /** The structural board, whose entries are not yet resolved into UI rows. */
@@ -566,7 +565,7 @@ export function buildTransitDisplayDataSet(
   stops: readonly StopWithContext[],
   radiusMeters: number,
   condition: TransitDisplayCondition,
-): TransitDisplayDataWithMetaData_RAW[] {
+): TransitDisplayDataWithMetaData[] {
   // distance filter: stops within radiusMeters of the center
   const nearbyStops: StopWithContext[] = filterStopsWithinRadius(stops, radiusMeters);
   // flatten each stop's stopTimes into candidates
@@ -578,18 +577,20 @@ export function buildTransitDisplayDataSet(
     boards,
     condition.maxEntries,
   );
-  // attach each display's meta descriptor; rows stay raw (caller resolves)
-  const meta: TransitDisplayDataWithMetaData_RAW[] = sortedAndCapped.map((board) => ({
-    meta: {
-      category: board.category,
-      routeTypes: board.routeTypes,
-      directions: board.directions,
-      max: condition.maxEntries,
-      radius: radiusMeters,
-    },
-    data: board,
-  }));
-  return meta;
+
+  const transitDisplayDataWithMetaData: TransitDisplayDataWithMetaData[] = sortedAndCapped.map(
+    (transitDisplayData) => ({
+      meta: {
+        category: transitDisplayData.category,
+        routeTypes: transitDisplayData.routeTypes,
+        directions: transitDisplayData.directions,
+        max: condition.maxEntries,
+        radius: radiusMeters,
+      },
+      data: transitDisplayData,
+    }),
+  );
+  return transitDisplayDataWithMetaData;
 }
 
 /**
@@ -603,10 +604,10 @@ export function buildTransitDisplayDataSet(
  * A full comparator (not a stable sort on one key), so reordering by route type
  * can never disturb the departures/arrivals or direction order set up earlier.
  */
-export function sortTransitDisplayDataWithMetaData_RAWForUi(
-  rawDisplays: readonly TransitDisplayDataWithMetaData_RAW[],
-): TransitDisplayDataWithMetaData_RAW[] {
-  const orderKey = (d: TransitDisplayDataWithMetaData_RAW): [number, number, number] => {
+export function sortTransitDisplayDataWithMetaData(
+  rawDisplays: readonly TransitDisplayDataWithMetaData[],
+): TransitDisplayDataWithMetaData[] {
+  const orderKey = (d: TransitDisplayDataWithMetaData): [number, number, number] => {
     const direction = d.meta.directions[0];
     return [
       ROUTE_TYPE_DISPLAY_ORDER.indexOf(d.meta.routeTypes[0]),

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -117,7 +117,12 @@ export interface TransitDisplayMeta {
   radius: number;
 }
 
-export interface TransitDisplayData {
+/**
+ * One resolved display, ready to render: its {@link TransitDisplayMeta} descriptor
+ * plus the UI rows. Produced from a {@link TransitDisplayData} board by
+ * {@link toTransitDisplayDataWithMetaData}.
+ */
+export interface TransitDisplayDataWithMetaData {
   /** Display descriptor (title + selection params). */
   meta: TransitDisplayMeta;
   /** The entry data this display renders. */
@@ -164,6 +169,14 @@ export interface TransitDisplayCandidate {
   entry: ContextualTimetableEntry;
   stopWithContext: StopWithContext;
 }
+
+/**
+ * One entry selected onto a board by {@link groupCandidatesIntoBoards} -- a
+ * {@link TransitDisplayCandidate} that passed category qualification. Same shape
+ * as a candidate; this alias marks the post-selection role (it is output, no
+ * longer a mere candidate) and reads as the singular of a board's `data`.
+ */
+export type TransitDisplayDatum = TransitDisplayCandidate;
 
 /**
  * Service-day minutes an entry is sorted and shown by, derived from the board's
@@ -366,16 +379,17 @@ function presentDirections(
 
 /**
  * One board's cell: which route type(s), direction(s) and category it is, plus
- * its candidates. Plain candidates (not UI rows), so the same shape flows through
+ * the entries selected for it in `data` ({@link TransitDisplayDatum}). These are
+ * raw stop events (not resolved UI rows), so the same shape flows through
  * grouping, sort + cap, and UI conversion without those concerns leaking into
  * each other.
  */
-export interface TransitDisplayBoard {
+export interface TransitDisplayData {
   routeTypes: readonly AppRouteTypeValue[];
   /** Direction(s) this board covers (see {@link TransitDisplayMeta.directions}). */
   directions: readonly (0 | 1 | 'none')[];
   category: TransitDisplayCategory;
-  candidates: TransitDisplayCandidate[];
+  data: TransitDisplayDatum[];
 }
 
 /** A cluster of candidates for one board's route-type scope, before the category split. */
@@ -442,16 +456,16 @@ export function clusterCandidatesByRouteType(
  * `splitByDirection` and merging the results, rather than having a per-mode rule
  * baked in here.
  *
- * Grouping only: it does not sort / cap ({@link sortAndCapBoards}) or resolve
- * display names ({@link toTransitDisplayData}). Empty cells are dropped, so the
+ * Grouping only: it does not sort / cap ({@link sortAndCapTransitDisplayData}) or resolve
+ * display names ({@link toTransitDisplayDataWithMetaData}). Empty cells are dropped, so the
  * present route types / directions fall out without a separate enumeration.
  */
 export function groupCandidatesIntoBoards(
   candidates: readonly TransitDisplayCandidate[],
   condition: TransitDisplayCondition,
-): TransitDisplayBoard[] {
+): TransitDisplayData[] {
   const clusters = clusterCandidatesByRouteType(candidates, condition.routeGrouping);
-  const boards: TransitDisplayBoard[] = [];
+  const boards: TransitDisplayData[] = [];
 
   for (const cluster of clusters) {
     if (!condition.splitByDirection) {
@@ -467,7 +481,7 @@ export function groupCandidatesIntoBoards(
           routeTypes: cluster.routeTypes,
           directions: presentDirections(boardCandidates),
           category,
-          candidates: boardCandidates,
+          data: boardCandidates,
         });
       }
       continue;
@@ -492,7 +506,7 @@ export function groupCandidatesIntoBoards(
           routeTypes: cluster.routeTypes,
           directions,
           category,
-          candidates: boardCandidates,
+          data: boardCandidates,
         });
       }
     }
@@ -502,32 +516,32 @@ export function groupCandidatesIntoBoards(
 }
 
 /**
- * Orders each board's candidates earliest-first by its category's time and caps
- * to `maxEntries`. Operates per board; the grouping is already done.
+ * Orders each board's entries (its `data`) earliest-first by its category's
+ * time and caps to `maxEntries`. Operates per board; the grouping is already done.
  */
-export function sortAndCapBoards(
-  boards: readonly TransitDisplayBoard[],
+export function sortAndCapTransitDisplayData(
+  transitDisplayData: readonly TransitDisplayData[],
   maxEntries: number,
-): TransitDisplayBoard[] {
-  return boards.map((board) => {
+): TransitDisplayData[] {
+  return transitDisplayData.map((data) => {
     // sort by the category's time (category-dependent)
-    const sorted = sortByCategory(board.candidates, board.category);
+    const sorted = sortByCategory(data.data, data.category);
     // cap: keep the earliest maxEntries (slice is non-mutating, expects sorted input)
-    return { ...board, candidates: sorted.slice(0, maxEntries) };
+    return { ...data, data: sorted.slice(0, maxEntries) };
   });
 }
 
 /**
  * Turns one board into UI data -- assembles its `meta`
  * descriptor (from the board cell + the `radiusMeters` / `maxEntries` scope) and
- * resolves display names for its candidates.
+ * resolves display names for its entries (`data`).
  */
-export function toTransitDisplayData(
-  board: TransitDisplayBoard,
+export function toTransitDisplayDataWithMetaData(
+  board: TransitDisplayData,
   preferredDisplayLangs: readonly string[],
   radiusMeters: number,
   maxEntries: number,
-): TransitDisplayData {
+): TransitDisplayDataWithMetaData {
   return {
     meta: {
       category: board.category,
@@ -536,7 +550,7 @@ export function toTransitDisplayData(
       max: maxEntries,
       radius: radiusMeters,
     },
-    data: buildTransitDisplayEntryData(board.candidates, preferredDisplayLangs, board.category),
+    data: buildTransitDisplayEntryData(board.data, preferredDisplayLangs, board.category),
   };
 }
 
@@ -546,9 +560,9 @@ export function toTransitDisplayData(
  * Each step is single-purpose so the next one's concern does not leak into it.
  *
  * Presentation is intentionally NOT done here: resolving display names / times
- * into UI data (via {@link toTransitDisplayData}) is left to the caller, so this
+ * into UI data (via {@link toTransitDisplayDataWithMetaData}) is left to the caller, so this
  * stays i18n-free and the UI owns rendering concerns. The caller maps the
- * returned boards through `toTransitDisplayData`.
+ * returned boards through `toTransitDisplayDataWithMetaData`.
  *
  * `radiusMeters` (the range stops are selected within) and `condition` (the
  * per-display selection condition) are both required so the caller states the
@@ -559,15 +573,16 @@ export function buildTransitDisplayDataSet(
   stops: readonly StopWithContext[],
   radiusMeters: number,
   condition: TransitDisplayCondition,
-): TransitDisplayBoard[] {
+): TransitDisplayData[] {
   // distance filter: stops within radiusMeters of the center
-  const nearbyStops = filterStopsWithinRadius(stops, radiusMeters);
+  const nearbyStops: StopWithContext[] = filterStopsWithinRadius(stops, radiusMeters);
   // flatten each stop's stopTimes into candidates
-  const candidates = toTransitDisplayCandidates(nearbyStops);
+  const candidates: TransitDisplayCandidate[] = toTransitDisplayCandidates(nearbyStops);
   // cluster by route type, optionally by direction, then split by category
-  const boards = groupCandidatesIntoBoards(candidates, condition);
+  const transitDisplayData: TransitDisplayData[] = groupCandidatesIntoBoards(candidates, condition);
   // sort by time, cap each board
-  return sortAndCapBoards(boards, condition.maxEntries);
+  const sortedAndCapped = sortAndCapTransitDisplayData(transitDisplayData, condition.maxEntries);
+  return sortedAndCapped;
 }
 
 /**
@@ -581,10 +596,10 @@ export function buildTransitDisplayDataSet(
  * A full comparator (not a stable sort on one key), so reordering by route type
  * can never disturb the departures/arrivals or direction order set up earlier.
  */
-export function sortTransitDisplayDataForUi(
-  displays: readonly TransitDisplayData[],
-): TransitDisplayData[] {
-  const orderKey = (d: TransitDisplayData): [number, number, number] => {
+export function sortTransitDisplayDataWithMetaDataForUi(
+  transitDisplayDataWithMetaData: readonly TransitDisplayDataWithMetaData[],
+): TransitDisplayDataWithMetaData[] {
+  const orderKey = (d: TransitDisplayDataWithMetaData): [number, number, number] => {
     const direction = d.meta.directions[0];
     return [
       ROUTE_TYPE_DISPLAY_ORDER.indexOf(d.meta.routeTypes[0]),
@@ -592,7 +607,7 @@ export function sortTransitDisplayDataForUi(
       DIRECTIONS.indexOf(direction === 'none' ? undefined : direction),
     ];
   };
-  return [...displays].sort((a, b) => {
+  return [...transitDisplayDataWithMetaData].sort((a, b) => {
     const ka = orderKey(a);
     const kb = orderKey(b);
     return ka[0] - kb[0] || ka[1] - kb[1] || ka[2] - kb[2];

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -451,37 +451,55 @@ export function groupCandidatesIntoBoards(
   candidates: readonly TransitDisplayCandidate[],
   condition: TransitDisplayCondition,
 ): TransitDisplayBoard[] {
-  return clusterCandidatesByRouteType(candidates, condition.routeGrouping)
-    .flatMap((cluster) => {
-      if (!condition.splitByDirection) {
-        // Not split: one board per category, covering the directions present.
-        return CATEGORIES.map((category) => {
-          const boardCandidates = cluster.candidates.filter((c) =>
-            categoryQualifies(c.entry, category),
-          );
-          return {
-            routeTypes: cluster.routeTypes,
-            directions: presentDirections(boardCandidates),
-            category,
-            candidates: boardCandidates,
-          };
+  const clusters = clusterCandidatesByRouteType(candidates, condition.routeGrouping);
+  const boards: TransitDisplayBoard[] = [];
+
+  for (const cluster of clusters) {
+    if (!condition.splitByDirection) {
+      // Not split: one board per category, covering the directions present.
+      for (const category of CATEGORIES) {
+        const boardCandidates = cluster.candidates.filter((c) =>
+          categoryQualifies(c.entry, category),
+        );
+        if (boardCandidates.length === 0) {
+          continue;
+        }
+        boards.push({
+          routeTypes: cluster.routeTypes,
+          directions: presentDirections(boardCandidates),
+          category,
+          candidates: boardCandidates,
         });
       }
-      // Split: one board per direction bucket (undefined / 0 / 1) per category.
-      return DIRECTIONS.flatMap((direction) => {
-        const directions: readonly (0 | 1 | 'none')[] = [direction ?? 'none'];
-        const inDirection = cluster.candidates.filter(
-          (c) => c.entry.routeDirection.direction === direction,
+      continue;
+    }
+
+    // Split: one board per (category, direction) bucket. Category-major
+    // (departures, then arrivals) so a board's departures always precede its
+    // arrivals -- e.g. at a terminus where one direction is arrivals-only and
+    // another is departures-only, the departures still list first. Empty buckets
+    // are skipped.
+    for (const category of CATEGORIES) {
+      for (const direction of DIRECTIONS) {
+        const boardCandidates = cluster.candidates.filter(
+          (c) =>
+            c.entry.routeDirection.direction === direction && categoryQualifies(c.entry, category),
         );
-        return CATEGORIES.map((category) => ({
+        if (boardCandidates.length === 0) {
+          continue;
+        }
+        const directions: readonly (0 | 1 | 'none')[] = [direction ?? 'none'];
+        boards.push({
           routeTypes: cluster.routeTypes,
           directions,
           category,
-          candidates: inDirection.filter((c) => categoryQualifies(c.entry, category)),
-        }));
-      });
-    })
-    .filter((board) => board.candidates.length > 0);
+          candidates: boardCandidates,
+        });
+      }
+    }
+  }
+
+  return boards;
 }
 
 /**

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -70,7 +70,6 @@ export interface TransitDisplayEntryData {
   headsign: string;
   /** Pre-formatted absolute display time (legacy presentation). */
   timeText: string;
-  isArrival: boolean;
   /** Boarding / drop-off availability and pattern-position flags for this event. */
   attributes: TimetableEntryAttributes;
   /** Service-day arrival minutes for `StopTimeTimeInfo` rendering. */
@@ -105,6 +104,12 @@ export interface TransitDisplayMeta {
    * when split by route type; several when route types are combined into one board.
    */
   routeTypes: readonly AppRouteTypeValue[];
+  /**
+   * Direction(s) of travel this board covers. `0` / `1` are GTFS `direction_id`
+   * (where the source provides it) and `'none'` is "no direction_id". One element
+   * when split by direction; several (the directions actually present) when not.
+   */
+  directions: readonly (0 | 1 | 'none')[];
   /** Row cap applied to this display's entries. */
   max: number;
   /** Radius (metres) the display's stops were selected within. */
@@ -141,6 +146,16 @@ export interface TransitDisplayCondition {
   maxEntries: number;
   /** How route types are grouped into boards. */
   routeGrouping: TransitDisplayRouteGrouping;
+  /**
+   * Whether to also split each board by direction of travel. When true, every
+   * route type is split by each trip's `routeDirection.direction` (`0` | `1` |
+   * `undefined`); when false, boards are not divided by direction. That
+   * `direction` mirrors GTFS `direction_id` where the source provides it
+   * (`undefined` otherwise) and is route-local / arbitrary across routes, so
+   * splitting can read poorly at multi-route stops -- the caller decides per
+   * display.
+   */
+  splitByDirection: boolean;
 }
 
 /** One stop event paired with the stop context it came from, before name resolution. */
@@ -208,21 +223,18 @@ export function selectByRouteType(
 }
 
 /**
- * Orders candidates earliest-first by the category's time and returns at most
- * `maxEntries` of them. Does not mutate the input.
+ * Orders candidates earliest-first by the category's time. Does not mutate the
+ * input.
  */
-export function sortAndCapByCategory(
+export function sortByCategory(
   candidates: readonly TransitDisplayCandidate[],
   category: TransitDisplayCategory,
-  maxEntries: number,
 ): TransitDisplayCandidate[] {
-  return [...candidates]
-    .sort(
-      (a, b) =>
-        minutesToDate(a.entry.serviceDate, categoryMinutes(a.entry, category)).getTime() -
-        minutesToDate(b.entry.serviceDate, categoryMinutes(b.entry, category)).getTime(),
-    )
-    .slice(0, maxEntries);
+  return [...candidates].sort(
+    (a, b) =>
+      minutesToDate(a.entry.serviceDate, categoryMinutes(a.entry, category)).getTime() -
+      minutesToDate(b.entry.serviceDate, categoryMinutes(b.entry, category)).getTime(),
+  );
 }
 
 export function buildTransitDisplayEntryData(
@@ -300,7 +312,6 @@ export function buildTransitDisplayEntryData(
       timeText: formatAbsoluteTime(
         minutesToDate(entry.serviceDate, categoryMinutes(entry, category)),
       ),
-      isArrival: entry.patternPosition.isTerminal,
       attributes: getTimetableEntryAttributes(entry),
       arrivalMinutes: entry.schedule.arrivalMinutes,
       departureMinutes: entry.schedule.departureMinutes,
@@ -317,12 +328,39 @@ export const NEARBY_RADIUS_M = 100;
 const CATEGORIES: readonly TransitDisplayCategory[] = ['departures', 'arrivals'];
 
 /**
- * One board's cell: which route type(s) and category it is, plus its candidates.
- * Plain candidates (not UI rows), so the same shape flows through grouping,
- * sort + cap, and UI conversion without those concerns leaking into each other.
+ * Direction buckets used to split a board by direction of travel. The values
+ * are `routeDirection.direction`: `undefined` (no direction on the trip), then
+ * `0` and `1` (the route's two opposite directions). `direction` mirrors GTFS
+ * `direction_id` where the source provides it, and is `undefined` otherwise
+ * (e.g. non-GTFS / ODPT sources). Empty buckets are dropped downstream, so trips
+ * without a direction collapse to one group.
+ */
+const DIRECTIONS: readonly (0 | 1 | undefined)[] = [undefined, 0, 1];
+
+/**
+ * Directions actually present among the candidates, in `DIRECTIONS` order, with
+ * the no-direction case as `'none'`. Used for a not-split board's `directions`,
+ * mirroring how present route types are listed (data-present, not enumerated).
+ */
+function presentDirections(
+  candidates: readonly TransitDisplayCandidate[],
+): readonly (0 | 1 | 'none')[] {
+  const present = new Set(candidates.map((c) => c.entry.routeDirection.direction));
+  return DIRECTIONS.filter((direction) => present.has(direction)).map(
+    (direction) => direction ?? 'none',
+  );
+}
+
+/**
+ * One board's cell: which route type(s), direction(s) and category it is, plus
+ * its candidates. Plain candidates (not UI rows), so the same shape flows through
+ * grouping, sort + cap, and UI conversion without those concerns leaking into
+ * each other.
  */
 export interface TransitDisplayBoard {
   routeTypes: readonly AppRouteTypeValue[];
+  /** Direction(s) this board covers (see {@link TransitDisplayMeta.directions}). */
+  directions: readonly (0 | 1 | 'none')[];
   category: TransitDisplayCategory;
   candidates: TransitDisplayCandidate[];
 }
@@ -381,26 +419,54 @@ export function clusterCandidatesByRouteType(
 
 /**
  * Groups candidates into boards: clusters them by route type (per
- * `routeGrouping`) then splits each cluster by category, yielding one board per
- * non-empty cell, in route-type display order x (departures, arrivals).
+ * `routeGrouping`), optionally by direction of travel (when `splitByDirection`),
+ * then by category, yielding one board per non-empty cell.
+ *
+ * A trip's `routeDirection.direction` (which mirrors GTFS `direction_id` where
+ * the source provides it) is route-local and arbitrary across routes, so a
+ * caller that wants direction split for some modes but not others (e.g. trains
+ * yes, buses no) composes it by calling with different `routeGrouping` /
+ * `splitByDirection` and merging the results, rather than having a per-mode rule
+ * baked in here.
  *
  * Grouping only: it does not sort / cap ({@link sortAndCapBoards}) or resolve
  * display names ({@link toTransitDisplayData}). Empty cells are dropped, so the
- * present route types fall out without a separate enumeration.
+ * present route types / directions fall out without a separate enumeration.
  */
 export function groupCandidatesIntoBoards(
   candidates: readonly TransitDisplayCandidate[],
-  routeGrouping: TransitDisplayRouteGrouping,
+  condition: TransitDisplayCondition,
 ): TransitDisplayBoard[] {
-  return clusterCandidatesByRouteType(candidates, routeGrouping)
-    .flatMap((cluster) =>
-      CATEGORIES.map((category) => ({
-        routeTypes: cluster.routeTypes,
-        category,
-        // keep only the candidates that qualify for this category's board
-        candidates: cluster.candidates.filter((c) => categoryQualifies(c.entry, category)),
-      })),
-    )
+  return clusterCandidatesByRouteType(candidates, condition.routeGrouping)
+    .flatMap((cluster) => {
+      if (!condition.splitByDirection) {
+        // Not split: one board per category, covering the directions present.
+        return CATEGORIES.map((category) => {
+          const boardCandidates = cluster.candidates.filter((c) =>
+            categoryQualifies(c.entry, category),
+          );
+          return {
+            routeTypes: cluster.routeTypes,
+            directions: presentDirections(boardCandidates),
+            category,
+            candidates: boardCandidates,
+          };
+        });
+      }
+      // Split: one board per direction bucket (undefined / 0 / 1) per category.
+      return DIRECTIONS.flatMap((direction) => {
+        const directions: readonly (0 | 1 | 'none')[] = [direction ?? 'none'];
+        const inDirection = cluster.candidates.filter(
+          (c) => c.entry.routeDirection.direction === direction,
+        );
+        return CATEGORIES.map((category) => ({
+          routeTypes: cluster.routeTypes,
+          directions,
+          category,
+          candidates: inDirection.filter((c) => categoryQualifies(c.entry, category)),
+        }));
+      });
+    })
     .filter((board) => board.candidates.length > 0);
 }
 
@@ -412,10 +478,12 @@ export function sortAndCapBoards(
   boards: readonly TransitDisplayBoard[],
   maxEntries: number,
 ): TransitDisplayBoard[] {
-  return boards.map((board) => ({
-    ...board,
-    candidates: sortAndCapByCategory(board.candidates, board.category, maxEntries),
-  }));
+  return boards.map((board) => {
+    // sort by the category's time (category-dependent)
+    const sorted = sortByCategory(board.candidates, board.category);
+    // cap: keep the earliest maxEntries (slice is non-mutating, expects sorted input)
+    return { ...board, candidates: sorted.slice(0, maxEntries) };
+  });
 }
 
 /**
@@ -433,6 +501,7 @@ export function toTransitDisplayData(
     meta: {
       category: board.category,
       routeTypes: board.routeTypes,
+      directions: board.directions,
       max: maxEntries,
       radius: radiusMeters,
     },
@@ -461,8 +530,8 @@ export function buildTransitDisplayDataSet(
   const nearbyStops = filterStopsWithinRadius(stops, radiusMeters);
   // flatten each stop's stopTimes into candidates
   const candidates = toTransitDisplayCandidates(nearbyStops);
-  // cluster by route type, then split by category, into boards
-  const boards = groupCandidatesIntoBoards(candidates, condition.routeGrouping);
+  // cluster by route type, optionally by direction, then split by category
+  const boards = groupCandidatesIntoBoards(candidates, condition);
   // sort by time, cap each board
   const cappedBoards = sortAndCapBoards(boards, condition.maxEntries);
   // resolve display names, build UI data

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -119,14 +119,29 @@ export interface TransitDisplayMeta {
 
 /**
  * One resolved display, ready to render: its {@link TransitDisplayMeta} descriptor
- * plus the UI rows. Produced from a {@link TransitDisplayData} board by
- * {@link toTransitDisplayDataWithMetaData}.
+ * plus the UI rows. Produced by resolving a board's rows with
+ * {@link buildTransitDisplayEntryData} (e.g. in the UI container).
  */
 export interface TransitDisplayDataWithMetaData {
   /** Display descriptor (title + selection params). */
   meta: TransitDisplayMeta;
   /** The entry data this display renders. */
   data: readonly TransitDisplayEntryData[];
+}
+
+/**
+ * PROVISIONAL NAME (`_RAW`, to be renamed). A display with its
+ * {@link TransitDisplayMeta} descriptor attached but its rows NOT yet resolved:
+ * `data` holds the structural board, so resolving it into UI rows (via
+ * {@link buildTransitDisplayEntryData}) is the caller's choice. `meta` restates
+ * the board's category / routeTypes /
+ * directions and adds `max` / `radius`.
+ */
+export interface TransitDisplayDataWithMetaData_RAW {
+  /** Display descriptor (title + selection params). */
+  meta: TransitDisplayMeta;
+  /** The structural board, whose entries are not yet resolved into UI rows. */
+  data: TransitDisplayData;
 }
 
 /**
@@ -457,7 +472,7 @@ export function clusterCandidatesByRouteType(
  * baked in here.
  *
  * Grouping only: it does not sort / cap ({@link sortAndCapTransitDisplayData}) or resolve
- * display names ({@link toTransitDisplayDataWithMetaData}). Empty cells are dropped, so the
+ * display names ({@link buildTransitDisplayEntryData}). Empty cells are dropped, so the
  * present route types / directions fall out without a separate enumeration.
  */
 export function groupCandidatesIntoBoards(
@@ -532,63 +547,54 @@ export function sortAndCapTransitDisplayData(
 }
 
 /**
- * Turns one board into UI data -- assembles its `meta`
- * descriptor (from the board cell + the `radiusMeters` / `maxEntries` scope) and
- * resolves display names for its entries (`data`).
- */
-export function toTransitDisplayDataWithMetaData(
-  board: TransitDisplayData,
-  preferredDisplayLangs: readonly string[],
-  radiusMeters: number,
-  maxEntries: number,
-): TransitDisplayDataWithMetaData {
-  return {
-    meta: {
-      category: board.category,
-      routeTypes: board.routeTypes,
-      directions: board.directions,
-      max: maxEntries,
-      radius: radiusMeters,
-    },
-    data: buildTransitDisplayEntryData(board.data, preferredDisplayLangs, board.category),
-  };
-}
-
-/**
  * Runs the structural board-building steps in sequence: distance filter ->
- * flatten -> group into boards (route-type / category clustering) -> sort + cap.
- * Each step is single-purpose so the next one's concern does not leak into it.
+ * flatten -> group into boards (route-type / category clustering) -> sort + cap,
+ * then attaches each display's `meta` descriptor. Each step is single-purpose so
+ * the next one's concern does not leak into it.
  *
- * Presentation is intentionally NOT done here: resolving display names / times
- * into UI data (via {@link toTransitDisplayDataWithMetaData}) is left to the caller, so this
- * stays i18n-free and the UI owns rendering concerns. The caller maps the
- * returned boards through `toTransitDisplayDataWithMetaData`.
+ * Rows are intentionally left RAW: the returned `data` holds the structural
+ * board, not resolved UI rows. Resolving display names / times into UI data (via
+ * {@link buildTransitDisplayEntryData}) is the caller's choice, so this stays
+ * i18n-free and the UI owns rendering.
  *
- * `radiusMeters` (the range stops are selected within) and `condition` (the
- * per-display selection condition) are both required so the caller states the
- * selection scope explicitly. {@link NEARBY_RADIUS_M} is the conventional
- * radius to pass.
+ * `radiusMeters` (the range stops are selected within; also each display's
+ * `meta.radius`) and `condition` (the per-display selection condition) are both
+ * required so the caller states the selection scope explicitly.
+ * {@link NEARBY_RADIUS_M} is the conventional radius to pass.
  */
 export function buildTransitDisplayDataSet(
   stops: readonly StopWithContext[],
   radiusMeters: number,
   condition: TransitDisplayCondition,
-): TransitDisplayData[] {
+): TransitDisplayDataWithMetaData_RAW[] {
   // distance filter: stops within radiusMeters of the center
   const nearbyStops: StopWithContext[] = filterStopsWithinRadius(stops, radiusMeters);
   // flatten each stop's stopTimes into candidates
   const candidates: TransitDisplayCandidate[] = toTransitDisplayCandidates(nearbyStops);
   // cluster by route type, optionally by direction, then split by category
-  const transitDisplayData: TransitDisplayData[] = groupCandidatesIntoBoards(candidates, condition);
+  const boards: TransitDisplayData[] = groupCandidatesIntoBoards(candidates, condition);
   // sort by time, cap each board
-  const sortedAndCapped = sortAndCapTransitDisplayData(transitDisplayData, condition.maxEntries);
-  return sortedAndCapped;
+  const sortedAndCapped: TransitDisplayData[] = sortAndCapTransitDisplayData(
+    boards,
+    condition.maxEntries,
+  );
+  // attach each display's meta descriptor; rows stay raw (caller resolves)
+  return sortedAndCapped.map((board) => ({
+    meta: {
+      category: board.category,
+      routeTypes: board.routeTypes,
+      directions: board.directions,
+      max: condition.maxEntries,
+      radius: radiusMeters,
+    },
+    data: board,
+  }));
 }
 
 /**
- * UI ordering for the displays, independent of how they were built or merged
- * (the container concatenates a no-split and a split call, so the raw order is
- * not canonical). Three levels:
+ * UI ordering for the raw displays (sorted on `meta`, before rows are resolved),
+ * independent of how they were built or merged (the container concatenates a
+ * no-split and a split call, so the raw order is not canonical). Three levels:
  *   1. route type, by `ROUTE_TYPE_DISPLAY_ORDER`
  *   2. within a route type: category, departures before arrivals
  *   3. within a category: direction, in `DIRECTIONS` order (none, 0, 1)
@@ -596,10 +602,10 @@ export function buildTransitDisplayDataSet(
  * A full comparator (not a stable sort on one key), so reordering by route type
  * can never disturb the departures/arrivals or direction order set up earlier.
  */
-export function sortTransitDisplayDataWithMetaDataForUi(
-  transitDisplayDataWithMetaData: readonly TransitDisplayDataWithMetaData[],
-): TransitDisplayDataWithMetaData[] {
-  const orderKey = (d: TransitDisplayDataWithMetaData): [number, number, number] => {
+export function sortTransitDisplayDataWithMetaData_RAWForUi(
+  rawDisplays: readonly TransitDisplayDataWithMetaData_RAW[],
+): TransitDisplayDataWithMetaData_RAW[] {
+  const orderKey = (d: TransitDisplayDataWithMetaData_RAW): [number, number, number] => {
     const direction = d.meta.directions[0];
     return [
       ROUTE_TYPE_DISPLAY_ORDER.indexOf(d.meta.routeTypes[0]),
@@ -607,7 +613,7 @@ export function sortTransitDisplayDataWithMetaDataForUi(
       DIRECTIONS.indexOf(direction === 'none' ? undefined : direction),
     ];
   };
-  return [...transitDisplayDataWithMetaData].sort((a, b) => {
+  return [...rawDisplays].sort((a, b) => {
     const ka = orderKey(a);
     const kb = orderKey(b);
     return ka[0] - kb[0] || ka[1] - kb[1] || ka[2] - kb[2];

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -541,22 +541,25 @@ export function toTransitDisplayData(
 }
 
 /**
- * Runs the board-building steps in sequence: distance filter -> flatten ->
- * group into boards (route-type / category clustering) -> sort + cap -> UI
- * convert. Each step is single-purpose so the next one's concern does not leak
- * into it.
+ * Runs the structural board-building steps in sequence: distance filter ->
+ * flatten -> group into boards (route-type / category clustering) -> sort + cap.
+ * Each step is single-purpose so the next one's concern does not leak into it.
  *
- * `radiusMeters` (the range stops are selected within; also each board's
- * `meta.radius`) and `condition` (the per-display selection condition) are both
- * required so the caller states the selection scope explicitly.
- * {@link NEARBY_RADIUS_M} is the conventional radius to pass.
+ * Presentation is intentionally NOT done here: resolving display names / times
+ * into UI data (via {@link toTransitDisplayData}) is left to the caller, so this
+ * stays i18n-free and the UI owns rendering concerns. The caller maps the
+ * returned boards through `toTransitDisplayData`.
+ *
+ * `radiusMeters` (the range stops are selected within) and `condition` (the
+ * per-display selection condition) are both required so the caller states the
+ * selection scope explicitly. {@link NEARBY_RADIUS_M} is the conventional
+ * radius to pass.
  */
 export function buildTransitDisplayDataSet(
   stops: readonly StopWithContext[],
-  preferredDisplayLangs: readonly string[],
   radiusMeters: number,
   condition: TransitDisplayCondition,
-): TransitDisplayData[] {
+): TransitDisplayBoard[] {
   // distance filter: stops within radiusMeters of the center
   const nearbyStops = filterStopsWithinRadius(stops, radiusMeters);
   // flatten each stop's stopTimes into candidates
@@ -564,11 +567,7 @@ export function buildTransitDisplayDataSet(
   // cluster by route type, optionally by direction, then split by category
   const boards = groupCandidatesIntoBoards(candidates, condition);
   // sort by time, cap each board
-  const cappedBoards = sortAndCapBoards(boards, condition.maxEntries);
-  // resolve display names, build UI data
-  return cappedBoards.map((board) =>
-    toTransitDisplayData(board, preferredDisplayLangs, radiusMeters, condition.maxEntries),
-  );
+  return sortAndCapBoards(boards, condition.maxEntries);
 }
 
 /**

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -35,7 +35,7 @@ export function transitDisplayMaxEntriesFor(infoLevel: InfoLevel): number {
 }
 
 /**
- * Stop-level fields of a {@link TransitDisplayEntryData}, grouped so consumers can
+ * Stop-level fields of a {@link TransitDisplayDatumForUi}, grouped so consumers can
  * tell stop context apart from the per-event (trip) fields.
  */
 export interface TransitDisplayEntryDataStop {
@@ -59,7 +59,7 @@ export interface TransitDisplayEntryDataStop {
   context: StopWithContext;
 }
 
-export interface TransitDisplayEntryData {
+export interface TransitDisplayDatumForUi {
   key: string;
   /** Stop-level context for this event. */
   stop: TransitDisplayEntryDataStop;
@@ -120,20 +120,20 @@ export interface TransitDisplayMeta {
 /**
  * One resolved display, ready to render: its {@link TransitDisplayMeta} descriptor
  * plus the UI rows. Produced by resolving a board's rows with
- * {@link buildTransitDisplayEntryData} (e.g. in the UI container).
+ * {@link buildTransitDisplayDatumForUi} (e.g. in the UI container).
  */
-export interface TransitDisplayDataWithMetaData {
+export interface TransitDisplayDataWithMetaDataForUi {
   /** Display descriptor (title + selection params). */
   meta: TransitDisplayMeta;
   /** The entry data this display renders. */
-  data: readonly TransitDisplayEntryData[];
+  data: readonly TransitDisplayDatumForUi[];
 }
 
 /**
  * PROVISIONAL NAME (`_RAW`, to be renamed). A display with its
  * {@link TransitDisplayMeta} descriptor attached but its rows NOT yet resolved:
  * `data` holds the structural board, so resolving it into UI rows (via
- * {@link buildTransitDisplayEntryData}) is the caller's choice. `meta` restates
+ * {@link buildTransitDisplayDatumForUi}) is the caller's choice. `meta` restates
  * the board's category / routeTypes /
  * directions and adds `max` / `radius`.
  */
@@ -278,11 +278,11 @@ export function sortByCategory(
   );
 }
 
-export function buildTransitDisplayEntryData(
-  candidates: readonly TransitDisplayCandidate[],
+export function buildTransitDisplayDatumForUi(
+  datum: readonly TransitDisplayDatum[],
   preferredDisplayLangs: readonly string[],
   category: TransitDisplayCategory,
-): TransitDisplayEntryData[] {
+): TransitDisplayDatumForUi[] {
   // Data-shaping half: resolve names and build the output objects for the
   // already-selected entries.
   // Stop names are per-stop, so resolve each at most once and share across the
@@ -299,7 +299,7 @@ export function buildTransitDisplayEntryData(
     return name;
   };
 
-  return candidates.map(({ entry, stopWithContext }) => {
+  return datum.map(({ entry, stopWithContext }) => {
     const agencyLangs = stopWithContext.agencies.map((agency) => agency.agency_lang);
     const routeAgency = stopWithContext.agencies.find(
       (agency) => agency.agency_id === entry.routeDirection.route.agency_id,
@@ -472,7 +472,7 @@ export function clusterCandidatesByRouteType(
  * baked in here.
  *
  * Grouping only: it does not sort / cap ({@link sortAndCapTransitDisplayData}) or resolve
- * display names ({@link buildTransitDisplayEntryData}). Empty cells are dropped, so the
+ * display names ({@link buildTransitDisplayDatumForUi}). Empty cells are dropped, so the
  * present route types / directions fall out without a separate enumeration.
  */
 export function groupCandidatesIntoBoards(
@@ -554,7 +554,7 @@ export function sortAndCapTransitDisplayData(
  *
  * Rows are intentionally left RAW: the returned `data` holds the structural
  * board, not resolved UI rows. Resolving display names / times into UI data (via
- * {@link buildTransitDisplayEntryData}) is the caller's choice, so this stays
+ * {@link buildTransitDisplayDatumForUi}) is the caller's choice, so this stays
  * i18n-free and the UI owns rendering.
  *
  * `radiusMeters` (the range stops are selected within; also each display's
@@ -579,7 +579,7 @@ export function buildTransitDisplayDataSet(
     condition.maxEntries,
   );
   // attach each display's meta descriptor; rows stay raw (caller resolves)
-  return sortedAndCapped.map((board) => ({
+  const meta: TransitDisplayDataWithMetaData_RAW[] = sortedAndCapped.map((board) => ({
     meta: {
       category: board.category,
       routeTypes: board.routeTypes,
@@ -589,6 +589,7 @@ export function buildTransitDisplayDataSet(
     },
     data: board,
   }));
+  return meta;
 }
 
 /**

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -26,7 +26,6 @@ const MAX_ENTRIES_BY_INFO_LEVEL: Record<InfoLevel, number> = {
   normal: 10,
   detailed: 20,
   verbose: 20,
-  // detailed: 10,
   // verbose: 10,
 };
 

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -1,20 +1,12 @@
 import type { InfoLevel } from '../../../types/app/settings';
-import type { AppRouteTypeValue, TimetableEntryAttributes } from '../../../types/app/transit';
+import type { AppRouteTypeValue } from '../../../types/app/transit';
 import type {
   ContextualTimetableEntry,
   StopWithContext,
-  TripInspectionTarget,
 } from '../../../types/app/transit-composed';
-import { routeTypesEmoji } from '../../../utils/route-type-emoji';
 import { ROUTE_TYPE_DISPLAY_ORDER } from '../route-type-display-order';
-import { formatDateKey, minutesToDate } from '../calendar-utils';
-import { getAgencyDisplayNames } from '../name-resolver/get-agency-display-name';
-import { getHeadsignDisplayNames } from '../name-resolver/get-headsign-display-names';
-import { getRouteDisplayNames } from '../name-resolver/get-route-display-names';
-import { getStopDisplayNames } from '../name-resolver/get-stop-display-names';
+import { minutesToDate } from '../calendar-utils';
 import { getTimetableEntryAttributes } from '../timetable-entry-attributes';
-import { formatAbsoluteTime } from '../time';
-import { buildTripInspectionTarget } from '../trip-inspection-target';
 
 /**
  * Per-board row cap by info level: terser levels show fewer departures, the
@@ -32,55 +24,6 @@ const MAX_ENTRIES_BY_INFO_LEVEL: Record<InfoLevel, number> = {
 /** Resolves the per-board row cap for the given info level. */
 export function transitDisplayMaxEntriesFor(infoLevel: InfoLevel): number {
   return MAX_ENTRIES_BY_INFO_LEVEL[infoLevel];
-}
-
-/**
- * Stop-level fields of a {@link TransitDisplayDatumForUi}, grouped so consumers can
- * tell stop context apart from the per-event (trip) fields.
- */
-export interface TransitDisplayDatumForUiStop {
-  /** Stop ID (used for selection and row keys). */
-  id: string;
-  /** Resolved display name of the stop. */
-  name: string;
-  /** Platform code of the stop, when present. */
-  platformCode: string | undefined;
-  /** Distance in metres from the query centre point, when known. */
-  distance: number | undefined;
-  /** Mode emojis for all route_types served by the stop (stop-level). */
-  routeTypesEmoji: string;
-  /**
-   * Source stop context (shared reference) this event belongs to.
-   *
-   * Carried verbatim so row consumers can render stop-level presentation
-   * directly from the stop / agency / route metadata already resolved on
-   * the source context.
-   */
-  context: StopWithContext;
-}
-
-export interface TransitDisplayDatumForUi {
-  key: string;
-  /** Stop-level context for this event. */
-  stop: TransitDisplayDatumForUiStop;
-  /** Mode emoji for this event's route (trip-level: bus / train / etc.). */
-  routeTypeEmoji: string;
-  routeName: string;
-  /** Resolved display name of the agency operating this event's route. */
-  agencyName: string;
-  headsign: string;
-  /** Pre-formatted absolute display time (legacy presentation). */
-  timeText: string;
-  /** Boarding / drop-off availability and pattern-position flags for this event. */
-  attributes: TimetableEntryAttributes;
-  /** Service-day arrival minutes for `StopTimeTimeInfo` rendering. */
-  arrivalMinutes: number;
-  /** Service-day departure minutes for `StopTimeTimeInfo` rendering. */
-  departureMinutes: number;
-  /** Service date the stop event belongs to. */
-  serviceDate: Date;
-  /** Target used to open trip inspection for this stop event. */
-  inspectionTarget: TripInspectionTarget;
 }
 
 /**
@@ -118,30 +61,51 @@ export interface TransitDisplayMeta {
 }
 
 /**
- * One resolved display, ready to render: its {@link TransitDisplayMeta} descriptor
- * plus the UI rows. Produced by resolving a board's rows with
- * {@link buildTransitDisplayDatumForUi} (e.g. in the UI container).
+ * One board's cell: which route type(s), direction(s) and category it is, plus
+ * the entries selected for it in `data` ({@link TransitDisplayDatum}). These are
+ * raw stop events (not resolved UI rows), so the same shape flows through
+ * grouping, sort + cap, and UI conversion without those concerns leaking into
+ * each other.
  */
-export interface TransitDisplayDataWithMetaDataForUi {
-  /** Display descriptor (title + selection params). */
-  meta: TransitDisplayMeta;
-  /** The entry data this display renders. */
-  data: readonly TransitDisplayDatumForUi[];
+export interface TransitDisplayData {
+  routeTypes: readonly AppRouteTypeValue[];
+  /** Direction(s) this board covers (see {@link TransitDisplayMeta.directions}). */
+  directions: readonly (0 | 1 | 'none')[];
+  category: TransitDisplayCategory;
+  data: TransitDisplayDatum[];
+}
+
+/** A cluster of candidates for one board's route-type scope, before the category split. */
+export interface RouteTypeCluster {
+  routeTypes: readonly AppRouteTypeValue[];
+  candidates: TransitDisplayCandidate[];
 }
 
 /**
- * A display with its {@link TransitDisplayMeta} descriptor attached but its rows
- * NOT yet resolved: `data` holds the structural board, so resolving it into UI
- * rows (via {@link buildTransitDisplayDatumForUi}) is the caller's choice. `meta`
- * restates the board's category / routeTypes / directions and adds `max` /
- * `radius`. The resolved counterpart is {@link TransitDisplayDataWithMetaDataForUi}.
+ * A display: its {@link TransitDisplayMeta} descriptor plus the structural board
+ * it describes in `data`. `meta` restates the board's category / routeTypes /
+ * directions and adds `max` / `radius`.
  */
 export interface TransitDisplayDataWithMetaData {
   /** Display descriptor (title + selection params). */
   meta: TransitDisplayMeta;
-  /** The structural board, whose entries are not yet resolved into UI rows. */
+  /** The structural board this display describes. */
   data: TransitDisplayData;
 }
+
+/** One stop event paired with the stop context it came from, before name resolution. */
+export interface TransitDisplayCandidate {
+  entry: ContextualTimetableEntry;
+  stopWithContext: StopWithContext;
+}
+
+/**
+ * One entry selected onto a board by {@link groupCandidatesIntoBoards} -- a
+ * {@link TransitDisplayCandidate} that passed category qualification. Same shape
+ * as a candidate; this alias marks the post-selection role (it is output, no
+ * longer a mere candidate) and reads as the singular of a board's `data`.
+ */
+export type TransitDisplayDatum = TransitDisplayCandidate;
 
 /**
  * How route types are grouped into boards:
@@ -178,26 +142,12 @@ export interface TransitDisplayCondition {
   splitByDirection: boolean;
 }
 
-/** One stop event paired with the stop context it came from, before name resolution. */
-export interface TransitDisplayCandidate {
-  entry: ContextualTimetableEntry;
-  stopWithContext: StopWithContext;
-}
-
-/**
- * One entry selected onto a board by {@link groupCandidatesIntoBoards} -- a
- * {@link TransitDisplayCandidate} that passed category qualification. Same shape
- * as a candidate; this alias marks the post-selection role (it is output, no
- * longer a mere candidate) and reads as the singular of a board's `data`.
- */
-export type TransitDisplayDatum = TransitDisplayCandidate;
-
 /**
  * Service-day minutes an entry is sorted and shown by, derived from the board's
  * category: an arrivals board uses arrival time (even for intermediate,
  * non-terminal stops); a departures board uses departure time.
  */
-function categoryMinutes(
+export function categoryMinutes(
   entry: ContextualTimetableEntry,
   category: TransitDisplayCategory,
 ): number {
@@ -277,90 +227,6 @@ export function sortByCategory(
   );
 }
 
-export function buildTransitDisplayDatumForUi(
-  datum: readonly TransitDisplayDatum[],
-  preferredDisplayLangs: readonly string[],
-  category: TransitDisplayCategory,
-): TransitDisplayDatumForUi[] {
-  // Data-shaping half: resolve names and build the output objects for the
-  // already-selected entries.
-  // Stop names are per-stop, so resolve each at most once and share across the
-  // selected entries that belong to the same stop.
-  const stopNameCache = new Map<string, string>();
-  const resolveStopName = (stopWithContext: StopWithContext): string => {
-    const cached = stopNameCache.get(stopWithContext.stop.stop_id);
-    if (cached !== undefined) {
-      return cached;
-    }
-    const agencyLangs = stopWithContext.agencies.map((agency) => agency.agency_lang);
-    const name = getStopDisplayNames(stopWithContext.stop, preferredDisplayLangs, agencyLangs).name;
-    stopNameCache.set(stopWithContext.stop.stop_id, name);
-    return name;
-  };
-
-  return datum.map(({ entry, stopWithContext }) => {
-    const agencyLangs = stopWithContext.agencies.map((agency) => agency.agency_lang);
-    const routeAgency = stopWithContext.agencies.find(
-      (agency) => agency.agency_id === entry.routeDirection.route.agency_id,
-    );
-    const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : agencyLangs;
-    const routeName = getRouteDisplayNames(
-      entry.routeDirection.route,
-      preferredDisplayLangs,
-      routeAgencyLangs,
-      'short',
-    ).resolved.name;
-    const headsign = getHeadsignDisplayNames(
-      entry.routeDirection,
-      preferredDisplayLangs,
-      routeAgencyLangs,
-      'stop',
-    ).resolved.name;
-    const agencyName = routeAgency
-      ? getAgencyDisplayNames(routeAgency, preferredDisplayLangs, routeAgencyLangs, 'short')
-          .resolved.name || routeAgency.agency_id
-      : '';
-    // Include the service date: TripLocator is per-service (not per-day), so the
-    // same (patternId, serviceId, tripIndex, stopIndex) can recur on different
-    // service dates within one board, which would collide as a React key.
-    // JSON.stringify (not a delimiter join) keeps the parts unambiguous: a
-    // patternId already embeds "__" (`${route_id}__${headsign}`), so a literal
-    // separator could let different tuples stringify to the same key.
-    const key = JSON.stringify([
-      stopWithContext.stop.stop_id,
-      formatDateKey(entry.serviceDate),
-      entry.tripLocator.patternId,
-      entry.tripLocator.serviceId,
-      entry.tripLocator.tripIndex,
-      entry.patternPosition.stopIndex,
-    ]);
-    const tripInspectionTarget = buildTripInspectionTarget(entry, entry.serviceDate);
-    return {
-      key,
-      stop: {
-        id: stopWithContext.stop.stop_id,
-        name: resolveStopName(stopWithContext),
-        platformCode: stopWithContext.stop.platform_code,
-        distance: stopWithContext.distance,
-        routeTypesEmoji: routeTypesEmoji(stopWithContext.routeTypes),
-        context: stopWithContext,
-      },
-      routeTypeEmoji: routeTypesEmoji([entry.routeDirection.route.route_type]),
-      routeName,
-      agencyName,
-      headsign,
-      timeText: formatAbsoluteTime(
-        minutesToDate(entry.serviceDate, categoryMinutes(entry, category)),
-      ),
-      attributes: getTimetableEntryAttributes(entry),
-      arrivalMinutes: entry.schedule.arrivalMinutes,
-      departureMinutes: entry.schedule.departureMinutes,
-      serviceDate: entry.serviceDate,
-      inspectionTarget: tripInspectionTarget,
-    };
-  });
-}
-
 /** Conventional radius (metres) for the nearby-stops displays; callers pass this explicitly. */
 export const NEARBY_RADIUS_M = 100;
 
@@ -389,27 +255,6 @@ function presentDirections(
   return DIRECTIONS.filter((direction) => present.has(direction)).map(
     (direction) => direction ?? 'none',
   );
-}
-
-/**
- * One board's cell: which route type(s), direction(s) and category it is, plus
- * the entries selected for it in `data` ({@link TransitDisplayDatum}). These are
- * raw stop events (not resolved UI rows), so the same shape flows through
- * grouping, sort + cap, and UI conversion without those concerns leaking into
- * each other.
- */
-export interface TransitDisplayData {
-  routeTypes: readonly AppRouteTypeValue[];
-  /** Direction(s) this board covers (see {@link TransitDisplayMeta.directions}). */
-  directions: readonly (0 | 1 | 'none')[];
-  category: TransitDisplayCategory;
-  data: TransitDisplayDatum[];
-}
-
-/** A cluster of candidates for one board's route-type scope, before the category split. */
-export interface RouteTypeCluster {
-  routeTypes: readonly AppRouteTypeValue[];
-  candidates: TransitDisplayCandidate[];
 }
 
 /** Present route types among candidates, in `ROUTE_TYPE_DISPLAY_ORDER`. */
@@ -552,9 +397,8 @@ export function sortAndCapTransitDisplayData(
  * the next one's concern does not leak into it.
  *
  * Rows are intentionally left RAW: the returned `data` holds the structural
- * board, not resolved UI rows. Resolving display names / times into UI data (via
- * {@link buildTransitDisplayDatumForUi}) is the caller's choice, so this stays
- * i18n-free and the UI owns rendering.
+ * board, not resolved UI rows. Resolving display names / times into UI data is
+ * the caller's choice, so this stays i18n-free and the UI owns rendering.
  *
  * `radiusMeters` (the range stops are selected within; also each display's
  * `meta.radius`) and `condition` (the per-display selection condition) are both
@@ -578,19 +422,17 @@ export function buildTransitDisplayDataSet(
     condition.maxEntries,
   );
 
-  const transitDisplayDataWithMetaData: TransitDisplayDataWithMetaData[] = sortedAndCapped.map(
-    (transitDisplayData) => ({
-      meta: {
-        category: transitDisplayData.category,
-        routeTypes: transitDisplayData.routeTypes,
-        directions: transitDisplayData.directions,
-        max: condition.maxEntries,
-        radius: radiusMeters,
-      },
-      data: transitDisplayData,
-    }),
-  );
-  return transitDisplayDataWithMetaData;
+  const dataWithMetaData: TransitDisplayDataWithMetaData[] = sortedAndCapped.map((data) => ({
+    meta: {
+      category: data.category,
+      routeTypes: data.routeTypes,
+      directions: data.directions,
+      max: condition.maxEntries,
+      radius: radiusMeters,
+    },
+    data: data,
+  }));
+  return dataWithMetaData;
 }
 
 /**

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -148,7 +148,12 @@
     "recentCount": "Latest {{count}} ({{radius}}m)",
     "entryCount": "{{count}} ({{radius}}m)",
     "departures": "DEPARTURES",
-    "arrivals": "ARRIVALS"
+    "arrivals": "ARRIVALS",
+    "filter": {
+      "label": "Boards to show",
+      "departures": "Departures",
+      "arrivals": "Arrivals"
+    }
   },
   "showTimetable": "Show timetable",
   "timetable": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -148,7 +148,12 @@
     "recentCount": "直近 {{count}} 件 ({{radius}}m)",
     "entryCount": "{{count}} 件 ({{radius}}m)",
     "departures": "出発 Departures",
-    "arrivals": "到着 Arrivals"
+    "arrivals": "到着 Arrivals",
+    "filter": {
+      "label": "表示する便",
+      "departures": "出発",
+      "arrivals": "到着"
+    }
   },
   "showTimetable": "時刻表を表示",
   "timetable": {

--- a/src/types/app/stop-browser.ts
+++ b/src/types/app/stop-browser.ts
@@ -1,0 +1,16 @@
+import type { StopTimeViewId } from '@/domain/transit/stop-time-views';
+
+/**
+ * StopBrowser state shared across the layout surfaces (multi-pane / bottom-sheet).
+ * Held in AppLayout above the layout swap so it survives switching surfaces.
+ * Group such cross-surface StopBrowser state here: adding another value is one
+ * field on this type, not another prop threaded through every layer.
+ */
+export interface StopBrowserSharedState {
+  /** Which stop-times view (tab) the StopBrowser shows. */
+  viewId: StopTimeViewId;
+  /** Surface-local route_type filter: route types hidden in the StopBrowser. */
+  hiddenRouteTypes: Set<number>;
+  /** Surface-local agency filter: agency IDs hidden in the StopBrowser. */
+  hiddenAgencyIds: Set<string>;
+}


### PR DESCRIPTION
## Summary

Adds the TransitDisplay split-flap board view to the StopBrowser and refines its data model, ordering, and surface state.

- **Board building**: nearby-stop stop events are grouped into boards by route type x category (departures / arrivals). Rail-like modes are split by direction; bus / trolleybus / ferry are kept whole (their `direction_id` is route-local and would mix unrelated routes at shared stops). Boards are re-ordered into a canonical UI order (route type -> category -> direction) so they stay consistent when modes co-occur at a stop.
- **Ordering / classification**: departures list before arrivals (even at termini); arrivals boards exclude origin departures; boards are formed by boardability / alightability; boarding-restriction labels show only at the verbose info level.
- **Filter**: a departures / arrivals filter on TransitDisplays, with bar and button metrics scaled by display size and a solid off-state color.
- **Surface state**: lift the StopBrowser view tab and surface-local route_type / agency filters into a shared state owned by AppLayout (above the layout-mode swap) so they survive switching between the multi-pane and bottom-sheet surfaces instead of resetting on remount.
- **Trip-pattern analysis**: source-level `direction_id` completeness / direction-count additions to the trip-patterns summary.

## Verification

- `typecheck`, `lint`, `test` (4406 passing), and the production `build` are all green.
- Browser verification of layout-swap state retention is being done locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)