### PR TITLE
feat(transit-display): TransitDisplay2 header stats, empty-state messaging, and render perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Storybook: `TransitDisplayEntry2` / `TransitDisplay2` の stories を追加した (#281)。
+- Storybook: `AbsoluteStopTime` の stories を追加した。
+
+### Changed
+
+- TransitDisplay2: route と stop で事業者言語の解決を分離し、headsign は route の運行事業者言語 (なければ `DEFAULT_AGENCY_LANG`) で、stop 名 / route badge は停留所の全事業者言語で解決するようにした (#281)。
+- Badge: `RouteBadge` / `AgencyBadge` の `showBorder` 既定値を `true` に変更した (全呼び出し元が明示指定済みのため既存表示は不変)。
+- StopTimeTimeInfo / TripInfo: 絶対 / 相対時刻および属性ラベルへ渡す表示サイズを、コンポーネントの `size` から per-size の変換テーブル経由で解決する形にした (#281)。
+- StopTimes: bottom sheet 行の絶対時刻サイズと余白を微調整した (#281)。
+
 ## [2026.06.08]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - Storybook: `TransitDisplayEntry2` / `TransitDisplay2` の stories を追加した (#281)。
 - Storybook: `AbsoluteStopTime` の stories を追加した。
+- TransitDisplay2: ヘッダに radius 圏内の集計 (のりば数 / 路線数 / 事業者数) と radius バッジを表示するようにした (#281)。
+- TransitDisplay2: 対象のりばが無い (`no-stops`) / 当日運行が無い (`no-service`) 場合に、その旨のメッセージを表示するようにした (#281)。
 
 ### Changed
 
@@ -20,6 +22,9 @@ and this project adheres to [CalVer](https://calver.org/).
 - Badge: `RouteBadge` / `AgencyBadge` の `showBorder` 既定値を `true` に変更した (全呼び出し元が明示指定済みのため既存表示は不変)。
 - StopTimeTimeInfo / TripInfo: 絶対 / 相対時刻および属性ラベルへ渡す表示サイズを、コンポーネントの `size` から per-size の変換テーブル経由で解決する形にした (#281)。
 - StopTimes: bottom sheet 行の絶対時刻サイズと余白を微調整した (#281)。
+- TransitDisplay2: ヘッダのバッジサイズ / レイアウトを表示サイズ連動に整理した (#281)。
+- TransitDisplay2: 地図ドラッグ中に発生していた board / 行の不要な再計算 (名前 / 色 / 行先解決、表示 stats) を `useMemo` 化して削減した (#281)。
+- transit display のデータ構築を整理した: 距離フィルタを `stop-meta-filter` の `filterStopsWithinDistance` に分離し、`groupCandidatesIntoBoards` の方向分岐を統合、`buildTransitDisplayDataSet` の TSDoc / tests を整備した (#281)。
 
 ## [2026.06.08]
 

--- a/src/components/absolute-stop-time.stories.tsx
+++ b/src/components/absolute-stop-time.stories.tsx
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AbsoluteStopTime } from './absolute-stop-time';
+
+const meta = {
+  title: 'StopTime/AbsoluteStopTime',
+  component: AbsoluteStopTime,
+  args: {
+    timeText: '14:30',
+    size: 'md',
+    weight: 'bold',
+    showArrivalMarker: false,
+    showDepartureMarker: false,
+  },
+  argTypes: {
+    size: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
+    weight: { control: 'inline-radio', options: ['normal', 'bold'] },
+    textColor: { control: 'color' },
+    showArrivalMarker: { control: 'boolean' },
+    showDepartureMarker: { control: 'boolean' },
+  },
+  decorators: [
+    (Story) => (
+      <div className="rounded-lg bg-[#f5f7fa] p-4 dark:bg-gray-800">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AbsoluteStopTime>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// --- Basic ---
+
+/** Default: plain absolute time with no marker. */
+export const Default: Story = {};
+
+/** Departure row: the time carries the departure marker suffix. */
+export const WithDepartureMarker: Story = {
+  args: { showDepartureMarker: true },
+};
+
+/** Arrival row: the time carries the arrival marker suffix. */
+export const WithArrivalMarker: Story = {
+  args: { showArrivalMarker: true },
+};
+
+/**
+ * Overnight time past midnight (service-day minutes >= 1440 render as 24:00+),
+ * so the widest realistic time text is exercised.
+ */
+export const OvernightTime: Story = {
+  args: { timeText: '27:45', showDepartureMarker: true },
+};
+
+// --- Variants ---
+
+/** Route-colored time text via `textColor`. */
+export const Colored: Story = {
+  args: { textColor: '#0d9488', showDepartureMarker: true },
+};
+
+/** Normal (non-bold) weight. */
+export const NormalWeight: Story = {
+  args: { weight: 'normal' },
+};
+
+const SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+
+/**
+ * The same time at every display size, smallest to largest. A departure marker is
+ * shown so the marker suffix scaling (it tracks the size) is visible too.
+ */
+export const SizeComparison: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      {SIZES.map((size) => (
+        <div key={size} className="flex items-center gap-3">
+          <span className="w-12 text-right text-xs text-gray-500">{size}</span>
+          <AbsoluteStopTime {...args} size={size} showDepartureMarker />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** Side-by-side of the no-marker / arrival / departure variants. */
+export const MarkerComparison: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-6">
+      <div className="flex flex-col items-center gap-1">
+        <span className="text-xs text-gray-500">none</span>
+        <AbsoluteStopTime {...args} showArrivalMarker={false} showDepartureMarker={false} />
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <span className="text-xs text-gray-500">arrival</span>
+        <AbsoluteStopTime {...args} showArrivalMarker showDepartureMarker={false} />
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <span className="text-xs text-gray-500">departure</span>
+        <AbsoluteStopTime {...args} showArrivalMarker={false} showDepartureMarker />
+      </div>
+    </div>
+  ),
+};
+
+// --- Kitchen sink ---
+
+/**
+ * Maximum-content scenario: overnight time text, both markers rendered, colored,
+ * at the largest size.
+ */
+export const KitchenSink: Story = {
+  args: {
+    timeText: '27:45',
+    size: 'xl',
+    weight: 'bold',
+    textColor: '#0d9488',
+    showArrivalMarker: true,
+    showDepartureMarker: true,
+  },
+};

--- a/src/components/badge/agency-badge.tsx
+++ b/src/components/badge/agency-badge.tsx
@@ -44,7 +44,7 @@ export function AgencyBadge({
   dataLang,
   agencyLangs = DEFAULT_AGENCY_LANG,
   infoLevel,
-  showBorder = false,
+  showBorder = true,
   enableVerboseExtras = false,
   className,
 }: AgencyBadgeProps) {

--- a/src/components/badge/route-badge.tsx
+++ b/src/components/badge/route-badge.tsx
@@ -47,7 +47,7 @@ export function RouteBadge({
   dataLang,
   agencyLangs = DEFAULT_AGENCY_LANG,
   infoLevel,
-  showBorder = false,
+  showBorder = true,
   enableVerboseExtras = false,
   className,
 }: RouteBadgeProps) {

--- a/src/components/relative-time.tsx
+++ b/src/components/relative-time.tsx
@@ -75,6 +75,7 @@ export function RelativeTime({
   return (
     <span
       className={cn(
+        // 'border',
         'flex flex-nowrap items-baseline leading-none font-bold whitespace-nowrap',
         justifyClassName,
         className,

--- a/src/components/stop-time-item.tsx
+++ b/src/components/stop-time-item.tsx
@@ -80,7 +80,7 @@ export function StopTimeItem({
   const tripInspectionTarget = buildTripInspectionTarget(entry, entry.serviceDate);
 
   return (
-    <div className="border-b border-[#e0e0e0] py-1 last:border-b-0 dark:border-gray-700">
+    <div className="border-b border-[#e0e0e0] py-1 pl-0 last:border-b-0 dark:border-gray-700">
       <div className="flex gap-2">
         <StopTimeTimeInfo
           arrivalMinutes={entry.schedule.arrivalMinutes}
@@ -88,6 +88,7 @@ export function StopTimeItem({
           serviceDate={entry.serviceDate}
           now={now}
           size="md"
+          align="right"
           showArrivalTime={display.showArrivalTime}
           showDepartureTime={display.showDepartureTime}
           collapseToleranceMinutes={display.collapseToleranceMinutes}

--- a/src/components/stop-time-time-info.tsx
+++ b/src/components/stop-time-time-info.tsx
@@ -74,6 +74,34 @@ export interface StopTimeTimeInfoProps extends WithServiceDate {
   onInspectTrip?: (target: TripInspectionTarget) => void;
 }
 
+/**
+ * Absolute-time text size per container display size. Maps the component-level
+ * `size` to the size passed to {@link AbsoluteStopTime}. Currently an identity
+ * mapping; per-size values are tuned here independently of
+ * {@link REL_TIME_SIZE_BY_SIZE}.
+ */
+const ABS_TIME_SIZE_BY_SIZE: Record<ExtendedDisplaySize, ExtendedDisplaySize> = {
+  xs: 'sm',
+  sm: 'md',
+  md: 'lg',
+  lg: 'xl',
+  xl: 'xl',
+};
+
+/**
+ * Relative-time text size per container display size. Maps the component-level
+ * `size` to the size passed to {@link RelativeTime}. Currently an identity
+ * mapping; per-size values are tuned here independently of
+ * {@link ABS_TIME_SIZE_BY_SIZE}.
+ */
+const REL_TIME_SIZE_BY_SIZE: Record<ExtendedDisplaySize, ExtendedDisplaySize> = {
+  xs: 'xs',
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+  xl: 'xl',
+};
+
 export function StopTimeTimeInfo({
   arrivalMinutes,
   departureMinutes,
@@ -107,7 +135,8 @@ export function StopTimeTimeInfo({
   const shouldShowArrivalAbsolute = showArrivalTime && !arrivalCollapsed;
   const shouldShowDepartureAbsolute = showDepartureTime;
   const shouldShowDepartureMarker = shouldShowArrivalAbsolute && shouldShowDepartureAbsolute;
-  const timeSize: ExtendedDisplaySize = size;
+  const absTimeSize = ABS_TIME_SIZE_BY_SIZE[size];
+  const relTimeSize = REL_TIME_SIZE_BY_SIZE[size];
 
   const textAlignClassName =
     align === 'left' ? 'text-left' : align === 'center' ? 'text-center' : 'text-right';
@@ -157,7 +186,7 @@ export function StopTimeTimeInfo({
         <RelativeTime
           time={time}
           now={now}
-          size={timeSize}
+          size={relTimeSize}
           align={align}
           showPastTime={true}
           hidePrefix={diffMs > 90 * 60 * 1000}
@@ -174,7 +203,7 @@ export function StopTimeTimeInfo({
             key={variant.key}
             timeText={variant.timeText}
             textColor={textAppearance?.color}
-            size={timeSize}
+            size={absTimeSize}
             weight={textAppearance?.weight}
             className={textAppearance?.className}
             showDepartureMarker={variant.showDepartureMarker}
@@ -193,6 +222,7 @@ export function StopTimeTimeInfo({
     <button
       type="button"
       className={cn(
+        // 'border',
         rootClassName,
         'cursor-pointer rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
       )}

--- a/src/components/stop-times-item.tsx
+++ b/src/components/stop-times-item.tsx
@@ -94,7 +94,7 @@ export function StopTimesItem({
           showAgency={showAgency}
         />
       </div>
-      <div className="flex items-center gap-3 pl-1">
+      <div className="flex items-center gap-2 pl-2">
         {/* Relative time hint — easy to scan at a glance (e.g. "あと5分").
             Kept as a non-wrapping single unit so the prefix stays glued to
             the value even on narrow screens. */}
@@ -123,7 +123,9 @@ export function StopTimesItem({
               <>
                 <AbsoluteStopTime
                   timeText={formatAbsoluteTime(displayTimes[i])}
-                  size="md"
+                  // size="md"
+                  size="lg"
+                  // size="xl"
                   showArrivalMarker={entry.patternPosition.isTerminal}
                   showDepartureMarker={false}
                   className="text-muted-foreground"

--- a/src/components/transit-display/transit-display-2.stories.tsx
+++ b/src/components/transit-display/transit-display-2.stories.tsx
@@ -20,6 +20,7 @@ import {
   stopHeadsignShort,
   storyMapCenter,
   storyNow,
+  storyTransitDisplayStats,
   tripHeadsignLong,
 } from '../../stories/fixtures';
 import type { Agency, Route, Stop } from '../../types/app/transit';
@@ -100,6 +101,7 @@ function makeDisplay(
       category: meta.category,
       data: [...rows],
     },
+    stats: storyTransitDisplayStats,
   };
 }
 

--- a/src/components/transit-display/transit-display-2.stories.tsx
+++ b/src/components/transit-display/transit-display-2.stories.tsx
@@ -1,0 +1,293 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import type {
+  TransitDisplayDataWithMetaData,
+  TransitDisplayDatum,
+  TransitDisplayMeta,
+} from '../../domain/transit/transit-info-display/build-transit-display-data';
+import {
+  agencyGx,
+  agencyTobus,
+  baseStop,
+  busRoute,
+  busRoute2,
+  createEntry,
+  emptyHeadsign,
+  headsignNakano,
+  headsignShinjuku,
+  longNameStop,
+  railRoute,
+  stopHeadsignShort,
+  storyMapCenter,
+  storyNow,
+  tripHeadsignLong,
+} from '../../stories/fixtures';
+import type { Agency, Route, Stop } from '../../types/app/transit';
+import type { StopServiceType, TranslatableText } from '../../types/app/transit-composed';
+import { TransitDisplay2 } from './transit-displays-2';
+
+/** Flat override knobs for {@link makeDatum}, assembled into the raw row shape. */
+interface MakeDatumOverrides {
+  stop?: Stop;
+  route?: Route;
+  agency?: Agency;
+  distance?: number;
+  tripHeadsign?: TranslatableText;
+  stopHeadsign?: TranslatableText;
+  departureMinutes?: number;
+  arrivalMinutes?: number;
+  stopIndex?: number;
+  isTerminal?: boolean;
+  isOrigin?: boolean;
+  pickupType?: StopServiceType;
+  dropOffType?: StopServiceType;
+}
+
+/**
+ * Build a raw {@link TransitDisplayDatum} for stories. `TransitDisplay2` passes
+ * raw rows down and resolves names / colors at the leaf, so stories construct the
+ * unresolved candidate ({@link createEntry} entry + its {@link StopWithContext}).
+ * The board derives each row's React key from stop id + pattern + stop index, so
+ * vary `tripHeadsign` / `stopIndex` across rows to keep keys unique.
+ */
+function makeDatum(overrides: MakeDatumOverrides = {}): TransitDisplayDatum {
+  const route = overrides.route ?? busRoute;
+  const agency = overrides.agency ?? agencyTobus;
+  const entry = createEntry({
+    route,
+    tripHeadsign: overrides.tripHeadsign,
+    stopHeadsign: overrides.stopHeadsign,
+    departureMinutes: overrides.departureMinutes,
+    arrivalMinutes: overrides.arrivalMinutes,
+    stopIndex: overrides.stopIndex,
+    isTerminal: overrides.isTerminal,
+    isOrigin: overrides.isOrigin,
+    pickupType: overrides.pickupType,
+    dropOffType: overrides.dropOffType,
+  });
+  return {
+    timetableEntry: entry,
+    stop: {
+      stop: overrides.stop ?? baseStop,
+      distance: overrides.distance ?? 235,
+      agencies: [agency],
+      routes: [route],
+      routeTypes: [route.route_type],
+      stopTimes: [],
+      stopServiceState: 'boardable',
+    },
+  };
+}
+
+/** Assemble a {@link TransitDisplayDataWithMetaData} from meta overrides and rows. */
+function makeDisplay(
+  metaOverrides: Partial<TransitDisplayMeta> = {},
+  rows: readonly TransitDisplayDatum[] = departureRows,
+): TransitDisplayDataWithMetaData {
+  const meta: TransitDisplayMeta = {
+    category: 'departures',
+    routeTypes: [3],
+    directions: [0],
+    max: 20,
+    radius: 100,
+    ...metaOverrides,
+  };
+  return {
+    meta,
+    data: {
+      routeTypes: meta.routeTypes,
+      directions: meta.directions,
+      category: meta.category,
+      data: [...rows],
+    },
+  };
+}
+
+const departureRows: TransitDisplayDatum[] = [
+  makeDatum({ departureMinutes: 870, stopIndex: 3, tripHeadsign: headsignNakano }),
+  makeDatum({
+    route: busRoute2,
+    departureMinutes: 873,
+    stopIndex: 5,
+    tripHeadsign: headsignShinjuku,
+    distance: 80,
+  }),
+  makeDatum({
+    departureMinutes: 877,
+    stopIndex: 7,
+    tripHeadsign: emptyHeadsign,
+    stopHeadsign: stopHeadsignShort,
+    distance: 410,
+  }),
+];
+
+const arrivalRows: TransitDisplayDatum[] = [
+  makeDatum({
+    departureMinutes: 871,
+    stopIndex: 12,
+    tripHeadsign: headsignNakano,
+    isTerminal: true,
+  }),
+  makeDatum({
+    route: busRoute2,
+    departureMinutes: 875,
+    stopIndex: 14,
+    tripHeadsign: headsignShinjuku,
+    isTerminal: true,
+  }),
+];
+
+const trainRows: TransitDisplayDatum[] = [
+  makeDatum({
+    route: railRoute,
+    agency: agencyGx,
+    departureMinutes: 872,
+    stopIndex: 3,
+    tripHeadsign: headsignNakano,
+    stop: longNameStop,
+  }),
+  makeDatum({
+    route: railRoute,
+    agency: agencyGx,
+    departureMinutes: 878,
+    stopIndex: 4,
+    tripHeadsign: headsignShinjuku,
+    stop: longNameStop,
+  }),
+];
+
+const meta = {
+  title: 'TransitDisplay/TransitDisplay2',
+  component: TransitDisplay2,
+  args: {
+    transitDisplayDataWithMetaData: makeDisplay(),
+    dataLangs: ['ja'],
+    now: storyNow,
+    mapCenter: storyMapCenter,
+    infoLevel: 'normal' as const,
+    size: 'md' as const,
+    onStopSelected: fn(),
+    onInspectTrip: fn(),
+  },
+  argTypes: {
+    transitDisplayDataWithMetaData: { control: 'object' },
+    infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
+    size: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
+  },
+  // Mirror the parent TransitDisplays2 wrapper (px-4) so framing / spacing match
+  // production.
+  decorators: [
+    (Story) => (
+      <div className="max-w-sm bg-white px-4 py-2 dark:bg-gray-900">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TransitDisplay2>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// --- Basic ---
+
+/** Default: a bus departure board. Up arrow + DEPARTURES in the header band. */
+export const Default: Story = {};
+
+// --- Variants ---
+
+/** Arrival board: right arrow + ARRIVALS, each row showing its arrival time. */
+export const ArrivalBoard: Story = {
+  args: {
+    transitDisplayDataWithMetaData: makeDisplay({ category: 'arrivals' }, arrivalRows),
+  },
+};
+
+/** Rail board: the header mode emoji follows the board's route type. */
+export const TrainDeparture: Story = {
+  args: {
+    transitDisplayDataWithMetaData: makeDisplay({ routeTypes: [2] }, trainRows),
+  },
+};
+
+/** Mixed route types on one board: rows keep their own route + agency colors. */
+export const MixedRouteTypes: Story = {
+  args: {
+    transitDisplayDataWithMetaData: makeDisplay({ routeTypes: [3, 2] }, [
+      ...departureRows,
+      ...trainRows,
+    ]),
+  },
+};
+
+/** The same board rendered at every display size, smallest to largest. */
+export const SizeComparison: Story = {
+  render: (args) => (
+    <div className="space-y-2">
+      {(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
+        <TransitDisplay2
+          key={size}
+          transitDisplayDataWithMetaData={args.transitDisplayDataWithMetaData}
+          dataLangs={args.dataLangs}
+          now={args.now}
+          mapCenter={args.mapCenter}
+          infoLevel={args.infoLevel}
+          size={size}
+          onStopSelected={args.onStopSelected}
+          onInspectTrip={args.onInspectTrip}
+        />
+      ))}
+    </div>
+  ),
+};
+
+// --- Edge cases ---
+
+/** No entries: only the header band renders (this view has no empty fallback row). */
+export const Empty: Story = {
+  args: {
+    transitDisplayDataWithMetaData: makeDisplay({}, []),
+  },
+};
+
+// --- Kitchen sink ---
+
+const kitchenSinkRows: TransitDisplayDatum[] = [
+  makeDatum({ departureMinutes: 870, stopIndex: 1, tripHeadsign: headsignNakano, isOrigin: true }),
+  makeDatum({
+    departureMinutes: 873,
+    stopIndex: 3,
+    stop: longNameStop,
+    tripHeadsign: tripHeadsignLong,
+    distance: 12,
+    pickupType: 1,
+    dropOffType: 1,
+  }),
+  makeDatum({
+    route: railRoute,
+    agency: agencyGx,
+    departureMinutes: 877,
+    stopIndex: 5,
+    tripHeadsign: emptyHeadsign,
+    stopHeadsign: stopHeadsignShort,
+    distance: 980,
+  }),
+  makeDatum({
+    route: busRoute2,
+    departureMinutes: 882,
+    stopIndex: 15,
+    tripHeadsign: headsignShinjuku,
+    isTerminal: true,
+  }),
+];
+
+/**
+ * Maximum-content board: long stop / headsign names, mixed route types, near and
+ * far distances, and the full attribute set, rendered at the verbose info level
+ * (distance badges + unavailability flags on).
+ */
+export const KitchenSink: Story = {
+  args: {
+    transitDisplayDataWithMetaData: makeDisplay({ routeTypes: [3, 2] }, kitchenSinkRows),
+    infoLevel: 'verbose' as const,
+  },
+};

--- a/src/components/transit-display/transit-display-entry-2.stories.tsx
+++ b/src/components/transit-display/transit-display-entry-2.stories.tsx
@@ -1,0 +1,312 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import type {
+  TransitDisplayDatum,
+  TransitDisplayMeta,
+} from '../../domain/transit/transit-info-display/build-transit-display-data';
+import {
+  agencyGx,
+  agencyNoColor,
+  agencyOretetsu,
+  agencyTobus,
+  baseStop,
+  busRoute,
+  createEntry,
+  emptyHeadsign,
+  headsignShort,
+  longNameStop,
+  noColorRoute,
+  railRoute,
+  stopHeadsignLong,
+  stopHeadsignShort,
+  storyMapCenter,
+  storyNow,
+  tramRoute,
+  tripHeadsignLong,
+} from '../../stories/fixtures';
+import type { Agency, Route, Stop } from '../../types/app/transit';
+import type { StopServiceType, TranslatableText } from '../../types/app/transit-composed';
+import { TransitDisplayEntry2 } from './transit-displays-2';
+
+/** Flat override knobs for {@link makeDatum}, assembled into the raw row shape. */
+interface MakeDatumOverrides {
+  stop?: Stop;
+  route?: Route;
+  agency?: Agency;
+  distance?: number;
+  tripHeadsign?: TranslatableText;
+  stopHeadsign?: TranslatableText;
+  departureMinutes?: number;
+  arrivalMinutes?: number;
+  stopIndex?: number;
+  isTerminal?: boolean;
+  isOrigin?: boolean;
+  pickupType?: StopServiceType;
+  dropOffType?: StopServiceType;
+}
+
+/**
+ * Build a raw {@link TransitDisplayDatum} for stories.
+ *
+ * Unlike the classic view, `TransitDisplayEntry2` consumes RAW data and resolves
+ * names / colors at the leaf via `dataLangs`, so stories construct the unresolved
+ * candidate ({@link createEntry} entry + its {@link StopWithContext}) rather than
+ * a presentational row. `agency` is kept in the stop context so the route agency
+ * (matched by `agency_id`) resolves for the AgencyBadge.
+ */
+function makeDatum(overrides: MakeDatumOverrides = {}): TransitDisplayDatum {
+  const route = overrides.route ?? busRoute;
+  const agency = overrides.agency ?? agencyTobus;
+  const entry = createEntry({
+    route,
+    tripHeadsign: overrides.tripHeadsign,
+    stopHeadsign: overrides.stopHeadsign,
+    departureMinutes: overrides.departureMinutes,
+    arrivalMinutes: overrides.arrivalMinutes,
+    stopIndex: overrides.stopIndex,
+    isTerminal: overrides.isTerminal,
+    isOrigin: overrides.isOrigin,
+    pickupType: overrides.pickupType,
+    dropOffType: overrides.dropOffType,
+  });
+  return {
+    timetableEntry: entry,
+    stop: {
+      stop: overrides.stop ?? baseStop,
+      distance: overrides.distance ?? 235,
+      agencies: [agency],
+      routes: [route],
+      routeTypes: [route.route_type],
+      stopTimes: [],
+      stopServiceState: 'boardable',
+    },
+  };
+}
+
+/** Assemble a {@link TransitDisplayMeta} from overrides. */
+function makeMeta(overrides: Partial<TransitDisplayMeta> = {}): TransitDisplayMeta {
+  return {
+    category: 'departures',
+    routeTypes: [3],
+    directions: [0],
+    max: 20,
+    radius: 100,
+    ...overrides,
+  };
+}
+
+const meta = {
+  title: 'TransitDisplay/TransitDisplayEntry2',
+  component: TransitDisplayEntry2,
+  args: {
+    data: makeDatum(),
+    meta: makeMeta(),
+    dataLangs: ['ja'],
+    now: storyNow,
+    mapCenter: storyMapCenter,
+    infoLevel: 'normal' as const,
+    size: 'md' as const,
+    onStopSelected: fn(),
+    onInspectTrip: fn(),
+  },
+  argTypes: {
+    data: { control: 'object' },
+    meta: { control: 'object' },
+    infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
+    size: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
+  },
+  // TransitDisplayEntry2 renders an <li>; wrap in a <ul> on the board's
+  // theme-aware panel face, mirroring the parent TransitDisplay2 body.
+  decorators: [
+    (Story) => (
+      <div className="max-w-sm rounded-sm bg-[#f5f7fa] p-3 dark:bg-gray-800">
+        <ul className="m-0 list-none p-0">
+          <Story />
+        </ul>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TransitDisplayEntry2>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// --- Basic ---
+
+/** Default: a single bus departure row. Use Controls to tweak any field. */
+export const Default: Story = {};
+
+// --- Variants ---
+
+/** Arrival row: the single time shown is the arrival time (the board's basis). */
+export const ArrivalRow: Story = {
+  args: {
+    data: makeDatum({ isTerminal: true }),
+    meta: makeMeta({ category: 'arrivals' }),
+  },
+};
+
+/** Rail row: route / agency colors and badges follow the trip's route + agency. */
+export const TrainRow: Story = {
+  args: {
+    data: makeDatum({ route: railRoute, agency: agencyGx, distance: 410 }),
+    meta: makeMeta({ routeTypes: [2] }),
+  },
+};
+
+/** Tram row: a different route type, color, and operating agency. */
+export const TramRow: Story = {
+  args: {
+    data: makeDatum({ route: tramRoute, agency: agencyOretetsu }),
+    meta: makeMeta({ routeTypes: [0] }),
+  },
+};
+
+// --- Headsign states ---
+
+/** Trip-only headsign: the classic case (`trip_headsign` populated). */
+export const HeadsignTripOnly: Story = {
+  args: {
+    data: makeDatum({ tripHeadsign: tripHeadsignLong }),
+  },
+};
+
+/**
+ * Stop-only headsign (Keio-bus pattern): `trip_headsign` is empty and
+ * `stop_headsign` is promoted to the destination slot.
+ */
+export const HeadsignStopOnly: Story = {
+  args: {
+    data: makeDatum({ tripHeadsign: emptyHeadsign, stopHeadsign: stopHeadsignShort }),
+  },
+};
+
+/** Both headsigns present: `stop_headsign` wins per GTFS (`prefer: 'stop'`). */
+export const HeadsignBoth: Story = {
+  args: {
+    data: makeDatum({ tripHeadsign: tripHeadsignLong, stopHeadsign: stopHeadsignLong }),
+  },
+};
+
+// --- Edge cases ---
+
+/** Long stop name + long headsign exercise wrapping in the right / second columns. */
+export const LongText: Story = {
+  args: {
+    data: makeDatum({ stop: longNameStop, tripHeadsign: tripHeadsignLong }),
+  },
+};
+
+/** Single-character headsign — minimum-length rendering. */
+export const ShortHeadsign: Story = {
+  args: {
+    data: makeDatum({ route: railRoute, agency: agencyGx, tripHeadsign: headsignShort }),
+    meta: makeMeta({ routeTypes: [2] }),
+  },
+};
+
+/** Route + agency without brand colors: the head bar falls back, badges stay readable. */
+export const NoColor: Story = {
+  args: {
+    data: makeDatum({ route: noColorRoute, agency: agencyNoColor }),
+  },
+};
+
+/** Platform code shown next to the stop name (longNameStop carries `platform_code`). */
+export const WithPlatformCode: Story = {
+  args: {
+    data: makeDatum({ route: railRoute, agency: agencyGx, stop: longNameStop }),
+    meta: makeMeta({ routeTypes: [2] }),
+  },
+};
+
+/**
+ * Verbose info level: the distance + direction badge and the pickup / drop-off
+ * unavailability labels appear (hidden at lower levels).
+ */
+export const VerboseDistanceAndFlags: Story = {
+  args: {
+    data: makeDatum({ distance: 80, pickupType: 1, dropOffType: 1 }),
+    infoLevel: 'verbose' as const,
+  },
+};
+
+// --- Variants: size ---
+
+const SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+
+/**
+ * The same row at every display size, smallest to largest: a short row that fits,
+ * then a long-text row so truncation / wrapping can be read at each size.
+ */
+export const SizeComparison: Story = {
+  render: (args) => (
+    <>
+      {SIZES.map((size) => (
+        <TransitDisplayEntry2
+          key={`short-${size}`}
+          data={makeDatum()}
+          meta={args.meta}
+          dataLangs={args.dataLangs}
+          now={args.now}
+          mapCenter={args.mapCenter}
+          infoLevel={args.infoLevel}
+          size={size}
+          onStopSelected={args.onStopSelected}
+          onInspectTrip={args.onInspectTrip}
+        />
+      ))}
+      {SIZES.map((size) => (
+        <TransitDisplayEntry2
+          key={`long-${size}`}
+          data={makeDatum({ stop: longNameStop, tripHeadsign: tripHeadsignLong })}
+          meta={args.meta}
+          dataLangs={args.dataLangs}
+          now={args.now}
+          mapCenter={args.mapCenter}
+          infoLevel={args.infoLevel}
+          size={size}
+          onStopSelected={args.onStopSelected}
+          onInspectTrip={args.onInspectTrip}
+        />
+      ))}
+    </>
+  ),
+};
+
+// --- Kitchen sink ---
+
+/**
+ * Maximum-content row: long stop name + headsign, platform code, near distance,
+ * and both pickup / drop-off unavailable so every label can appear. Rendered per
+ * info level since the right-column badge and the unavailability flags are
+ * verbose-only.
+ */
+const kitchenSinkArgs = {
+  data: makeDatum({
+    route: railRoute,
+    agency: agencyGx,
+    stop: longNameStop,
+    tripHeadsign: tripHeadsignLong,
+    stopHeadsign: stopHeadsignLong,
+    distance: 12,
+    isTerminal: true,
+    isOrigin: true,
+    pickupType: 1 as StopServiceType,
+    dropOffType: 1 as StopServiceType,
+  }),
+  meta: makeMeta({ routeTypes: [2] }),
+} as const;
+
+export const KitchenSinkInfoLevelSimple: Story = {
+  args: { ...kitchenSinkArgs, infoLevel: 'simple' as const },
+};
+export const KitchenSinkInfoLevelNormal: Story = {
+  args: { ...kitchenSinkArgs, infoLevel: 'normal' as const },
+};
+export const KitchenSinkInfoLevelDetailed: Story = {
+  args: { ...kitchenSinkArgs, infoLevel: 'detailed' as const },
+};
+export const KitchenSinkInfoLevelVerbose: Story = {
+  args: { ...kitchenSinkArgs, infoLevel: 'verbose' as const },
+};

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -732,7 +732,7 @@ export function TransitDisplayEntry2({
 
       {/* Trip info / 3 columns: Time, Route, Stop */}
       {/* 1st columns: Time */}
-      <div className="flex flex-0 border-0 px-0 pt-0">
+      <div className="flex flex-0 border-0 pt-0 pl-1">
         {/* Local TimeInfo: shows timeText; tap selects the stop + opens inspection. */}
         <StopTimeTimeInfo
           arrivalMinutes={timetableEntry.schedule.arrivalMinutes}

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -204,6 +204,8 @@ export function TransitDisplays2({
     );
   }
 
+  // console.debug(`TransitDisplayStatus: radius=${status.radius}, state=${status.state}`);
+
   const presentCategories = FILTERABLE_CATEGORIES.filter((category) =>
     dataWithMeta.some((display) => display.meta.category === category),
   );

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -16,6 +16,7 @@ import {
   type TransitDisplayDataWithMetaData,
   type TransitDisplayDatum,
   type TransitDisplayMeta,
+  type TransitDisplayStatus,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
 import { computeTransitDisplayDatumStats } from '@/domain/transit/compute-transit-display-datum-stats';
 import { getBearingDeg } from '@/domain/transit/distance';
@@ -141,6 +142,8 @@ const HEADER_STATS_ICONS_BY_SIZE: Record<
 export interface TransitDisplays2Props {
   /** Raw displays (meta + unresolved board); rows are passed down and resolved at the leaf ({@link TransitDisplayEntry2}). */
   dataWithMeta: readonly TransitDisplayDataWithMetaData[];
+  /** Build state + radius, for the empty-state message (no stops / no service). */
+  status: TransitDisplayStatus;
   /** Display language chain forwarded down to the leaf ({@link TransitDisplayEntry2}) for name / color resolution. */
   dataLangs: readonly string[];
   now: Date;
@@ -175,6 +178,7 @@ const DEFAULT_CATEGORIES: Record<TransitDisplayCategory, boolean> = {
  */
 export function TransitDisplays2({
   dataWithMeta,
+  status,
   dataLangs,
   now,
   mapCenter,
@@ -183,18 +187,32 @@ export function TransitDisplays2({
   onStopSelected,
   onInspectTrip,
 }: TransitDisplays2Props) {
+  const { t } = useTranslation();
   const [shownCategories, setShownCategories] =
     useState<Record<TransitDisplayCategory, boolean>>(DEFAULT_CATEGORIES);
+
+  // No boards to show because the dataset itself is empty: either no stops within
+  // the radius (`no-stops`) or stops exist but none have service today
+  // (`no-service`). Show the reason instead of a blank view.
+  if (status.state === 'no-stops' || status.state === 'no-service') {
+    return (
+      <div className="text-muted-foreground px-4 py-6 text-center text-sm">
+        {t(status.state === 'no-service' ? 'transitDisplay2.noService' : 'transitDisplay2.empty', {
+          radius: status.radius,
+        })}
+      </div>
+    );
+  }
 
   const presentCategories = FILTERABLE_CATEGORIES.filter((category) =>
     dataWithMeta.some((display) => display.meta.category === category),
   );
 
+  const visibleData = dataWithMeta.filter((display) => shownCategories[display.meta.category]);
+
   const toggleCategory = (category: TransitDisplayCategory) => {
     setShownCategories((prev) => ({ ...prev, [category]: !prev[category] }));
   };
-
-  const visibleData = dataWithMeta.filter((display) => shownCategories[display.meta.category]);
 
   return (
     // <div className="font-dotgothic16 px-4 pb-0">

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 
 import { ArrowRight, ArrowUp, Building2, Clock, Radio, Route, Signpost } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -203,8 +203,6 @@ export function TransitDisplays2({
       </div>
     );
   }
-
-  // console.debug(`TransitDisplayStatus: radius=${status.radius}, state=${status.state}`);
 
   const presentCategories = FILTERABLE_CATEGORIES.filter((category) =>
     dataWithMeta.some((display) => display.meta.category === category),
@@ -463,19 +461,27 @@ export function TransitDisplay2({
 
   const infoLevelFlag = useInfoLevel(infoLevel);
   const { t } = useTranslation();
+
   // Board title: mode emoji + departures/arrivals phrase. The
   // route type and basis are structured meta; the UI composes the localized text.
   // The board's title carries the departure/arrival distinction, so rows do not
   // repeat it: each row shows a single time (the board's basis) without a label.
   const isArrivalBoard = meta.category === 'arrivals';
+
   const routeTypeIcon = routeTypesEmoji(meta.routeTypes);
   const title = t(isArrivalBoard ? 'transitDisplay2.arrivals' : 'transitDisplay2.departures');
+
   // Displayed (post-cap) stats are derivable from the rendered rows, so the
-  // component computes them here rather than carrying them on `stats`.
-  const displayedStats = computeTransitDisplayDatumStats(transitDisplayData.data);
+  // component computes them here rather than carrying them on `stats`. Memoized on
+  // the rows: it depends only on the board data, not on mapCenter / now, so a map
+  // drag does not recompute it.
+  const displayedStats = useMemo(
+    () => computeTransitDisplayDatumStats(transitDisplayData.data),
+    [transitDisplayData.data],
+  );
+
   // A board that mixes route types: rows then show their own trip route-type emoji.
   // const hasMultiRoutes = meta.routeTypes.length >= 2;
-
   return (
     // Each board is a theme-aware panel with a soft rounded border; stacked
     // boards are separated by their own surface and margin.
@@ -647,45 +653,58 @@ export function TransitDisplayEntry2({
 
   const { stop: stopWithContext, timetableEntry } = data;
 
-  // [IMPORTANT] Use domain logic to determine the starting/ending point.
-  const attributes = getTimetableEntryAttributes(timetableEntry);
+  // Attribute / route color / headsign / stop name resolution depends only on the
+  // row data and the display languages -- NOT on mapCenter or now. Memoize it so a
+  // map drag (which re-renders the row to update `bearing`) does not re-run this
+  // resolution while data / dataLangs are unchanged.
+  const resolved = useMemo(() => {
+    const { stop: swc, timetableEntry: entry } = data;
+    // [IMPORTANT] Use domain logic to determine the starting/ending point.
+    const attributes = getTimetableEntryAttributes(entry);
+    const route = entry.routeDirection.route;
+    const routeAgency = swc.agencies.find((agency) => agency.agency_id === route.agency_id);
+    const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : DEFAULT_AGENCY_LANG;
+    const { routeColor } = resolveRouteColors(route, 'css-hex');
+    const headsign = getHeadsignDisplayNames(
+      entry.routeDirection,
+      dataLangs,
+      routeAgencyLangs,
+      'stop',
+    ).resolved.name;
+    const stopAgencyLangs = swc.agencies.map((agency) => agency.agency_lang);
+    const stopName = getStopDisplayNames(swc.stop, dataLangs, stopAgencyLangs).name;
+    // Distance is baked on the row (query-time), so it is data, not mapCenter.
+    const distanceRounded = swc.distance != null ? Math.round(swc.distance) : null;
+    // Inspection target for the time tap. The classic view gets this prebuilt by
+    // buildTransitDisplayDatumForUi; this view keeps rows raw, so build it here so
+    // StopTimeTimeInfo renders as an inspection button (it stays a plain div when
+    // inspectTarget is missing).
+    const inspectTarget = buildTripInspectionTarget(entry, entry.serviceDate);
+    return {
+      attributes,
+      routeAgency,
+      routeColor,
+      headsign,
+      stopAgencyLangs,
+      stopName,
+      distanceRounded,
+      inspectTarget,
+    };
+  }, [data, dataLangs]);
+  const {
+    attributes,
+    routeAgency,
+    routeColor,
+    headsign,
+    stopAgencyLangs,
+    stopName,
+    distanceRounded,
+    inspectTarget,
+  } = resolved;
 
-  // Route
-  const route = timetableEntry.routeDirection.route;
-  const routeAgency = stopWithContext.agencies.find(
-    (agency) => agency.agency_id === route.agency_id,
-  );
-  const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : DEFAULT_AGENCY_LANG;
-  const { routeColor } = resolveRouteColors(route, 'css-hex');
-
-  // Headsign
-  const headsign = getHeadsignDisplayNames(
-    timetableEntry.routeDirection,
-    dataLangs,
-    routeAgencyLangs,
-    'stop',
-  ).resolved.name;
-
-  // Stop agency
-  const stopAgencies = stopWithContext.agencies;
-  const stopAgencyLangs = stopAgencies.map((agency) => agency.agency_lang);
-  // const { agencyColor } = routeAgency ? resolveAgencyColors(routeAgency, 'css-hex') : {};
-
-  // Stop
-  const stop = stopWithContext.stop;
-  const stopName = getStopDisplayNames(stop, dataLangs, stopAgencyLangs).name;
-
-  // Distance is baked on the row (query-time); bearing is computed live from the
-  // current map center so the direction arrow tracks panning, like StopInfo.
-  const distanceRounded =
-    stopWithContext.distance != null ? Math.round(stopWithContext.distance) : null;
-  const bearing = mapCenter ? getBearingDeg(mapCenter, stop) : null;
-
-  // Inspection target for the time tap. The classic view gets this prebuilt by
-  // buildTransitDisplayDatumForUi; this view keeps rows raw, so build it here so
-  // StopTimeTimeInfo renders as an inspection button (it stays a plain div when
-  // inspectTarget is missing).
-  const inspectTarget = buildTripInspectionTarget(timetableEntry, timetableEntry.serviceDate);
+  // Bearing is computed live from the current map center so the direction arrow
+  // tracks panning (like StopInfo); it stays outside the memo.
+  const bearing = mapCenter ? getBearingDeg(mapCenter, stopWithContext.stop) : null;
 
   return (
     // No `data-stop-id` here: the same stop id can appear in several rows across

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -32,6 +32,7 @@ import { AgencyBadge } from '../badge/agency-badge';
 import { StopTimeTimeInfo } from '../stop-time-time-info';
 import { Separator } from '../ui/separator';
 import { PlatformCodeLabel } from '../stop/platform-code-label';
+import { DEFAULT_AGENCY_LANG } from '@/config/transit-defaults';
 
 const BOARD_PANEL_BG = 'bg-[#f5f7fa] dark:bg-gray-800';
 
@@ -479,41 +480,40 @@ export function TransitDisplayEntry2({
   const infoLevelFlag = useInfoLevel(infoLevel);
 
   const { stop: stopWithContext, timetableEntry } = data;
+
   // [IMPORTANT] Use domain logic to determine the starting/ending point.
   const attributes = getTimetableEntryAttributes(timetableEntry);
 
-  // Distance is baked on the row (query-time); bearing is computed live from the
-  // current map center so the direction arrow tracks panning, like StopInfo.
-  const distanceRounded =
-    stopWithContext.distance != null ? Math.round(stopWithContext.distance) : null;
-  const bearing = mapCenter ? getBearingDeg(mapCenter, data.stop.stop) : null;
-
-  const agencyLangs = stopWithContext.agencies.map((agency) => agency.agency_lang);
+  // Route
+  const route = timetableEntry.routeDirection.route;
   const routeAgency = stopWithContext.agencies.find(
-    (agency) => agency.agency_id === timetableEntry.routeDirection.route.agency_id,
+    (agency) => agency.agency_id === route.agency_id,
   );
-  const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : agencyLangs;
-  // const routeName = getRouteDisplayNames(
-  //   timetableEntry.routeDirection.route,
-  //   dataLangs,
-  //   routeAgencyLangs,
-  //   'short',
-  // ).resolved.name;
+  const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : DEFAULT_AGENCY_LANG;
+  const { routeColor } = resolveRouteColors(route, 'css-hex');
+
+  // Headsign
   const headsign = getHeadsignDisplayNames(
     timetableEntry.routeDirection,
     dataLangs,
     routeAgencyLangs,
     'stop',
   ).resolved.name;
-  // const agencyName = routeAgency
-  //   ? getAgencyDisplayNames(routeAgency, dataLangs, routeAgencyLangs, 'short').resolved.name ||
-  //     routeAgency.agency_id
-  //   : '';
 
-  const { routeColor } = resolveRouteColors(timetableEntry.routeDirection.route, 'css-hex');
+  // Stop agency
+  const stopAgencies = stopWithContext.agencies;
+  const stopAgencyLangs = stopAgencies.map((agency) => agency.agency_lang);
   // const { agencyColor } = routeAgency ? resolveAgencyColors(routeAgency, 'css-hex') : {};
 
-  const stopName = getStopDisplayNames(stopWithContext.stop, dataLangs, agencyLangs).name;
+  // Stop
+  const stop = stopWithContext.stop;
+  const stopName = getStopDisplayNames(stop, dataLangs, stopAgencyLangs).name;
+
+  // Distance is baked on the row (query-time); bearing is computed live from the
+  // current map center so the direction arrow tracks panning, like StopInfo.
+  const distanceRounded =
+    stopWithContext.distance != null ? Math.round(stopWithContext.distance) : null;
+  const bearing = mapCenter ? getBearingDeg(mapCenter, stop) : null;
 
   // Inspection target for the time tap. The classic view gets this prebuilt by
   // buildTransitDisplayDatumForUi; this view keeps rows raw, so build it here so
@@ -579,10 +579,11 @@ export function TransitDisplayEntry2({
         <div className="flex items-center gap-2">
           <RouteBadge
             route={timetableEntry.routeDirection.route}
-            size={DISTANCE_BADGE_SIZE_BY_SIZE[size]}
             dataLang={dataLangs}
+            agencyLangs={stopAgencyLangs}
             infoLevel={infoLevel}
-            showBorder={false}
+            size={DISTANCE_BADGE_SIZE_BY_SIZE[size]}
+            showBorder={true}
           />
           <TimetableEntryAttributesLabels
             size={TIMETABLE_ENTRY_ATTRIBUTES_LABELS_SIZE_BY_SIZE[size]}

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -1,12 +1,13 @@
 import { Fragment, useState } from 'react';
 
-import { ArrowRight, ArrowUp } from 'lucide-react';
+import { ArrowRight, ArrowUp, Building2, Clock, Radio, Route, Signpost } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import type { LatLng } from '@/types/app/map';
 import type { TripInspectionTarget } from '@/types/app/transit-composed';
 
 import { DistanceBadge } from '@/components/badge/distance-badge';
+import { IconTextBadge } from '@/components/badge/icon-text-badge';
 import { TimetableEntryAttributesLabels } from '@/components/label/timetable-entry-attributes-labels';
 import type { ExtendedDisplaySize } from '@/components/shared/display-size';
 import { Button } from '@/components/ui/button';
@@ -16,6 +17,7 @@ import {
   type TransitDisplayDatum,
   type TransitDisplayMeta,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
+import { computeTransitDisplayDatumStats } from '@/domain/transit/compute-transit-display-datum-stats';
 import { getBearingDeg } from '@/domain/transit/distance';
 import { resolveRouteColors } from '@/domain/transit/color-resolver/route-colors';
 import { routeTypesEmoji } from '@/utils/route-type-emoji';
@@ -33,6 +35,7 @@ import { StopTimeTimeInfo } from '../stop-time-time-info';
 import { Separator } from '../ui/separator';
 import { PlatformCodeLabel } from '../stop/platform-code-label';
 import { DEFAULT_AGENCY_LANG } from '@/config/transit-defaults';
+import i18n from '@/i18n';
 
 const BOARD_PANEL_BG = 'bg-[#f5f7fa] dark:bg-gray-800';
 
@@ -88,6 +91,51 @@ const DISTANCE_BADGE_SIZE_BY_SIZE: Record<ExtendedDisplaySize, ExtendedDisplaySi
   md: 'sm',
   lg: 'md',
   xl: 'lg',
+};
+
+/**
+ * Styling for one header IconTextBadge: the component `size` (padding / base
+ * scale) plus class overrides for the text half and the icon svg (to scale
+ * beyond the component's built-in presets, which cap at ~14px).
+ */
+interface HeaderBadgeStyle {
+  size: ExtendedDisplaySize;
+  textClass: string;
+  iconClass: string;
+}
+
+/**
+ * Header badge styling per display size, in two variants:
+ * - `small`: the four stats badges ({@link StatsBadges}).
+ * - `large`: the radius badge.
+ *
+ * `props.size` is the single input; consumers pick `small` / `large` internally.
+ * Starting values -- tune here.
+ */
+const HEADER_STATS_ICONS_BY_SIZE: Record<
+  ExtendedDisplaySize,
+  { small: HeaderBadgeStyle; large: HeaderBadgeStyle }
+> = {
+  xs: {
+    small: { size: 'xs', textClass: 'text-[8px]', iconClass: '[&>svg]:size-2' },
+    large: { size: 'xs', textClass: 'text-[10px]', iconClass: '[&>svg]:size-2.5' },
+  },
+  sm: {
+    small: { size: 'xs', textClass: 'text-[8px]', iconClass: '[&>svg]:size-2' },
+    large: { size: 'xs', textClass: 'text-[10px]', iconClass: '[&>svg]:size-2.5' },
+  },
+  md: {
+    small: { size: 'xs', textClass: 'text-[8px]', iconClass: '[&>svg]:size-2' },
+    large: { size: 'xs', textClass: 'text-xs', iconClass: '[&>svg]:size-3' },
+  },
+  lg: {
+    small: { size: 'sm', textClass: 'text-base', iconClass: '[&>svg]:size-4' },
+    large: { size: 'sm', textClass: 'text-xl', iconClass: '[&>svg]:size-5' },
+  },
+  xl: {
+    small: { size: 'md', textClass: 'text-2xl', iconClass: '[&>svg]:size-6' },
+    large: { size: 'md', textClass: 'text-3xl', iconClass: '[&>svg]:size-8' },
+  },
 };
 
 export interface TransitDisplays2Props {
@@ -240,7 +288,7 @@ function TransitDisplayCategoryFilter({
   return (
     <div
       role="group"
-      aria-label={t('transitDisplay.filter.label')}
+      aria-label={t('transitDisplay2.filter.label')}
       className={cn(
         'mb-2 flex items-center rounded-sm',
         'border-0',
@@ -282,7 +330,9 @@ function TransitDisplayCategoryFilter({
               />
             )}
             <span className="truncate">
-              {t(isArrival ? 'transitDisplay.filter.arrivals' : 'transitDisplay.filter.departures')}
+              {t(
+                isArrival ? 'transitDisplay2.filter.arrivals' : 'transitDisplay2.filter.departures',
+              )}
             </span>
           </Button>
         );
@@ -300,6 +350,73 @@ export interface TransitDisplay2Props {
   size: ExtendedDisplaySize;
   onStopSelected: (stopId: string) => void;
   onInspectTrip?: (target: TripInspectionTarget) => void;
+}
+
+/**
+ * Verbose-only badge row that renders a stats scope as icon badges. Icon choices
+ * follow the data-source group summary convention: Signpost = stops, Route =
+ * routes, Building2 = agencies, Shapes = route types, Clock = entries.
+ * `entryCount` is omitted for the stop-set scope (which has no entry count).
+ */
+function StatsBadges({
+  size,
+  entryCount,
+  stopCount,
+  routeCount,
+  agencyCount,
+}: {
+  size: ExtendedDisplaySize;
+  entryCount?: number;
+  stopCount: number;
+  routeCount: number;
+  agencyCount: number;
+}) {
+  const { size: badgeSize, textClass, iconClass } = HEADER_STATS_ICONS_BY_SIZE[size].small;
+
+  return (
+    <div className="flex flex-col items-end gap-0.5 border-0">
+      {/* Row 1: entries (optional) + stops. */}
+      <div className="flex flex-wrap items-center justify-end gap-1">
+        {entryCount !== undefined && (
+          <IconTextBadge
+            size={badgeSize}
+            icon={<Clock />}
+            text={`${entryCount.toLocaleString(i18n.language)}`}
+            textClassName={textClass}
+            iconClassName={iconClass}
+            aria-label="entries"
+          />
+        )}
+        <IconTextBadge
+          size={badgeSize}
+          icon={<Signpost />}
+          text={`${stopCount.toLocaleString(i18n.language)}`}
+          textClassName={textClass}
+          iconClassName={iconClass}
+          aria-label="stops"
+        />
+      </div>
+      {/* Row 2: routes + agencies. */}
+      <div className="flex flex-wrap items-center justify-end gap-1">
+        <IconTextBadge
+          size={badgeSize}
+          icon={<Route />}
+          text={`${routeCount.toLocaleString(i18n.language)}`}
+          textClassName={textClass}
+          iconClassName={iconClass}
+          aria-label="routes"
+        />
+        <IconTextBadge
+          size={badgeSize}
+          icon={<Building2 />}
+          text={`${agencyCount.toLocaleString(i18n.language)}`}
+          textClassName={textClass}
+          iconClassName={iconClass}
+          aria-label="agencies"
+        />
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -322,7 +439,7 @@ export function TransitDisplay2({
   onStopSelected,
   onInspectTrip,
 }: TransitDisplay2Props) {
-  const { meta, data: transitDisplayData } = transitDisplayDataWithMetaData;
+  const { meta, data: transitDisplayData, stats } = transitDisplayDataWithMetaData;
 
   const infoLevelFlag = useInfoLevel(infoLevel);
   const { t } = useTranslation();
@@ -332,7 +449,10 @@ export function TransitDisplay2({
   // repeat it: each row shows a single time (the board's basis) without a label.
   const isArrivalBoard = meta.category === 'arrivals';
   const routeTypeIcon = routeTypesEmoji(meta.routeTypes);
-  const title = t(isArrivalBoard ? 'transitDisplay.arrivals' : 'transitDisplay.departures');
+  const title = t(isArrivalBoard ? 'transitDisplay2.arrivals' : 'transitDisplay2.departures');
+  // Displayed (post-cap) stats are derivable from the rendered rows, so the
+  // component computes them here rather than carrying them on `stats`.
+  const displayedStats = computeTransitDisplayDatumStats(transitDisplayData.data);
   // A board that mixes route types: rows then show their own trip route-type emoji.
   // const hasMultiRoutes = meta.routeTypes.length >= 2;
 
@@ -347,32 +467,46 @@ export function TransitDisplay2({
         // BOARD_FRAME_COLOR,
       )}
     >
+      {/* Board meta in brief: category, route type(s), direction(s), row cap, radius. */}
+      {infoLevelFlag.isVerboseEnabled && (
+        <div className="flex flex-col items-end gap-0.5 text-[8px]">
+          <p className="m-0 w-full min-w-0 text-right">
+            [{meta.category} / rt {meta.routeTypes.join(',')} / dir {meta.directions.join(',')} /
+            (max:{meta.max}/{meta.radius}m)]
+          </p>
+          {/* <p className="m-0 w-full min-w-0 text-right">
+            [withinRadius: {stats.stopsInRadius.stopCount} stops / {stats.stopsInRadius.routeCount}{' '}
+            routes / {stats.stopsInRadius.agencyCount} agencies /{' '}
+            {stats.stopsInRadius.routeTypeCount} types]
+          </p> */}
+          {/* <p className="m-0 w-full min-w-0 text-right">
+            [qualifying: {stats.qualifying.entryCount} entries / {stats.qualifying.stopCount} stops
+            / {stats.qualifying.routeCount} routes / {stats.qualifying.agencyCount} agencies /{' '}
+            {stats.qualifying.routeTypeCount} types]
+          </p> */}
+          <p className="m-0 w-full min-w-0 text-right">
+            [shown: {displayedStats.entryCount} entries / {displayedStats.stopCount} stops /{' '}
+            {displayedStats.routeCount} routes / {displayedStats.agencyCount} agencies /{' '}
+            {displayedStats.routeTypeCount} types]
+          </p>
+        </div>
+      )}
       {/* Header band: title left, radius right, on a single line, on the board's
           theme-aware panel face. */}
       <div
         className={cn(
-          'flex flex-col gap-1 border-b-0 px-4 py-2',
+          'flex flex-col gap-1 border-b-0 py-1 pr-2 pl-4',
+          // 'border',
           // BOARD_PANEL_BG,
           // BOARD_FRAME_COLOR,
         )}
       >
-        {/* Board meta in brief: category, route type(s), direction(s), row cap, radius. */}
-        {infoLevelFlag.isVerboseEnabled && (
-          <div className="flex items-baseline gap-3">
-            <p className="m-0 ml-auto w-full min-w-0 text-right text-xs">
-              [{meta.category} / rt {meta.routeTypes.join(',')} / dir {meta.directions.join(',')}{' '}
-              (max:
-              {meta.max},{meta.radius}
-              m)]
-            </p>
-          </div>
-        )}
-        <div className="flex items-baseline justify-between gap-3">
+        <div className="flex items-center justify-between gap-3 border-0">
           {/* Title — board basis arrow (up = departures, right = arrivals) + mode + phrase.
               The arrow is decorative; the phrase already states departures/arrivals. */}
           <h3
             className={cn(
-              'flex min-w-0 items-center gap-4 font-bold tracking-[0.18em] uppercase',
+              'flex min-w-0 items-center gap-2 font-bold tracking-[0.18em] uppercase',
               TITLE_TEXT_CLASS_BY_SIZE[size],
             )}
           >
@@ -392,18 +526,30 @@ export function TransitDisplay2({
             {routeTypeIcon}
             <span className="truncate">{title}</span>
           </h3>
-          {/* Radius the board's stops were selected within (count is intentionally omitted). */}
-          <p
-            className={cn(
-              'm-0 shrink-0 text-[11px] tracking-[0.12em] whitespace-nowrap',
-              ROW_TEXT_CLASS_BY_SIZE[size],
+
+          {/* Right side: stats badges + radius, grouped and right-aligned. */}
+          <div className="flex shrink-0 items-center gap-1">
+            <IconTextBadge
+              size={HEADER_STATS_ICONS_BY_SIZE[size].large.size}
+              icon={<Radio />}
+              text={`${meta.radius.toLocaleString(i18n.language)}m`}
+              textClassName={HEADER_STATS_ICONS_BY_SIZE[size].large.textClass}
+              iconClassName={HEADER_STATS_ICONS_BY_SIZE[size].large.iconClass}
+              frameClassName="p-1 border-none"
+              aria-label="radius"
+            />
+            {infoLevelFlag.isDetailedEnabled && (
+              <StatsBadges
+                size={size}
+                entryCount={stats.qualifying.entryCount}
+                stopCount={stats.qualifying.stopCount}
+                routeCount={stats.qualifying.routeCount}
+                agencyCount={stats.qualifying.agencyCount}
+              />
             )}
-          >
-            {meta.radius}m
-          </p>
+          </div>
         </div>
       </div>
-
       {/* Body: the rows (or the empty fallback). */}
       <div className={cn(BOARD_PANEL_BG, 'p-0')}>
         <ul className="m-0 list-none p-0">

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -13,7 +13,6 @@ import type { ExtendedDisplaySize } from '@/components/shared/display-size';
 import { TransitDisplays } from '@/components/transit-display/transit-displays';
 import {
   buildTransitDisplayDataSet,
-  NEARBY_RADIUS_M,
   resolveTransitDisplayState,
   sortTransitDisplayDataWithMetaData,
   transitDisplayMaxEntriesFor,
@@ -26,6 +25,8 @@ import { filterStopsWithinDistance } from '@/domain/transit/stop-meta-filter';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('TransitDisplaysContainer');
+
+export const NEARBY_RADIUS_M = 100;
 
 /**
  * Route types whose boards are NOT split by direction: bus, trolleybus, and

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -14,6 +14,7 @@ import { TransitDisplays } from '@/components/transit-display/transit-displays';
 import {
   buildTransitDisplayDataSet,
   NEARBY_RADIUS_M,
+  resolveTransitDisplayState,
   sortTransitDisplayDataWithMetaData,
   transitDisplayMaxEntriesFor,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
@@ -21,6 +22,10 @@ import { ROUTE_TYPE_DISPLAY_ORDER } from '@/domain/transit/route-type-display-or
 import type { StopTimeViewId } from '@/domain/transit/stop-time-views';
 import type { AppRouteTypeValue } from '@/types/app/transit';
 import { TransitDisplays2 } from './transit-displays-2';
+import { filterStopsWithinDistance } from '@/domain/transit/stop-meta-filter';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('TransitDisplaysContainer');
 
 /**
  * Route types whose boards are NOT split by direction: bus, trolleybus, and
@@ -74,7 +79,23 @@ export function TransitDisplaysContainer({
   const stopIdsKey = useMemo(() => stopTimes.map((swc) => swc.stop.stop_id).join(','), [stopTimes]);
   const scrollFade = useScrollFades(contentRef, stopIdsKey);
 
+  // distance filter: stops within radiusMeters of the center
+  const nearbyStops: StopWithContext[] = filterStopsWithinDistance(stopTimes, NEARBY_RADIUS_M);
+
+  const transitDisplayStatus = {
+    radius: NEARBY_RADIUS_M,
+    state: resolveTransitDisplayState(nearbyStops),
+  };
+  logger.debug(`TransitDisplayStatus: ${JSON.stringify(transitDisplayStatus)}`);
+
   const transitDisplayData = useMemo(() => {
+    // Build boards only when there is something to show; `no-stops` / `no-service`
+    // produce no boards, so skip the work and let TransitDisplays2 render the
+    // reason from `transitDisplayStatus`.
+    if (transitDisplayStatus.state !== 'ready') {
+      return [];
+    }
+
     const maxEntries = transitDisplayMaxEntriesFor(infoLevel);
 
     // Per-mode direction policy is composed here rather than inside the builder:
@@ -86,18 +107,24 @@ export function TransitDisplaysContainer({
     // sortTransitDisplayDataWithMetaData (so the order is correct
     // regardless of which modes share a stop -- the raw concat is not in display
     // order). Rows stay raw here; TransitDisplays resolves them into UI data.
-    const directionUnsplitRaw = buildTransitDisplayDataSet(stopTimes, NEARBY_RADIUS_M, {
+
+    const directionUnsplitRaw = buildTransitDisplayDataSet(nearbyStops, NEARBY_RADIUS_M, {
       maxEntries,
       routeGrouping: { kind: 'custom', groups: NO_SPLIT_ROUTE_TYPES.map((t) => [t]) },
       splitByDirection: false,
     });
-    const directionSplitRaw = buildTransitDisplayDataSet(stopTimes, NEARBY_RADIUS_M, {
+    const directionSplitRaw = buildTransitDisplayDataSet(nearbyStops, NEARBY_RADIUS_M, {
       maxEntries,
       routeGrouping: { kind: 'custom', groups: DIRECTION_SPLIT_ROUTE_TYPES.map((t) => [t]) },
       splitByDirection: true,
     });
-    return sortTransitDisplayDataWithMetaData([...directionUnsplitRaw, ...directionSplitRaw]);
-  }, [stopTimes, infoLevel]);
+
+    return sortTransitDisplayDataWithMetaData([
+      //
+      ...directionUnsplitRaw,
+      ...directionSplitRaw,
+    ]);
+  }, [infoLevel, nearbyStops, transitDisplayStatus.state]);
 
   return (
     <div
@@ -111,6 +138,7 @@ export function TransitDisplaysContainer({
       {viewId === 'transit-display' ? (
         <TransitDisplays
           dataWithMeta={transitDisplayData}
+          status={transitDisplayStatus}
           dataLangs={dataLangs}
           emptyMessage={t('stop.timetable.allFilteredOut')}
           now={now}
@@ -123,6 +151,7 @@ export function TransitDisplaysContainer({
       ) : (
         <TransitDisplays2
           dataWithMeta={transitDisplayData}
+          status={transitDisplayStatus}
           dataLangs={dataLangs}
           now={now}
           mapCenter={mapCenter}

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type RefObject } from 'react';
+import { useEffect, useMemo, type RefObject } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -80,14 +80,25 @@ export function TransitDisplaysContainer({
   const stopIdsKey = useMemo(() => stopTimes.map((swc) => swc.stop.stop_id).join(','), [stopTimes]);
   const scrollFade = useScrollFades(contentRef, stopIdsKey);
 
-  // distance filter: stops within radiusMeters of the center
-  const nearbyStops: StopWithContext[] = filterStopsWithinDistance(stopTimes, NEARBY_RADIUS_M);
+  // distance filter: stops within radiusMeters of the center. Memoized so its
+  // reference is stable while stopTimes are unchanged -- otherwise the
+  // transitDisplayData useMemo below (which depends on it) would rebuild every render.
+  const nearbyStops = useMemo(
+    () => filterStopsWithinDistance(stopTimes, NEARBY_RADIUS_M),
+    [stopTimes],
+  );
 
-  const transitDisplayStatus = {
-    radius: NEARBY_RADIUS_M,
-    state: resolveTransitDisplayState(nearbyStops),
-  };
-  logger.debug(`TransitDisplayStatus: ${JSON.stringify(transitDisplayStatus)}`);
+  const transitDisplayStatus = useMemo(
+    () => ({ radius: NEARBY_RADIUS_M, state: resolveTransitDisplayState(nearbyStops) }),
+    [nearbyStops],
+  );
+
+  // Log only when the status value (radius / state) changes, not every render.
+  useEffect(() => {
+    logger.debug(
+      `TransitDisplayStatus: radius=${transitDisplayStatus.radius}, state=${transitDisplayStatus.state}`,
+    );
+  }, [transitDisplayStatus.radius, transitDisplayStatus.state]);
 
   const transitDisplayData = useMemo(() => {
     // Build boards only when there is something to show; `no-stops` / `no-service`

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import {
   type TransitDisplayCategory,
   type TransitDisplayDataWithMetaData,
+  type TransitDisplayStatus,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
 import {
   buildTransitDisplayDatumForUi,
@@ -109,6 +110,8 @@ const HEADSIGN_WIDTH_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
 export interface TransitDisplaysProps {
   /** Raw displays (meta + unresolved board); rows are resolved here for rendering. */
   dataWithMeta: readonly TransitDisplayDataWithMetaData[];
+  /** Build state + radius, for the empty-state message (no stops / no service). */
+  status: TransitDisplayStatus;
   /** Display language chain passed to {@link buildTransitDisplayDatumForUi} for row resolution. */
   dataLangs: readonly string[];
   emptyMessage: string;
@@ -143,6 +146,7 @@ const DEFAULT_CATEGORIES: Record<TransitDisplayCategory, boolean> = {
  */
 export function TransitDisplays({
   dataWithMeta,
+  status,
   dataLangs,
   emptyMessage,
   now,
@@ -152,6 +156,8 @@ export function TransitDisplays({
   onStopSelected,
   onInspectTrip,
 }: TransitDisplaysProps) {
+  const { t } = useTranslation();
+
   const [shownCategories, setShownCategories] =
     useState<Record<TransitDisplayCategory, boolean>>(DEFAULT_CATEGORIES);
 
@@ -166,6 +172,19 @@ export function TransitDisplays({
       })),
     [dataWithMeta, dataLangs],
   );
+
+  // No boards to show because the dataset itself is empty: either no stops within
+  // the radius (`no-stops`) or stops exist but none have service today
+  // (`no-service`). Show the reason instead of a blank view.
+  if (status.state === 'no-stops' || status.state === 'no-service') {
+    return (
+      <div className="text-muted-foreground px-4 py-6 text-center text-sm">
+        {t(status.state === 'no-service' ? 'transitDisplay2.noService' : 'transitDisplay2.empty', {
+          radius: status.radius,
+        })}
+      </div>
+    );
+  }
 
   // Only offer toggles for categories that actually have a board, so the bar
   // mirrors what is on screen rather than always showing both.

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -349,7 +349,6 @@ export function TransitDisplay({
   onStopSelected,
   onInspectTrip,
 }: TransitDisplayProps) {
-  const infoLevelFlag = useInfoLevel(infoLevel);
   const { t } = useTranslation();
   // Airport-board-style title: mode emoji + departures/arrivals phrase. The
   // route type and basis are structured meta; the UI composes the localized text.
@@ -385,16 +384,6 @@ export function TransitDisplay({
           BOARD_FRAME_COLOR,
         )}
       >
-        {/* Board meta in brief: category, route type(s), direction(s), row cap, radius. */}
-        {infoLevelFlag.isVerboseEnabled && (
-          <div className="flex items-baseline gap-3">
-            <p className="m-0 ml-auto w-full min-w-0 text-right text-xs text-amber-200/80">
-              [{dataWithMeta.meta.category} / rt {dataWithMeta.meta.routeTypes.join(',')} / dir{' '}
-              {dataWithMeta.meta.directions.join(',')} (max:{dataWithMeta.meta.max},
-              {dataWithMeta.meta.radius}m)]
-            </p>
-          </div>
-        )}
         <div className="flex items-baseline justify-between gap-3">
           {/* Title — board basis arrow (up = departures, right = arrivals) + mode + phrase.
               The arrow is decorative; the phrase already states departures/arrivals. */}

--- a/src/components/trip-info.tsx
+++ b/src/components/trip-info.tsx
@@ -14,6 +14,7 @@ import type { InfoLevelFlags } from '../utils/create-info-level';
 import { routeTypeEmoji } from '../utils/route-type-emoji';
 import { AgencyBadge } from './badge/agency-badge';
 import { RouteBadge } from './badge/route-badge';
+import type { BaseLabelSize } from './label/base-label';
 import { TimetableEntryAttributesLabels } from './label/timetable-entry-attributes-labels';
 
 const sizeVariants = {
@@ -39,6 +40,16 @@ const sizeVariants = {
     label: 'text-[0.5rem]',
   },
 } as const;
+
+/**
+ * Size passed to {@link TimetableEntryAttributesLabels}, mapped from TripInfo's
+ * own `size`. Currently an identity mapping; per-size values are tuned here.
+ */
+const ATTRIBUTES_LABELS_SIZE_BY_SIZE: Record<keyof typeof sizeVariants, BaseLabelSize> = {
+  xs: 'xs',
+  sm: 'sm',
+  md: 'sm',
+};
 
 /**
  * Headsign display within TripInfo.
@@ -208,7 +219,7 @@ export function TripInfo({
 
       {attributes && (
         <TimetableEntryAttributesLabels
-          size={size}
+          size={ATTRIBUTES_LABELS_SIZE_BY_SIZE[size]}
           attributes={attributes}
           showDisplayTerminal={true}
           showDisplayOrigin={true}

--- a/src/domain/transit/__tests__/compute-route-stats.test.ts
+++ b/src/domain/transit/__tests__/compute-route-stats.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { makeRoute } from '../../../__tests__/helpers';
+import type { AppRouteTypeValue, Route } from '../../../types/app/transit';
+import { computeRouteStats } from '../compute-route-stats';
+
+/** A route with an explicit agency_id (agencyCount derives from each route). */
+function routeOf(id: string, routeType: AppRouteTypeValue, agencyId: string): Route {
+  return { ...makeRoute(id, routeType), agency_id: agencyId };
+}
+
+describe('computeRouteStats', () => {
+  it('returns all-zero stats for no routes', () => {
+    expect(computeRouteStats([])).toEqual({ routeCount: 0, agencyCount: 0, routeTypeCount: 0 });
+  });
+
+  // Exercises all three dimensions at once with duplicates, asserted as a whole
+  // so a metric leaking into the wrong field is caught.
+  it('counts distinct routes / agencies / route types together, deduping', () => {
+    const routes = [
+      routeOf('r1', 3, 'a'),
+      routeOf('r1', 3, 'a'), // exact duplicate
+      routeOf('r2', 3, 'a'), // same agency + type, new route
+      routeOf('r3', 2, 'b'), // new route, type, agency
+      routeOf('r4', 11, 'a'), // new route + type, agency a again
+    ];
+    expect(computeRouteStats(routes)).toEqual({
+      routeCount: 4, // r1, r2, r3, r4
+      agencyCount: 2, // a, b
+      routeTypeCount: 3, // 3, 2, 11
+    });
+  });
+
+  it('keeps falsy-but-valid route types (0, -1)', () => {
+    // The `!= null` guard must keep 0 (tram) and -1 (unknown); a truthy check
+    // would wrongly drop them.
+    const stats = computeRouteStats([routeOf('r0', 0, 'a'), routeOf('rm1', -1, 'a')]);
+    expect(stats.routeTypeCount).toBe(2);
+  });
+
+  it('skips a missing route_type without counting it as a type', () => {
+    const malformed: Route = {
+      ...routeOf('r1', 3, 'a'),
+      route_type: undefined as unknown as AppRouteTypeValue,
+    };
+    const stats = computeRouteStats([malformed, routeOf('r2', 3, 'a')]);
+    expect(stats.routeCount).toBe(2); // both counted by id
+    expect(stats.routeTypeCount).toBe(1); // only r2's type 3
+  });
+
+  it('counts distinct agencies by agency_id', () => {
+    const routes = [routeOf('r1', 3, 'a'), routeOf('r2', 3, 'b'), routeOf('r3', 3, 'a')];
+    expect(computeRouteStats(routes).agencyCount).toBe(2);
+  });
+});

--- a/src/domain/transit/__tests__/compute-stop-with-meta-stats.test.ts
+++ b/src/domain/transit/__tests__/compute-stop-with-meta-stats.test.ts
@@ -1,29 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import { makeStop, makeStopWithContext } from '../../../__tests__/helpers';
-import type { Agency, AppRouteTypeValue } from '../../../types/app/transit';
-import type { StopWithContext } from '../../../types/app/transit-composed';
+import { makeRoute, makeStop } from '../../../__tests__/helpers';
+import type { AppRouteTypeValue, Route } from '../../../types/app/transit';
+import type { StopWithMeta } from '../../../types/app/transit-composed';
 import { computeStopWithMetaStats } from '../compute-stop-with-meta-stats';
 
-function makeAgency(id: string): Agency {
-  return {
-    agency_id: id,
-    agency_name: `Agency ${id}`,
-    agency_long_name: `Agency ${id}`,
-    agency_short_name: '',
-    agency_names: {},
-    agency_long_names: {},
-    agency_short_names: {},
-    agency_url: '',
-    agency_lang: 'ja',
-    agency_timezone: 'Asia/Tokyo',
-    agency_fare_url: '',
-    agency_colors: [],
-  };
+/** A route with an explicit agency_id (agencyCount derives from each route). */
+function routeOf(id: string, routeType: AppRouteTypeValue, agencyId: string): Route {
+  return { ...makeRoute(id, routeType), agency_id: agencyId };
 }
 
-function withAgencies(swc: StopWithContext, agencies: Agency[]): StopWithContext {
-  return { ...swc, agencies };
+/** A minimal StopWithMeta carrying the given routes (the only field summarized). */
+function stopWith(routes: Route[]): StopWithMeta {
+  return { stop: makeStop('s'), agencies: [], routes };
 }
 
 describe('computeStopWithMetaStats', () => {
@@ -36,24 +25,17 @@ describe('computeStopWithMetaStats', () => {
     });
   });
 
-  // A multi-stop set exercising every field at once, with cross-stop AND
-  // intra-stop repeats of agencies / routes / route types, asserted as a whole
-  // so a metric leaking into the wrong field is caught.
+  // Multi-stop set exercising every field at once, with cross-stop AND intra-stop
+  // repeats of routes / agencies / route types, asserted as a whole so a metric
+  // leaking into the wrong field is caught.
   it('aggregates all metrics together, deduping every entity dimension', () => {
-    const agencyA = makeAgency('a');
-    const agencyB = makeAgency('b');
-    const agencyC = makeAgency('c');
-    const stops: StopWithContext[] = [
-      // routes r1,r2 both type 3; agencies a,b (a duplicated within the stop)
-      withAgencies(makeStopWithContext(makeStop('s1'), ['r1', 'r2'], [3]), [
-        agencyA,
-        agencyA,
-        agencyB,
-      ]),
-      // routes r2 (repeat, type 3), r3 (type 2); agency b (repeat across stops)
-      withAgencies(makeStopWithContext(makeStop('s2'), ['r2', 'r3'], [3, 2]), [agencyB]),
-      // route r4 (type 11); agency c
-      withAgencies(makeStopWithContext(makeStop('s3'), ['r4'], [11]), [agencyC]),
+    const stops: StopWithMeta[] = [
+      // r1 (listed twice in this stop), r2 -- both type 3, agency a
+      stopWith([routeOf('r1', 3, 'a'), routeOf('r1', 3, 'a'), routeOf('r2', 3, 'a')]),
+      // r2 (repeat across stops), r3 type 2 agency b
+      stopWith([routeOf('r2', 3, 'a'), routeOf('r3', 2, 'b')]),
+      // r4 type 11 agency c
+      stopWith([routeOf('r4', 11, 'c')]),
     ];
 
     expect(computeStopWithMetaStats(stops)).toEqual({
@@ -64,11 +46,10 @@ describe('computeStopWithMetaStats', () => {
     });
   });
 
-  it('counts a service-less stop in stopCount but contributes no agencies/routes', () => {
-    const agencyA = makeAgency('a');
-    const stops: StopWithContext[] = [
-      withAgencies(makeStopWithContext(makeStop('s1'), ['r1'], [3]), [agencyA]),
-      makeStopWithContext(makeStop('empty'), []), // no routes/agencies, no service
+  it('counts a route-less stop in stopCount but not in route/agency counts', () => {
+    const stops: StopWithMeta[] = [
+      stopWith([routeOf('r1', 3, 'a')]),
+      stopWith([]), // no routes
     ];
     expect(computeStopWithMetaStats(stops)).toEqual({
       stopCount: 2,
@@ -78,42 +59,27 @@ describe('computeStopWithMetaStats', () => {
     });
   });
 
-  it('dedupes duplicate routes within a single stop', () => {
-    const stats = computeStopWithMetaStats([
-      makeStopWithContext(makeStop('s1'), ['r1', 'r1'], [3]),
-    ]);
-    expect(stats.routeCount).toBe(1);
-    expect(stats.routeTypeCount).toBe(1);
-  });
-
   it('counts falsy-but-valid route types (0, -1)', () => {
-    // The `!= null` guard must keep 0 (tram) and -1 (unknown); a truthy check
-    // would wrongly drop them.
+    // The `!= null` guard must keep 0 (tram) and -1 (unknown).
     const stats = computeStopWithMetaStats([
-      makeStopWithContext(makeStop('s1'), ['r0', 'rm1'], [0, -1]),
+      stopWith([routeOf('r0', 0, 'a'), routeOf('rm1', -1, 'a')]),
     ]);
     expect(stats.routeTypeCount).toBe(2);
   });
 
   it('skips a route with a missing route_type without counting it as a type', () => {
-    const swc = makeStopWithContext(makeStop('s1'), ['r1'], [3]);
-    // Malformed data: a route whose route_type is absent at runtime.
-    const malformed: StopWithContext = {
-      ...swc,
-      routes: [{ ...swc.routes[0], route_type: undefined as unknown as AppRouteTypeValue }],
+    const malformed: Route = {
+      ...routeOf('r1', 3, 'a'),
+      route_type: undefined as unknown as AppRouteTypeValue,
     };
-    const stats = computeStopWithMetaStats([malformed]);
-    expect(stats.routeCount).toBe(1); // route still counted by id
+    const stats = computeStopWithMetaStats([stopWith([malformed])]);
+    expect(stats.routeCount).toBe(1); // still counted by id
     expect(stats.routeTypeCount).toBe(0); // missing type not counted
   });
 
   it('counts stopCount by element, not by distinct stop_id', () => {
-    // Two entries with the same stop_id still count as two stops: callers are
-    // expected to pass one entry per stop, so stopCount is `stops.length`.
-    const stops = [
-      makeStopWithContext(makeStop('dup'), ['r1'], [3]),
-      makeStopWithContext(makeStop('dup'), ['r2'], [2]),
-    ];
+    // Both stops share a stop_id; stopCount is stops.length, so they count as two.
+    const stops = [stopWith([routeOf('r1', 3, 'a')]), stopWith([routeOf('r2', 2, 'a')])];
     expect(computeStopWithMetaStats(stops).stopCount).toBe(2);
   });
 });

--- a/src/domain/transit/__tests__/compute-stop-with-meta-stats.test.ts
+++ b/src/domain/transit/__tests__/compute-stop-with-meta-stats.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import { makeStop, makeStopWithContext } from '../../../__tests__/helpers';
+import type { Agency, AppRouteTypeValue } from '../../../types/app/transit';
+import type { StopWithContext } from '../../../types/app/transit-composed';
+import { computeStopWithMetaStats } from '../compute-stop-with-meta-stats';
+
+function makeAgency(id: string): Agency {
+  return {
+    agency_id: id,
+    agency_name: `Agency ${id}`,
+    agency_long_name: `Agency ${id}`,
+    agency_short_name: '',
+    agency_names: {},
+    agency_long_names: {},
+    agency_short_names: {},
+    agency_url: '',
+    agency_lang: 'ja',
+    agency_timezone: 'Asia/Tokyo',
+    agency_fare_url: '',
+    agency_colors: [],
+  };
+}
+
+function withAgencies(swc: StopWithContext, agencies: Agency[]): StopWithContext {
+  return { ...swc, agencies };
+}
+
+describe('computeStopWithMetaStats', () => {
+  it('returns all-zero stats for an empty stop set', () => {
+    expect(computeStopWithMetaStats([])).toEqual({
+      stopCount: 0,
+      agencyCount: 0,
+      routeCount: 0,
+      routeTypeCount: 0,
+    });
+  });
+
+  // A multi-stop set exercising every field at once, with cross-stop AND
+  // intra-stop repeats of agencies / routes / route types, asserted as a whole
+  // so a metric leaking into the wrong field is caught.
+  it('aggregates all metrics together, deduping every entity dimension', () => {
+    const agencyA = makeAgency('a');
+    const agencyB = makeAgency('b');
+    const agencyC = makeAgency('c');
+    const stops: StopWithContext[] = [
+      // routes r1,r2 both type 3; agencies a,b (a duplicated within the stop)
+      withAgencies(makeStopWithContext(makeStop('s1'), ['r1', 'r2'], [3]), [
+        agencyA,
+        agencyA,
+        agencyB,
+      ]),
+      // routes r2 (repeat, type 3), r3 (type 2); agency b (repeat across stops)
+      withAgencies(makeStopWithContext(makeStop('s2'), ['r2', 'r3'], [3, 2]), [agencyB]),
+      // route r4 (type 11); agency c
+      withAgencies(makeStopWithContext(makeStop('s3'), ['r4'], [11]), [agencyC]),
+    ];
+
+    expect(computeStopWithMetaStats(stops)).toEqual({
+      stopCount: 3,
+      agencyCount: 3, // a, b, c
+      routeCount: 4, // r1, r2, r3, r4
+      routeTypeCount: 3, // 3, 2, 11
+    });
+  });
+
+  it('counts a service-less stop in stopCount but contributes no agencies/routes', () => {
+    const agencyA = makeAgency('a');
+    const stops: StopWithContext[] = [
+      withAgencies(makeStopWithContext(makeStop('s1'), ['r1'], [3]), [agencyA]),
+      makeStopWithContext(makeStop('empty'), []), // no routes/agencies, no service
+    ];
+    expect(computeStopWithMetaStats(stops)).toEqual({
+      stopCount: 2,
+      agencyCount: 1,
+      routeCount: 1,
+      routeTypeCount: 1,
+    });
+  });
+
+  it('dedupes duplicate routes within a single stop', () => {
+    const stats = computeStopWithMetaStats([
+      makeStopWithContext(makeStop('s1'), ['r1', 'r1'], [3]),
+    ]);
+    expect(stats.routeCount).toBe(1);
+    expect(stats.routeTypeCount).toBe(1);
+  });
+
+  it('counts falsy-but-valid route types (0, -1)', () => {
+    // The `!= null` guard must keep 0 (tram) and -1 (unknown); a truthy check
+    // would wrongly drop them.
+    const stats = computeStopWithMetaStats([
+      makeStopWithContext(makeStop('s1'), ['r0', 'rm1'], [0, -1]),
+    ]);
+    expect(stats.routeTypeCount).toBe(2);
+  });
+
+  it('skips a route with a missing route_type without counting it as a type', () => {
+    const swc = makeStopWithContext(makeStop('s1'), ['r1'], [3]);
+    // Malformed data: a route whose route_type is absent at runtime.
+    const malformed: StopWithContext = {
+      ...swc,
+      routes: [{ ...swc.routes[0], route_type: undefined as unknown as AppRouteTypeValue }],
+    };
+    const stats = computeStopWithMetaStats([malformed]);
+    expect(stats.routeCount).toBe(1); // route still counted by id
+    expect(stats.routeTypeCount).toBe(0); // missing type not counted
+  });
+
+  it('counts stopCount by element, not by distinct stop_id', () => {
+    // Two entries with the same stop_id still count as two stops: callers are
+    // expected to pass one entry per stop, so stopCount is `stops.length`.
+    const stops = [
+      makeStopWithContext(makeStop('dup'), ['r1'], [3]),
+      makeStopWithContext(makeStop('dup'), ['r2'], [2]),
+    ];
+    expect(computeStopWithMetaStats(stops).stopCount).toBe(2);
+  });
+});

--- a/src/domain/transit/__tests__/stop-meta-filter.test.ts
+++ b/src/domain/transit/__tests__/stop-meta-filter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { makeStopMeta } from '../../../__tests__/helpers';
+import type { StopWithMeta } from '../../../types/app/transit-composed';
+import { filterStopsWithinDistance } from '../stop-meta-filter';
+
+/** A stop meta at a given distance (metres), with a unique id for assertions. */
+function stopAtDistance(stopId: string, distance: number | undefined): StopWithMeta {
+  return { ...makeStopMeta(stopId), distance };
+}
+
+describe('filterStopsWithinDistance', () => {
+  it('keeps stops within the distance and drops the ones beyond it', () => {
+    const near = stopAtDistance('near', 50);
+    const far = stopAtDistance('far', 150);
+
+    expect(filterStopsWithinDistance([near, far], 100)).toEqual([near]);
+  });
+
+  it('keeps a stop exactly at the max distance (boundary is inclusive)', () => {
+    const onEdge = stopAtDistance('edge', 100);
+
+    expect(filterStopsWithinDistance([onEdge], 100)).toEqual([onEdge]);
+  });
+
+  it('keeps a stop at distance 0', () => {
+    const here = stopAtDistance('here', 0);
+
+    expect(filterStopsWithinDistance([here], 100)).toEqual([here]);
+  });
+
+  it('drops stops whose distance is undefined', () => {
+    const unknown = stopAtDistance('unknown', undefined);
+    const near = stopAtDistance('near', 10);
+
+    expect(filterStopsWithinDistance([unknown, near], 100)).toEqual([near]);
+  });
+
+  it('returns an empty array when no stop is within the distance', () => {
+    const far = stopAtDistance('far', 500);
+
+    expect(filterStopsWithinDistance([far], 100)).toEqual([]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(filterStopsWithinDistance([], 100)).toEqual([]);
+  });
+
+  it('preserves the input order of the surviving stops', () => {
+    const a = stopAtDistance('a', 10);
+    const b = stopAtDistance('b', 90);
+    const c = stopAtDistance('c', 40);
+
+    const result = filterStopsWithinDistance([a, b, c], 100);
+
+    expect(result.map((s) => s.stop.stop_id)).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/src/domain/transit/compute-route-stats.ts
+++ b/src/domain/transit/compute-route-stats.ts
@@ -1,0 +1,47 @@
+import type { Route } from '../../types/app/transit';
+
+/**
+ * Distinct-entity counts over a set of routes.
+ *
+ * The shared core of the stop / entry stat helpers: given any collection of
+ * routes (duplicates allowed), it counts the distinct routes, agencies, and
+ * route types. Agencies are taken from each route's `agency_id`.
+ */
+export interface RouteStats {
+  /** Distinct routes (`route_id`). */
+  routeCount: number;
+  /** Distinct agencies (`agency_id`). */
+  agencyCount: number;
+  /** Distinct route types (a missing `route_type` is not counted). */
+  routeTypeCount: number;
+}
+
+/**
+ * Compute {@link RouteStats} for a set of routes in a single pass.
+ *
+ * Deduplicates by `route_id` / `agency_id` / `route_type`. The `route_type`
+ * accumulation uses a `!= null` guard so valid 0 / -1 are kept while a missing
+ * value is dropped.
+ *
+ * @param routes - The routes to summarize (duplicates allowed).
+ * @returns The distinct-entity counts.
+ */
+export function computeRouteStats(routes: readonly Route[]): RouteStats {
+  const routeIds = new Set<string>();
+  const agencyIds = new Set<string>();
+  const routeTypes = new Set<number>();
+
+  for (const route of routes) {
+    routeIds.add(route.route_id);
+    agencyIds.add(route.agency_id);
+    if (route.route_type != null) {
+      routeTypes.add(route.route_type);
+    }
+  }
+
+  return {
+    routeCount: routeIds.size,
+    agencyCount: agencyIds.size,
+    routeTypeCount: routeTypes.size,
+  };
+}

--- a/src/domain/transit/compute-stop-with-meta-stats.ts
+++ b/src/domain/transit/compute-stop-with-meta-stats.ts
@@ -1,0 +1,71 @@
+import type { StopWithMeta } from '../../types/app/transit-composed';
+
+/**
+ * Static composition summary for a set of stops.
+ *
+ * Describes WHAT a stop set (e.g. all stops within a radius) contains, not its
+ * current service state: how many stops, and how many distinct agencies /
+ * routes / route types serve them. All fields are derived from each stop's
+ * resolved {@link StopWithMeta} context, so an entity with no upcoming service
+ * still counts -- this is intentional static metadata ("what operates around
+ * here"). Distinct from the per-stop {@link StopWithMeta.stats} (one stop's own
+ * counts); for time-windowed service counts use `computeStopsCounts` instead.
+ */
+export interface StopWithMetaStats {
+  /**
+   * Number of stops in the set. This is the element count (`stops.length`), not
+   * a distinct-`stop_id` count: callers are expected to pass one entry per stop
+   * (as the nearby-stop pipeline does), so the two coincide.
+   */
+  stopCount: number;
+  /** Distinct agencies (`agency_id`) serving the stops. */
+  agencyCount: number;
+  /** Distinct routes (`route_id`) serving the stops. */
+  routeCount: number;
+  /**
+   * Distinct route types serving the stops (from each route's `route_type`).
+   * A route whose `route_type` is missing (malformed data) is not counted, so
+   * `null` / `undefined` never appears as a "type".
+   */
+  routeTypeCount: number;
+}
+
+/**
+ * Compute the static {@link StopWithMetaStats} for a set of stops in a single
+ * pass.
+ *
+ * Takes the base {@link StopWithMeta} (not the full `StopWithContext`) so it can
+ * summarize any stop collection. The distinct agency / route / route-type counts
+ * are accumulated in one traversal; route types are read from each route's
+ * `route_type` (not a stop's dynamic `routeTypes` field).
+ *
+ * @param stops - The stop set to summarize.
+ * @returns The static composition summary.
+ */
+export function computeStopWithMetaStats(stops: readonly StopWithMeta[]): StopWithMetaStats {
+  const agencyIds = new Set<string>();
+  const routeIds = new Set<string>();
+  const routeTypes = new Set<number>();
+
+  for (const swm of stops) {
+    for (const agency of swm.agencies) {
+      agencyIds.add(agency.agency_id);
+    }
+    for (const route of swm.routes) {
+      routeIds.add(route.route_id);
+      // Guard malformed data: a missing route_type must not be counted as a
+      // type. `!= null` keeps valid 0 / -1 while dropping null / undefined.
+      if (route.route_type != null) {
+        routeTypes.add(route.route_type);
+      }
+    }
+  }
+
+  return {
+    // Element count, not distinct stop_id (see StopWithMetaStats.stopCount).
+    stopCount: stops.length,
+    agencyCount: agencyIds.size,
+    routeCount: routeIds.size,
+    routeTypeCount: routeTypes.size,
+  };
+}

--- a/src/domain/transit/compute-stop-with-meta-stats.ts
+++ b/src/domain/transit/compute-stop-with-meta-stats.ts
@@ -1,71 +1,41 @@
 import type { StopWithMeta } from '../../types/app/transit-composed';
+import { computeRouteStats, type RouteStats } from './compute-route-stats';
 
 /**
- * Static composition summary for a set of stops.
+ * Static composition summary for a set of stops: the stop count plus the
+ * {@link RouteStats} (distinct routes / agencies / route types) of the routes
+ * serving them.
  *
  * Describes WHAT a stop set (e.g. all stops within a radius) contains, not its
- * current service state: how many stops, and how many distinct agencies /
- * routes / route types serve them. All fields are derived from each stop's
- * resolved {@link StopWithMeta} context, so an entity with no upcoming service
- * still counts -- this is intentional static metadata ("what operates around
- * here"). Distinct from the per-stop {@link StopWithMeta.stats} (one stop's own
- * counts); for time-windowed service counts use `computeStopsCounts` instead.
+ * current service state, so a route / agency with no upcoming service still
+ * counts -- intentional static metadata ("what operates around here"). Distinct
+ * from the per-stop {@link StopWithMeta.stats} (one stop's own counts); for
+ * time-windowed service counts use `computeStopsCounts` instead.
  */
-export interface StopWithMetaStats {
+export interface StopWithMetaStats extends RouteStats {
   /**
    * Number of stops in the set. This is the element count (`stops.length`), not
    * a distinct-`stop_id` count: callers are expected to pass one entry per stop
    * (as the nearby-stop pipeline does), so the two coincide.
    */
   stopCount: number;
-  /** Distinct agencies (`agency_id`) serving the stops. */
-  agencyCount: number;
-  /** Distinct routes (`route_id`) serving the stops. */
-  routeCount: number;
-  /**
-   * Distinct route types serving the stops (from each route's `route_type`).
-   * A route whose `route_type` is missing (malformed data) is not counted, so
-   * `null` / `undefined` never appears as a "type".
-   */
-  routeTypeCount: number;
 }
 
 /**
- * Compute the static {@link StopWithMetaStats} for a set of stops in a single
- * pass.
+ * Compute the static {@link StopWithMetaStats} for a set of stops.
  *
  * Takes the base {@link StopWithMeta} (not the full `StopWithContext`) so it can
- * summarize any stop collection. The distinct agency / route / route-type counts
- * are accumulated in one traversal; route types are read from each route's
- * `route_type` (not a stop's dynamic `routeTypes` field).
+ * summarize any stop collection. The route / agency / route-type counts come
+ * from {@link computeRouteStats} over the routes serving the stops, so
+ * `agencyCount` reflects each route's `agency_id`.
  *
  * @param stops - The stop set to summarize.
  * @returns The static composition summary.
  */
 export function computeStopWithMetaStats(stops: readonly StopWithMeta[]): StopWithMetaStats {
-  const agencyIds = new Set<string>();
-  const routeIds = new Set<string>();
-  const routeTypes = new Set<number>();
-
-  for (const swm of stops) {
-    for (const agency of swm.agencies) {
-      agencyIds.add(agency.agency_id);
-    }
-    for (const route of swm.routes) {
-      routeIds.add(route.route_id);
-      // Guard malformed data: a missing route_type must not be counted as a
-      // type. `!= null` keeps valid 0 / -1 while dropping null / undefined.
-      if (route.route_type != null) {
-        routeTypes.add(route.route_type);
-      }
-    }
-  }
-
   return {
     // Element count, not distinct stop_id (see StopWithMetaStats.stopCount).
     stopCount: stops.length,
-    agencyCount: agencyIds.size,
-    routeCount: routeIds.size,
-    routeTypeCount: routeTypes.size,
+    ...computeRouteStats(stops.flatMap((swm) => swm.routes)),
   };
 }

--- a/src/domain/transit/compute-transit-display-datum-stats.ts
+++ b/src/domain/transit/compute-transit-display-datum-stats.ts
@@ -1,0 +1,48 @@
+import { computeRouteStats, type RouteStats } from './compute-route-stats';
+import type { TransitDisplayDatum } from './transit-info-display/build-transit-display-data';
+
+/**
+ * Stats over a set of {@link TransitDisplayDatum} (a board's entries -- the stop
+ * events on it): the entry / stop counts plus the {@link RouteStats} of the
+ * routes those entries run on. The entry-side counterpart of the stop-set
+ * `StopWithMetaStats`. The scope depends on which entries are measured -- the
+ * pre-cap board yields "qualifying" totals, the capped board yields displayed
+ * totals.
+ */
+export interface TransitDisplayDatumStats extends RouteStats {
+  /** Number of entries (stop events): the length of the datum array. */
+  entryCount: number;
+  /** Distinct stops the entries come from (by `stop_id`). */
+  stopCount: number;
+}
+
+/**
+ * Compute {@link TransitDisplayDatumStats} for a set of board entries in a
+ * single pass.
+ *
+ * The entry-side counterpart of `computeStopWithMetaStats`: it counts the
+ * entries plus the distinct stops / routes / agencies / route types they
+ * involve. Run it on the pre-cap board for the "qualifying" totals (the cap
+ * discards them downstream). A route whose `route_type` is missing is not
+ * counted as a type.
+ *
+ * @param rows - The board entries to summarize.
+ * @returns The entry-set stats.
+ */
+export function computeTransitDisplayDatumStats(
+  rows: readonly TransitDisplayDatum[],
+): TransitDisplayDatumStats {
+  const stopIds = new Set<string>();
+  for (const row of rows) {
+    stopIds.add(row.stop.stop.stop_id);
+  }
+
+  // Route / agency / route-type distinct counts are the shared route-stat core.
+  const routeStats = computeRouteStats(rows.map((row) => row.timetableEntry.routeDirection.route));
+
+  return {
+    entryCount: rows.length,
+    stopCount: stopIds.size,
+    ...routeStats,
+  };
+}

--- a/src/domain/transit/stop-meta-filter.ts
+++ b/src/domain/transit/stop-meta-filter.ts
@@ -1,0 +1,21 @@
+import type { StopWithMeta } from '../../types/app/transit-composed';
+
+/**
+ * Distance filter: stops whose precomputed `distance` is within
+ * `maxDistanceMeters` of the query centre. `distance` is precomputed (metres),
+ * so no coordinate maths is needed here.
+ *
+ * Generic over {@link StopWithMeta} (the type that carries `distance`), so the
+ * concrete input type -- e.g. `StopWithContext` -- is preserved in the result.
+ * Stops with an undefined `distance` are dropped; input order is preserved.
+ *
+ * @param stops - The stops to filter (each carrying a precomputed `distance`).
+ * @param maxDistanceMeters - Inclusive upper bound in metres.
+ * @returns The stops within the distance, in input order.
+ */
+export function filterStopsWithinDistance<T extends StopWithMeta>(
+  stops: readonly T[],
+  maxDistanceMeters: number,
+): T[] {
+  return stops.filter((stop) => stop.distance !== undefined && stop.distance <= maxDistanceMeters);
+}

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -645,8 +645,24 @@ describe('sortTransitDisplayDataWithMetaData', () => {
     directions: readonly (0 | 1 | 'none')[] = ['none'],
   ): TransitDisplayDataWithMetaData {
     return {
-      meta: { category, routeTypes: [routeType], directions, max: 10, radius: 100 },
+      meta: {
+        category,
+        routeTypes: [routeType],
+        directions,
+        max: 10,
+        radius: 100,
+      },
       data: { routeTypes: [routeType], directions, category, data: [] },
+      stats: {
+        stopsInRadius: { stopCount: 0, agencyCount: 0, routeCount: 0, routeTypeCount: 0 },
+        qualifying: {
+          entryCount: 0,
+          stopCount: 0,
+          agencyCount: 0,
+          routeCount: 0,
+          routeTypeCount: 0,
+        },
+      },
     };
   }
 

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -20,9 +20,9 @@ import type {
 import { ROUTE_TYPE_DISPLAY_ORDER } from '../../route-type-display-order';
 import { getTimetableEntryAttributes } from '../../timetable-entry-attributes';
 import {
+  buildTransitDisplayDataSet,
   categoryQualifies,
   clusterCandidatesByRouteType,
-  filterStopsWithinRadius,
   groupCandidatesIntoBoards,
   sortAndCapTransitDisplayData,
   sortByCategory,
@@ -231,59 +231,6 @@ describe('categoryQualifies', () => {
     categoryQualifies(ENTRY, 'departures');
 
     expect(getTimetableEntryAttributes).toHaveBeenCalledWith(ENTRY);
-  });
-});
-
-describe('filterStopsWithinRadius', () => {
-  /** A stop context at a given distance (metres), with a unique id for assertions. */
-  function stopAtDistance(stopId: string, distance: number | undefined): StopWithContext {
-    return { ...STUB_STOP, stop: makeStop(stopId), distance };
-  }
-
-  it('keeps stops within the radius and drops the ones beyond it', () => {
-    const near = stopAtDistance('near', 50);
-    const far = stopAtDistance('far', 150);
-
-    expect(filterStopsWithinRadius([near, far], 100)).toEqual([near]);
-  });
-
-  it('keeps a stop exactly at the radius (boundary is inclusive)', () => {
-    const onEdge = stopAtDistance('edge', 100);
-
-    expect(filterStopsWithinRadius([onEdge], 100)).toEqual([onEdge]);
-  });
-
-  it('keeps a stop at distance 0', () => {
-    const here = stopAtDistance('here', 0);
-
-    expect(filterStopsWithinRadius([here], 100)).toEqual([here]);
-  });
-
-  it('drops stops whose distance is undefined', () => {
-    const unknown = stopAtDistance('unknown', undefined);
-    const near = stopAtDistance('near', 10);
-
-    expect(filterStopsWithinRadius([unknown, near], 100)).toEqual([near]);
-  });
-
-  it('returns an empty array when no stop is within the radius', () => {
-    const far = stopAtDistance('far', 500);
-
-    expect(filterStopsWithinRadius([far], 100)).toEqual([]);
-  });
-
-  it('returns an empty array for empty input', () => {
-    expect(filterStopsWithinRadius([], 100)).toEqual([]);
-  });
-
-  it('preserves the input order of the surviving stops', () => {
-    const a = stopAtDistance('a', 10);
-    const b = stopAtDistance('b', 90);
-    const c = stopAtDistance('c', 40);
-
-    const result = filterStopsWithinRadius([a, b, c], 100);
-
-    expect(result.map((s) => s.stop.stop_id)).toEqual(['a', 'b', 'c']);
   });
 });
 
@@ -740,5 +687,18 @@ describe('sortTransitDisplayDataWithMetaData', () => {
 
   it('returns an empty array for empty input', () => {
     expect(sortTransitDisplayDataWithMetaData([])).toEqual([]);
+  });
+});
+
+describe('buildTransitDisplayDataSet', () => {
+  // The board-building steps are covered individually above; this guards the
+  // orchestrator's empty case: no stops -> no displays.
+  it('returns no displays for an empty stop set', () => {
+    const result = buildTransitDisplayDataSet([], 100, {
+      maxEntries: 20,
+      routeGrouping: { kind: 'none' },
+      splitByDirection: false,
+    });
+    expect(result).toEqual([]);
   });
 });

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -235,14 +235,15 @@ describe('categoryQualifies', () => {
 });
 
 describe('clusterCandidatesByRouteType', () => {
-  it("'route': one cluster per route type in display order, candidates placed by type", () => {
+  it("'route': one cluster per eligible route type in display order, candidates placed by type", () => {
     const subway = candidateOf(subwayRoute); // route_type 1
     const bus = candidateOf(busRoute); // route_type 3
 
-    const clusters = clusterCandidatesByRouteType([subway, bus], { kind: 'route' });
+    const clusters = clusterCandidatesByRouteType([subway, bus], { kind: 'route' }, [1, 3]);
 
-    // One cluster per ROUTE_TYPE_DISPLAY_ORDER entry, each a single-type cluster.
-    expect(clusters.map((c) => c.routeTypes)).toEqual(ROUTE_TYPE_DISPLAY_ORDER.map((t) => [t]));
+    // One single-type cluster per eligible type, in display order.
+    const eligible = ROUTE_TYPE_DISPLAY_ORDER.filter((t) => t === 1 || t === 3);
+    expect(clusters.map((c) => c.routeTypes)).toEqual(eligible.map((t) => [t]));
     expect(clusters.find((c) => c.routeTypes[0] === busRoute.route_type)?.candidates).toEqual([
       bus,
     ]);
@@ -251,11 +252,28 @@ describe('clusterCandidatesByRouteType', () => {
     ]);
   });
 
-  it("'none': a single cluster of all candidates; routeTypes are present types in display order", () => {
+  it("'route': an eligible route type with no candidates yields an empty cluster", () => {
+    const bus = candidateOf(busRoute); // 3; route_type 2 is eligible but has no candidate
+
+    const clusters = clusterCandidatesByRouteType([bus], { kind: 'route' }, [2, 3]);
+
+    const railCluster = clusters.find((c) => c.routeTypes[0] === railRoute.route_type);
+    expect(railCluster?.candidates).toEqual([]);
+  });
+
+  it("'route': ignores route types not in effectiveRouteTypes", () => {
+    const bus = candidateOf(busRoute); // 3
+
+    const clusters = clusterCandidatesByRouteType([bus], { kind: 'route' }, [3]);
+
+    expect(clusters.map((c) => c.routeTypes)).toEqual([[3]]);
+  });
+
+  it("'none': a single cluster of all candidates; routeTypes are eligible types in display order", () => {
     const subway = candidateOf(subwayRoute); // 1
     const bus = candidateOf(busRoute); // 3
 
-    const clusters = clusterCandidatesByRouteType([subway, bus], { kind: 'none' });
+    const clusters = clusterCandidatesByRouteType([subway, bus], { kind: 'none' }, [1, 3]);
 
     expect(clusters).toHaveLength(1);
     // 3 precedes 1 in ROUTE_TYPE_DISPLAY_ORDER.
@@ -268,10 +286,11 @@ describe('clusterCandidatesByRouteType', () => {
     const rail = candidateOf(railRoute); // 2
     const bus = candidateOf(busRoute); // 3
 
-    const clusters = clusterCandidatesByRouteType([subway, rail, bus], {
-      kind: 'custom',
-      groups: [[1], [1, 2], [3, 1]],
-    });
+    const clusters = clusterCandidatesByRouteType(
+      [subway, rail, bus],
+      { kind: 'custom', groups: [[1], [1, 2], [3, 1]] },
+      [1, 2, 3],
+    );
 
     expect(clusters).toHaveLength(3);
     // [1, 2] stays [1, 2] (group order), not the display order [2, 1].
@@ -282,53 +301,64 @@ describe('clusterCandidatesByRouteType', () => {
     const subway = candidateOf(subwayRoute); // 1
     const rail = candidateOf(railRoute); // 2
 
-    const clusters = clusterCandidatesByRouteType([subway, rail], {
-      kind: 'custom',
-      groups: [[1], [1, 2]],
-    });
+    const clusters = clusterCandidatesByRouteType(
+      [subway, rail],
+      { kind: 'custom', groups: [[1], [1, 2]] },
+      [1, 2],
+    );
 
     // subway (1) appears in both clusters; candidates keep the input order.
     expect(clusters[0].candidates).toEqual([subway]);
     expect(clusters[1].candidates).toEqual([subway, rail]);
   });
 
-  it("'custom': drops route types absent from the candidates", () => {
-    const subway = candidateOf(subwayRoute); // 1; route_type 2 is absent
+  it("'custom': drops route types not eligible, and a group left with none", () => {
+    const subway = candidateOf(subwayRoute); // 1; only route_type 1 is eligible
 
-    const clusters = clusterCandidatesByRouteType([subway], { kind: 'custom', groups: [[2, 1]] });
+    const partial = clusterCandidatesByRouteType(
+      [subway],
+      { kind: 'custom', groups: [[2, 1]] },
+      [1],
+    );
+    expect(partial[0].routeTypes).toEqual([1]); // 2 dropped (not eligible)
+    expect(partial[0].candidates).toEqual([subway]);
 
-    expect(clusters[0].routeTypes).toEqual([1]); // 2 dropped (not present)
-    expect(clusters[0].candidates).toEqual([subway]);
+    const dropped = clusterCandidatesByRouteType([subway], { kind: 'custom', groups: [[2]] }, [1]);
+    expect(dropped).toEqual([]); // whole group ineligible -> no cluster
   });
 
   it("'route': keeps the input order of candidates within a single type's cluster", () => {
     const bus1 = candidateOf(busRoute); // 3
     const bus2 = candidateOf(busRoute); // 3
 
-    const clusters = clusterCandidatesByRouteType([bus1, bus2], { kind: 'route' });
+    const clusters = clusterCandidatesByRouteType([bus1, bus2], { kind: 'route' }, [3]);
 
     const busCluster = clusters.find((c) => c.routeTypes[0] === busRoute.route_type);
     expect(busCluster?.candidates).toEqual([bus1, bus2]);
   });
 
-  it("'route': returns the full display-order skeleton even with no candidates (all clusters empty)", () => {
-    const clusters = clusterCandidatesByRouteType([], { kind: 'route' });
+  it("'route': returns a cluster per eligible type even with no candidates (all empty)", () => {
+    const clusters = clusterCandidatesByRouteType([], { kind: 'route' }, [1, 2, 3]);
 
-    // Structure is data-independent: one single-type cluster per display-order entry.
-    expect(clusters.map((c) => c.routeTypes)).toEqual(ROUTE_TYPE_DISPLAY_ORDER.map((t) => [t]));
+    const eligible = ROUTE_TYPE_DISPLAY_ORDER.filter((t) => t === 1 || t === 2 || t === 3);
+    expect(clusters.map((c) => c.routeTypes)).toEqual(eligible.map((t) => [t]));
     expect(clusters.every((c) => c.candidates.length === 0)).toBe(true);
   });
 
-  it("'none': returns a single empty cluster with no route types for no candidates", () => {
-    const clusters = clusterCandidatesByRouteType([], { kind: 'none' });
-
-    expect(clusters).toEqual([{ routeTypes: [], candidates: [] }]);
+  it('returns no eligible clusters when effectiveRouteTypes is empty', () => {
+    expect(clusterCandidatesByRouteType([], { kind: 'route' }, [])).toEqual([]);
+    // 'none' still returns its single cluster, but with no route types.
+    expect(clusterCandidatesByRouteType([], { kind: 'none' }, [])).toEqual([
+      { routeTypes: [], candidates: [] },
+    ]);
+    const bus = candidateOf(busRoute);
+    expect(clusterCandidatesByRouteType([bus], { kind: 'custom', groups: [[3]] }, [])).toEqual([]);
   });
 
   it("'custom': returns no clusters for an empty groups list", () => {
     const bus = candidateOf(busRoute);
 
-    expect(clusterCandidatesByRouteType([bus], { kind: 'custom', groups: [] })).toEqual([]);
+    expect(clusterCandidatesByRouteType([bus], { kind: 'custom', groups: [] }, [3])).toEqual([]);
   });
 });
 
@@ -368,11 +398,16 @@ describe('groupCandidatesIntoBoards', () => {
   };
   const split: TransitDisplayCondition = { ...notSplit, splitByDirection: true };
 
+  // Nearby stops the boards are built for. `effectiveRouteTypes` is derived from
+  // these stops' `routeTypes`, so they must cover the candidates' route types.
+  const busStops: readonly StopWithContext[] = [STUB_STOP]; // routeTypes [3], boardable
+  const busAndSubwayStops: readonly StopWithContext[] = [{ ...STUB_STOP, routeTypes: [1, 3] }];
+
   it('not split: produces a departures and an arrivals board per cluster', () => {
     const a = cand({ direction: 0 });
     const b = cand({ direction: 1 });
 
-    const boards = groupCandidatesIntoBoards([a, b], notSplit);
+    const boards = groupCandidatesIntoBoards([a, b], notSplit, busStops);
 
     expect(boards).toHaveLength(2);
     expect(boards.map((bd) => bd.category)).toEqual(['departures', 'arrivals']);
@@ -387,7 +422,7 @@ describe('groupCandidatesIntoBoards', () => {
     const plain0 = cand({ direction: 0 }); // qualifies both
     const terminal1 = cand({ direction: 1, isTerminal: true }); // arrivals only
 
-    const boards = groupCandidatesIntoBoards([plain0, terminal1], notSplit);
+    const boards = groupCandidatesIntoBoards([plain0, terminal1], notSplit, busStops);
 
     const departures = boards.find((bd) => bd.category === 'departures');
     const arrivals = boards.find((bd) => bd.category === 'arrivals');
@@ -403,7 +438,7 @@ describe('groupCandidatesIntoBoards', () => {
     const dir0 = cand({ direction: 0 });
     // no direction 1 -> its buckets are empty and dropped
 
-    const boards = groupCandidatesIntoBoards([noDir, dir0], split);
+    const boards = groupCandidatesIntoBoards([noDir, dir0], split, busStops);
 
     // Category-major: all departures (in direction order) before all arrivals.
     expect(boards.map((bd) => ({ directions: bd.directions, category: bd.category }))).toEqual([
@@ -420,7 +455,7 @@ describe('groupCandidatesIntoBoards', () => {
   it('split: drops a board left empty after category qualification', () => {
     const terminal0 = cand({ direction: 0, isTerminal: true }); // arrivals only
 
-    const boards = groupCandidatesIntoBoards([terminal0], split);
+    const boards = groupCandidatesIntoBoards([terminal0], split, busStops);
 
     // direction-0 departures board is empty (terminal excluded) and dropped.
     expect(boards).toHaveLength(1);
@@ -429,23 +464,38 @@ describe('groupCandidatesIntoBoards', () => {
     expect(boards[0].data).toEqual([terminal0]);
   });
 
-  it('returns no boards for empty input', () => {
-    expect(groupCandidatesIntoBoards([], notSplit)).toEqual([]);
-    expect(groupCandidatesIntoBoards([], split)).toEqual([]);
+  it('returns no boards when there are candidates but the cells are empty', () => {
+    // Stops in service, but no candidates -> every cell is empty -> no boards.
+    expect(groupCandidatesIntoBoards([], notSplit, busStops)).toEqual([]);
+    expect(groupCandidatesIntoBoards([], split, busStops)).toEqual([]);
+  });
+
+  it('returns no boards when there are no stops', () => {
+    expect(groupCandidatesIntoBoards([cand({ direction: 0 })], notSplit, [])).toEqual([]);
+  });
+
+  it('returns no boards when every stop is out of service today', () => {
+    const noServiceStops: readonly StopWithContext[] = [
+      { ...STUB_STOP, stopServiceState: 'no-service' },
+    ];
+
+    expect(groupCandidatesIntoBoards([cand({ direction: 0 })], notSplit, noServiceStops)).toEqual(
+      [],
+    );
   });
 
   it("respects the route grouping: 'route' yields per-route-type boards in display order", () => {
     const bus = cand({ route: busRoute }); // 3
     const subway = cand({ route: subwayRoute }); // 1
 
-    const boards = groupCandidatesIntoBoards([bus, subway], {
-      maxEntries: 100,
-      routeGrouping: { kind: 'route' },
-      splitByDirection: false,
-    });
+    const boards = groupCandidatesIntoBoards(
+      [bus, subway],
+      { maxEntries: 100, routeGrouping: { kind: 'route' }, splitByDirection: false },
+      busAndSubwayStops,
+    );
 
-    // Empty route-type clusters are dropped; 3 precedes 1 in display order, and
-    // each surviving type yields a departures + arrivals board.
+    // Empty cells are dropped; 3 precedes 1 in display order, and each route type
+    // with candidates yields a departures + arrivals board.
     expect(boards.map((bd) => ({ routeTypes: bd.routeTypes, category: bd.category }))).toEqual([
       { routeTypes: [3], category: 'departures' },
       { routeTypes: [3], category: 'arrivals' },

--- a/src/domain/transit/transit-info-display/build-transit-display-data-for-ui.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data-for-ui.ts
@@ -22,6 +22,7 @@ import {
   type TransitDisplayDatum,
   type TransitDisplayMeta,
 } from './build-transit-display-data';
+import { DEFAULT_AGENCY_LANG } from '@/config/transit-defaults';
 
 /**
  * Stop-level fields of a {@link TransitDisplayDatumForUi}, grouped so consumers can
@@ -99,34 +100,42 @@ export function buildTransitDisplayDatumForUi(
     if (cached !== undefined) {
       return cached;
     }
-    const agencyLangs = stopWithContext.agencies.map((agency) => agency.agency_lang);
-    const name = getStopDisplayNames(stopWithContext.stop, preferredDisplayLangs, agencyLangs).name;
-    stopNameCache.set(stopWithContext.stop.stop_id, name);
-    return name;
+    const stopAgencies = stopWithContext.agencies;
+    const stopAgencyLangs = stopAgencies.map((agency) => agency.agency_lang);
+    const stopName = getStopDisplayNames(
+      stopWithContext.stop,
+      preferredDisplayLangs,
+      stopAgencyLangs,
+    ).name;
+    stopNameCache.set(stopWithContext.stop.stop_id, stopName);
+    return stopName;
   };
 
   return datum.map(({ timetableEntry, stop: stopWithContext }) => {
-    const agencyLangs = stopWithContext.agencies.map((agency) => agency.agency_lang);
+    // [IMPORTANT] Use domain logic to determine the starting/ending point.
+    const attributes = getTimetableEntryAttributes(timetableEntry);
+
+    // Route
+    const route = timetableEntry.routeDirection.route;
     const routeAgency = stopWithContext.agencies.find(
-      (agency) => agency.agency_id === timetableEntry.routeDirection.route.agency_id,
+      (agency) => agency.agency_id === route.agency_id,
     );
-    const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : agencyLangs;
-    const routeName = getRouteDisplayNames(
-      timetableEntry.routeDirection.route,
-      preferredDisplayLangs,
-      routeAgencyLangs,
-      'short',
-    ).resolved.name;
+    const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : DEFAULT_AGENCY_LANG;
+    const routeName = getRouteDisplayNames(route, preferredDisplayLangs, routeAgencyLangs, 'short')
+      .resolved.name;
+    const agencyName = routeAgency
+      ? getAgencyDisplayNames(routeAgency, preferredDisplayLangs, routeAgencyLangs, 'short')
+          .resolved.name || routeAgency.agency_id
+      : '';
+
+    // Headsign
     const headsign = getHeadsignDisplayNames(
       timetableEntry.routeDirection,
       preferredDisplayLangs,
       routeAgencyLangs,
       'stop',
     ).resolved.name;
-    const agencyName = routeAgency
-      ? getAgencyDisplayNames(routeAgency, preferredDisplayLangs, routeAgencyLangs, 'short')
-          .resolved.name || routeAgency.agency_id
-      : '';
+
     // Include the service date: TripLocator is per-service (not per-day), so the
     // same (patternId, serviceId, tripIndex, stopIndex) can recur on different
     // service dates within one board, which would collide as a React key.
@@ -145,6 +154,7 @@ export function buildTransitDisplayDatumForUi(
       timetableEntry,
       timetableEntry.serviceDate,
     );
+
     return {
       key,
       stop: {
@@ -162,7 +172,7 @@ export function buildTransitDisplayDatumForUi(
       timeText: formatAbsoluteTime(
         minutesToDate(timetableEntry.serviceDate, categoryMinutes(timetableEntry, category)),
       ),
-      attributes: getTimetableEntryAttributes(timetableEntry),
+      attributes,
       arrivalMinutes: timetableEntry.schedule.arrivalMinutes,
       departureMinutes: timetableEntry.schedule.departureMinutes,
       serviceDate: timetableEntry.serviceDate,

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -6,6 +6,11 @@ import type {
 } from '../../../types/app/transit-composed';
 import { ROUTE_TYPE_DISPLAY_ORDER } from '../route-type-display-order';
 import { minutesToDate } from '../calendar-utils';
+import { computeStopWithMetaStats, type StopWithMetaStats } from '../compute-stop-with-meta-stats';
+import {
+  computeTransitDisplayDatumStats,
+  type TransitDisplayDatumStats,
+} from '../compute-transit-display-datum-stats';
 import { getTimetableEntryAttributes } from '../timetable-entry-attributes';
 
 /**
@@ -82,15 +87,33 @@ export interface RouteTypeCluster {
 }
 
 /**
- * A display: its {@link TransitDisplayMeta} descriptor plus the structural board
- * it describes in `data`. `meta` restates the board's category / routeTypes /
- * directions and adds `max` / `radius`.
+ * Derived aggregate stats attached to one display, kept because they cannot be
+ * recovered from the capped rows in `data`. Two scopes:
+ * - `stopsInRadius`: dataset-level (all stops within the board's radius; the same
+ *   value on every board of one build, like {@link TransitDisplayMeta.radius}).
+ * - `qualifying`: per-board, the pre-cap ("qualifying") entry stats; consumers
+ *   compare it against the rendered rows to detect truncation.
+ */
+export interface TransitDisplayStats {
+  /** Stats for ALL stops within the board's radius (dataset-level). */
+  stopsInRadius: StopWithMetaStats;
+  /** Pre-cap stats of the board's entries (per-board). */
+  qualifying: TransitDisplayDatumStats;
+}
+
+/**
+ * A display: its {@link TransitDisplayMeta} descriptor, the structural board it
+ * describes in `data`, and the derived {@link TransitDisplayStats}. `meta`
+ * restates the board's category / routeTypes / directions and adds `max` /
+ * `radius`.
  */
 export interface TransitDisplayDataWithMetaData {
   /** Display descriptor (title + selection params). */
   meta: TransitDisplayMeta;
   /** The structural board this display describes. */
   data: TransitDisplayData;
+  /** Derived aggregate stats (radius-scope + per-board pre-cap). */
+  stats: TransitDisplayStats;
 }
 
 /** One stop event paired with the stop context it came from, before name resolution. */
@@ -433,7 +456,14 @@ export function buildTransitDisplayDataSet(
     condition.maxEntries,
   );
 
-  const dataWithMetaData: TransitDisplayDataWithMetaData[] = sortedAndCapped.map((data) => ({
+  // Dataset-level stats for all stops in radius (computed once, shared by every
+  // board). Includes service-less stops, so it cannot be derived from the capped
+  // per-board rows.
+  const stopsInRadius = computeStopWithMetaStats(nearbyStops);
+
+  // sortAndCapTransitDisplayData maps `boards` in order, so sortedAndCapped[i]
+  // corresponds to boards[i]; the pre-cap ("qualifying") stats come from boards[i].
+  const dataWithMetaData: TransitDisplayDataWithMetaData[] = sortedAndCapped.map((data, i) => ({
     meta: {
       category: data.category,
       routeTypes: data.routeTypes,
@@ -442,6 +472,10 @@ export function buildTransitDisplayDataSet(
       radius: radiusMeters,
     },
     data: data,
+    stats: {
+      stopsInRadius,
+      qualifying: computeTransitDisplayDatumStats(boards[i].data),
+    },
   }));
   return dataWithMetaData;
 }

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -277,6 +277,18 @@ function presentDirections(
   );
 }
 
+/**
+ * One direction bucket for {@link groupCandidatesIntoBoards}: which candidates
+ * belong to it (`matches`) and how to label the resulting board's `directions`
+ * (`directionsOf`). Not split = a single bucket spanning all present directions;
+ * split = one bucket per direction value. Modeling both as a list lets the
+ * category / filter / skip / push logic run once instead of being duplicated.
+ */
+interface DirectionGroup {
+  matches: (candidate: TransitDisplayCandidate) => boolean;
+  directionsOf: (selected: readonly TransitDisplayCandidate[]) => readonly (0 | 1 | 'none')[];
+}
+
 /** Present route types among candidates, in `ROUTE_TYPE_DISPLAY_ORDER`. */
 function presentRouteTypesInDisplayOrder(
   candidates: readonly TransitDisplayCandidate[],
@@ -348,57 +360,31 @@ export function groupCandidatesIntoBoards(
   const clusters = clusterCandidatesByRouteType(candidates, condition.routeGrouping);
   const boards: TransitDisplayData[] = [];
 
+  // Direction buckets: not split = a single bucket spanning all present
+  // directions; split = one bucket per direction. Category-major iteration
+  // (departures, then arrivals) keeps a board's departures before its arrivals,
+  // e.g. at a terminus where one direction is arrivals-only and another is
+  // departures-only. Empty cells are skipped.
+  const directionGroups: readonly DirectionGroup[] = condition.splitByDirection
+    ? DIRECTIONS.map((direction) => ({
+        matches: (c) => c.timetableEntry.routeDirection.direction === direction,
+        directionsOf: () => [direction ?? 'none'],
+      }))
+    : [{ matches: () => true, directionsOf: presentDirections }];
+
   for (const cluster of clusters) {
-    if (!condition.splitByDirection) {
-      // Not split: one board per category, covering the directions present.
-      for (const category of CATEGORIES) {
-        const boardCandidates = cluster.candidates.filter((c) =>
-          categoryQualifies(c.timetableEntry, category),
-        );
-
-        console.debug(
-          `Board candidates for route types ${cluster.routeTypes.join(',')}, category ${category}, no direction split: ${boardCandidates.length}`,
-        );
-
-        if (boardCandidates.length === 0) {
-          continue;
-        }
-        boards.push({
-          routeTypes: cluster.routeTypes,
-          directions: presentDirections(boardCandidates),
-          category,
-          data: boardCandidates,
-        });
-      }
-      continue;
-    }
-
-    // Split: one board per (category, direction) bucket. Category-major
-    // (departures, then arrivals) so a board's departures always precede its
-    // arrivals -- e.g. at a terminus where one direction is arrivals-only and
-    // another is departures-only, the departures still list first. Empty buckets
-    // are skipped.
     for (const category of CATEGORIES) {
-      for (const direction of DIRECTIONS) {
+      for (const group of directionGroups) {
         const boardCandidates = cluster.candidates.filter(
-          (c) =>
-            c.timetableEntry.routeDirection.direction === direction &&
-            categoryQualifies(c.timetableEntry, category),
-        );
-
-        console.debug(
-          `Board candidates for route types ${cluster.routeTypes.join(',')}, category ${category}, direction ${
-            direction ?? 'none'
-          }: ${boardCandidates.length}`,
+          (c) => group.matches(c) && categoryQualifies(c.timetableEntry, category),
         );
 
         if (boardCandidates.length === 0) {
           continue;
         }
-        const directions: readonly (0 | 1 | 'none')[] = [direction ?? 'none'];
         boards.push({
           routeTypes: cluster.routeTypes,
-          directions,
+          directions: group.directionsOf(boardCandidates),
           category,
           data: boardCandidates,
         });

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -289,14 +289,6 @@ interface DirectionGroup {
   directionsOf: (selected: readonly TransitDisplayCandidate[]) => readonly (0 | 1 | 'none')[];
 }
 
-/** Present route types among candidates, in `ROUTE_TYPE_DISPLAY_ORDER`. */
-function presentRouteTypesInDisplayOrder(
-  candidates: readonly TransitDisplayCandidate[],
-): AppRouteTypeValue[] {
-  const present = new Set(candidates.map((c) => c.timetableEntry.routeDirection.route.route_type));
-  return ROUTE_TYPE_DISPLAY_ORDER.filter((routeType) => present.has(routeType));
-}
-
 /**
  * Clusters candidates by route type, per the grouping strategy:
  * - `route`: one cluster per route type (in `ROUTE_TYPE_DISPLAY_ORDER`)
@@ -312,29 +304,48 @@ function presentRouteTypesInDisplayOrder(
 export function clusterCandidatesByRouteType(
   candidates: readonly TransitDisplayCandidate[],
   grouping: TransitDisplayRouteGrouping,
+  effectiveRouteTypes: readonly AppRouteTypeValue[],
 ): RouteTypeCluster[] {
+  // This value represents the route types to output even when candidates is empty.
+  const requiredRouteTypes = ROUTE_TYPE_DISPLAY_ORDER.filter((rt) =>
+    effectiveRouteTypes.includes(rt),
+  );
+
+  // per route type
   if (grouping.kind === 'route') {
-    return ROUTE_TYPE_DISPLAY_ORDER.map((routeType) => ({
-      routeTypes: [routeType],
-      candidates: selectByRouteType(candidates, routeType),
-    }));
+    return requiredRouteTypes.map((routeType) => {
+      return {
+        routeTypes: [routeType],
+        candidates: selectByRouteType(candidates, routeType),
+      };
+    });
   }
-  const presentTypes = presentRouteTypesInDisplayOrder(candidates);
+
+  // no grouping
   if (grouping.kind === 'none') {
-    return [{ routeTypes: presentTypes, candidates: [...candidates] }];
+    return [
+      {
+        routeTypes: requiredRouteTypes.flat(),
+        candidates: [...candidates],
+      },
+    ];
   }
+
   // 'custom': one cluster per group (groups may overlap). Keep each group's own
   // order for routeTypes (present types only), so the caller's order is honored.
-  const presentSet = new Set<number>(presentTypes);
-  return grouping.groups.map((group) => {
-    const groupSet = new Set<number>(group);
-    return {
-      routeTypes: group.filter((routeType) => presentSet.has(routeType)),
-      candidates: candidates.filter((c) =>
-        groupSet.has(c.timetableEntry.routeDirection.route.route_type),
-      ),
-    };
-  });
+  // const presentSet = new Set<number>(presentRouteTypes);
+  const presentSet = new Set<number>(requiredRouteTypes);
+  return grouping.groups
+    .map((group) => {
+      const groupSet = new Set<number>(group);
+      return {
+        routeTypes: group.filter((routeType) => presentSet.has(routeType)),
+        candidates: candidates.filter((c) =>
+          groupSet.has(c.timetableEntry.routeDirection.route.route_type),
+        ),
+      };
+    })
+    .filter((cluster) => cluster.routeTypes.length > 0);
 }
 
 /**
@@ -356,8 +367,22 @@ export function clusterCandidatesByRouteType(
 export function groupCandidatesIntoBoards(
   candidates: readonly TransitDisplayCandidate[],
   condition: TransitDisplayCondition,
+  // effectiveRouteTypes: readonly AppRouteTypeValue[],
+  stops: readonly StopWithContext[],
 ): TransitDisplayData[] {
-  const clusters = clusterCandidatesByRouteType(candidates, condition.routeGrouping);
+  // All route types served by the stops (from each stop's `routeTypes`,
+  // independent of whether any trips remain), in display order -- so a route type
+  // present at a stop can be surfaced as an empty board even with no candidates.
+  const effectiveRouteTypes: readonly AppRouteTypeValue[] = ROUTE_TYPE_DISPLAY_ORDER.filter(
+    (routeType) => stops.some((stop) => stop.routeTypes.includes(routeType)),
+  );
+
+  const clusters = clusterCandidatesByRouteType(
+    candidates,
+    condition.routeGrouping,
+    effectiveRouteTypes,
+  );
+
   const boards: TransitDisplayData[] = [];
 
   // Direction buckets: not split = a single bucket spanning all present
@@ -379,9 +404,18 @@ export function groupCandidatesIntoBoards(
           (c) => group.matches(c) && categoryQualifies(c.timetableEntry, category),
         );
 
+        if (stops.length === 0) {
+          continue;
+        }
+
+        if (stops.every((stop) => stop.stopServiceState === 'no-service')) {
+          continue;
+        }
+
         if (boardCandidates.length === 0) {
           continue;
         }
+
         boards.push({
           routeTypes: cluster.routeTypes,
           directions: group.directionsOf(boardCandidates),
@@ -433,11 +467,17 @@ export function buildTransitDisplayDataSet(
 ): TransitDisplayDataWithMetaData[] {
   // distance filter: stops within radiusMeters of the center
   const nearbyStops: StopWithContext[] = filterStopsWithinDistance(stops, radiusMeters);
+
   // flatten each stop's stopTimes into candidates
   const candidates: TransitDisplayCandidate[] = toTransitDisplayCandidates(nearbyStops);
+
   // cluster by route type, optionally by direction, then split by category
-  const boards: TransitDisplayData[] = groupCandidatesIntoBoards(candidates, condition);
-  // sort by time, cap each board
+  const boards: TransitDisplayData[] = groupCandidatesIntoBoards(
+    candidates,
+    condition,
+    nearbyStops,
+  );
+
   const sortedAndCapped: TransitDisplayData[] = sortAndCapTransitDisplayData(
     boards,
     condition.maxEntries,
@@ -495,3 +535,22 @@ export function sortTransitDisplayDataWithMetaData(
     return ka[0] - kb[0] || ka[1] - kb[1] || ka[2] - kb[2];
   });
 }
+
+  export type TransitDisplayStopsState = 'ready' | 'no-stops' | 'no-service';
+  export type TransitDisplayStatus = {
+    radius: number;
+    state: TransitDisplayStopsState;
+  };
+
+  export function resolveTransitDisplayState(
+    stops: readonly StopWithContext[],
+  ): TransitDisplayStopsState {
+    if (stops.length === 0) {
+      return 'no-stops';
+    }
+    if (stops.every((stop) => stop.stopServiceState === 'no-service')) {
+      return 'no-service';
+    }
+    return 'ready';
+  }
+

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -7,6 +7,7 @@ import type {
 import { ROUTE_TYPE_DISPLAY_ORDER } from '../route-type-display-order';
 import { minutesToDate } from '../calendar-utils';
 import { computeStopWithMetaStats, type StopWithMetaStats } from '../compute-stop-with-meta-stats';
+import { filterStopsWithinDistance } from '../stop-meta-filter';
 import {
   computeTransitDisplayDatumStats,
   type TransitDisplayDatumStats,
@@ -206,18 +207,6 @@ export function categoryQualifies(
 }
 
 /**
- * Distance filter: stops whose precomputed `distance` is within
- * `radiusMeters` of the query centre. `distance` is precomputed (metres), so no
- * coordinate maths is needed here.
- */
-export function filterStopsWithinRadius(
-  stops: readonly StopWithContext[],
-  radiusMeters: number,
-): StopWithContext[] {
-  return stops.filter((stop) => stop.distance !== undefined && stop.distance <= radiusMeters);
-}
-
-/**
  * Flattens every stop's `stopTimes` into candidates, each paired with its source
  * stop context: the single candidate type the selectors below operate on.
  */
@@ -366,6 +355,11 @@ export function groupCandidatesIntoBoards(
         const boardCandidates = cluster.candidates.filter((c) =>
           categoryQualifies(c.timetableEntry, category),
         );
+
+        console.debug(
+          `Board candidates for route types ${cluster.routeTypes.join(',')}, category ${category}, no direction split: ${boardCandidates.length}`,
+        );
+
         if (boardCandidates.length === 0) {
           continue;
         }
@@ -391,6 +385,13 @@ export function groupCandidatesIntoBoards(
             c.timetableEntry.routeDirection.direction === direction &&
             categoryQualifies(c.timetableEntry, category),
         );
+
+        console.debug(
+          `Board candidates for route types ${cluster.routeTypes.join(',')}, category ${category}, direction ${
+            direction ?? 'none'
+          }: ${boardCandidates.length}`,
+        );
+
         if (boardCandidates.length === 0) {
           continue;
         }
@@ -445,7 +446,7 @@ export function buildTransitDisplayDataSet(
   condition: TransitDisplayCondition,
 ): TransitDisplayDataWithMetaData[] {
   // distance filter: stops within radiusMeters of the center
-  const nearbyStops: StopWithContext[] = filterStopsWithinRadius(stops, radiusMeters);
+  const nearbyStops: StopWithContext[] = filterStopsWithinDistance(stops, radiusMeters);
   // flatten each stop's stopTimes into candidates
   const candidates: TransitDisplayCandidate[] = toTransitDisplayCandidates(nearbyStops);
   // cluster by route type, optionally by direction, then split by category

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -247,9 +247,6 @@ export function sortByCategory(
   );
 }
 
-/** Conventional radius (metres) for the nearby-stops displays; callers pass this explicitly. */
-export const NEARBY_RADIUS_M = 100;
-
 /** Board categories, in the order they appear within a route type (departures then arrivals). */
 const CATEGORIES: readonly TransitDisplayCategory[] = ['departures', 'arrivals'];
 
@@ -290,14 +287,24 @@ interface DirectionGroup {
 }
 
 /**
- * Clusters candidates by route type, per the grouping strategy:
- * - `route`: one cluster per route type (in `ROUTE_TYPE_DISPLAY_ORDER`)
- * - `none`: a single cluster of all candidates (its `routeTypes` are the present types)
+ * Clusters candidates by route type, per the grouping strategy. `effectiveRouteTypes`
+ * is the set of route types eligible to appear -- typically the route types served
+ * by the nearby stops -- so a board's `routeTypes` reflect what the stops offer. It
+ * is intersected with `ROUTE_TYPE_DISPLAY_ORDER` for ordering and dedup.
+ *
+ * - `route`: one cluster per eligible route type (display order); an eligible type
+ *   with no candidates yields an empty cluster.
+ * - `none`: a single cluster of all candidates; its `routeTypes` are the eligible
+ *   types in display order.
  * - `custom`: one cluster per caller-supplied group, in the given order. Each
- *   board's `routeTypes` keep the group's order (present types only), not the
- *   display order, so the caller controls the emoji order. Groups may overlap --
- *   each cluster independently keeps the candidates whose route type is in its
- *   group, so a route type listed in two groups appears on both boards.
+ *   cluster's `routeTypes` are the group's eligible types (group order preserved,
+ *   not display order), and a group with no eligible type is dropped. Groups may
+ *   overlap -- each cluster independently keeps the candidates whose route type is
+ *   in its group, so a route type listed in two groups appears on both boards.
+ *
+ * Eligibility only constrains which route types form clusters and how they are
+ * labelled; empty clusters are NOT turned into boards --
+ * {@link groupCandidatesIntoBoards} drops empty category cells.
  *
  * Clustering is lossy, so the caller chooses the strategy via the condition.
  */
@@ -306,40 +313,30 @@ export function clusterCandidatesByRouteType(
   grouping: TransitDisplayRouteGrouping,
   effectiveRouteTypes: readonly AppRouteTypeValue[],
 ): RouteTypeCluster[] {
-  // This value represents the route types to output even when candidates is empty.
-  const requiredRouteTypes = ROUTE_TYPE_DISPLAY_ORDER.filter((rt) =>
+  // Eligible route types in display order (those served by the stops).
+  const eligibleRouteTypes = ROUTE_TYPE_DISPLAY_ORDER.filter((rt) =>
     effectiveRouteTypes.includes(rt),
   );
 
-  // per route type
   if (grouping.kind === 'route') {
-    return requiredRouteTypes.map((routeType) => {
-      return {
-        routeTypes: [routeType],
-        candidates: selectByRouteType(candidates, routeType),
-      };
-    });
+    return eligibleRouteTypes.map((routeType) => ({
+      routeTypes: [routeType],
+      candidates: selectByRouteType(candidates, routeType),
+    }));
   }
 
-  // no grouping
   if (grouping.kind === 'none') {
-    return [
-      {
-        routeTypes: requiredRouteTypes.flat(),
-        candidates: [...candidates],
-      },
-    ];
+    return [{ routeTypes: eligibleRouteTypes, candidates: [...candidates] }];
   }
 
   // 'custom': one cluster per group (groups may overlap). Keep each group's own
-  // order for routeTypes (present types only), so the caller's order is honored.
-  // const presentSet = new Set<number>(presentRouteTypes);
-  const presentSet = new Set<number>(requiredRouteTypes);
+  // order for routeTypes (eligible types only), so the caller's order is honored.
+  const eligibleSet = new Set<number>(eligibleRouteTypes);
   return grouping.groups
     .map((group) => {
       const groupSet = new Set<number>(group);
       return {
-        routeTypes: group.filter((routeType) => presentSet.has(routeType)),
+        routeTypes: group.filter((routeType) => eligibleSet.has(routeType)),
         candidates: candidates.filter((c) =>
           groupSet.has(c.timetableEntry.routeDirection.route.route_type),
         ),
@@ -349,9 +346,15 @@ export function clusterCandidatesByRouteType(
 }
 
 /**
- * Groups candidates into boards: clusters them by route type (per
- * `routeGrouping`), optionally by direction of travel (when `splitByDirection`),
- * then by category, yielding one board per non-empty cell.
+ * Groups candidates into boards: derives the eligible route types from `stops`
+ * (each stop's `routeTypes`, independent of whether trips remain), clusters
+ * candidates by route type (per `routeGrouping`), optionally by direction of
+ * travel (when `splitByDirection`), then by category, yielding one board per
+ * non-empty cell.
+ *
+ * `stops` are the (already distance-filtered) nearby stops. As a guard it returns
+ * no boards when there are no stops, or none are in service today -- the same
+ * empty cases the caller surfaces via {@link resolveTransitDisplayState}.
  *
  * A trip's `routeDirection.direction` (which mirrors GTFS `direction_id` where
  * the source provides it) is route-local and arbitrary across routes, so a
@@ -367,12 +370,16 @@ export function clusterCandidatesByRouteType(
 export function groupCandidatesIntoBoards(
   candidates: readonly TransitDisplayCandidate[],
   condition: TransitDisplayCondition,
-  // effectiveRouteTypes: readonly AppRouteTypeValue[],
   stops: readonly StopWithContext[],
 ): TransitDisplayData[] {
-  // All route types served by the stops (from each stop's `routeTypes`,
-  // independent of whether any trips remain), in display order -- so a route type
-  // present at a stop can be surfaced as an empty board even with no candidates.
+  // Nothing to show when there are no stops, or none are in service today.
+  if (stops.length === 0 || stops.every((stop) => stop.stopServiceState === 'no-service')) {
+    return [];
+  }
+
+  // Route types served by the stops (from each stop's `routeTypes`, independent
+  // of whether any trips remain), in display order -- so a board's routeTypes
+  // reflect what the stops offer.
   const effectiveRouteTypes: readonly AppRouteTypeValue[] = ROUTE_TYPE_DISPLAY_ORDER.filter(
     (routeType) => stops.some((stop) => stop.routeTypes.includes(routeType)),
   );
@@ -403,14 +410,6 @@ export function groupCandidatesIntoBoards(
         const boardCandidates = cluster.candidates.filter(
           (c) => group.matches(c) && categoryQualifies(c.timetableEntry, category),
         );
-
-        if (stops.length === 0) {
-          continue;
-        }
-
-        if (stops.every((stop) => stop.stopServiceState === 'no-service')) {
-          continue;
-        }
 
         if (boardCandidates.length === 0) {
           continue;
@@ -448,17 +447,23 @@ export function sortAndCapTransitDisplayData(
 /**
  * Runs the structural board-building steps in sequence: distance filter ->
  * flatten -> group into boards (route-type / category clustering) -> sort + cap,
- * then attaches each display's `meta` descriptor. Each step is single-purpose so
- * the next one's concern does not leak into it.
+ * then attaches each display's `meta` descriptor and derived `stats`. Each step
+ * is single-purpose so the next one's concern does not leak into it.
+ *
+ * Returns an empty array when no boards result -- e.g. no stops within the radius,
+ * none in service today, or no candidate qualifies for any cell (see
+ * {@link groupCandidatesIntoBoards}); the caller decides the empty-state UI (see
+ * {@link resolveTransitDisplayState}).
  *
  * Rows are intentionally left RAW: the returned `data` holds the structural
  * board, not resolved UI rows. Resolving display names / times into UI data is
- * the caller's choice, so this stays i18n-free and the UI owns rendering.
+ * the caller's choice, so this stays i18n-free and the UI owns rendering. Each
+ * display also carries {@link TransitDisplayStats} (radius-scope stop stats plus
+ * the per-board pre-cap entry stats) that cannot be recovered from the capped rows.
  *
  * `radiusMeters` (the range stops are selected within; also each display's
  * `meta.radius`) and `condition` (the per-display selection condition) are both
  * required so the caller states the selection scope explicitly.
- * {@link NEARBY_RADIUS_M} is the conventional radius to pass.
  */
 export function buildTransitDisplayDataSet(
   stops: readonly StopWithContext[],
@@ -536,21 +541,20 @@ export function sortTransitDisplayDataWithMetaData(
   });
 }
 
-  export type TransitDisplayStopsState = 'ready' | 'no-stops' | 'no-service';
-  export type TransitDisplayStatus = {
-    radius: number;
-    state: TransitDisplayStopsState;
-  };
+export type TransitDisplayStopsState = 'ready' | 'no-stops' | 'no-service';
+export type TransitDisplayStatus = {
+  radius: number;
+  state: TransitDisplayStopsState;
+};
 
-  export function resolveTransitDisplayState(
-    stops: readonly StopWithContext[],
-  ): TransitDisplayStopsState {
-    if (stops.length === 0) {
-      return 'no-stops';
-    }
-    if (stops.every((stop) => stop.stopServiceState === 'no-service')) {
-      return 'no-service';
-    }
-    return 'ready';
+export function resolveTransitDisplayState(
+  stops: readonly StopWithContext[],
+): TransitDisplayStopsState {
+  if (stops.length === 0) {
+    return 'no-stops';
   }
-
+  if (stops.every((stop) => stop.stopServiceState === 'no-service')) {
+    return 'no-service';
+  }
+  return 'ready';
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -165,6 +165,8 @@
     "recentCount": "Latest {{count}} ({{radius}}m)",
     "entryCount": "{{count}} ({{radius}}m)",
     "stopCount": "{{count}} stops",
+    "empty": "Transit display covers stops within {{radius}}m",
+    "noService": "No service today at stops",
     "departures": "DEPARTURES",
     "arrivals": "ARRIVALS",
     "filter": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -152,6 +152,19 @@
   "transitDisplay": {
     "recentCount": "Latest {{count}} ({{radius}}m)",
     "entryCount": "{{count}} ({{radius}}m)",
+    "stopCount": "{{count}} stops",
+    "departures": "DEPARTURES",
+    "arrivals": "ARRIVALS",
+    "filter": {
+      "label": "Boards to show",
+      "departures": "Departures",
+      "arrivals": "Arrivals"
+    }
+  },
+  "transitDisplay2": {
+    "recentCount": "Latest {{count}} ({{radius}}m)",
+    "entryCount": "{{count}} ({{radius}}m)",
+    "stopCount": "{{count}} stops",
     "departures": "DEPARTURES",
     "arrivals": "ARRIVALS",
     "filter": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -165,6 +165,8 @@
     "recentCount": "直近 {{count}} 件 ({{radius}}m)",
     "entryCount": "{{count}} 件 ({{radius}}m)",
     "stopCount": "{{count}} のりば",
+    "empty": "{{radius}}m 以内にのりばがありません",
+    "noService": "本日の運行便はありません",
     "departures": "出発",
     "arrivals": "到着",
     "filter": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -152,8 +152,21 @@
   "transitDisplay": {
     "recentCount": "直近 {{count}} 件 ({{radius}}m)",
     "entryCount": "{{count}} 件 ({{radius}}m)",
+    "stopCount": "{{count}} のりば",
     "departures": "出発 Departures",
     "arrivals": "到着 Arrivals",
+    "filter": {
+      "label": "表示する便",
+      "departures": "出発",
+      "arrivals": "到着"
+    }
+  },
+  "transitDisplay2": {
+    "recentCount": "直近 {{count}} 件 ({{radius}}m)",
+    "entryCount": "{{count}} 件 ({{radius}}m)",
+    "stopCount": "{{count}} のりば",
+    "departures": "出発",
+    "arrivals": "到着",
     "filter": {
       "label": "表示する便",
       "departures": "出発",

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -4,6 +4,8 @@
  * Provides realistic test data based on actual GTFS sources.
  * Import from `src/stories/fixtures` in story files.
  */
+import type { StopWithMetaStats } from '../domain/transit/compute-stop-with-meta-stats';
+import type { TransitDisplayStats } from '../domain/transit/transit-info-display/build-transit-display-data';
 import type { Agency, Route, Stop } from '../types/app/transit';
 import type {
   ContextualTimetableEntry,
@@ -1298,6 +1300,23 @@ export const headsignLong: TranslatableText = {
     'ja-Hrkt': 'ひじょうに ながい もくてきち けいゆ ちてん を たすう ふくむ いきさき',
     en: 'Very Long Destination Via Many Intermediate Points',
   },
+};
+
+/**
+ * Default radius-scope stop stats for TransitDisplay meta in stories.
+ * Mirrors a small multi-agency cluster (the exact figures are illustrative).
+ */
+export const storyStopStats: StopWithMetaStats = {
+  stopCount: 6,
+  agencyCount: 2,
+  routeCount: 3,
+  routeTypeCount: 1,
+};
+
+/** Default derived stats bundle for a TransitDisplay (radius-scope + per-board). */
+export const storyTransitDisplayStats: TransitDisplayStats = {
+  stopsInRadius: storyStopStats,
+  qualifying: { entryCount: 8, stopCount: 6, routeCount: 3, agencyCount: 2, routeTypeCount: 1 },
 };
 
 /** Default service date for stories. */


### PR DESCRIPTION
## Summary

Continues the `transit-display-2` (modern board) work (#281): adds header stats and empty-state messaging, extracts/cleans the build pipeline, and removes redundant per-render work measured during map drags.

## Changes

### Added
- **Header stats**: TransitDisplay2 header now shows the radius-scope summary (stop / route / agency counts) plus a radius badge, driven by a new domain stat layer (`computeStopWithMetaStats`, `computeRouteStats`, `computeTransitDisplayDatumStats`, `TransitDisplayStats`).
- **Empty-state messaging**: when there are no stops within the radius (`no-stops`) or none are in service today (`no-service`), the view shows the reason instead of a blank panel. The container gates board building on `resolveTransitDisplayState`, so `buildTransitDisplayDataSet` runs only when there is something to show.

### Changed
- **Header layout / sizing**: badge size, text, and layout scale with the display size via a single `HEADER_STATS_ICONS_BY_SIZE` table (small/large variants).
- **Performance**: memoized the per-render work that does not depend on `mapCenter`/`now` — per-entry name/color/headsign/attribute resolution and the board `displayedStats`. Map drags still re-render (distance/bearing track `mapCenter`), but redundant resolution is skipped (measured ~67% fewer resolution calls per drag). The container also memoizes `nearbyStops`/`status` and logs status changes via an effect instead of every render.

### Refactor
- Extracted the distance filter to `stop-meta-filter` as `filterStopsWithinDistance` (generic over `StopWithMeta`, param renamed `maxDistanceMeters`).
- Deduped the split/not-split direction branches in `groupCandidatesIntoBoards`.
- Finalized TSDoc and tests for `buildTransitDisplayDataSet` / `groupCandidatesIntoBoards` / `clusterCandidatesByRouteType`; moved `NEARBY_RADIUS_M` to the container (consumer that owns the radius).
- Earlier branch work: stories for `TransitDisplayEntry2` / `TransitDisplay2` / `AbsoluteStopTime`, route/stop agency-language resolution split, `RouteBadge`/`AgencyBadge` `showBorder` default → `true`, table-driven display sizes.

## Notes
- The remaining per-drag data churn originates upstream (`useStopsForBounds` → `useNearbyStopTimes` re-fetching on map move), outside the transit-display layer — left as a separate task.

## Verification
- `npm run typecheck:build`, `npm run lint`, `npm run test`, `npm run build` all pass.
- Render behaviour measured in-browser (Chrome DevTools): idle = 0 re-renders; map-drag resolution calls reduced after memoization.

Refs: #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)