### PR TITLE
chore(data): update expired GTFS resources (hankyu-ferry, chiyoda-bus, kyoto-bus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [CalVer](https://calver.org/).
 - TransitDisplay2: ヘッダのバッジサイズ / レイアウトを表示サイズ連動に整理した (#281)。
 - TransitDisplay2: 地図ドラッグ中に発生していた board / 行の不要な再計算 (名前 / 色 / 行先解決、表示 stats) を `useMemo` 化して削減した (#281)。
 - transit display のデータ構築を整理した: 距離フィルタを `stop-meta-filter` の `filterStopsWithinDistance` に分離し、`groupCandidatesIntoBoards` の方向分岐を統合、`buildTransitDisplayDataSet` の TSDoc / tests を整備した (#281)。
+- Data-source: hankyu-ferry の GTFS resource を 20260610 版へ更新。
+- Data-source: chiyoda-bus の GTFS resource を 20260601 版へ更新。
+- Data-source: kyoto-bus の GTFS resource を 20260613 版へ更新。
 
 ## [2026.06.08]
 

--- a/pipeline/config/resources/gtfs/chiyoda-bus.ts
+++ b/pipeline/config/resources/gtfs/chiyoda-bus.ts
@@ -18,8 +18,8 @@ const chiyodaBus: GtfsSourceDefinition = {
       datasetUrl:
         'https://ckan.odpt.org/dataset/hitachi_automobile_transportation_chiyoda_alllines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/hitachi_automobile_transportation_chiyoda_alllines/resource/0dfb9750-ed72-4f5a-9368-76ad4a5adea9',
-      resourceId: '0dfb9750-ed72-4f5a-9368-76ad4a5adea9',
+        'https://ckan.odpt.org/dataset/hitachi_automobile_transportation_chiyoda_alllines/resource/45cab9b6-8e6a-405e-812d-20503c622326',
+      resourceId: '45cab9b6-8e6a-405e-812d-20503c622326',
     },
     provider: {
       name: {
@@ -36,7 +36,7 @@ const chiyodaBus: GtfsSourceDefinition = {
     /** GtfsResource */
     routeTypes: ['bus'],
     downloadUrl:
-      'https://api-public.odpt.org/api/v4/files/odpt/HitachiAutomobileTransportation/Chiyoda_ALLLINES.zip?date=20260401',
+      'https://api-public.odpt.org/api/v4/files/odpt/HitachiAutomobileTransportation/Chiyoda_ALLLINES.zip?date=20260601',
   },
   pipeline: {
     outDir: 'chiyoda-bus',

--- a/pipeline/config/resources/gtfs/hankyu-ferry.ts
+++ b/pipeline/config/resources/gtfs/hankyu-ferry.ts
@@ -17,8 +17,8 @@ const hankyuFerry: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/hankyu_ferry',
       datasetUrl: 'https://ckan.odpt.org/dataset/hankyu_ferry_schedul_hankyu',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/hankyu_ferry_schedul_hankyu/resource/1c1fa67f-7a81-4107-b7f3-fe098096cb27',
-      resourceId: '1c1fa67f-7a81-4107-b7f3-fe098096cb27',
+        'https://ckan.odpt.org/dataset/hankyu_ferry_schedul_hankyu/resource/96223965-11e6-4b52-9662-9413a0f32f52',
+      resourceId: '96223965-11e6-4b52-9662-9413a0f32f52',
     },
     provider: {
       name: {
@@ -39,7 +39,7 @@ const hankyuFerry: GtfsSourceDefinition = {
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
     downloadUrl:
-      'https://api.odpt.org/api/v4/files/odpt/HankyuFerry/schedul_hankyu.zip?date=20260522',
+      'https://api.odpt.org/api/v4/files/odpt/HankyuFerry/schedul_hankyu.zip?date=20260610',
   },
   pipeline: {
     outDir: 'hankyu-ferry',

--- a/pipeline/config/resources/gtfs/kyoto-bus.ts
+++ b/pipeline/config/resources/gtfs/kyoto-bus.ts
@@ -17,8 +17,8 @@ const kyotoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/kyoto_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/kyoto_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/59778778-ecc0-4146-89b6-c7e275cf9c48',
-      resourceId: '59778778-ecc0-4146-89b6-c7e275cf9c48',
+        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/586d66a4-1562-49bc-92d1-5b1e50cc13bd',
+      resourceId: '586d66a4-1562-49bc-92d1-5b1e50cc13bd',
     },
     provider: {
       name: {
@@ -38,7 +38,7 @@ const kyotoBus: GtfsSourceDefinition = {
     routeTypes: ['bus'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260516',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260613',
   },
   pipeline: {
     outDir: 'kyoto-bus',


### PR DESCRIPTION
## Summary

The scheduled **Update Transit Data** / **Check Transit Resources** runs failed because several adopted ODPT feeds expired (or were about to). Bump the sources that have a valid current resource to their latest CKAN version.

## Updated sources (resourceUrl / resourceId / downloadUrl date)

| Source | date | Note |
| --- | --- | --- |
| hankyu-ferry | 20260522 → **20260610** | adopted feed was expiring 2026-06-09; new CKAN resource |
| chiyoda-bus | 20260401 → **20260601** | adopted feed expired; `REMOTE_NEW_IN_PERIOD` (valid 2026-06-02 – 2027-12-31) |
| kyoto-bus | 20260516 → **20260613** | new CKAN version, valid 2026-06-07 – 2026-09-30, GTFS validation: no errors |

Each source's `catalog.resourceUrl`, `catalog.resourceId`, and `downloadUrl` (`date=`) were updated to the current CKAN resource.

## Not updated (no valid successor)

- **chuo-bus** and **suginami-gsm** are `ADOPTED_EXPIRED` + `REMOTE_NO_VALID_DATA` (no currently valid resource on ODPT), so they cannot be bumped here. They need a separate decision (verify on CKAN / disable / accept expired).

## Verification

- `npm run typecheck`, `prettier --check` pass for the changed files.
- Pipeline download / build / validate run in CI (the resource fetch needs the ODPT consumer key configured in the workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)