### PR TITLE
chore(data-source): update keio-bus to 20260404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [CalVer](https://calver.org/).
 ### Changed
 
 - Hooks: `useScrollFades` を `useScrollOverflow` にリネームした (`showTop` / `showBottom` -> `hasContentAbove` / `hasContentBelow`、`handleScroll` -> `update`。フェードではなく「スクロール上下に隠れたコンテンツの有無の観測」という責務を名前に反映。挙動変更なし)。
+- Data-source: keio-bus の GTFS resource を 20260404 版へ更新。
 
 ### Fixed
 

--- a/pipeline/config/resources/gtfs/keio-bus.ts
+++ b/pipeline/config/resources/gtfs/keio-bus.ts
@@ -16,8 +16,8 @@ const keioBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/keio_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/keio_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/d0212d4f-cc57-4fc6-9b90-6197e2d38552',
-      resourceId: 'd0212d4f-cc57-4fc6-9b90-6197e2d38552',
+        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/76ce041a-6817-4e3e-a1a3-39e33153f0e0',
+      resourceId: '76ce041a-6817-4e3e-a1a3-39e33153f0e0',
     },
     provider: {
       name: {
@@ -43,7 +43,7 @@ const keioBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260401',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260404',
   },
   pipeline: {
     outDir: 'keio-bus',


### PR DESCRIPTION
## Summary

Update the Keio Bus GTFS resource definition to the latest version published on CKAN.

- `resourceId`: `d0212d4f-...` -> `76ce041a-6817-4e3e-a1a3-39e33153f0e0`
- `resourceUrl`: follows the new `resourceId`
- `downloadUrl` date: `20260401` -> `20260404`

Feed validity (from the downloaded feed_info): 20260404 - 20261231.

## CHANGELOG

Added under `[Unreleased]` / `Changed`:

> Data-source: keio-bus の GTFS resource を 20260404 版へ更新。

## Notes

- Only the resource definition and CHANGELOG are committed here. The actual data bundles (`public/`) and `download-meta` are regenerated/committed by CI.
- Verified locally end-to-end (download -> build:db -> v2-data -> insights -> global-insights -> catalog -> validate -> sync); kobus `data.json` / `insights.json` validate OK. This feed contains no shapes (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)