### PR TITLE
refactor(domain): split timetable stats counts by axis (faithful vs passenger)

### DIFF
--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -304,8 +304,8 @@ describe('App anchor error toast', () => {
       filteredNearbyStopsCounts: {
         total: number;
         nonEmpty: number;
-        originCount: number;
-        boardableCount: number;
+        position: { originCount: number };
+        passenger: { boardableCount: number };
       };
     };
   };
@@ -600,7 +600,7 @@ describe('App anchor error toast', () => {
       expect(props.globalFilter.omitEmptyStops).toBe(true);
       expect(props.globalFilter.isOmitEmptyStopsForced).toBe(true);
       expect(props.filteredNearbyStopsCounts.total).toBe(1);
-      expect(props.filteredNearbyStopsCounts.boardableCount).toBe(1);
+      expect(props.filteredNearbyStopsCounts.passenger.boardableCount).toBe(1);
     });
   });
 

--- a/src/components/dialog/__tests__/dialog-memoization.test.tsx
+++ b/src/components/dialog/__tests__/dialog-memoization.test.tsx
@@ -306,20 +306,16 @@ beforeEach(() => {
   computeTimetableEntryStatsMock.mockReset();
   computeTimetableEntryStatsMock.mockReturnValue({
     totalCount: 1,
-    originCount: 1,
-    terminalCount: 0,
-    passingCount: 0,
-    boardableCount: 1,
-    nonBoardableCount: 0,
-    dropOffOnlyCount: 0,
-    noDropOffCount: 0,
-    routeCount: 1,
-    directionCount: 1,
-    tripHeadsignCount: 1,
-    stopHeadsignCount: 1,
-    patternCount: 1,
-    serviceCount: 1,
-    uniqueTripCount: 1,
+    position: { originCount: 1, terminalCount: 0, passingCount: 0 },
+    signal: { noPickupCount: 0, noDropOffCount: 0 },
+    passenger: { boardableCount: 1, nonBoardableCount: 0 },
+    routeDirection: {
+      routeCount: 1,
+      directionCount: 1,
+      tripHeadsignCount: 1,
+      stopHeadsignCount: 1,
+    },
+    tripLocator: { patternCount: 1, serviceCount: 1, uniqueTripCount: 1 },
   });
   tripStopsRenderMock.mockReset();
   vi.stubGlobal(

--- a/src/components/dialog/__tests__/timetable-dialog-state-leak.test.tsx
+++ b/src/components/dialog/__tests__/timetable-dialog-state-leak.test.tsx
@@ -57,13 +57,16 @@ vi.mock('@/components/verbose/verbose-timetable-summary', () => ({
 vi.mock('@/domain/transit/timetable-stats', () => ({
   computeTimetableEntryStats: () => ({
     totalCount: 0,
-    originCount: 0,
-    terminalCount: 0,
-    boardableCount: 0,
-    nonBoardableCount: 0,
-    noPickupCount: 0,
-    noDropOffCount: 0,
-    dropOffOnlyCount: 0,
+    position: { originCount: 0, terminalCount: 0, passingCount: 0 },
+    signal: { noPickupCount: 0, noDropOffCount: 0 },
+    passenger: { boardableCount: 0, nonBoardableCount: 0 },
+    routeDirection: {
+      routeCount: 0,
+      directionCount: 0,
+      tripHeadsignCount: 0,
+      stopHeadsignCount: 0,
+    },
+    tripLocator: { patternCount: 0, serviceCount: 0, uniqueTripCount: 0 },
   }),
 }));
 

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -564,14 +564,14 @@ export const TimetableDialog = memo(function TimetableDialog({
               {/* Boardability filter */}
               <BoardabilityFilter
                 boardable={showBoardableOnly}
-                count={stopEventAttributesFilteredEntriesStats.boardableCount}
+                count={stopEventAttributesFilteredEntriesStats.passenger.boardableCount}
                 onToggleBoardable={onToggleShowBoardableOnly}
               />
               {/* Origin filter — hidden when no origin entries exist at this stop */}
-              {stopEventAttributesFilteredEntriesStats.originCount > 0 && (
+              {stopEventAttributesFilteredEntriesStats.position.originCount > 0 && (
                 <OriginFilter
                   origin={showOriginOnly}
-                  count={stopEventAttributesFilteredEntriesStats.originCount}
+                  count={stopEventAttributesFilteredEntriesStats.position.originCount}
                   onToggleOrigin={onToggleShowOriginOnly}
                 />
               )}

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -501,6 +501,7 @@ export const TimetableDialog = memo(function TimetableDialog({
                 headsign={data.headsign}
                 serviceDate={data.serviceDate}
                 timetableEntries={stopEventAttributesFilteredEntries}
+                stats={stopEventAttributesFilteredEntriesStats}
                 omitted={data.omitted}
                 stopServiceState={data.stopServiceState}
               />

--- a/src/components/stop-browser-header.stories.tsx
+++ b/src/components/stop-browser-header.stories.tsx
@@ -31,12 +31,17 @@ import { StopBrowserHeader } from './stop-browser-header';
 const defaultStopsRadius = PERF_PROFILES.normal.data.stops.nearbyRadius;
 const selectView = (id: StopTimeViewId) => STOP_TIMES_VIEWS.find((v) => v.id === id);
 const defaultSelectedView = selectView(DEFAULT_VIEW_ID);
-const defaultCounts = { total: 12, nonEmpty: 7, originCount: 3, boardableCount: 5 };
+const defaultCounts = {
+  total: 12,
+  nonEmpty: 7,
+  position: { originCount: 3 },
+  passenger: { boardableCount: 5 },
+};
 const defaultFilteredNearbyStopsCounts = {
   total: 7,
   nonEmpty: 7,
-  originCount: 3,
-  boardableCount: 5,
+  position: { originCount: 3 },
+  passenger: { boardableCount: 5 },
 };
 
 /** All route type values defined in APP_ROUTE_TYPES except the `-1` unknown placeholder. */
@@ -103,17 +108,47 @@ export const Default: Story = {};
 export const Loading: Story = {
   args: {
     hasNearbyLoaded: false,
-    counts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
-    nearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
-    filteredNearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    counts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
+    nearbyStopsCounts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
+    filteredNearbyStopsCounts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
   },
 };
 
 export const NoStops: Story = {
   args: {
-    counts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
-    nearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
-    filteredNearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    counts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
+    nearbyStopsCounts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
+    filteredNearbyStopsCounts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
     presentRouteTypes: [],
     presentAgencies: [],
   },
@@ -121,9 +156,24 @@ export const NoStops: Story = {
 
 export const NoOperatingStops: Story = {
   args: {
-    counts: { total: 8, nonEmpty: 0, originCount: 0, boardableCount: 0 },
-    nearbyStopsCounts: { total: 8, nonEmpty: 0, originCount: 0, boardableCount: 0 },
-    filteredNearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    counts: {
+      total: 8,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
+    nearbyStopsCounts: {
+      total: 8,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
+    filteredNearbyStopsCounts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
     omitEmptyStops: true,
     presentRouteTypes: [3],
     presentAgencies: [agencyTobus],
@@ -132,26 +182,71 @@ export const NoOperatingStops: Story = {
 
 export const OperatingOnlyActive: Story = {
   args: {
-    counts: { total: 15, nonEmpty: 9, originCount: 4, boardableCount: 7 },
-    nearbyStopsCounts: { total: 15, nonEmpty: 9, originCount: 4, boardableCount: 7 },
-    filteredNearbyStopsCounts: { total: 9, nonEmpty: 9, originCount: 4, boardableCount: 7 },
+    counts: {
+      total: 15,
+      nonEmpty: 9,
+      position: { originCount: 4 },
+      passenger: { boardableCount: 7 },
+    },
+    nearbyStopsCounts: {
+      total: 15,
+      nonEmpty: 9,
+      position: { originCount: 4 },
+      passenger: { boardableCount: 7 },
+    },
+    filteredNearbyStopsCounts: {
+      total: 9,
+      nonEmpty: 9,
+      position: { originCount: 4 },
+      passenger: { boardableCount: 7 },
+    },
     omitEmptyStops: true,
   },
 };
 
 export const OriginFilterHidden: Story = {
   args: {
-    counts: { total: 12, nonEmpty: 7, originCount: 0, boardableCount: 5 },
-    nearbyStopsCounts: { total: 12, nonEmpty: 7, originCount: 0, boardableCount: 5 },
-    filteredNearbyStopsCounts: { total: 7, nonEmpty: 7, originCount: 0, boardableCount: 5 },
+    counts: {
+      total: 12,
+      nonEmpty: 7,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 5 },
+    },
+    nearbyStopsCounts: {
+      total: 12,
+      nonEmpty: 7,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 5 },
+    },
+    filteredNearbyStopsCounts: {
+      total: 7,
+      nonEmpty: 7,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 5 },
+    },
   },
 };
 
 export const OriginFilterActiveWithoutNearbyOrigins: Story = {
   args: {
-    counts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
-    nearbyStopsCounts: { total: 12, nonEmpty: 7, originCount: 0, boardableCount: 5 },
-    filteredNearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    counts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
+    nearbyStopsCounts: {
+      total: 12,
+      nonEmpty: 7,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 5 },
+    },
+    filteredNearbyStopsCounts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
     showOriginOnly: true,
   },
 };
@@ -252,9 +347,24 @@ export const ViewVerboseDescription: Story = {
 export const SizeComparison: Story = {
   args: {
     infoLevel: 'verbose',
-    counts: { total: 42, nonEmpty: 28, originCount: 6, boardableCount: 15 },
-    nearbyStopsCounts: { total: 42, nonEmpty: 28, originCount: 6, boardableCount: 15 },
-    filteredNearbyStopsCounts: { total: 21, nonEmpty: 21, originCount: 6, boardableCount: 15 },
+    counts: {
+      total: 42,
+      nonEmpty: 28,
+      position: { originCount: 6 },
+      passenger: { boardableCount: 15 },
+    },
+    nearbyStopsCounts: {
+      total: 42,
+      nonEmpty: 28,
+      position: { originCount: 6 },
+      passenger: { boardableCount: 15 },
+    },
+    filteredNearbyStopsCounts: {
+      total: 21,
+      nonEmpty: 21,
+      position: { originCount: 6 },
+      passenger: { boardableCount: 15 },
+    },
     omitEmptyStops: true,
   },
   render: (args) => (
@@ -317,9 +427,24 @@ export const InfoLevelVerbose: Story = {
 
 const kitchenSinkArgs: Story['args'] = {
   hasNearbyLoaded: true,
-  counts: { total: 42, nonEmpty: 28, originCount: 6, boardableCount: 15 },
-  nearbyStopsCounts: { total: 42, nonEmpty: 28, originCount: 6, boardableCount: 15 },
-  filteredNearbyStopsCounts: { total: 21, nonEmpty: 21, originCount: 6, boardableCount: 15 },
+  counts: {
+    total: 42,
+    nonEmpty: 28,
+    position: { originCount: 6 },
+    passenger: { boardableCount: 15 },
+  },
+  nearbyStopsCounts: {
+    total: 42,
+    nonEmpty: 28,
+    position: { originCount: 6 },
+    passenger: { boardableCount: 15 },
+  },
+  filteredNearbyStopsCounts: {
+    total: 21,
+    nonEmpty: 21,
+    position: { originCount: 6 },
+    passenger: { boardableCount: 15 },
+  },
   stopsRadius: defaultStopsRadius,
   dataLangs: ['ja'],
   omitEmptyStops: true,

--- a/src/components/stop-browser-header.tsx
+++ b/src/components/stop-browser-header.tsx
@@ -121,7 +121,7 @@ export function StopBrowserHeader({
 
   const operatingStopsActiveBg = 'var(--info)';
   const operatingStopsBorder = 'var(--info)';
-  const shouldShowOriginFilter = showOriginOnly || nearbyStopsCounts.originCount > 0;
+  const shouldShowOriginFilter = showOriginOnly || nearbyStopsCounts.position.originCount > 0;
   const nearbyStopsCountsDebugLog = formatStopsCountsDebugLog(nearbyStopsCounts);
   const filteredNearbyStopsCountsDebugLog = formatStopsCountsDebugLog(filteredNearbyStopsCounts);
   const countsDebugLog = formatStopsCountsDebugLog(counts);
@@ -202,7 +202,7 @@ export function StopBrowserHeader({
         <BoardabilityFilter
           boardable={showBoardableOnly}
           onToggleBoardable={onToggleShowBoardableOnly}
-          count={countsForFilterLabel.boardableCount}
+          count={countsForFilterLabel.passenger.boardableCount}
           size={pillSize}
         />
 
@@ -211,7 +211,7 @@ export function StopBrowserHeader({
           <OriginFilter
             origin={showOriginOnly}
             onToggleOrigin={onToggleShowOriginOnly}
-            count={countsForFilterLabel.originCount}
+            count={countsForFilterLabel.position.originCount}
             size={pillSize}
           />
         )}
@@ -272,5 +272,5 @@ export function StopBrowserHeader({
 }
 
 function formatStopsCountsDebugLog(counts: StopsCounts): string {
-  return `total=${counts.total} nonEmpty=${counts.nonEmpty} boardable=${counts.boardableCount} origin=${counts.originCount}`;
+  return `total=${counts.total} nonEmpty=${counts.nonEmpty} boardable=${counts.passenger.boardableCount} origin=${counts.position.originCount}`;
 }

--- a/src/components/stop-browser.stories.tsx
+++ b/src/components/stop-browser.stories.tsx
@@ -189,8 +189,18 @@ export const Loading: Story = {
     hasNearbyLoaded: false,
     stopTimes: [],
     timetableEntriesStateByStopId: new Map<string, TimetableEntriesState>(),
-    nearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
-    filteredNearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    nearbyStopsCounts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
+    filteredNearbyStopsCounts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
   },
 };
 
@@ -198,8 +208,18 @@ export const NoStops: Story = {
   args: {
     stopTimes: [],
     timetableEntriesStateByStopId: new Map<string, TimetableEntriesState>(),
-    nearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
-    filteredNearbyStopsCounts: { total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 },
+    nearbyStopsCounts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
+    filteredNearbyStopsCounts: {
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    },
   },
 };
 

--- a/src/components/stops-summary.stories.tsx
+++ b/src/components/stops-summary.stories.tsx
@@ -6,22 +6,22 @@ import { StopsSummary } from './stops-summary';
 const defaultTotalCount: StopsCounts = {
   total: 60,
   nonEmpty: 42,
-  originCount: 8,
-  boardableCount: 36,
+  position: { originCount: 8 },
+  passenger: { boardableCount: 36 },
 };
 
 const emptyCount: StopsCounts = {
   total: 0,
   nonEmpty: 0,
-  originCount: 0,
-  boardableCount: 0,
+  position: { originCount: 0 },
+  passenger: { boardableCount: 0 },
 };
 
 const noOperatingCount: StopsCounts = {
   total: 24,
   nonEmpty: 0,
-  originCount: 0,
-  boardableCount: 0,
+  position: { originCount: 0 },
+  passenger: { boardableCount: 0 },
 };
 
 const meta = {
@@ -176,8 +176,8 @@ const kitchenSinkArgs = {
   totalCount: {
     total: 1_234,
     nonEmpty: 987,
-    originCount: 321,
-    boardableCount: 876,
+    position: { originCount: 321 },
+    passenger: { boardableCount: 876 },
   },
   filteredCount: 987,
   nearbyRadius: 2_000,

--- a/src/components/stops-summary.tsx
+++ b/src/components/stops-summary.tsx
@@ -71,7 +71,7 @@ function buildStopsSummaryText(
 }
 
 function formatStopsCountsDebugLog(counts: StopsCounts): string {
-  return `total=${counts.total} nonEmpty=${counts.nonEmpty} boardable=${counts.boardableCount} origin=${counts.originCount}`;
+  return `total=${counts.total} nonEmpty=${counts.nonEmpty} boardable=${counts.passenger.boardableCount} origin=${counts.position.originCount}`;
 }
 
 export function StopsSummary({

--- a/src/components/timetable/timetable-metadata.tsx
+++ b/src/components/timetable/timetable-metadata.tsx
@@ -44,15 +44,15 @@ function PatternPositionAxisStats({ stats }: { stats: TimetableEntryStats }) {
     <span>
       {'['}
       {t('timetable.metadata.originCount', {
-        count: stats.originCount.toLocaleString(i18n.language),
+        count: stats.position.originCount.toLocaleString(i18n.language),
       })}
       {' / '}
       {t('timetable.metadata.terminalCount', {
-        count: stats.terminalCount.toLocaleString(i18n.language),
+        count: stats.position.terminalCount.toLocaleString(i18n.language),
       })}
       {' / '}
       {t('timetable.metadata.passingCount', {
-        count: stats.passingCount.toLocaleString(i18n.language),
+        count: stats.position.passingCount.toLocaleString(i18n.language),
       })}
       {']'}
     </span>
@@ -70,7 +70,7 @@ function PatternPositionAxisBadges({ stats }: { stats: TimetableEntryStats }) {
     <div className="flex flex-wrap gap-1">
       <LabelCountBadge
         label={t('timetable.entry.origin')}
-        count={stats.originCount}
+        count={stats.position.originCount}
         size="sm"
         frameClassName="border-blue-500"
         labelClassName={originLabelBadgeClassName}
@@ -78,7 +78,7 @@ function PatternPositionAxisBadges({ stats }: { stats: TimetableEntryStats }) {
       />
       <LabelCountBadge
         label={t('timetable.entry.terminal')}
-        count={stats.terminalCount}
+        count={stats.position.terminalCount}
         size="sm"
         frameClassName="border-gray-500"
         labelClassName={terminalLabelBadgeClassName}
@@ -102,19 +102,19 @@ function BoardingAxisStats({ stats }: { stats: TimetableEntryStats }) {
     <span>
       {'['}
       {t('timetable.metadata.boardableCount', {
-        count: stats.boardableCount.toLocaleString(i18n.language),
+        count: stats.passenger.boardableCount.toLocaleString(i18n.language),
       })}
       {' / '}
       {t('timetable.metadata.nonBoardableCount', {
-        count: stats.nonBoardableCount.toLocaleString(i18n.language),
+        count: stats.passenger.nonBoardableCount.toLocaleString(i18n.language),
       })}
       {' / '}
       {t('timetable.metadata.dropOffOnlyCount', {
-        count: stats.dropOffOnlyCount.toLocaleString(i18n.language),
+        count: stats.signal.noPickupCount.toLocaleString(i18n.language),
       })}
       {' / '}
       {t('timetable.metadata.noDropOffCount', {
-        count: stats.noDropOffCount.toLocaleString(i18n.language),
+        count: stats.signal.noDropOffCount.toLocaleString(i18n.language),
       })}
       {']'}
     </span>
@@ -135,22 +135,22 @@ function BoardingAxisBadges({ stats }: { stats: TimetableEntryStats }) {
     <div className="flex flex-wrap gap-1">
       <LabelCountBadge
         label={t('stop.serviceState.boardable')}
-        count={stats.boardableCount}
+        count={stats.passenger.boardableCount}
         size="sm"
       />
-      {/* <LabelCountBadge label={t('timetable.entry.noPickup')} count={stats.nonBoardableCount} /> */}
+      {/* <LabelCountBadge label={t('timetable.entry.noPickup')} count={stats.passenger.nonBoardableCount} /> */}
       <LabelCountBadge
         label={t('timetable.entry.noPickup')}
-        count={stats.nonBoardableCount}
+        count={stats.passenger.nonBoardableCount}
         size="sm"
         frameClassName="border-yellow-600"
         labelClassName={noPickupLabelBadgeClassName}
         countClassName={noPickupCountBadgeClassName}
       />
-      {/* <LabelCountBadge label={t('timetable.entry.noDropOff')} count={stats.noDropOffCount} /> */}
+      {/* <LabelCountBadge label={t('timetable.entry.noDropOff')} count={stats.signal.noDropOffCount} /> */}
       <LabelCountBadge
         label={t('timetable.entry.noDropOff')}
-        count={stats.noDropOffCount}
+        count={stats.signal.noDropOffCount}
         size="sm"
         frameClassName="border-dashed border-yellow-600"
         labelClassName={noDropOffLabelBadgeClassName}
@@ -158,7 +158,7 @@ function BoardingAxisBadges({ stats }: { stats: TimetableEntryStats }) {
       />
       <LabelCountBadge
         label={t('stop.serviceState.dropOffOnly')}
-        count={stats.dropOffOnlyCount}
+        count={stats.signal.noPickupCount}
         size="sm"
       />
     </div>
@@ -182,19 +182,19 @@ function RouteDirectionAxisStats({ stats }: { stats: TimetableEntryStats }) {
       <span>
         {'['}
         {t('timetable.metadata.routeCount', {
-          count: stats.routeCount.toLocaleString(i18n.language),
+          count: stats.routeDirection.routeCount.toLocaleString(i18n.language),
         })}
         {' / '}
         {t('timetable.metadata.headsignCount', {
-          count: stats.stopHeadsignCount.toLocaleString(i18n.language),
+          count: stats.routeDirection.stopHeadsignCount.toLocaleString(i18n.language),
         })}
         {'] / ['}
         {t('timetable.metadata.routeHeadsignCount', {
-          count: stats.tripHeadsignCount.toLocaleString(i18n.language),
+          count: stats.routeDirection.tripHeadsignCount.toLocaleString(i18n.language),
         })}
         {' / '}
         {t('timetable.metadata.directionCount', {
-          count: stats.directionCount.toLocaleString(i18n.language),
+          count: stats.routeDirection.directionCount.toLocaleString(i18n.language),
         })}
         {']'}
       </span>

--- a/src/components/verbose/verbose-timetable-summary.tsx
+++ b/src/components/verbose/verbose-timetable-summary.tsx
@@ -1,19 +1,27 @@
 import type { TimetableEntry } from '../../types/app/transit-composed';
 import type { StopServiceState } from '../../types/app/transit';
 import type { TimetableOmitted } from '../../types/app/repository';
+import type { TimetableEntryStats } from '../../domain/transit/timetable-stats';
 import { formatDateKey } from '../../domain/transit/calendar-utils';
-import { isBoardableForPassenger } from '../../domain/transit/timetable-entry-for-passenger';
 
 /**
  * Debug dump of timetable-level metadata and entry statistics.
  * Includes its own details/summary for collapsed display.
  * Only rendered in verbose info level.
+ *
+ * Goal is an exhaustive, debug-useful dump of the data. The canonical
+ * scalar counts come from {@link TimetableEntryStats} (passed in, not
+ * recomputed, so this dump always agrees with the dialog metadata and
+ * the boardable-only filter), grouped by the same axes. Breakdowns that
+ * the stats object does not carry (per-direction / per-pattern tallies,
+ * dwell) are computed inline from `timetableEntries`.
  */
 export function VerboseTimetableSummary({
   type,
   headsign,
   serviceDate,
   timetableEntries,
+  stats,
   omitted,
   stopServiceState,
 }: {
@@ -21,16 +29,14 @@ export function VerboseTimetableSummary({
   headsign?: string;
   serviceDate: Date;
   timetableEntries: TimetableEntry[];
+  /** Canonical aggregated counts for `timetableEntries` (computed by the parent). */
+  stats: TimetableEntryStats;
   omitted: TimetableOmitted;
   stopServiceState: StopServiceState;
 }) {
-  // Domain-consistent counts using isBoardableForPassenger (pickupType !== 1 AND not the
-  // pattern's last stop). pickupType 2/3 (phone/coordination required) are
-  // considered boardable.
-  const dropOff = timetableEntries.filter((e) => !isBoardableForPassenger(e)).length;
-  const boardable = timetableEntries.length - dropOff;
-  const originCount = timetableEntries.filter((e) => e.patternPosition.isFirstStop).length;
-  const terminalCount = timetableEntries.filter((e) => e.patternPosition.isLastStop).length;
+  // Breakdowns not carried by TimetableEntryStats (per-value tallies),
+  // computed inline because the verbose dump wants the full distribution,
+  // not just the unique-value count the stats object exposes.
 
   // Direction breakdown
   const dirCounts = new Map<string, number>();
@@ -68,8 +74,28 @@ export function VerboseTimetableSummary({
           </span>
           {headsign != null && <span className="block">[headsign] &quot;{headsign}&quot;</span>}
           <span className="block">
-            [entries] total={timetableEntries.length} boardable={boardable} dropOffOnly={dropOff}{' '}
-            origin={originCount} terminal={terminalCount}
+            [entries] total={stats.totalCount} uniqueTrips={stats.tripLocator.uniqueTripCount}
+          </span>
+          <span className="block">
+            [position] origin={stats.position.originCount} terminal={stats.position.terminalCount}{' '}
+            passing={stats.position.passingCount}
+          </span>
+          <span className="block">
+            [passenger] boardable={stats.passenger.boardableCount} nonBoardable=
+            {stats.passenger.nonBoardableCount}
+          </span>
+          <span className="block">
+            [signal] noPickup={stats.signal.noPickupCount} noDropOff={stats.signal.noDropOffCount}
+          </span>
+          <span className="block">
+            [routeDirection] routes={stats.routeDirection.routeCount} directions=
+            {stats.routeDirection.directionCount} tripHeadsigns=
+            {stats.routeDirection.tripHeadsignCount} stopHeadsigns=
+            {stats.routeDirection.stopHeadsignCount}
+          </span>
+          <span className="block">
+            [tripLocator] patterns={stats.tripLocator.patternCount} services=
+            {stats.tripLocator.serviceCount}
           </span>
           <span className="block">
             [direction]{' '}

--- a/src/domain/transit/__tests__/compute-stops-counts.test.ts
+++ b/src/domain/transit/__tests__/compute-stops-counts.test.ts
@@ -41,8 +41,8 @@ describe('computeStopsCounts', () => {
     expect(computeStopsCounts([])).toEqual({
       total: 0,
       nonEmpty: 0,
-      originCount: 0,
-      boardableCount: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
     });
   });
 
@@ -66,10 +66,10 @@ describe('computeStopsCounts', () => {
     ).toEqual({
       total: 5,
       nonEmpty: 4,
-      originCount: 2,
+      position: { originCount: 2 },
       // oneStopTrip is NOT boardable: isBoardableForPassenger treats a last-stop row
       // as not boardable even when it is also the first stop.
-      boardableCount: 1,
+      passenger: { boardableCount: 1 },
     });
   });
 
@@ -108,8 +108,8 @@ describe('computeStopsCounts', () => {
     ).toEqual({
       total: 6,
       nonEmpty: 6,
-      originCount: 2,
-      boardableCount: 3,
+      position: { originCount: 2 },
+      passenger: { boardableCount: 3 },
     });
   });
 });

--- a/src/domain/transit/__tests__/derive-filtered-nearby-stops.test.ts
+++ b/src/domain/transit/__tests__/derive-filtered-nearby-stops.test.ts
@@ -82,12 +82,17 @@ describe('deriveFilteredNearbyStops', () => {
 
     expect(result.filtered).toEqual([]);
     expect(result.timetableEntriesStateByStopId.size).toBe(0);
-    expect(result.rawCounts).toEqual({ total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 });
+    expect(result.rawCounts).toEqual({
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    });
     expect(result.filteredCounts).toEqual({
       total: 0,
       nonEmpty: 0,
-      originCount: 0,
-      boardableCount: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
     });
   });
 
@@ -231,15 +236,15 @@ describe('deriveFilteredNearbyStops', () => {
     // (1 stop, originCount=1 since the stop has at least one origin
     // entry, boardableCount=1 since at least one boardable entry exists).
     expect(result.rawCounts.total).toBe(1);
-    expect(result.rawCounts.originCount).toBe(1);
-    expect(result.rawCounts.boardableCount).toBe(1);
+    expect(result.rawCounts.position.originCount).toBe(1);
+    expect(result.rawCounts.passenger.boardableCount).toBe(1);
 
     // filteredCounts is post-globalFilter; still 1 stop because we did
     // not enable omitEmptyStops, and the remaining entry is both an
     // origin and boardable so all per-attribute counts are 1.
     expect(result.filteredCounts.total).toBe(1);
-    expect(result.filteredCounts.originCount).toBe(1);
-    expect(result.filteredCounts.boardableCount).toBe(1);
+    expect(result.filteredCounts.position.originCount).toBe(1);
+    expect(result.filteredCounts.passenger.boardableCount).toBe(1);
   });
 
   it('returns drop-off-only state when every pre-globalFilter entry is drop-off-only', () => {
@@ -340,8 +345,8 @@ describe('deriveFilteredNearbyStops', () => {
     expect(result.rawCounts).toEqual({
       total: 4,
       nonEmpty: 3,
-      originCount: 1,
-      boardableCount: 2,
+      position: { originCount: 1 },
+      passenger: { boardableCount: 2 },
     });
 
     // filteredCounts: showBoardableOnly removes the entries inside
@@ -351,8 +356,8 @@ describe('deriveFilteredNearbyStops', () => {
     expect(result.filteredCounts).toEqual({
       total: 2,
       nonEmpty: 2,
-      originCount: 1,
-      boardableCount: 2,
+      position: { originCount: 1 },
+      passenger: { boardableCount: 2 },
     });
 
     // Filtered list reflects the same two stops in input order.
@@ -427,10 +432,10 @@ describe('deriveFilteredNearbyStops', () => {
 
     // rawCounts: both stops counted, route-type filter only.
     expect(result.rawCounts.total).toBe(2);
-    expect(result.rawCounts.originCount).toBe(1);
+    expect(result.rawCounts.position.originCount).toBe(1);
     // filteredCounts: only the origin stop survives the globalFilter + omit.
     expect(result.filteredCounts.total).toBe(1);
-    expect(result.filteredCounts.originCount).toBe(1);
+    expect(result.filteredCounts.position.originCount).toBe(1);
   });
 
   it('returns no-service state for stops with empty stopTimes pre-filter', () => {
@@ -502,12 +507,17 @@ describe('deriveFilteredNearbyStops', () => {
 
     expect(result.filtered).toEqual([]);
     expect(result.timetableEntriesStateByStopId.size).toBe(0);
-    expect(result.rawCounts).toEqual({ total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 });
+    expect(result.rawCounts).toEqual({
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    });
     expect(result.filteredCounts).toEqual({
       total: 0,
       nonEmpty: 0,
-      originCount: 0,
-      boardableCount: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
     });
   });
 
@@ -529,12 +539,17 @@ describe('deriveFilteredNearbyStops', () => {
 
     expect(result.filtered).toEqual([]);
     expect(result.timetableEntriesStateByStopId.size).toBe(0);
-    expect(result.rawCounts).toEqual({ total: 0, nonEmpty: 0, originCount: 0, boardableCount: 0 });
+    expect(result.rawCounts).toEqual({
+      total: 0,
+      nonEmpty: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
+    });
     expect(result.filteredCounts).toEqual({
       total: 0,
       nonEmpty: 0,
-      originCount: 0,
-      boardableCount: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
     });
   });
 

--- a/src/domain/transit/__tests__/timetable-stats.test.ts
+++ b/src/domain/transit/__tests__/timetable-stats.test.ts
@@ -72,20 +72,16 @@ describe('computeTimetableEntryStats', () => {
     const stats = computeTimetableEntryStats([], TEST_AGENCIES, TEST_LANGS);
     expect(stats).toEqual({
       totalCount: 0,
-      originCount: 0,
-      terminalCount: 0,
-      passingCount: 0,
-      boardableCount: 0,
-      nonBoardableCount: 0,
-      dropOffOnlyCount: 0,
-      noDropOffCount: 0,
-      routeCount: 0,
-      directionCount: 0,
-      tripHeadsignCount: 0,
-      stopHeadsignCount: 0,
-      patternCount: 0,
-      serviceCount: 0,
-      uniqueTripCount: 0,
+      position: { originCount: 0, terminalCount: 0, passingCount: 0 },
+      signal: { noPickupCount: 0, noDropOffCount: 0 },
+      passenger: { boardableCount: 0, nonBoardableCount: 0 },
+      routeDirection: {
+        routeCount: 0,
+        directionCount: 0,
+        tripHeadsignCount: 0,
+        stopHeadsignCount: 0,
+      },
+      tripLocator: { patternCount: 0, serviceCount: 0, uniqueTripCount: 0 },
     });
   });
 
@@ -99,9 +95,9 @@ describe('computeTimetableEntryStats', () => {
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.totalCount).toBe(4);
-      expect(stats.originCount).toBe(1);
-      expect(stats.terminalCount).toBe(1);
-      expect(stats.passingCount).toBe(2);
+      expect(stats.position.originCount).toBe(1);
+      expect(stats.position.terminalCount).toBe(1);
+      expect(stats.position.passingCount).toBe(2);
     });
 
     it('counts both origin and terminal on a single-stop pattern', () => {
@@ -110,9 +106,9 @@ describe('computeTimetableEntryStats', () => {
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.totalCount).toBe(1);
-      expect(stats.originCount).toBe(1);
-      expect(stats.terminalCount).toBe(1);
-      expect(stats.passingCount).toBe(0);
+      expect(stats.position.originCount).toBe(1);
+      expect(stats.position.terminalCount).toBe(1);
+      expect(stats.position.passingCount).toBe(0);
     });
   });
 
@@ -121,12 +117,14 @@ describe('computeTimetableEntryStats', () => {
       const entries = [makeEntry(), makeEntry({ isLastStop: true }), makeEntry({ pickupType: 1 })];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.totalCount).toBe(3);
-      expect(stats.boardableCount).toBe(1);
-      expect(stats.nonBoardableCount).toBe(2);
-      expect(stats.boardableCount + stats.nonBoardableCount).toBe(stats.totalCount);
+      expect(stats.passenger.boardableCount).toBe(1);
+      expect(stats.passenger.nonBoardableCount).toBe(2);
+      expect(stats.passenger.boardableCount + stats.passenger.nonBoardableCount).toBe(
+        stats.totalCount,
+      );
     });
 
-    it('counts dropOffOnly entries (= explicit pickup_type === 1)', () => {
+    it('counts no-pickup entries (= explicit pickup_type === 1)', () => {
       const entries = [
         makeEntry({ pickupType: 1 }),
         makeEntry({ pickupType: 1 }),
@@ -134,8 +132,8 @@ describe('computeTimetableEntryStats', () => {
         makeEntry(),
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
-      expect(stats.dropOffOnlyCount).toBe(2);
-      expect(stats.nonBoardableCount).toBe(3);
+      expect(stats.signal.noPickupCount).toBe(2);
+      expect(stats.passenger.nonBoardableCount).toBe(3);
     });
 
     it('counts noDropOff entries (= explicit drop_off_type === 1)', () => {
@@ -145,7 +143,7 @@ describe('computeTimetableEntryStats', () => {
         makeEntry(),
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
-      expect(stats.noDropOffCount).toBe(2);
+      expect(stats.signal.noDropOffCount).toBe(2);
     });
   });
 
@@ -158,9 +156,9 @@ describe('computeTimetableEntryStats', () => {
         makeEntry({ routeId: 'rB', headsign: 'X' }),
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
-      expect(stats.routeCount).toBe(2);
-      expect(stats.stopHeadsignCount).toBe(2);
-      expect(stats.tripHeadsignCount).toBe(2);
+      expect(stats.routeDirection.routeCount).toBe(2);
+      expect(stats.routeDirection.stopHeadsignCount).toBe(2);
+      expect(stats.routeDirection.tripHeadsignCount).toBe(2);
     });
 
     it('counts unique resolved stop headsigns', () => {
@@ -170,7 +168,7 @@ describe('computeTimetableEntryStats', () => {
         makeEntry(),
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
-      expect(stats.stopHeadsignCount).toBe(3);
+      expect(stats.routeDirection.stopHeadsignCount).toBe(3);
     });
 
     it('counts unique direction values (undefined is one value)', () => {
@@ -181,7 +179,7 @@ describe('computeTimetableEntryStats', () => {
         makeEntry(),
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
-      expect(stats.directionCount).toBe(3);
+      expect(stats.routeDirection.directionCount).toBe(3);
     });
   });
 
@@ -193,8 +191,8 @@ describe('computeTimetableEntryStats', () => {
         makeEntry({ patternId: 'p2', serviceId: 's1', tripIndex: 2 }),
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
-      expect(stats.patternCount).toBe(2);
-      expect(stats.serviceCount).toBe(2);
+      expect(stats.tripLocator.patternCount).toBe(2);
+      expect(stats.tripLocator.serviceCount).toBe(2);
     });
 
     it('uniqueTripCount equals totalCount for a non-circular pattern', () => {
@@ -204,8 +202,8 @@ describe('computeTimetableEntryStats', () => {
         makeEntry({ patternId: 'p1', serviceId: 's1', tripIndex: 2 }),
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
-      expect(stats.uniqueTripCount).toBe(3);
-      expect(stats.uniqueTripCount).toBe(stats.totalCount);
+      expect(stats.tripLocator.uniqueTripCount).toBe(3);
+      expect(stats.tripLocator.uniqueTripCount).toBe(stats.totalCount);
     });
 
     it('uniqueTripCount is lower than totalCount for circular patterns', () => {
@@ -219,7 +217,7 @@ describe('computeTimetableEntryStats', () => {
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
       expect(stats.totalCount).toBe(4);
-      expect(stats.uniqueTripCount).toBe(2);
+      expect(stats.tripLocator.uniqueTripCount).toBe(2);
     });
   });
 
@@ -272,26 +270,26 @@ describe('computeTimetableEntryStats', () => {
     expect(stats.totalCount).toBe(4);
 
     // A axis
-    expect(stats.originCount).toBe(2);
-    expect(stats.terminalCount).toBe(1);
-    expect(stats.passingCount).toBe(1);
+    expect(stats.position.originCount).toBe(2);
+    expect(stats.position.terminalCount).toBe(1);
+    expect(stats.position.passingCount).toBe(1);
 
     // B axis
-    expect(stats.boardableCount).toBe(2);
-    expect(stats.nonBoardableCount).toBe(2);
-    expect(stats.dropOffOnlyCount).toBe(1);
-    expect(stats.noDropOffCount).toBe(0);
+    expect(stats.passenger.boardableCount).toBe(2);
+    expect(stats.passenger.nonBoardableCount).toBe(2);
+    expect(stats.signal.noPickupCount).toBe(1);
+    expect(stats.signal.noDropOffCount).toBe(0);
 
     // C axis: resolver picks stopHeadsign when present (entry 2 -> 'X-via'),
     // so headsign and routeHeadsign uniqueness reflects that override.
-    expect(stats.routeCount).toBe(2);
-    expect(stats.stopHeadsignCount).toBe(3); // X, X-via, Y
-    expect(stats.tripHeadsignCount).toBe(2); // X, Y
-    expect(stats.directionCount).toBe(2);
+    expect(stats.routeDirection.routeCount).toBe(2);
+    expect(stats.routeDirection.stopHeadsignCount).toBe(3); // X, X-via, Y
+    expect(stats.routeDirection.tripHeadsignCount).toBe(2); // X, Y
+    expect(stats.routeDirection.directionCount).toBe(2);
 
     // D axis
-    expect(stats.patternCount).toBe(2);
-    expect(stats.serviceCount).toBe(1);
-    expect(stats.uniqueTripCount).toBe(2);
+    expect(stats.tripLocator.patternCount).toBe(2);
+    expect(stats.tripLocator.serviceCount).toBe(1);
+    expect(stats.tripLocator.uniqueTripCount).toBe(2);
   });
 });

--- a/src/domain/transit/compute-stops-counts.ts
+++ b/src/domain/transit/compute-stops-counts.ts
@@ -26,10 +26,10 @@ export function computeStopsCounts<T extends StopTimesCarrier>(items: readonly T
         counts.nonEmpty += 1;
       }
       if (item.stopTimes.some((entry) => entry.patternPosition.isFirstStop)) {
-        counts.originCount += 1;
+        counts.position.originCount += 1;
       }
       if (hasBoardableEntry(item.stopTimes)) {
-        counts.boardableCount += 1;
+        counts.passenger.boardableCount += 1;
       }
 
       return counts;
@@ -37,8 +37,8 @@ export function computeStopsCounts<T extends StopTimesCarrier>(items: readonly T
     {
       total: 0,
       nonEmpty: 0,
-      originCount: 0,
-      boardableCount: 0,
+      position: { originCount: 0 },
+      passenger: { boardableCount: 0 },
     },
   );
 }

--- a/src/domain/transit/timetable-stats.ts
+++ b/src/domain/transit/timetable-stats.ts
@@ -10,29 +10,34 @@ import { resolveAgencyLang } from '@/config/transit-defaults';
 /**
  * Aggregated statistics computed from a list of {@link TimetableEntry}.
  *
- * Each count answers a single question on a single axis. Counts on
- * different axes are independent, so summing them is meaningless
- * (e.g. one entry can be counted in both `originCount` and
- * `boardableCount`).
+ * Counts are grouped into sub-objects by axis. Each axis answers a
+ * single kind of question; counts on different axes are independent, so
+ * summing across them is meaningless (e.g. one entry can be counted in
+ * both `position.originCount` and `passenger.boardableCount`).
  *
- * Axes:
- * - **A (pattern position)**: `originCount` / `terminalCount` / `passingCount`.
- *   `originCount` and `terminalCount` are NOT mutually exclusive — a
- *   single-stop pattern (= `totalStops === 1`) increments both. `passingCount`
- *   is strictly mid-route (= `!isFirstStop && !isLastStop`).
- * - **B (boarding)**: `boardableCount` / `nonBoardableCount` /
- *   `dropOffOnlyCount` / `noDropOffCount`. The boardable / non-boardable
- *   pair partitions all entries (sum equals `totalCount`).
- *   `dropOffOnlyCount` (= explicit `pickup_type === 1`) and `noDropOffCount`
- *   (= explicit `drop_off_type === 1`) are independent GTFS signals.
- * - **C (route direction)**: unique counts of `route_id`, resolved
- *   headsign (= the user-facing string from {@link getHeadsignDisplayNames}),
- *   `(route, headsign)` pairs, observed `direction` values, plus the
- *   number of entries whose `stopHeadsign` is set.
- * - **D (trip locator)**: unique counts of `patternId`, `serviceId`,
- *   and `(patternId, serviceId, tripIndex)` triples. `uniqueTripCount`
- *   can be lower than `totalCount` for 6-shape / circular patterns
- *   where the same trip visits the same stop more than once.
+ * The grouping keeps two semantic layers from being mixed under one
+ * heading (Issue #162): faithful counts read straight from the source
+ * (`position`, `signal`) vs interpreted counts that combine the signal
+ * with the pattern position for the passenger (`passenger`).
+ *
+ * - **`position`** (faithful, pattern role): `originCount` /
+ *   `terminalCount` / `passingCount`. `originCount` and `terminalCount`
+ *   are NOT mutually exclusive — a single-stop pattern (= `totalStops
+ *   === 1`) increments both. `passingCount` is strictly mid-route
+ *   (= `!isFirstStop && !isLastStop`).
+ * - **`signal`** (faithful, raw GTFS pickup/drop-off): `noPickupCount`
+ *   (= explicit `pickup_type === 1`) and `noDropOffCount` (= explicit
+ *   `drop_off_type === 1`) are independent GTFS signals.
+ * - **`passenger`** (interpreted, value for passenger): `boardableCount`
+ *   / `nonBoardableCount`, judged by {@link isBoardableForPassenger}.
+ *   The pair partitions all entries (sum equals `totalCount`).
+ * - **`routeDirection`** (identity): unique counts of `route_id`,
+ *   observed `direction` values, resolved trip/stop headsigns (the
+ *   user-facing strings from {@link getHeadsignDisplayNames}).
+ * - **`tripLocator`** (identity): unique counts of `patternId`,
+ *   `serviceId`, and `(patternId, serviceId, tripIndex)` triples.
+ *   `uniqueTripCount` can be lower than `totalCount` for 6-shape /
+ *   circular patterns where the same trip visits the same stop twice.
  *
  * @see computeTimetableEntryStats
  */
@@ -40,43 +45,55 @@ export interface TimetableEntryStats {
   /** Total number of entries (= input length). */
   totalCount: number;
 
-  // A axis: pattern position
-  /** Entries where this stop is the trip's origin (= `isFirstStop === true`). */
-  originCount: number;
-  /** Entries where this stop is the trip's terminal (= `isLastStop === true`). */
-  terminalCount: number;
-  /** Entries where this stop is mid-route (= `!isFirstStop && !isLastStop`). */
-  passingCount: number;
+  /** Faithful: pattern role of the stop event. */
+  position: {
+    /** Entries where this stop is the trip's origin (= `isFirstStop === true`). */
+    originCount: number;
+    /** Entries where this stop is the trip's terminal (= `isLastStop === true`). */
+    terminalCount: number;
+    /** Entries where this stop is mid-route (= `!isFirstStop && !isLastStop`). */
+    passingCount: number;
+  };
 
-  // B axis: boarding availability
-  /** Entries where boarding is available (= `isBoardableForPassenger`). */
-  boardableCount: number;
-  /** Entries where boarding is NOT available (= `!isBoardableForPassenger`). */
-  nonBoardableCount: number;
-  /** Entries with explicit `pickup_type === 1` (= GTFS "drop-off only"). */
-  dropOffOnlyCount: number;
-  /** Entries with explicit `drop_off_type === 1` (= alighting unavailable). */
-  noDropOffCount: number;
+  /** Faithful: raw GTFS pickup / drop-off signals. */
+  signal: {
+    /** Entries with explicit `pickup_type === 1` (no pickup available). */
+    noPickupCount: number;
+    /** Entries with explicit `drop_off_type === 1` (no drop-off available). */
+    noDropOffCount: number;
+  };
 
-  // C axis: route direction
-  /** Number of unique `route_id` values across the entries. */
-  routeCount: number;
-  /** Number of unique `direction` values observed (`undefined` is one value). */
-  directionCount: number;
-  tripHeadsignCount: number;
-  stopHeadsignCount: number;
+  /** Interpreted: value for the passenger. */
+  passenger: {
+    /** Entries where boarding is available (= `isBoardableForPassenger`). */
+    boardableCount: number;
+    /** Entries where boarding is NOT available (= `!isBoardableForPassenger`). */
+    nonBoardableCount: number;
+  };
 
-  // D axis: trip locator
-  /** Number of unique `patternId` values. */
-  patternCount: number;
-  /** Number of unique `serviceId` values. */
-  serviceCount: number;
-  /**
-   * Number of unique `(patternId, serviceId, tripIndex)` triples.
-   * Differs from `totalCount` when 6-shape / circular patterns place
-   * the same trip at the same stop multiple times.
-   */
-  uniqueTripCount: number;
+  /** Identity: route / direction / headsign uniqueness. */
+  routeDirection: {
+    /** Number of unique `route_id` values across the entries. */
+    routeCount: number;
+    /** Number of unique `direction` values observed (`undefined` is one value). */
+    directionCount: number;
+    tripHeadsignCount: number;
+    stopHeadsignCount: number;
+  };
+
+  /** Identity: trip locator uniqueness. */
+  tripLocator: {
+    /** Number of unique `patternId` values. */
+    patternCount: number;
+    /** Number of unique `serviceId` values. */
+    serviceCount: number;
+    /**
+     * Number of unique `(patternId, serviceId, tripIndex)` triples.
+     * Differs from `totalCount` when 6-shape / circular patterns place
+     * the same trip at the same stop multiple times.
+     */
+    uniqueTripCount: number;
+  };
 }
 
 /**
@@ -107,7 +124,7 @@ export function computeTimetableEntryStats(
   let passingCount = 0;
   let boardableCount = 0;
   let nonBoardableCount = 0;
-  let dropOffOnlyCount = 0;
+  let noPickupCount = 0;
   let noDropOffCount = 0;
 
   const routeIds = new Set<string>();
@@ -137,7 +154,7 @@ export function computeTimetableEntryStats(
       nonBoardableCount++;
     }
     if (entry.boarding.pickupType === 1) {
-      dropOffOnlyCount++;
+      noPickupCount++;
     }
     if (entry.boarding.dropOffType === 1) {
       noDropOffCount++;
@@ -179,19 +196,29 @@ export function computeTimetableEntryStats(
 
   return {
     totalCount: entries.length,
-    originCount,
-    terminalCount,
-    passingCount,
-    boardableCount,
-    nonBoardableCount,
-    dropOffOnlyCount,
-    noDropOffCount,
-    routeCount: routeIds.size,
-    directionCount: directions.size,
-    tripHeadsignCount: tripsHeadsigns.size,
-    stopHeadsignCount: stopHeadsigns.size,
-    patternCount: patternIds.size,
-    serviceCount: serviceIds.size,
-    uniqueTripCount: trips.size,
+    position: {
+      originCount,
+      terminalCount,
+      passingCount,
+    },
+    signal: {
+      noPickupCount,
+      noDropOffCount,
+    },
+    passenger: {
+      boardableCount,
+      nonBoardableCount,
+    },
+    routeDirection: {
+      routeCount: routeIds.size,
+      directionCount: directions.size,
+      tripHeadsignCount: tripsHeadsigns.size,
+      stopHeadsignCount: stopHeadsigns.size,
+    },
+    tripLocator: {
+      patternCount: patternIds.size,
+      serviceCount: serviceIds.size,
+      uniqueTripCount: trips.size,
+    },
   };
 }

--- a/src/types/app/stop.ts
+++ b/src/types/app/stop.ts
@@ -1,6 +1,27 @@
+/**
+ * Aggregate counts over a set of stops.
+ *
+ * Counts are grouped by axis to keep faithful (read straight from the
+ * source) and interpreted (judged for the passenger) layers from being
+ * mixed under one heading (Issue #162):
+ * - `position` is faithful (pattern role).
+ * - `passenger` is interpreted (value for the passenger).
+ */
 export interface StopsCounts {
+  /** Total number of stops. */
   total: number;
+  /** Stops with at least one stop time. */
   nonEmpty: number;
-  originCount: number;
-  boardableCount: number;
+
+  /** Faithful: pattern role of the stops' entries. */
+  position: {
+    /** Stops with at least one origin entry (= `isFirstStop`). */
+    originCount: number;
+  };
+
+  /** Interpreted: value for the passenger. */
+  passenger: {
+    /** Stops with at least one boardable entry (= `isBoardableForPassenger`). */
+    boardableCount: number;
+  };
 }


### PR DESCRIPTION
## Summary

Issue #162 item 5: the timetable stats grouped faithful counts (read
straight from the source) and interpreted counts (judged for the
passenger) under one conceptual axis, so a field name did not say which
semantic layer it belonged to. This splits both count structs into
nested sub-objects by axis.

### `TimetableEntryStats`

```
{ totalCount, position, signal, passenger, routeDirection, tripLocator }
```

- `position` (faithful): originCount / terminalCount / passingCount
- `signal` (faithful, raw GTFS): noPickupCount / noDropOffCount
- `passenger` (interpreted): boardableCount / nonBoardableCount
- `routeDirection` / `tripLocator`: identity counts

The previously misleading `dropOffOnlyCount` is renamed to
`signal.noPickupCount` -- it counts the raw `pickup_type === 1` signal;
"drop-off only" was an interpretation. i18n keys and display strings
are unchanged; only access paths change.

### `StopsCounts`

```
{ total, nonEmpty, position: { originCount }, passenger: { boardableCount } }
```

### VerboseTimetableSummary

Now consumes the parent's memoized `TimetableEntryStats` instead of
recomputing boardable / origin / terminal inline, and dumps the counts
grouped by axis so the verbose debug panel shows the faithful (`signal`)
and interpreted (`passenger`) layers separately. Per-direction /
per-pattern tallies and dwell stay inline (the stats object does not
carry those distributions). No output field is lost; passing /
uniqueTrips / signal / routeDirection / tripLocator counts are added.

## Behavior

No behavior change: the same predicates produce the same numbers, now
under axis-scoped keys. (The `compute-stops-counts` boardability
consolidation that made the badge agree with the boardable-only filter
already landed in #290; this PR is purely the naming/structure split.)

## Verification

- typecheck / Prettier / ESLint (`eslint .`) / `npm run build` pass
- Vitest: 4,516 tests pass
- Browser-verified with real data (`?sources=kobus&stop=kobus:0787_00`,
  a drop-off-only stop): nearby badges (運行中 / 乗車可 / 始発) and the
  "降車専用" label unchanged; timetable dialog metadata intact; the
  verbose [TimetableSummary] dump renders the new axis-grouped lines
  (`[passenger] nonBoardable=144` and `[signal] noPickup=144` shown
  separately); no console errors

## Note

The passenger-axis names (`boardableCount` / `nonBoardableCount`) may be
revisited if Issue #162 item 3 introduces a normalized operational-state
vocabulary; that is item 3's scope, not leftover here.

Refs: #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)