### PR TITLE
docs: timetable stop-event state model spec + isNoPassengerService 1/1 caveat

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,17 +13,18 @@
 
 ## Web app implementation docs
 
-| File                                                               | Purpose                                                               |
-| ------------------------------------------------------------------ | --------------------------------------------------------------------- |
-| [system-architecture.md](./system-architecture.md)                 | GitHub Actions、pipeline、Vercel 配信の簡易システム構成。             |
-| [map-architecture.md](./map-architecture.md)                       | MapView hoist、layout mode、z-index、pan/zoom、click/tap event 制御。 |
-| [runtime-configuration.md](./runtime-configuration.md)             | Logger、mode 定義、URL parameter、MockRepository、diagnostics。       |
-| [platform-pwa.md](./platform-pwa.md)                               | PWA cache、platform behavior、iOS standalone / safe-area。            |
-| [frontend-styling.md](./frontend-styling.md)                       | Tailwind CSS、Prettier、ESLint、shadcn/ui、Dialog / ScrollFadeEdge。  |
-| [transit-data-and-repository.md](./transit-data-and-repository.md) | Stop ID lookup、GTFS i18n、TransitRepository API。                    |
-| [web-storage.md](./web-storage.md)                                 | Web Storage 取得 / availability hook、SSOT semantics、不可時の挙動。  |
-| [storage.md](./storage.md)                                         | Storage を背景に持つ各 repository の挙動仕様。                        |
-| [dependency-notes.md](./dependency-notes.md)                       | 依存更新の注意事項。                                                  |
+| File                                                                         | Purpose                                                                        |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [system-architecture.md](./system-architecture.md)                           | GitHub Actions、pipeline、Vercel 配信の簡易システム構成。                      |
+| [map-architecture.md](./map-architecture.md)                                 | MapView hoist、layout mode、z-index、pan/zoom、click/tap event 制御。          |
+| [runtime-configuration.md](./runtime-configuration.md)                       | Logger、mode 定義、URL parameter、MockRepository、diagnostics。                |
+| [platform-pwa.md](./platform-pwa.md)                                         | PWA cache、platform behavior、iOS standalone / safe-area。                     |
+| [frontend-styling.md](./frontend-styling.md)                                 | Tailwind CSS、Prettier、ESLint、shadcn/ui、Dialog / ScrollFadeEdge。           |
+| [transit-data-and-repository.md](./transit-data-and-repository.md)           | Stop ID lookup、GTFS i18n、TransitRepository API。                             |
+| [timetable-stop-event-state-model.md](./timetable-stop-event-state-model.md) | 停車イベントの state model(2軸: faithful / passenger)。Issue #162 の決定記録。 |
+| [web-storage.md](./web-storage.md)                                           | Web Storage 取得 / availability hook、SSOT semantics、不可時の挙動。           |
+| [storage.md](./storage.md)                                                   | Storage を背景に持つ各 repository の挙動仕様。                                 |
+| [dependency-notes.md](./dependency-notes.md)                                 | 依存更新の注意事項。                                                           |
 
 ## Pipeline independence
 

--- a/docs/timetable-stop-event-state-model.md
+++ b/docs/timetable-stop-event-state-model.md
@@ -1,0 +1,118 @@
+# Timetable Stop-Event State Model
+
+How the app models the state of a single stop event (one trip stopping at
+one stop). This is the spec deliverable for Issue #162. It records the
+chosen model, the decision not to introduce a normalized operational-state
+enum, and the data caveats that drove that decision.
+
+## The two axes
+
+A stop event answers two distinct questions that must not be collapsed
+into one:
+
+1. **Faithful facts** -- "what does the source say about this stop event",
+   read straight from the GTFS signals and the pattern role, with no
+   inference. This is the data-viewer philosophy: display the data as-is.
+2. **Value for the passenger** -- "what does this mean for a passenger"
+   (can they board / alight here), combining the signal with the pattern
+   position via the current (interim) rule.
+
+These are not exclusive: they are often shown together. The canonical
+case is a through-service last row -- faithfully "terminal" (it is the
+pattern's last stop) AND, for the passenger, potentially "boardable" (the
+train continues onto another operator). On the surface this reads as a
+contradiction; the correct model presents it as information ("last stop of
+this feed, but you can still board"), not a conflict. Resolving that
+display tension is per-source policy in Issue #145.
+
+The faithful axis has two faithful sub-kinds: pattern **position** (role
+in the trip) and raw **signal** (pickup / drop-off).
+
+## Code map
+
+| Layer                  | Concern                              | Code                                                                                                          |
+| ---------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Faithful: position     | first / last / mid                   | `patternPosition.isFirstStop` / `isLastStop`; `getTimetableEntryAttributes`                                   |
+| Faithful: signal       | raw pickup / drop-off                | `canBoardSignal` / `canAlight`; `isNoPassengerService` (explicit 1/1); `requiresArrangement` (2/3)            |
+| Interpreted: passenger | can board / alight (inference incl.) | `isBoardableForPassenger` / `isAlightableForPassenger` (and `*Signal` form for raw-array scans)               |
+| Display: transit board | departure / arrival                  | `timetable-entry-for-transit-display.ts` (`isDeparture` / `isArrival`), delegating to the passenger judgments |
+
+Aggregation mirrors the axes: `TimetableEntryStats` groups counts into
+`position` / `signal` (faithful) and `passenger` (interpreted), plus
+`routeDirection` / `tripLocator`; `StopsCounts` into `position` /
+`passenger`. See Issue #162 item 5 (landed).
+
+A separate collection-level state already exists:
+`TimetableEntriesState = 'boardable' | 'drop-off-only' | 'no-service'`
+(`StopServiceState`). It is per-stop/collection ("does this stop have any
+boardable entry today"), already an interpreted rollup via
+`isBoardableForPassenger`, and is NOT a per-stop-event state.
+
+## Decision (Issue #162 item 3)
+
+**Do not introduce a per-stop-event operational-state enum** (the
+`regular` / `drop-off-only` / `boarding-only` / `pass-through`
+normalization). Keep the axes separate; if a surface ever needs a single
+operational label, derive it in the presentation layer as an
+inference-inclusive value, kept distinct from the explicit-signal
+pass-through (`isNoPassengerService`).
+
+Rationale:
+
+- **No consumer needs it.** Stats, the verbose dump, filters, and labels
+  are all served by the separate axes. A per-event enum would be premature
+  abstraction.
+- **It would collapse the two axes.** A single `drop-off-only` value folds
+  faithful position, faithful signal, and interpreted boardability into one
+  bucket -- exactly the layer-mixing Issue #162 set out to remove.
+- **Vocabulary duplication.** It would overlap the existing collection-level
+  `TimetableEntriesState` (same value names, different scope).
+- **Fragile to Issue #145.** When the feed-boundary rule changes, a single
+  enum's definition would need reworking; separate axes simply let the
+  faithful "terminal" fact and the interpreted "boardable" value coexist.
+
+This is not permanent: a concrete per-event operational-label need, plus a
+resolved Issue #145, could justify revisiting it (likely as a presentation
+-layer derivation that rolls up into the collection-level state).
+
+## StopServiceType 2/3 (Issue #162 item 4)
+
+Arrangement-required values (2 = phone agency, 3 = coordinate with driver)
+are treated as boardable/alightable on a **separate restriction axis**
+(`requiresArrangement`), not as distinct states. A future operational
+label, if ever derived, would treat 2/3 as "available with restriction",
+not its own state.
+
+## Caveat: explicit 1/1 is source- AND trip-dependent
+
+`isNoPassengerService` returns true for explicit `pickup_type === 1 &&
+drop_off_type === 1`. GTFS Best Practices cite deadhead trips / internal
+timing points / garages as the canonical referents, but a true return does
+NOT guarantee "no passenger service" in reality. Measured on the
+2026-06-13 feed:
+
+- 360 rows of 1/1 exist, only in `ktbus` (関東バス, 316) and `tome`
+  (Tokyo Metro, 44); the other 45 sources omit pickup/drop-off signals.
+- `tome` uses 1/1 to mark **through-service feed boundaries** (Kita-Senju /
+  Yoyogi-Uehara / Kotake-Mukaihara), not deadhead/garage. The real meaning
+  varies trip by trip:
+    - Express (Metro Hakone Romancecar, pattern `tome:p117`) genuinely passes
+      Yoyogi-Uehara without serving it -- a real no-stop.
+    - Local (`tome:p107` toward Hon-Atsugi) marks the same real, used
+      interchange stop 1/1 -- a feed-boundary artifact, not a real
+      no-service.
+
+Therefore `isNoPassengerService` must not be used as a standalone
+cross-source "is this a pass-through" test; it needs source/trip context.
+The explicit-signal pass-through (faithful) and any derived pass-through
+(interpreted) must stay distinct. Per-source resolution is Issue #145.
+
+## Related / out of scope
+
+- **Issue #145** -- per-source feed-boundary signal-trust policy. Required
+  to release through-service boarding ("terminal but boardable"); not a
+  prerequisite for this spec.
+- **Passenger-axis display component** -- a display part for the passenger
+  axis parallel to the faithful `TimetableEntryAttributesLabels` (so
+  "terminal" and "boardable" can be shown side by side). A follow-up
+  enhancement, tracked separately, not part of Issue #162.

--- a/src/domain/transit/timetable-entry-boarding.ts
+++ b/src/domain/transit/timetable-entry-boarding.ts
@@ -30,6 +30,21 @@ export function requiresArrangement(entry: TimetableEntry): boolean {
  * typical -- but not guaranteed -- referents (stop_times.txt section,
  * snapshot 2026-06-11):
  * https://gtfs.org/documentation/schedule/schedule-best-practices/#stop_timestxt
+ *
+ * CAUTION: the real-world meaning of 1/1 is source- AND trip-dependent,
+ * so a true return does NOT guarantee "no passenger service" in reality.
+ * Measured on the 2026-06-13 feed (tome / Tokyo Metro): 1/1 also marks
+ * the through-service feed boundary where a Metro pattern hands off to
+ * another operator. Two distinct realities collapse onto 1/1 there:
+ *   - Express through-runs (e.g. Metro Hakone Romancecar, pattern
+ *     tome:p117) genuinely pass Yoyogi-Uehara without serving it -- a
+ *     real no-stop.
+ *   - Local through-runs (e.g. tome:p107 toward Hon-Atsugi) mark
+ *     Yoyogi-Uehara 1/1 even though it is a real, used interchange
+ *     stop -- a feed-boundary artifact, not a real no-service.
+ * Do not treat this predicate as a standalone "is this a pass-through"
+ * test across sources; pair it with source/trip context. See Issue #162
+ * (state model) and Issue #145 (per-source feed-boundary policy).
  */
 export function isNoPassengerService(entry: TimetableEntry): boolean {
   return entry.boarding.pickupType === 1 && entry.boarding.dropOffType === 1;


### PR DESCRIPTION
## Summary

Closes the remaining work on Issue #162 (item 3): records the stop-event
state-model decision and the supporting data caveat. Documentation only --
no code behavior change.

### `docs/timetable-stop-event-state-model.md` (new)

The spec deliverable for Issue #162. Records:
- the two-axis model (faithful facts vs value for the passenger) and the
  code map for each layer;
- **decision (item 3): do NOT introduce a per-stop-event operational-state
  enum; keep the axes separate** (option C), with rationale (no consumer /
  avoids collapsing the axes / avoids vocabulary duplication with the
  collection-level `TimetableEntriesState` / robust to Issue #145);
- the 2/3 restriction axis (item 4);
- the caveat that explicit 1/1 (`isNoPassengerService`) is source- and
  trip-dependent.

Indexed in `docs/README.md`.

### `isNoPassengerService` TSDoc caveat

Adds a caveat that a true return does not guarantee real "no passenger
service": on the 2026-06-13 feed, `tome` (Tokyo Metro) uses 1/1 to mark
through-service feed boundaries, where the meaning varies trip by trip
(express genuine no-stop vs local feed-boundary artifact at a real
interchange stop). Callers must pair it with source/trip context.

## Context

Items 1, 2, 4, 5, 6 of Issue #162 were already done (item 5 landed in
PR #291). This PR lands item 3's decision + spec, which is the last
remaining deliverable. The passenger-axis display follow-up (formerly
"Gap 1") is split out to #292 and is intentionally out of scope here.

## Verification

- typecheck / Prettier / ESLint pass (TSDoc comment change is ASCII-only).
- Docs only; no runtime/behavior change.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)