### PR TITLE
feat(domain): per-source endpoint-signal-trust for boardability/alightability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Boardability: 他社直通の境界となる last stop (フィード境界) を乗車可として扱う per-source endpoint-signal-trust を導入した。信頼対象は東京メトロ (`tome`) / りんかい線 (`twrr`) / 都営地下鉄 (`toaran`) で、これらでは last stop / first stop の乗降可否を pickup_type / drop_off_type の signal のみで判定する。従来 last stop として発着案内・乗車可フィルタから除外されていた直通便 (例: 千代田線→JR 常磐線の綾瀬、りんかい線→JR 埼京線の大崎) が乗車可として表示されるようになった (東京メトロ 約 3,211 / 都営地下鉄 約 1,339 / りんかい線 大崎 152 行)。横浜市営地下鉄のように真の終点に pickup_type=0 を残す事業者は対象外 (#297, #145)。
+- Boardability: `isBoardableForPassenger` / `isAlightableForPassenger` を「signal のみ」(`...BySignal`) と「signal + 位置」(`...BySignalAndPosition`) の判定に分割し、事業者方針で振り分ける selector に整理した。降車側も対称化し、発着案内の `isDeparture` / `isArrival` を利用者観点判定に一本化した。`canBoardSignal` / `canBoard` / `canAlight` は統合・削除した (#297)。
+
 ## [2026.06.11]
 
 ### Added

--- a/src/domain/transit/__tests__/timetable-entry-for-passenger.test.ts
+++ b/src/domain/transit/__tests__/timetable-entry-for-passenger.test.ts
@@ -5,9 +5,60 @@ import {
   canBoardSignal,
   isAlightableForPassenger,
   isBoardableForPassenger,
-  isBoardableForPassengerSignal,
+  isBoardableForPassengerBySignal,
+  isBoardableForPassengerBySignalAndPosition,
+  isEndpointSignalTrustedByPrefix,
+  isEndpointSignalTrustedByRoute,
 } from '../timetable-entry-for-passenger';
+import type { Route } from '../../../types/app/transit';
 import { makeEntry } from './make-timetable-entry';
+
+// ---------------------------------------------------------------------------
+// isEndpointSignalTrustedByRoute (per-source endpoint-signal trust policy)
+// ---------------------------------------------------------------------------
+
+function routeWithId(routeId: string): Route {
+  return {
+    route_id: routeId,
+    route_type: 1,
+    agency_id: `${routeId.split(':')[0]}:agency`,
+    route_short_name: '',
+    route_short_names: {},
+    route_long_name: '',
+    route_long_names: {},
+    route_color: '000000',
+    route_text_color: 'FFFFFF',
+  };
+}
+
+describe('isEndpointSignalTrustedByPrefix', () => {
+  it('trusts the configured through-running rail/subway source prefixes', () => {
+    expect(isEndpointSignalTrustedByPrefix('tome')).toBe(true);
+    expect(isEndpointSignalTrustedByPrefix('twrr')).toBe(true);
+    expect(isEndpointSignalTrustedByPrefix('toaran')).toBe(true);
+  });
+
+  it('does not trust prefixes outside the set', () => {
+    expect(isEndpointSignalTrustedByPrefix('minkuru')).toBe(false);
+    expect(isEndpointSignalTrustedByPrefix('kobus')).toBe(false);
+    expect(isEndpointSignalTrustedByPrefix('')).toBe(false);
+  });
+});
+
+describe('isEndpointSignalTrustedByRoute', () => {
+  it('trusts through-running rail/subway sources whose endpoint signals are spec-correct', () => {
+    expect(isEndpointSignalTrustedByRoute(routeWithId('tome:5'))).toBe(true); // Tokyo Metro
+    expect(isEndpointSignalTrustedByRoute(routeWithId('twrr:1'))).toBe(true); // TWR Rinkai
+    expect(isEndpointSignalTrustedByRoute(routeWithId('toaran:4'))).toBe(true); // Toei Train
+  });
+
+  it('does not trust sources outside the set (absence is not a reliability judgment)', () => {
+    expect(isEndpointSignalTrustedByRoute(routeWithId('minkuru:1'))).toBe(false); // Toei Bus
+    expect(isEndpointSignalTrustedByRoute(routeWithId('kobus:10'))).toBe(false); // Keio Bus (diligent but no through-running)
+    expect(isEndpointSignalTrustedByRoute(routeWithId('yht:3'))).toBe(false); // Yokohama Municipal Subway
+    expect(isEndpointSignalTrustedByRoute(routeWithId('unknown:1'))).toBe(false);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // canBoardSignal
@@ -158,21 +209,42 @@ describe('isBoardableForPassenger', () => {
 });
 
 // ---------------------------------------------------------------------------
-// isBoardableForPassengerSignal
+// isBoardableForPassengerBySignal
 // ---------------------------------------------------------------------------
 
-describe('isBoardableForPassengerSignal', () => {
+describe('isBoardableForPassengerBySignal', () => {
+  it('judges from the raw pickup_type alone, ignoring the position', () => {
+    expect(isBoardableForPassengerBySignal(0)).toBe(true);
+    expect(isBoardableForPassengerBySignal(1)).toBe(false);
+    expect(isBoardableForPassengerBySignal(2)).toBe(true);
+    expect(isBoardableForPassengerBySignal(3)).toBe(true);
+  });
+
+  it('mirrors canBoardSignal exactly', () => {
+    const pickupTypes = [0, 1, 2, 3] as const;
+    for (const pickupType of pickupTypes) {
+      expect(isBoardableForPassengerBySignal(pickupType)).toBe(canBoardSignal(pickupType));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isBoardableForPassengerBySignalAndPosition
+// ---------------------------------------------------------------------------
+
+describe('isBoardableForPassengerBySignalAndPosition', () => {
   it('judges from the raw pickup_type and the last-stop flag', () => {
-    expect(isBoardableForPassengerSignal(0, false)).toBe(true);
-    expect(isBoardableForPassengerSignal(1, false)).toBe(false);
-    expect(isBoardableForPassengerSignal(0, true)).toBe(false);
-    expect(isBoardableForPassengerSignal(2, false)).toBe(true);
-    expect(isBoardableForPassengerSignal(3, false)).toBe(true);
+    expect(isBoardableForPassengerBySignalAndPosition(0, false)).toBe(true);
+    expect(isBoardableForPassengerBySignalAndPosition(1, false)).toBe(false);
+    expect(isBoardableForPassengerBySignalAndPosition(0, true)).toBe(false);
+    expect(isBoardableForPassengerBySignalAndPosition(2, false)).toBe(true);
+    expect(isBoardableForPassengerBySignalAndPosition(3, false)).toBe(true);
   });
 
   it('matches isBoardableForPassenger for every signal/position combination', () => {
-    // The entry-based judgment delegates here; this pins the equivalence
-    // from the other side so the two forms cannot drift apart.
+    // makeEntry's route prefix ('r1') is not endpoint-signal-trusted, so
+    // isBoardableForPassenger selects this signal-and-position form. This
+    // pins the equivalence from the other side so the two cannot drift apart.
     const pickupTypes = [0, 1, 2, 3] as const;
     const flags = [false, true] as const;
     for (const pickupType of pickupTypes) {
@@ -180,7 +252,7 @@ describe('isBoardableForPassengerSignal', () => {
         for (const isLastStop of flags) {
           const entry = makeEntry({ pickupType, isFirstStop, isLastStop });
           expect(
-            isBoardableForPassengerSignal(pickupType, isLastStop),
+            isBoardableForPassengerBySignalAndPosition(pickupType, isLastStop),
             `pickup=${pickupType} first=${isFirstStop} last=${isLastStop}`,
           ).toBe(isBoardableForPassenger(entry));
         }

--- a/src/domain/transit/__tests__/timetable-entry-for-passenger.test.ts
+++ b/src/domain/transit/__tests__/timetable-entry-for-passenger.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
-  canAlight,
-  canBoard,
-  canBoardSignal,
   isAlightableForPassenger,
+  isAlightableForPassengerBySignal,
+  isAlightableForPassengerBySignalAndPosition,
   isBoardableForPassenger,
   isBoardableForPassengerBySignal,
   isBoardableForPassengerBySignalAndPosition,
@@ -61,90 +60,7 @@ describe('isEndpointSignalTrustedByRoute', () => {
 });
 
 // ---------------------------------------------------------------------------
-// canBoardSignal
-// ---------------------------------------------------------------------------
-
-describe('canBoardSignal', () => {
-  it('interprets each pickup_type value', () => {
-    expect(canBoardSignal(0)).toBe(true); // regularly scheduled pickup
-    expect(canBoardSignal(1)).toBe(false); // no pickup available
-    expect(canBoardSignal(2)).toBe(true); // must phone agency
-    expect(canBoardSignal(3)).toBe(true); // must coordinate with driver
-  });
-});
-
-// ---------------------------------------------------------------------------
-// canBoard
-// ---------------------------------------------------------------------------
-
-describe('canBoard', () => {
-  it('returns true for pickupType 0 (regularly scheduled pickup)', () => {
-    expect(canBoard(makeEntry({ pickupType: 0 }))).toBe(true);
-  });
-
-  it('returns false for pickupType 1 (no pickup available)', () => {
-    expect(canBoard(makeEntry({ pickupType: 1 }))).toBe(false);
-  });
-
-  it('returns true for pickupType 2 (must phone agency)', () => {
-    expect(canBoard(makeEntry({ pickupType: 2 }))).toBe(true);
-  });
-
-  it('returns true for pickupType 3 (must coordinate with driver)', () => {
-    expect(canBoard(makeEntry({ pickupType: 3 }))).toBe(true);
-  });
-
-  it('ignores pattern position (signal-only): last stop with pickupType 0', () => {
-    expect(canBoard(makeEntry({ pickupType: 0, isLastStop: true }))).toBe(true);
-  });
-
-  it('ignores pattern position (signal-only): single-stop pattern', () => {
-    expect(canBoard(makeEntry({ pickupType: 0, isFirstStop: true, isLastStop: true }))).toBe(true);
-  });
-
-  it('ignores dropOffType', () => {
-    expect(canBoard(makeEntry({ pickupType: 0, dropOffType: 1 }))).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// canAlight
-// ---------------------------------------------------------------------------
-
-describe('canAlight', () => {
-  it('returns true for dropOffType 0 (regularly scheduled drop off)', () => {
-    expect(canAlight(makeEntry({ dropOffType: 0 }))).toBe(true);
-  });
-
-  it('returns false for dropOffType 1 (no drop off available)', () => {
-    expect(canAlight(makeEntry({ dropOffType: 1 }))).toBe(false);
-  });
-
-  it('returns true for dropOffType 2 (must phone agency)', () => {
-    expect(canAlight(makeEntry({ dropOffType: 2 }))).toBe(true);
-  });
-
-  it('returns true for dropOffType 3 (must coordinate with driver)', () => {
-    expect(canAlight(makeEntry({ dropOffType: 3 }))).toBe(true);
-  });
-
-  it('ignores pattern position (signal-only): first stop with dropOffType 0', () => {
-    expect(canAlight(makeEntry({ dropOffType: 0, isFirstStop: true }))).toBe(true);
-  });
-
-  it('ignores pattern position (signal-only): single-stop pattern', () => {
-    expect(canAlight(makeEntry({ dropOffType: 0, isFirstStop: true, isLastStop: true }))).toBe(
-      true,
-    );
-  });
-
-  it('ignores pickupType', () => {
-    expect(canAlight(makeEntry({ dropOffType: 0, pickupType: 1 }))).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// isBoardableForPassenger (PROVISIONAL interim rule: canBoard && !isLastStop)
+// isBoardableForPassenger (PROVISIONAL interim rule: signal boardable && not last stop)
 // ---------------------------------------------------------------------------
 
 describe('isBoardableForPassenger', () => {
@@ -186,6 +102,16 @@ describe('isBoardableForPassenger', () => {
     ).toBe(false);
   });
 
+  it('releases a last-stop boardable row for an endpoint-signal-trusted source', () => {
+    // tome (Tokyo Metro) is endpoint-signal-trusted, so the selector judges
+    // by signal alone: a last-stop through-service row stays boardable.
+    expect(
+      isBoardableForPassenger(
+        makeEntry({ pickupType: 0, isLastStop: true, route: routeWithId('tome:5') }),
+      ),
+    ).toBe(true);
+  });
+
   it('matches the interim truth table for every signal/position combination', () => {
     // Expected = boardable per the signal (pickupType !== 1) and not the
     // pattern's last stop. isFirstStop never affects the result. Written as
@@ -218,13 +144,6 @@ describe('isBoardableForPassengerBySignal', () => {
     expect(isBoardableForPassengerBySignal(1)).toBe(false);
     expect(isBoardableForPassengerBySignal(2)).toBe(true);
     expect(isBoardableForPassengerBySignal(3)).toBe(true);
-  });
-
-  it('mirrors canBoardSignal exactly', () => {
-    const pickupTypes = [0, 1, 2, 3] as const;
-    for (const pickupType of pickupTypes) {
-      expect(isBoardableForPassengerBySignal(pickupType)).toBe(canBoardSignal(pickupType));
-    }
   });
 });
 
@@ -262,7 +181,7 @@ describe('isBoardableForPassengerBySignalAndPosition', () => {
 });
 
 // ---------------------------------------------------------------------------
-// isAlightableForPassenger (PROVISIONAL interim rule: canAlight && !isFirstStop)
+// isAlightableForPassenger (PROVISIONAL interim rule: signal alightable && not first stop)
 // ---------------------------------------------------------------------------
 
 describe('isAlightableForPassenger', () => {
@@ -302,6 +221,16 @@ describe('isAlightableForPassenger', () => {
     ).toBe(false);
   });
 
+  it('releases a first-stop alightable row for an endpoint-signal-trusted source', () => {
+    // tome (Tokyo Metro) is endpoint-signal-trusted, so the selector judges
+    // by signal alone: a first-stop through-service arrival stays alightable.
+    expect(
+      isAlightableForPassenger(
+        makeEntry({ dropOffType: 0, isFirstStop: true, route: routeWithId('tome:5') }),
+      ),
+    ).toBe(true);
+  });
+
   it('matches the interim truth table for every signal/position combination', () => {
     // Expected = alightable per the signal (dropOffType !== 1) and not the
     // pattern's first stop. isLastStop never affects the result. Written as
@@ -318,6 +247,52 @@ describe('isAlightableForPassenger', () => {
             isAlightableForPassenger(entry),
             `dropOff=${dropOffType} first=${isFirstStop} last=${isLastStop}`,
           ).toBe(expected);
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAlightableForPassengerBySignal
+// ---------------------------------------------------------------------------
+
+describe('isAlightableForPassengerBySignal', () => {
+  it('judges from the raw drop_off_type alone, ignoring the position', () => {
+    expect(isAlightableForPassengerBySignal(0)).toBe(true);
+    expect(isAlightableForPassengerBySignal(1)).toBe(false);
+    expect(isAlightableForPassengerBySignal(2)).toBe(true);
+    expect(isAlightableForPassengerBySignal(3)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAlightableForPassengerBySignalAndPosition
+// ---------------------------------------------------------------------------
+
+describe('isAlightableForPassengerBySignalAndPosition', () => {
+  it('judges from the raw drop_off_type and the first-stop flag', () => {
+    expect(isAlightableForPassengerBySignalAndPosition(0, false)).toBe(true);
+    expect(isAlightableForPassengerBySignalAndPosition(1, false)).toBe(false);
+    expect(isAlightableForPassengerBySignalAndPosition(0, true)).toBe(false);
+    expect(isAlightableForPassengerBySignalAndPosition(2, false)).toBe(true);
+    expect(isAlightableForPassengerBySignalAndPosition(3, false)).toBe(true);
+  });
+
+  it('matches isAlightableForPassenger for every signal/position combination', () => {
+    // makeEntry's route prefix ('r1') is not endpoint-signal-trusted, so
+    // isAlightableForPassenger selects this signal-and-position form. This
+    // pins the equivalence from the other side so the two cannot drift apart.
+    const dropOffTypes = [0, 1, 2, 3] as const;
+    const flags = [false, true] as const;
+    for (const dropOffType of dropOffTypes) {
+      for (const isFirstStop of flags) {
+        for (const isLastStop of flags) {
+          const entry = makeEntry({ dropOffType, isFirstStop, isLastStop });
+          expect(
+            isAlightableForPassengerBySignalAndPosition(dropOffType, isFirstStop),
+            `dropOff=${dropOffType} first=${isFirstStop} last=${isLastStop}`,
+          ).toBe(isAlightableForPassenger(entry));
         }
       }
     }

--- a/src/domain/transit/timetable-entry-for-passenger.ts
+++ b/src/domain/transit/timetable-entry-for-passenger.ts
@@ -16,6 +16,63 @@
  */
 
 import type { StopServiceType, TimetableEntry } from '../../types/app/transit-composed';
+import type { Route } from '../../types/app/transit';
+import { extractPrefix } from './prefixed-id';
+
+/**
+ * Source prefixes whose Last-stop / First-stop signal is trusted
+ * directly: the boarding/drop-off signal alone decides at endpoints,
+ * without the pattern-position fallback.
+ *
+ * A prefix belongs here when BOTH hold:
+ *  1. The feed sets pickup_type / drop_off_type at the Last stop and the
+ *     First stop per the GTFS spec -- true terminals marked pickup_type 1,
+ *     true origins drop_off_type 1 -- so the endpoint signal is correct.
+ *  2. It is a railway / subway whose real operation runs beyond the
+ *     feed's trip (inter-operator through-running), so a Last/First stop
+ *     can be a feed boundary rather than a real terminus / origin.
+ *
+ * This is NOT a data-reliability ranking, and absence does NOT mean a
+ * source is less reliable: most buses satisfy (1) but not (2) -- no
+ * through-running, so nothing to release -- and are excluded with no
+ * loss. (A per-feed property: Toei Train `toaran` qualifies; Toei Bus
+ * `minkuru`, same brand different feed, does not.)
+ *
+ * TEMPORARY / local prototype, each entry verified individually. Toei
+ * Train checked at the terminal level (2026-06-13): through lines
+ * (Asakusa / Mita / Shinjuku) carry pickup_type 0 only at real
+ * boundaries (Oshiage, Sengakuji, Meguro, Shinjuku); the non-through
+ * Oedo line marks every terminal pickup_type 1. See Issue #145.
+ */
+const THROUGH_RUNNING_SIGNAL_TRUSTED_PREFIXES: ReadonlySet<string> = new Set<string>([
+  'tome', // Tokyo Metro
+  'twrr', // TWR Rinkai
+  'toaran', // Toei Train
+]);
+
+/**
+ * Whether the endpoint signal is trusted for the given source prefix.
+ * Core, source-level check (see {@link THROUGH_RUNNING_SIGNAL_TRUSTED_PREFIXES}).
+ * For callers that already hold a prefix; otherwise use
+ * {@link isEndpointSignalTrustedByRoute}.
+ */
+export function isEndpointSignalTrustedByPrefix(prefix: string): boolean {
+  return THROUGH_RUNNING_SIGNAL_TRUSTED_PREFIXES.has(prefix);
+}
+
+/**
+ * Whether the endpoint signal is trusted for the given route. Resolves
+ * the source prefix from `route_id` and delegates to
+ * {@link isEndpointSignalTrustedByPrefix}.
+ *
+ * The judgment currently keys on the source prefix only, but taking the
+ * whole {@link Route} lets a future criterion (e.g. `route_type` /
+ * `agency_id`) be absorbed here without changing the call sites.
+ */
+export function isEndpointSignalTrustedByRoute(route: Route): boolean {
+  const prefix = extractPrefix(route.route_id);
+  return isEndpointSignalTrustedByPrefix(prefix);
+}
 
 /**
  * Whether a passenger can board per a raw GTFS pickup_type value.
@@ -72,17 +129,31 @@ export function canAlight(entry: TimetableEntry): boolean {
 }
 
 /**
- * PROVISIONAL: signal-level form of {@link isBoardableForPassenger},
- * for callers that scan raw timetable rows before {@link TimetableEntry}
- * objects exist (e.g. the repositories' full-service-day boardability
- * scan in getUpcomingTimetableEntries).
+ * PROVISIONAL: boardability judged by the pickup signal ALONE (mode A) --
+ * the pattern position is ignored. Applied when the source's endpoint
+ * signals are trusted (see {@link isEndpointSignalTrustedByRoute}), so a
+ * last-stop through-service row is released as boardable.
+ *
+ * Scalar form (no {@link TimetableEntry}) so repositories can call it
+ * while scanning raw timetable rows.
+ */
+export function isBoardableForPassengerBySignal(pickupType: StopServiceType): boolean {
+  return canBoardSignal(pickupType);
+}
+
+/**
+ * PROVISIONAL: boardability judged by the pickup signal AND the pattern
+ * position (mode B) -- a last stop is treated as not boardable. This is
+ * the conservative default for sources whose endpoint signals are not
+ * trusted; scalar form so repositories can call it while scanning raw
+ * timetable rows.
  *
  * The exact judgment rule is still being specified (state model:
- * Issue #162; feed boundaries: Issue #145). Interim rule: boardable
- * per the signal and not the pattern's last stop -- the same
- * inference as the former isDropOffOnly, which this rule replaces.
+ * Issue #162; feed boundaries: Issue #145). Interim rule: boardable per
+ * the signal and not the pattern's last stop -- the same inference as the
+ * former isDropOffOnly, which this rule replaces.
  */
-export function isBoardableForPassengerSignal(
+export function isBoardableForPassengerBySignalAndPosition(
   pickupType: StopServiceType,
   isLastStop: boolean,
 ): boolean {
@@ -160,14 +231,22 @@ export function isBoardableForPassengerSignal(
 
 /**
  * PROVISIONAL: whether a passenger can board this stop event as a
- * service they can actually ride. Unlike {@link canBoard} (signal
- * only), this combines the signal with the pattern position.
+ * service they can actually ride.
  *
- * Delegates to {@link isBoardableForPassengerSignal}; the interim rule
- * and its rationale live there.
+ * Picks the judgment by per-source policy:
+ * - endpoint-signal-trusted source ({@link isEndpointSignalTrustedByRoute}):
+ *   {@link isBoardableForPassengerBySignal} (signal alone).
+ * - otherwise: {@link isBoardableForPassengerBySignalAndPosition}
+ *   (signal AND pattern position).
+ *
+ * TEMPORARY local prototype; the trusted set is hardcoded. See Issue #145.
  */
 export function isBoardableForPassenger(entry: TimetableEntry): boolean {
-  return isBoardableForPassengerSignal(entry.boarding.pickupType, entry.patternPosition.isLastStop);
+  const { pickupType } = entry.boarding;
+  if (isEndpointSignalTrustedByRoute(entry.routeDirection.route)) {
+    return isBoardableForPassengerBySignal(pickupType);
+  }
+  return isBoardableForPassengerBySignalAndPosition(pickupType, entry.patternPosition.isLastStop);
 }
 
 /**

--- a/src/domain/transit/timetable-entry-for-passenger.ts
+++ b/src/domain/transit/timetable-entry-for-passenger.ts
@@ -45,8 +45,8 @@ import { extractPrefix } from './prefixed-id';
  * through-running). Adding it here would wrongly release every terminus
  * as boardable, so it fails (1) and (2) both.
  *
- * TEMPORARY / local prototype, each entry verified individually. Toei
- * Train checked at the terminal level (2026-06-13): through lines
+ * Each entry is verified individually. Toei Train was checked at the
+ * terminal level (2026-06-13): through lines
  * (Asakusa / Mita / Shinjuku) carry pickup_type 0 only at real
  * boundaries (Oshiage, Sengakuji, Meguro, Shinjuku); the non-through
  * Oedo line marks every terminal pickup_type 1. See Issue #145.
@@ -150,7 +150,8 @@ export function isBoardableForPassengerBySignalAndPosition(
  * - otherwise: {@link isBoardableForPassengerBySignalAndPosition}
  *   (signal AND pattern position).
  *
- * TEMPORARY local prototype; the trusted set is hardcoded. See Issue #145.
+ * The trusted set is configured in
+ * {@link THROUGH_RUNNING_SIGNAL_TRUSTED_PREFIXES}.
  */
 export function isBoardableForPassenger(entry: TimetableEntry): boolean {
   const { pickupType } = entry.boarding;
@@ -227,7 +228,8 @@ export function isAlightableForPassengerBySignalAndPosition(
  * - otherwise: {@link isAlightableForPassengerBySignalAndPosition}
  *   (signal AND pattern position).
  *
- * TEMPORARY local prototype; the trusted set is hardcoded. See Issue #145.
+ * The trusted set is configured in
+ * {@link THROUGH_RUNNING_SIGNAL_TRUSTED_PREFIXES}.
  */
 export function isAlightableForPassenger(entry: TimetableEntry): boolean {
   const { dropOffType } = entry.boarding;

--- a/src/domain/transit/timetable-entry-for-passenger.ts
+++ b/src/domain/transit/timetable-entry-for-passenger.ts
@@ -38,6 +38,13 @@ import { extractPrefix } from './prefixed-id';
  * loss. (A per-feed property: Toei Train `toaran` qualifies; Toei Bus
  * `minkuru`, same brand different feed, does not.)
  *
+ * A counter-example for (1): Yokohama Municipal Subway `yht` leaves
+ * pickup_type 0 on its real terminals -- all 1,901 last-stop rows are
+ * pickup_type 0 (2026-06-14: Shonandai, Azamino, Nakayama, Hiyoshi, plus
+ * short-turn terminals), and the network is self-contained (no
+ * through-running). Adding it here would wrongly release every terminus
+ * as boardable, so it fails (1) and (2) both.
+ *
  * TEMPORARY / local prototype, each entry verified individually. Toei
  * Train checked at the terminal level (2026-06-13): through lines
  * (Asakusa / Mita / Shinjuku) carry pickup_type 0 only at real

--- a/src/domain/transit/timetable-entry-for-passenger.ts
+++ b/src/domain/transit/timetable-entry-for-passenger.ts
@@ -75,20 +75,20 @@ export function isEndpointSignalTrustedByRoute(route: Route): boolean {
 }
 
 /**
- * Whether a passenger can board per a raw GTFS pickup_type value.
+ * PROVISIONAL: boardability judged by the GTFS pickup_type signal ALONE
+ * -- the pattern position is ignored. Applied when the source's endpoint
+ * signals are trusted (see {@link isEndpointSignalTrustedByRoute}), so a
+ * last-stop through-service row is released as boardable.
  *
- * Signal-level form of {@link canBoard} for callers that hold the raw
- * value without a {@link TimetableEntry} (e.g. repositories scanning
- * timetable JSON arrays).
- *
- * Arrangement-required values 2 (phone agency) and 3 (coordinate with
- * driver) count as boardable; combine with `requiresArrangement` in
- * `timetable-entry-boarding.ts` to tell them apart from a regular
- * pickup.
+ * Scalar form (no {@link TimetableEntry}) so repositories can call it
+ * while scanning raw timetable rows. Arrangement-required values 2 (phone
+ * agency) and 3 (coordinate with driver) count as boardable; combine with
+ * `requiresArrangement` in `timetable-entry-boarding.ts` to tell them
+ * apart from a regular pickup.
  */
-export function canBoardSignal(pickupType: StopServiceType): boolean {
+export function isBoardableForPassengerBySignal(pickupType: StopServiceType): boolean {
   switch (pickupType) {
-    case 0: // GTFS: Regularly scheduled pickup
+    case 0: // GTFS: Regularly scheduled pickup.
       return true;
     case 1: // GTFS: No pickup available.
       return false;
@@ -100,129 +100,33 @@ export function canBoardSignal(pickupType: StopServiceType): boolean {
 }
 
 /**
- * Whether a passenger can board at this stop event, judged from the
- * GTFS pickup_type signal alone (no pattern-role inference). See
- * {@link canBoardSignal} for the value interpretation.
- */
-export function canBoard(entry: TimetableEntry): boolean {
-  return canBoardSignal(entry.boarding.pickupType);
-}
-
-/**
- * Whether a passenger can alight at this stop event, judged from the
- * GTFS drop_off_type signal alone (no pattern-role inference).
- *
- * Arrangement-required values 2 and 3 count as alightable; see
- * {@link canBoard}.
- */
-export function canAlight(entry: TimetableEntry): boolean {
-  switch (entry.boarding.dropOffType) {
-    case 0: // GTFS: Regularly scheduled drop off.
-      return true;
-    case 1: // GTFS: No drop off available.
-      return false;
-    case 2: // GTFS: Must phone agency to arrange drop off.
-      return true;
-    case 3: // GTFS: Must coordinate with driver to arrange drop off.
-      return true;
-  }
-}
-
-/**
- * PROVISIONAL: boardability judged by the pickup signal ALONE (mode A) --
- * the pattern position is ignored. Applied when the source's endpoint
- * signals are trusted (see {@link isEndpointSignalTrustedByRoute}), so a
- * last-stop through-service row is released as boardable.
+ * PROVISIONAL: boardability judged by the pickup signal AND the pattern
+ * position -- a last stop is treated as not boardable. This is the
+ * conservative default for sources whose endpoint signals are not trusted;
+ * for trusted sources the selector {@link isBoardableForPassenger} uses
+ * {@link isBoardableForPassengerBySignal} (the signal alone) instead.
  *
  * Scalar form (no {@link TimetableEntry}) so repositories can call it
  * while scanning raw timetable rows.
- */
-export function isBoardableForPassengerBySignal(pickupType: StopServiceType): boolean {
-  return canBoardSignal(pickupType);
-}
-
-/**
- * PROVISIONAL: boardability judged by the pickup signal AND the pattern
- * position (mode B) -- a last stop is treated as not boardable. This is
- * the conservative default for sources whose endpoint signals are not
- * trusted; scalar form so repositories can call it while scanning raw
- * timetable rows.
  *
  * The exact judgment rule is still being specified (state model:
  * Issue #162; feed boundaries: Issue #145). Interim rule: boardable per
  * the signal and not the pattern's last stop -- the same inference as the
- * former isDropOffOnly, which this rule replaces.
+ * former isDropOffOnly, which this rule replaces. A last stop is not
+ * necessarily a true terminus: a through-service onto another operator
+ * continues past a feed boundary (e.g. Tokyo Metro at Ayase, TWR Rinkai
+ * at Osaki), but without a trusted endpoint signal it is treated as not
+ * boardable here. See Issue #145.
  */
 export function isBoardableForPassengerBySignalAndPosition(
   pickupType: StopServiceType,
   isLastStop: boolean,
 ): boolean {
-  // The last-stop rule below knowingly excludes two real-world classes
-  // of boardable through-services (kept for reference; both measured on
-  // the 2026-06-11 feed snapshots):
-  //
-  // 1. Single-stop patterns (isFirstStop && isLastStop): trips whose
-  //    feed description is one served row -- below the GTFS definition
-  //    of a trip ("a sequence of two or more stops"). Real instance:
-  //    5 Tokyo Metro weekday trips through onto JR Joban, departing
-  //    Ayase 05:45-06:33 toward Toride / Matsudo with pickup 0 /
-  //    drop_off 1 (trip_id 50B0509K00 etc.). The operator writes the
-  //    signals correctly there, so the signal alone could judge them.
-  //
-  // 2. Full-run last rows of through-services: the pattern's last stop
-  //    is a feed boundary, not a terminus -- the train continues onto
-  //    another operator's line. Real instances: Tokyo Metro at Ayase,
-  //    e.g. 07:06 Toride / 07:10 Kashiwa (stop 19 of 19, pickup 0);
-  //    TWR Rinkai at Osaki, 152 rows/day continuing onto JR toward
-  //    Kawagoe etc. About 4,700 rows/day across the rail sources.
-  //
-  // Why class 1 is not exempted on its own: releasing only the 5
-  // single-row departures while the far more numerous class-2 trains
-  // stay hidden would render a misleading board at Ayase ("only 5
-  // trains toward Toride all morning"). Both classes must be released
-  // together, which requires the per-source signal-trust policy
-  // tracked in Issue #145 (e.g. Yokohama Municipal Subway leaves
-  // pickup_type 0 on real terminals, so a blanket signal-trust or a
-  // route_type split alone is not safe).
-
-  // Ideally this would be judged by the boarding signal alone, but
-  // current data quality makes that impossible:
-  // - For a source like Tokyo Metro, a last-stop row could safely be
-  //   judged boardable (its signals are written reliably).
-  // - But not every subway operator produces data of that quality
-  //   (e.g. Yokohama Municipal Subway leaves pickup_type 0 on real
-  //   terminals), so the decision cannot be made by route type alone.
-  //
-  // /** Implementation sketch: trust the signal in all cases */
-  // return canBoardSignal(pickupType)
-  //
-  // /** Implementation sketch: for subway / rail route types, judge a
-  //  *  last-stop row boardable per the signal (route_type would have
-  //  *  to become a parameter of this function) */
-  //
-  // switch (routeType) {
-  //   case 1: // Subway
-  //     return canBoardSignal(pickupType);
-  //   case 2: // Rail
-  //     return canBoardSignal(pickupType);
-  //   default:
-  //     if (isLastStop) {
-  //       return false;
-  //     } else {
-  //       return canBoardSignal(pickupType);
-  //     }
-  // }
-
-  // For now, treating the last stop as not boardable is the realistic
-  // implementation. Note that a last stop is NOT necessarily a terminus
-  // (a through-service onto another line continues past it), but it is
-  // still treated as not boardable here.
-
   if (isLastStop) {
     return false;
   }
 
-  if (!canBoardSignal(pickupType)) {
+  if (!isBoardableForPassengerBySignal(pickupType)) {
     return false;
   }
 
@@ -250,23 +154,81 @@ export function isBoardableForPassenger(entry: TimetableEntry): boolean {
 }
 
 /**
- * PROVISIONAL: whether a passenger can alight from this stop event as
- * a service they actually arrive on. Unlike {@link canAlight} (signal
- * only), this combines the signal with the pattern position.
+ * PROVISIONAL: alightability judged by the GTFS drop_off_type signal
+ * ALONE -- the pattern position is ignored. Applied when the source's
+ * endpoint signals are trusted (see {@link isEndpointSignalTrustedByRoute}),
+ * so a first-stop through-service row (a feed-boundary arrival continuing
+ * from another operator) is released as alightable.
  *
- * Symmetric to {@link isBoardableForPassenger}; the rule is equally
- * interim. Interim rule: alightable per the signal and not the
- * pattern's first stop -- the same inference as the former
- * isBoardingOnly, which this function replaces.
+ * Mirror of {@link isBoardableForPassengerBySignal}. Scalar form (no
+ * {@link TimetableEntry}) so repositories can call it while scanning raw
+ * timetable rows. Arrangement-required values 2 and 3 count as
+ * alightable.
  */
-export function isAlightableForPassenger(entry: TimetableEntry): boolean {
-  if (entry.patternPosition.isFirstStop) {
+export function isAlightableForPassengerBySignal(dropOffType: StopServiceType): boolean {
+  switch (dropOffType) {
+    case 0: // GTFS: Regularly scheduled drop off.
+      return true;
+    case 1: // GTFS: No drop off available.
+      return false;
+    case 2: // GTFS: Must phone agency to arrange drop off.
+      return true;
+    case 3: // GTFS: Must coordinate with driver to arrange drop off.
+      return true;
+  }
+}
+
+/**
+ * PROVISIONAL: alightability judged by the drop_off signal AND the
+ * pattern position -- a first stop is treated as not alightable. This is
+ * the conservative default for sources whose endpoint signals are not
+ * trusted; for trusted sources the selector {@link isAlightableForPassenger}
+ * uses {@link isAlightableForPassengerBySignal} (the signal alone) instead.
+ *
+ * Mirror of {@link isBoardableForPassengerBySignalAndPosition}. Scalar
+ * form so repositories can call it while scanning raw timetable rows.
+ * Interim rule: alightable per the signal and not the pattern's first stop
+ * -- the same inference as the former isBoardingOnly, which this rule
+ * replaces. A first stop is not necessarily a true origin: a
+ * through-service arriving from another operator continues past a feed
+ * boundary, but without a trusted endpoint signal it is treated as not
+ * alightable here. See Issue #145.
+ */
+export function isAlightableForPassengerBySignalAndPosition(
+  dropOffType: StopServiceType,
+  isFirstStop: boolean,
+): boolean {
+  if (isFirstStop) {
     return false;
   }
 
-  if (!canAlight(entry)) {
+  if (!isAlightableForPassengerBySignal(dropOffType)) {
     return false;
   }
 
   return true;
+}
+
+/**
+ * PROVISIONAL: whether a passenger can alight from this stop event as
+ * a service they actually arrive on.
+ *
+ * Mirror of {@link isBoardableForPassenger}; picks the judgment by the
+ * same per-source policy:
+ * - endpoint-signal-trusted source ({@link isEndpointSignalTrustedByRoute}):
+ *   {@link isAlightableForPassengerBySignal} (signal alone).
+ * - otherwise: {@link isAlightableForPassengerBySignalAndPosition}
+ *   (signal AND pattern position).
+ *
+ * TEMPORARY local prototype; the trusted set is hardcoded. See Issue #145.
+ */
+export function isAlightableForPassenger(entry: TimetableEntry): boolean {
+  const { dropOffType } = entry.boarding;
+  if (isEndpointSignalTrustedByRoute(entry.routeDirection.route)) {
+    return isAlightableForPassengerBySignal(dropOffType);
+  }
+  return isAlightableForPassengerBySignalAndPosition(
+    dropOffType,
+    entry.patternPosition.isFirstStop,
+  );
 }

--- a/src/repositories/athenai-repository/athenai-repository-v2.ts
+++ b/src/repositories/athenai-repository/athenai-repository-v2.ts
@@ -35,7 +35,11 @@ import {
   sortTimetableEntriesByDepartureTime,
   sortTimetableEntriesChronologically,
 } from '../../domain/transit/sort-timetable-entries';
-import { isBoardableForPassengerSignal } from '../../domain/transit/timetable-entry-for-passenger';
+import {
+  isBoardableForPassengerBySignal,
+  isBoardableForPassengerBySignalAndPosition,
+  isEndpointSignalTrustedByRoute,
+} from '../../domain/transit/timetable-entry-for-passenger';
 import { getTimetableEntriesState } from '../../domain/transit/timetable-service-state';
 import { createLogger } from '../../lib/logger';
 import type { Bounds, LatLng, RouteShape } from '../../types/app/map';
@@ -471,6 +475,9 @@ export class AthenaiRepositoryV2 implements TransitRepository {
       const totalStops = pattern.stops.length;
       const stopIndex = group.si;
       const isLastStopPosition = stopIndex === totalStops - 1;
+      // Per-source policy (constant per group); future criteria are
+      // absorbed inside isEndpointSignalTrustedByRoute. See Issue #145.
+      const trustEndpointSignal = isEndpointSignalTrustedByRoute(route);
       const routeDirection = this.resolveRouteDirection(route, pattern, stopIndex);
       const todayTripInsights = this.resolveTripInsights(group.tp, stopIndex, serviceDay);
       const yesterdayTripInsights = this.resolveTripInsights(group.tp, stopIndex, prevServiceDay);
@@ -509,7 +516,10 @@ export class AthenaiRepositoryV2 implements TransitRepository {
             fullDayCount++;
             if (!hasBoardable) {
               const pt = pickupTypes?.[j] ?? 0;
-              if (isBoardableForPassengerSignal(pt, isLastStopPosition)) {
+              const boardable = trustEndpointSignal
+                ? isBoardableForPassengerBySignal(pt)
+                : isBoardableForPassengerBySignalAndPosition(pt, isLastStopPosition);
+              if (boardable) {
                 hasBoardable = true;
               }
             }

--- a/src/repositories/mock-repository/mock-repository.ts
+++ b/src/repositories/mock-repository/mock-repository.ts
@@ -22,7 +22,11 @@ import {
   sortTimetableEntriesByDepartureTime,
   sortTimetableEntriesChronologically,
 } from '../../domain/transit/sort-timetable-entries';
-import { isBoardableForPassengerSignal } from '../../domain/transit/timetable-entry-for-passenger';
+import {
+  isBoardableForPassengerBySignal,
+  isBoardableForPassengerBySignalAndPosition,
+  isEndpointSignalTrustedByRoute,
+} from '../../domain/transit/timetable-entry-for-passenger';
 import { getTimetableEntriesState } from '../../domain/transit/timetable-service-state';
 import type { Bounds, LatLng, RouteShape } from '../../types/app/map';
 import type {
@@ -176,6 +180,8 @@ export class MockRepository implements TransitRepository {
       if (!route) {
         continue;
       }
+      // Per-source policy (constant per route); see Issue #145.
+      const trustEndpointSignal = isEndpointSignalTrustedByRoute(route);
 
       const allMinutes = generateFixedMinutes(routeId, headsign);
 
@@ -191,8 +197,13 @@ export class MockRepository implements TransitRepository {
 
         // Count full-day entries and check boardability (per occurrence).
         fullDayCount += allMinutes.length;
-        if (!hasBoardable && isBoardableForPassengerSignal(pickupType, position.isLastStop)) {
-          hasBoardable = true;
+        if (!hasBoardable) {
+          const boardable = trustEndpointSignal
+            ? isBoardableForPassengerBySignal(pickupType)
+            : isBoardableForPassengerBySignalAndPosition(pickupType, position.isLastStop);
+          if (boardable) {
+            hasBoardable = true;
+          }
         }
 
         const upcoming = allMinutes

--- a/src/types/app/repository.ts
+++ b/src/types/app/repository.ts
@@ -58,7 +58,8 @@ export interface TimetableQueryMeta {
    * what `data` contains. A stop with `isBoardableOnServiceDay === false`
    * and `totalEntries > 0` is a drop-off-only stop.
    *
-   * Boardability is judged by `isBoardableForPassengerSignal` in
+   * Boardability is judged by `isBoardableForPassengerBySignal` /
+   * `isBoardableForPassengerBySignalAndPosition` (per-source policy) in
    * `src/domain/transit/timetable-entry-for-passenger.ts` (the
    * signal-level form of `isBoardableForPassenger`).
    */


### PR DESCRIPTION
## Summary

Introduce a **per-source endpoint-signal-trust policy** so that, on sources whose GTFS endpoint signals are spec-correct, a last-stop through-service (a feed boundary continuing onto another operator, `pickup_type=0`) is judged **boardable by the signal alone** -- instead of being hidden by the conservative last-stop fallback.

## Background

On through-running rail/subway, a feed is scoped to one operator, so a trip's last stop can be a feed boundary (the train continues onto another line) rather than a real terminus. The previous position-based rule hid these as non-boardable. See #145 (TWR Rinkai / Osaki case).

## What changed

- `isEndpointSignalTrustedByPrefix` / `isEndpointSignalTrustedByRoute` with a trusted set: `tome` (Tokyo Metro), `twrr` (TWR Rinkai), `toaran` (Toei Train). Each verified individually; the set's TSDoc documents the two criteria and a counter-example (`yht` Yokohama Municipal, which leaves `pickup_type 0` on real terminals).
- Boardability split into `isBoardableForPassengerBySignal` (signal alone), `isBoardableForPassengerBySignalAndPosition` (signal + position), and the `isBoardableForPassenger` selector that picks per-source.
- Symmetric alighting side (`isAlightableForPassenger*`); `isDeparture` / `isArrival` now both delegate to the passenger-perspective judgment.
- Removed now-unused `canBoardSignal` / `canBoard` / `canAlight` (inlined into the BySignal functions).
- Repos (`athenai-repository-v2`, `mock-repository`) wired through `isEndpointSignalTrustedByRoute`.

## Impact (last-stop rows newly surfaced as boardable, all services)

- **tome**: ~3,211 (中央林間, 元町・中華街, 浦和美園, 我孫子, 東葉勝田台, ...)
- **toaran**: ~1,339 (Asakusa 60% / Shinjuku 46% / Mita 31%; Oedo / tram / AGT: 0)
- **twrr** Osaki: 152 (川越 101, 大宮 31, 赤羽 10, ...)

## Verification

- typecheck / prettier / eslint / vitest (4,511) / build: all green
- Browser A/B at Ayase (`tome:519`): trusted on -> JR Joban destinations (取手 / 松戸 / 我孫子 / 柏) surface as boardable; trusted off -> they disappear. True terminals (`pickup_type=1`) stay excluded in both.

## Notes

- The trusted set is hardcoded; expanding it (auditing more operators) is future work.
- #145 (Osaki boardability) is resolved. Display-side follow-ups are tracked separately: #294 (arrival vs departure time), #295 (terminal vs through wording), #296 (Transit Display direction grouping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
