### PR TITLE
refactor: stats axis cleanup + TimetableMetadata badge axis separation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - Boardability: 他社直通の境界となる last stop (フィード境界) を乗車可として扱う per-source endpoint-signal-trust を導入した。信頼対象は東京メトロ (`tome`) / りんかい線 (`twrr`) / 都営地下鉄 (`toaran`) で、これらでは last stop / first stop の乗降可否を pickup_type / drop_off_type の signal のみで判定する。従来 last stop として発着案内・乗車可フィルタから除外されていた直通便 (例: 千代田線→JR 常磐線の綾瀬、りんかい線→JR 埼京線の大崎) が乗車可として表示されるようになった (東京メトロ 約 3,211 / 都営地下鉄 約 1,339 / りんかい線 大崎 152 行)。横浜市営地下鉄のように真の終点に pickup_type=0 を残す事業者は対象外 (#297, #145)。
 - Boardability: `isBoardableForPassenger` / `isAlightableForPassenger` を「signal のみ」(`...BySignal`) と「signal + 位置」(`...BySignalAndPosition`) の判定に分割し、事業者方針で振り分ける selector に整理した。降車側も対称化し、発着案内の `isDeparture` / `isArrival` を利用者観点判定に一本化した。`canBoardSignal` / `canBoard` / `canAlight` は統合・削除した (#297)。
+- TimetableEntryStats: faithful な集計軸 `signal` を `boarding` にリネームし、pickup_type / drop_off_type を「不可」だけでなく全値 (0/1/2/3) の分布 (`pickupTypeCounts` / `dropOffTypeCounts`) として持つようにした。利用者観点の `passenger` 軸には降車側 (`alightableCount` / `nonAlightableCount`) を対称に追加した (#298, #162)。
+- TimetableMetadata: 時刻表ダイアログの集計バッジで faithful (signal) と interpreted (passenger) の軸が混在していた問題を解消し、position / boarding (faithful) / passenger (interpreted) のバッジに分離した。passenger バッジは verbose 情報レベルでのみ表示し、デバッグ用の集計 span は `VerboseTimetableSummary` に集約した (#298)。
+- i18n: 未使用だった `stop.serviceState.boardable` ("運行中") を `inService` にリネームした (`passenger.boardableCount` ("乗車可") との混同を回避)。`stopTimeView` を `relativeTime` / `absoluteTime` / `passenger` / `endpoint` のサブグループに構造化し、将来の発着可否・端点種別 (現実の起終点 vs 直通境界) 表示用キーを足場として追加した (#162)。
 
 ## [2026.06.11]
 

--- a/src/components/__tests__/relative-time.test.tsx
+++ b/src/components/__tests__/relative-time.test.tsx
@@ -7,9 +7,9 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => {
       const labels: Record<string, string> = {
-        'stopTimeView.soon': 'まもなく',
-        'stopTimeView.in': 'あと',
-        'stopTimeView.minutes': '分',
+        'stopTimeView.relativeTime.soon': 'まもなく',
+        'stopTimeView.relativeTime.in': 'あと',
+        'stopTimeView.relativeTime.minutes': '分',
       };
       return labels[key] ?? key;
     },

--- a/src/components/absolute-stop-time.tsx
+++ b/src/components/absolute-stop-time.tsx
@@ -52,12 +52,12 @@ export function AbsoluteStopTime({
       {timeText}
       {showArrivalMarker && (
         <span className={cn('font-normal opacity-70', variant.marker)}>
-          {t('stopTimeView.arrivingAbsolute')}
+          {t('stopTimeView.absoluteTime.arrivingMarker')}
         </span>
       )}
       {showDepartureMarker && (
         <span className={cn('font-normal opacity-70', variant.marker)}>
-          {t('stopTimeView.departingAbsolute')}
+          {t('stopTimeView.absoluteTime.departingMarker')}
         </span>
       )}
     </div>

--- a/src/components/dialog/__tests__/dialog-memoization.test.tsx
+++ b/src/components/dialog/__tests__/dialog-memoization.test.tsx
@@ -311,7 +311,12 @@ beforeEach(() => {
       pickupTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
       dropOffTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
     },
-    passenger: { boardableCount: 1, nonBoardableCount: 0 },
+    passenger: {
+      boardableCount: 1,
+      nonBoardableCount: 0,
+      alightableCount: 1,
+      nonAlightableCount: 0,
+    },
     routeDirection: {
       routeCount: 1,
       directionCount: 1,

--- a/src/components/dialog/__tests__/dialog-memoization.test.tsx
+++ b/src/components/dialog/__tests__/dialog-memoization.test.tsx
@@ -307,7 +307,10 @@ beforeEach(() => {
   computeTimetableEntryStatsMock.mockReturnValue({
     totalCount: 1,
     position: { originCount: 1, terminalCount: 0, passingCount: 0 },
-    signal: { noPickupCount: 0, noDropOffCount: 0 },
+    boarding: {
+      pickupTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
+      dropOffTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
+    },
     passenger: { boardableCount: 1, nonBoardableCount: 0 },
     routeDirection: {
       routeCount: 1,

--- a/src/components/dialog/__tests__/timetable-dialog-state-leak.test.tsx
+++ b/src/components/dialog/__tests__/timetable-dialog-state-leak.test.tsx
@@ -58,7 +58,10 @@ vi.mock('@/domain/transit/timetable-stats', () => ({
   computeTimetableEntryStats: () => ({
     totalCount: 0,
     position: { originCount: 0, terminalCount: 0, passingCount: 0 },
-    signal: { noPickupCount: 0, noDropOffCount: 0 },
+    boarding: {
+      pickupTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
+      dropOffTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
+    },
     passenger: { boardableCount: 0, nonBoardableCount: 0 },
     routeDirection: {
       routeCount: 0,

--- a/src/components/dialog/__tests__/timetable-dialog-state-leak.test.tsx
+++ b/src/components/dialog/__tests__/timetable-dialog-state-leak.test.tsx
@@ -62,7 +62,12 @@ vi.mock('@/domain/transit/timetable-stats', () => ({
       pickupTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
       dropOffTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
     },
-    passenger: { boardableCount: 0, nonBoardableCount: 0 },
+    passenger: {
+      boardableCount: 0,
+      nonBoardableCount: 0,
+      alightableCount: 0,
+      nonAlightableCount: 0,
+    },
     routeDirection: {
       routeCount: 0,
       directionCount: 0,

--- a/src/components/dialog/timetable-dialog.tsx
+++ b/src/components/dialog/timetable-dialog.tsx
@@ -63,6 +63,7 @@ interface EntriesPanelProps {
   timetableEntries: TimetableEntry[];
   entryStats: TimetableEntryStats;
   agencies: Agency[];
+  infoLevel: InfoLevel;
   dataLangs: readonly string[];
   filteredCount: number;
 }
@@ -75,8 +76,9 @@ interface EntriesPanelProps {
 function EntriesPanel({
   timetableEntries,
   entryStats,
-  dataLangs,
   agencies,
+  infoLevel,
+  dataLangs,
   filteredCount,
 }: EntriesPanelProps) {
   return (
@@ -84,6 +86,7 @@ function EntriesPanel({
       {filteredCount > 0 && (
         <TimetableMetadata
           timetableEntries={timetableEntries}
+          infoLevel={infoLevel}
           dataLang={dataLangs}
           agencies={agencies}
           stats={entryStats}
@@ -527,6 +530,7 @@ export const TimetableDialog = memo(function TimetableDialog({
                 timetableEntries={allTimetableEntries}
                 entryStats={allEntriesStats}
                 agencies={data.agencies}
+                infoLevel={infoLevel}
                 dataLangs={dataLangs}
                 filteredCount={allTimetableEntries.length}
               />
@@ -538,6 +542,7 @@ export const TimetableDialog = memo(function TimetableDialog({
                 timetableEntries={entriesBeforeRouteHeadsignFilter}
                 entryStats={entriesBeforeRouteHeadsignFilterStats}
                 agencies={data.agencies}
+                infoLevel={infoLevel}
                 dataLangs={dataLangs}
                 filteredCount={entriesBeforeRouteHeadsignFilter.length}
               />
@@ -549,6 +554,7 @@ export const TimetableDialog = memo(function TimetableDialog({
                 timetableEntries={routeHeadsignFilteredEntries}
                 entryStats={routeHeadsignFilteredEntriesStats}
                 agencies={data.agencies}
+                infoLevel={infoLevel}
                 dataLangs={dataLangs}
                 filteredCount={routeHeadsignFilteredEntries.length}
               />

--- a/src/components/relative-time.tsx
+++ b/src/components/relative-time.tsx
@@ -83,20 +83,22 @@ export function RelativeTime({
       style={{ color: style.color, opacity: style.opacity }}
     >
       {parts.kind === 'futureWithinMinute' ? (
-        <span className={v.imminent}>{t('stopTimeView.soon')}</span>
+        <span className={v.imminent}>{t('stopTimeView.relativeTime.soon')}</span>
       ) : parts.tense === 'past' ? (
         <span>
           <span className={v.number}>-{parts.minutes}</span>
-          <span className={`${v.label} font-normal`}>{t('stopTimeView.minutes')}</span>
+          <span className={`${v.label} font-normal`}>{t('stopTimeView.relativeTime.minutes')}</span>
         </span>
       ) : (
         <>
           {parts.showPrefix && (
-            <span className={`${v.label} font-normal`}>{t('stopTimeView.in')}</span>
+            <span className={`${v.label} font-normal`}>{t('stopTimeView.relativeTime.in')}</span>
           )}
           <span>
             <span className={v.number}>{parts.minutes}</span>
-            <span className={`${v.label} font-normal`}>{t('stopTimeView.minutes')}</span>
+            <span className={`${v.label} font-normal`}>
+              {t('stopTimeView.relativeTime.minutes')}
+            </span>
           </span>
         </>
       )}

--- a/src/components/stop-time-item.stories.tsx
+++ b/src/components/stop-time-item.stories.tsx
@@ -283,7 +283,7 @@ export const InfoLevelComparison: Story = {
  * position (so the terminal marker and `RelativeTime` interact) and
  * one further down (so the terminal marker sits next to an
  * absolute-only time). Terminal rows exercise the
- * `stopTimeView.arrivingAbsolute` i18n key and are the easiest way to
+ * `stopTimeView.absoluteTime.arrivingMarker` i18n key and are the easiest way to
  * eyeball the "着" / "Arr" opt-out behaviour from Storybook.
  */
 export const MultipleItems: Story = {
@@ -328,7 +328,7 @@ export const MultipleItems: Story = {
 
 /**
  * Multi-item list stacked across every supported language so the
- * `stopTimeView.arrivingAbsolute` marker can be verified per locale:
+ * `stopTimeView.absoluteTime.arrivingMarker` marker can be verified per locale:
  * ja shows "着" next to terminal absolute times, en shows "Arr",
  * and other locales follow their own key value or fall through the
  * locale chain. Locale owners can still opt out for any language by

--- a/src/components/timetable/timetable-metadata.tsx
+++ b/src/components/timetable/timetable-metadata.tsx
@@ -110,11 +110,11 @@ function BoardingAxisStats({ stats }: { stats: TimetableEntryStats }) {
       })}
       {' / '}
       {t('timetable.metadata.dropOffOnlyCount', {
-        count: stats.signal.noPickupCount.toLocaleString(i18n.language),
+        count: stats.boarding.pickupTypeCounts[1].toLocaleString(i18n.language),
       })}
       {' / '}
       {t('timetable.metadata.noDropOffCount', {
-        count: stats.signal.noDropOffCount.toLocaleString(i18n.language),
+        count: stats.boarding.dropOffTypeCounts[1].toLocaleString(i18n.language),
       })}
       {']'}
     </span>
@@ -147,10 +147,10 @@ function BoardingAxisBadges({ stats }: { stats: TimetableEntryStats }) {
         labelClassName={noPickupLabelBadgeClassName}
         countClassName={noPickupCountBadgeClassName}
       />
-      {/* <LabelCountBadge label={t('timetable.entry.noDropOff')} count={stats.signal.noDropOffCount} /> */}
+      {/* <LabelCountBadge label={t('timetable.entry.noDropOff')} count={stats.boarding.dropOffTypeCounts[1]} /> */}
       <LabelCountBadge
         label={t('timetable.entry.noDropOff')}
-        count={stats.signal.noDropOffCount}
+        count={stats.boarding.dropOffTypeCounts[1]}
         size="sm"
         frameClassName="border-dashed border-yellow-600"
         labelClassName={noDropOffLabelBadgeClassName}
@@ -158,7 +158,7 @@ function BoardingAxisBadges({ stats }: { stats: TimetableEntryStats }) {
       />
       <LabelCountBadge
         label={t('stop.serviceState.dropOffOnly')}
-        count={stats.signal.noPickupCount}
+        count={stats.boarding.pickupTypeCounts[1]}
         size="sm"
       />
     </div>

--- a/src/components/timetable/timetable-metadata.tsx
+++ b/src/components/timetable/timetable-metadata.tsx
@@ -6,9 +6,12 @@ import type { Agency, Route } from '@/types/app/transit';
 import type { TimetableEntry } from '@/types/app/transit-composed';
 import { LabelCountBadge } from '../badge/label-count-badge';
 import { RouteCountBadge } from '../badge/route-count-badge';
+import type { InfoLevel } from '@/types/app/settings';
+import { useInfoLevel } from '@/hooks/use-info-level';
 
 interface TimetableMetadataProps {
   timetableEntries: TimetableEntry[];
+  infoLevel: InfoLevel;
   dataLang: readonly string[];
   agencies: Agency[];
   /**
@@ -125,7 +128,6 @@ function PassengerAxisBadges({ stats }: { stats: TimetableEntryStats }) {
   );
 }
 
-
 /**
  * Render timetable statistics and per-route counts above the timetable grid.
  *
@@ -134,10 +136,13 @@ function PassengerAxisBadges({ stats }: { stats: TimetableEntryStats }) {
  */
 export function TimetableMetadata({
   timetableEntries,
+  infoLevel,
   dataLang,
   agencies,
   stats,
 }: TimetableMetadataProps) {
+  const infoLevelFlag = useInfoLevel(infoLevel);
+
   const { t, i18n } = useTranslation();
   const allMinutes = timetableEntries.map((entry) => getDisplayMinutes(entry));
   const count = allMinutes.length;
@@ -187,7 +192,7 @@ export function TimetableMetadata({
       <div className="flex flex-wrap items-start gap-1">
         <PatternPositionAxisBadges stats={stats} />
         <BoardingAxisBadges stats={stats} />
-        {false && <PassengerAxisBadges stats={stats} />}
+        {infoLevelFlag.isVerboseEnabled && <PassengerAxisBadges stats={stats} />}
       </div>
 
       {/* Routes with their counts.

--- a/src/components/timetable/timetable-metadata.tsx
+++ b/src/components/timetable/timetable-metadata.tsx
@@ -34,31 +34,6 @@ function computeAverageInterval(minutes: number[]): number | null {
   return Math.round(totalSpan / (minutes.length - 1));
 }
 
-/**
- * Render the A-axis (pattern position) stats span:
- * `[origin / terminal / passing]`.
- */
-function PatternPositionAxisStats({ stats }: { stats: TimetableEntryStats }) {
-  const { t, i18n } = useTranslation();
-  return (
-    <span>
-      {'['}
-      {t('timetable.metadata.originCount', {
-        count: stats.position.originCount.toLocaleString(i18n.language),
-      })}
-      {' / '}
-      {t('timetable.metadata.terminalCount', {
-        count: stats.position.terminalCount.toLocaleString(i18n.language),
-      })}
-      {' / '}
-      {t('timetable.metadata.passingCount', {
-        count: stats.position.passingCount.toLocaleString(i18n.language),
-      })}
-      {']'}
-    </span>
-  );
-}
-
 function PatternPositionAxisBadges({ stats }: { stats: TimetableEntryStats }) {
   const { t } = useTranslation();
   const originLabelBadgeClassName = 'bg-blue-500 text-white';
@@ -88,44 +63,12 @@ function PatternPositionAxisBadges({ stats }: { stats: TimetableEntryStats }) {
   );
 }
 
-/**
- * Render the B-axis (boarding availability) stats span:
- * `[boardable / non-boardable / drop-off-only / no-drop-off]`.
- *
- * Reads only the boarding-related fields of {@link TimetableEntryStats},
- * so callers can pass either the all-entries or filtered-entries stats
- * depending on the metadata block scope.
- */
-function BoardingAxisStats({ stats }: { stats: TimetableEntryStats }) {
-  const { t, i18n } = useTranslation();
-  return (
-    <span>
-      {'['}
-      {t('timetable.metadata.boardableCount', {
-        count: stats.passenger.boardableCount.toLocaleString(i18n.language),
-      })}
-      {' / '}
-      {t('timetable.metadata.nonBoardableCount', {
-        count: stats.passenger.nonBoardableCount.toLocaleString(i18n.language),
-      })}
-      {' / '}
-      {t('timetable.metadata.dropOffOnlyCount', {
-        count: stats.boarding.pickupTypeCounts[1].toLocaleString(i18n.language),
-      })}
-      {' / '}
-      {t('timetable.metadata.noDropOffCount', {
-        count: stats.boarding.dropOffTypeCounts[1].toLocaleString(i18n.language),
-      })}
-      {']'}
-    </span>
-  );
-}
-
 function BoardingAxisBadges({ stats }: { stats: TimetableEntryStats }) {
   const { t } = useTranslation();
   const noPickupLabelBadgeClassName =
     'border-yellow-600 bg-yellow-100 text-yellow-900 dark:border-yellow-600 dark:bg-yellow-950 dark:text-yellow-200';
   const noPickupCountBadgeClassName = 'border-l border-yellow-600 bg-background text-foreground';
+
   const noDropOffLabelBadgeClassName =
     'bg-yellow-100 text-yellow-900 dark:bg-yellow-950 dark:text-yellow-200';
   const noDropOffCountBadgeClassName =
@@ -134,20 +77,13 @@ function BoardingAxisBadges({ stats }: { stats: TimetableEntryStats }) {
   return (
     <div className="flex flex-wrap gap-1">
       <LabelCountBadge
-        label={t('stop.serviceState.boardable')}
-        count={stats.passenger.boardableCount}
-        size="sm"
-      />
-      {/* <LabelCountBadge label={t('timetable.entry.noPickup')} count={stats.passenger.nonBoardableCount} /> */}
-      <LabelCountBadge
         label={t('timetable.entry.noPickup')}
-        count={stats.passenger.nonBoardableCount}
+        count={stats.boarding.pickupTypeCounts[1]}
         size="sm"
         frameClassName="border-yellow-600"
         labelClassName={noPickupLabelBadgeClassName}
         countClassName={noPickupCountBadgeClassName}
       />
-      {/* <LabelCountBadge label={t('timetable.entry.noDropOff')} count={stats.boarding.dropOffTypeCounts[1]} /> */}
       <LabelCountBadge
         label={t('timetable.entry.noDropOff')}
         count={stats.boarding.dropOffTypeCounts[1]}
@@ -156,51 +92,39 @@ function BoardingAxisBadges({ stats }: { stats: TimetableEntryStats }) {
         labelClassName={noDropOffLabelBadgeClassName}
         countClassName={noDropOffCountBadgeClassName}
       />
+    </div>
+  );
+}
+
+function PassengerAxisBadges({ stats }: { stats: TimetableEntryStats }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-wrap gap-1">
       <LabelCountBadge
-        label={t('stop.serviceState.dropOffOnly')}
-        count={stats.boarding.pickupTypeCounts[1]}
+        label={t('stopTimeView.passenger.boardable')}
+        count={stats.passenger.boardableCount}
+        size="sm"
+      />
+      <LabelCountBadge
+        label={t('stopTimeView.passenger.nonBoardable')}
+        count={stats.passenger.nonBoardableCount}
+        size="sm"
+      />
+      <LabelCountBadge
+        label={t('stopTimeView.passenger.alightable')}
+        count={stats.passenger.alightableCount}
+        size="sm"
+      />
+      <LabelCountBadge
+        label={t('stopTimeView.passenger.nonAlightable')}
+        count={stats.passenger.nonAlightableCount}
         size="sm"
       />
     </div>
   );
 }
 
-/**
- * Render the C-axis (route direction) stats span. Split into two
- * bracket groups: `[route / headsign]` for unique-name signals and
- * `[routeHeadsign / stopHeadsignOverride / direction]` for combined /
- * override / direction signals.
- *
- * `headsignCount` is currently aggregated from `tripHeadsign.name`;
- * sources that publish trip_headsign as empty (= rely on stop_headsign,
- * e.g. kobus) will report `headsignCount === 1`.
- */
-function RouteDirectionAxisStats({ stats }: { stats: TimetableEntryStats }) {
-  const { t, i18n } = useTranslation();
-  return (
-    <>
-      <span>
-        {'['}
-        {t('timetable.metadata.routeCount', {
-          count: stats.routeDirection.routeCount.toLocaleString(i18n.language),
-        })}
-        {' / '}
-        {t('timetable.metadata.headsignCount', {
-          count: stats.routeDirection.stopHeadsignCount.toLocaleString(i18n.language),
-        })}
-        {'] / ['}
-        {t('timetable.metadata.routeHeadsignCount', {
-          count: stats.routeDirection.tripHeadsignCount.toLocaleString(i18n.language),
-        })}
-        {' / '}
-        {t('timetable.metadata.directionCount', {
-          count: stats.routeDirection.directionCount.toLocaleString(i18n.language),
-        })}
-        {']'}
-      </span>
-    </>
-  );
-}
 
 /**
  * Render timetable statistics and per-route counts above the timetable grid.
@@ -258,29 +182,12 @@ export function TimetableMetadata({
             })}
           </span>
         )}
-        {false && (
-          <>
-            {' / '}
-            <PatternPositionAxisStats stats={stats} />
-          </>
-        )}
-        {false && (
-          <>
-            {' / '}
-            <BoardingAxisStats stats={stats} />
-          </>
-        )}
-        {false && (
-          <>
-            {' / '}
-            <RouteDirectionAxisStats stats={stats} />
-          </>
-        )}
       </p>
 
       <div className="flex flex-wrap items-start gap-1">
         <PatternPositionAxisBadges stats={stats} />
         <BoardingAxisBadges stats={stats} />
+        {false && <PassengerAxisBadges stats={stats} />}
       </div>
 
       {/* Routes with their counts.

--- a/src/components/verbose/verbose-timetable-summary.tsx
+++ b/src/components/verbose/verbose-timetable-summary.tsx
@@ -47,10 +47,10 @@ export function VerboseTimetableSummary({
   }
 
   // Pattern breakdown (stopIndex/totalStops combinations)
-  const patternCounts = new Map<string, number>();
+  const positionPatternCounts = new Map<string, number>();
   for (const e of timetableEntries) {
     const key = `[${e.patternPosition.stopIndex + 1}/${e.patternPosition.totalStops}]`;
-    patternCounts.set(key, (patternCounts.get(key) ?? 0) + 1);
+    positionPatternCounts.set(key, (positionPatternCounts.get(key) ?? 0) + 1);
   }
 
   // Dwell time stats
@@ -73,50 +73,58 @@ export function VerboseTimetableSummary({
             [timetable] serviceDate={formatDateKey(serviceDate)} type={type}
           </span>
           {headsign != null && <span className="block">[headsign] &quot;{headsign}&quot;</span>}
+
+          {dwellCount > 0 && <span className="block">[dwell] count={dwellCount}</span>}
           <span className="block">
-            [entries] total={stats.totalCount} uniqueTrips={stats.tripLocator.uniqueTripCount}
+            [state] stopServiceState={stopServiceState} omitted.nonBoardable=
+            {omitted.nonBoardable}
           </span>
+
+          {/* TimetableEntryStats  */}
+          <span className="block">[stats.totalCount] total={stats.totalCount}</span>
           <span className="block">
-            [position] origin={stats.position.originCount} terminal={stats.position.terminalCount}{' '}
-            passing={stats.position.passingCount}
+            [stats.position] origin={stats.position.originCount} terminal=
+            {stats.position.terminalCount} passing={stats.position.passingCount}
           </span>
+
           <span className="block">
-            [passenger] boardable={stats.passenger.boardableCount} nonBoardable=
-            {stats.passenger.nonBoardableCount}
-          </span>
-          <span className="block">
-            [boarding] pickupType(0/1/2/3)={stats.boarding.pickupTypeCounts[0]}/
+            [stats.boarding] pickupType(0/1/2/3)={stats.boarding.pickupTypeCounts[0]}/
             {stats.boarding.pickupTypeCounts[1]}/{stats.boarding.pickupTypeCounts[2]}/
             {stats.boarding.pickupTypeCounts[3]} dropOffType(0/1/2/3)=
             {stats.boarding.dropOffTypeCounts[0]}/{stats.boarding.dropOffTypeCounts[1]}/
             {stats.boarding.dropOffTypeCounts[2]}/{stats.boarding.dropOffTypeCounts[3]}
           </span>
+
           <span className="block">
-            [routeDirection] routes={stats.routeDirection.routeCount} directions=
+            [stats.passenger] boardable={stats.passenger.boardableCount} nonBoardable=
+            {stats.passenger.nonBoardableCount} alightable={stats.passenger.alightableCount}{' '}
+            nonAlightable={stats.passenger.nonAlightableCount}
+          </span>
+
+          <span className="block">
+            [stats.routeDirection] routes={stats.routeDirection.routeCount} directions=
             {stats.routeDirection.directionCount} tripHeadsigns=
             {stats.routeDirection.tripHeadsignCount} stopHeadsigns=
             {stats.routeDirection.stopHeadsignCount}
           </span>
+
           <span className="block">
-            [tripLocator] patterns={stats.tripLocator.patternCount} services=
-            {stats.tripLocator.serviceCount}
+            [stats.tripLocator] patterns={stats.tripLocator.patternCount} services=
+            {stats.tripLocator.serviceCount} uniqueTrips={stats.tripLocator.uniqueTripCount}
           </span>
+
           <span className="block">
             [direction]{' '}
             {Array.from(dirCounts.entries())
               .map(([dir, n]) => `${dir}:${n}`)
               .join(' ')}
           </span>
+
           <span className="block">
             [pattern]{' '}
-            {Array.from(patternCounts.entries())
+            {Array.from(positionPatternCounts.entries())
               .map(([pat, n]) => `${pat}:${n}`)
               .join(' ')}
-          </span>
-          {dwellCount > 0 && <span className="block">[dwell] count={dwellCount}</span>}
-          <span className="block">
-            [state] stopServiceState={stopServiceState} omitted.nonBoardable=
-            {omitted.nonBoardable}
           </span>
         </span>
       </div>

--- a/src/components/verbose/verbose-timetable-summary.tsx
+++ b/src/components/verbose/verbose-timetable-summary.tsx
@@ -85,7 +85,11 @@ export function VerboseTimetableSummary({
             {stats.passenger.nonBoardableCount}
           </span>
           <span className="block">
-            [signal] noPickup={stats.signal.noPickupCount} noDropOff={stats.signal.noDropOffCount}
+            [boarding] pickupType(0/1/2/3)={stats.boarding.pickupTypeCounts[0]}/
+            {stats.boarding.pickupTypeCounts[1]}/{stats.boarding.pickupTypeCounts[2]}/
+            {stats.boarding.pickupTypeCounts[3]} dropOffType(0/1/2/3)=
+            {stats.boarding.dropOffTypeCounts[0]}/{stats.boarding.dropOffTypeCounts[1]}/
+            {stats.boarding.dropOffTypeCounts[2]}/{stats.boarding.dropOffTypeCounts[3]}
           </span>
           <span className="block">
             [routeDirection] routes={stats.routeDirection.routeCount} directions=

--- a/src/domain/transit/__tests__/timetable-stats.test.ts
+++ b/src/domain/transit/__tests__/timetable-stats.test.ts
@@ -77,7 +77,12 @@ describe('computeTimetableEntryStats', () => {
         pickupTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
         dropOffTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
       },
-      passenger: { boardableCount: 0, nonBoardableCount: 0 },
+      passenger: {
+        boardableCount: 0,
+        nonBoardableCount: 0,
+        alightableCount: 0,
+        nonAlightableCount: 0,
+      },
       routeDirection: {
         routeCount: 0,
         directionCount: 0,
@@ -123,6 +128,20 @@ describe('computeTimetableEntryStats', () => {
       expect(stats.passenger.boardableCount).toBe(1);
       expect(stats.passenger.nonBoardableCount).toBe(2);
       expect(stats.passenger.boardableCount + stats.passenger.nonBoardableCount).toBe(
+        stats.totalCount,
+      );
+    });
+
+    it('partitions alightable vs non-alightable', () => {
+      const entries = [
+        makeEntry(),
+        makeEntry({ isFirstStop: true, stopIndex: 0 }),
+        makeEntry({ dropOffType: 1 }),
+      ];
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
+      expect(stats.passenger.alightableCount).toBe(1);
+      expect(stats.passenger.nonAlightableCount).toBe(2);
+      expect(stats.passenger.alightableCount + stats.passenger.nonAlightableCount).toBe(
         stats.totalCount,
       );
     });

--- a/src/domain/transit/__tests__/timetable-stats.test.ts
+++ b/src/domain/transit/__tests__/timetable-stats.test.ts
@@ -73,7 +73,10 @@ describe('computeTimetableEntryStats', () => {
     expect(stats).toEqual({
       totalCount: 0,
       position: { originCount: 0, terminalCount: 0, passingCount: 0 },
-      signal: { noPickupCount: 0, noDropOffCount: 0 },
+      boarding: {
+        pickupTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
+        dropOffTypeCounts: { 0: 0, 1: 0, 2: 0, 3: 0 },
+      },
       passenger: { boardableCount: 0, nonBoardableCount: 0 },
       routeDirection: {
         routeCount: 0,
@@ -124,7 +127,7 @@ describe('computeTimetableEntryStats', () => {
       );
     });
 
-    it('counts no-pickup entries (= explicit pickup_type === 1)', () => {
+    it('counts the faithful pickupType distribution (here: two type 1, two type 0)', () => {
       const entries = [
         makeEntry({ pickupType: 1 }),
         makeEntry({ pickupType: 1 }),
@@ -132,18 +135,30 @@ describe('computeTimetableEntryStats', () => {
         makeEntry(),
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
-      expect(stats.signal.noPickupCount).toBe(2);
+      expect(stats.boarding.pickupTypeCounts).toEqual({ 0: 2, 1: 2, 2: 0, 3: 0 });
       expect(stats.passenger.nonBoardableCount).toBe(3);
     });
 
-    it('counts noDropOff entries (= explicit drop_off_type === 1)', () => {
+    it('counts the faithful dropOffType distribution (here: two type 1, one type 0)', () => {
       const entries = [
         makeEntry({ dropOffType: 1, isFirstStop: true, stopIndex: 0 }),
         makeEntry({ dropOffType: 1 }),
         makeEntry(),
       ];
       const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
-      expect(stats.signal.noDropOffCount).toBe(2);
+      expect(stats.boarding.dropOffTypeCounts).toEqual({ 0: 1, 1: 2, 2: 0, 3: 0 });
+    });
+
+    it('counts arrangement-required values 2 / 3 in the distribution', () => {
+      const entries = [
+        makeEntry({ pickupType: 0, dropOffType: 0 }),
+        makeEntry({ pickupType: 1, dropOffType: 2 }),
+        makeEntry({ pickupType: 2, dropOffType: 3 }),
+        makeEntry({ pickupType: 3, dropOffType: 1 }),
+      ];
+      const stats = computeTimetableEntryStats(entries, TEST_AGENCIES, TEST_LANGS);
+      expect(stats.boarding.pickupTypeCounts).toEqual({ 0: 1, 1: 1, 2: 1, 3: 1 });
+      expect(stats.boarding.dropOffTypeCounts).toEqual({ 0: 1, 1: 1, 2: 1, 3: 1 });
     });
   });
 
@@ -277,8 +292,8 @@ describe('computeTimetableEntryStats', () => {
     // B axis
     expect(stats.passenger.boardableCount).toBe(2);
     expect(stats.passenger.nonBoardableCount).toBe(2);
-    expect(stats.signal.noPickupCount).toBe(1);
-    expect(stats.signal.noDropOffCount).toBe(0);
+    expect(stats.boarding.pickupTypeCounts[1]).toBe(1);
+    expect(stats.boarding.dropOffTypeCounts[1]).toBe(0);
 
     // C axis: resolver picks stopHeadsign when present (entry 2 -> 'X-via'),
     // so headsign and routeHeadsign uniqueness reflects that override.

--- a/src/domain/transit/timetable-stats.ts
+++ b/src/domain/transit/timetable-stats.ts
@@ -1,4 +1,4 @@
-import type { TimetableEntry } from '@/types/app/transit-composed';
+import type { StopServiceType, TimetableEntry } from '@/types/app/transit-composed';
 import { getHeadsignDisplayNames } from './name-resolver/get-headsign-display-names';
 import { isBoardableForPassenger } from './timetable-entry-for-passenger';
 import type { Agency } from '@/types/app/transit';
@@ -25,9 +25,10 @@ import { resolveAgencyLang } from '@/config/transit-defaults';
  *   are NOT mutually exclusive — a single-stop pattern (= `totalStops
  *   === 1`) increments both. `passingCount` is strictly mid-route
  *   (= `!isFirstStop && !isLastStop`).
- * - **`signal`** (faithful, raw GTFS pickup/drop-off): `noPickupCount`
- *   (= explicit `pickup_type === 1`) and `noDropOffCount` (= explicit
- *   `drop_off_type === 1`) are independent GTFS signals.
+ * - **`boarding`** (faithful, `TimetableEntry.boarding`): per-value
+ *   distributions `pickupTypeCounts` / `dropOffTypeCounts` over the
+ *   `boarding.pickupType` / `boarding.dropOffType` values (0/1/2/3). No
+ *   interpretation; each value's meaning follows the GTFS spec.
  * - **`passenger`** (interpreted, value for passenger): `boardableCount`
  *   / `nonBoardableCount`, judged by {@link isBoardableForPassenger}.
  *   The pair partitions all entries (sum equals `totalCount`).
@@ -55,12 +56,16 @@ export interface TimetableEntryStats {
     passingCount: number;
   };
 
-  /** Faithful: raw GTFS pickup / drop-off signals. */
-  signal: {
-    /** Entries with explicit `pickup_type === 1` (no pickup available). */
-    noPickupCount: number;
-    /** Entries with explicit `drop_off_type === 1` (no drop-off available). */
-    noDropOffCount: number;
+  /** Faithful: distribution of `TimetableEntry.boarding` values. */
+  boarding: {
+    /**
+     * Count of entries per `boarding.pickupType` value (0=regular,
+     * 1=not available, 2=phone agency, 3=coordinate with driver).
+     * Faithful distribution; no interpretation.
+     */
+    pickupTypeCounts: Record<StopServiceType, number>;
+    /** Count of entries per `boarding.dropOffType` value (same encoding). */
+    dropOffTypeCounts: Record<StopServiceType, number>;
   };
 
   /** Interpreted: value for the passenger. */
@@ -119,13 +124,19 @@ export function computeTimetableEntryStats(
   agencies: readonly Agency[],
   preferredDisplayLangs: readonly string[],
 ): TimetableEntryStats {
-  let originCount = 0;
-  let terminalCount = 0;
+  // stop position in the trip pattern (origin/terminal/passing) is a fundamental structural
+  let firstStop = 0;
+  let lastStopCount = 0;
   let passingCount = 0;
-  let boardableCount = 0;
-  let nonBoardableCount = 0;
-  let noPickupCount = 0;
-  let noDropOffCount = 0;
+
+  // faithful per-value distribution of boarding.pickupType / dropOffType
+  // (0/1/2/3); independent of pattern position and of boardable/alightable
+  const pickupTypeCounts: Record<StopServiceType, number> = { 0: 0, 1: 0, 2: 0, 3: 0 };
+  const dropOffTypeCounts: Record<StopServiceType, number> = { 0: 0, 1: 0, 2: 0, 3: 0 };
+
+  // boardability for passenger is a derived interpretation of the raw GTFS signals,
+  let boardableForPassengerCount = 0;
+  let nonBoardableForPassengerCount = 0;
 
   const routeIds = new Set<string>();
   const tripsHeadsigns = new Set<string>();
@@ -139,26 +150,22 @@ export function computeTimetableEntryStats(
     const agencyLangs = resolveAgencyLang(agencies, entry.routeDirection.route.agency_id);
 
     if (entry.patternPosition.isFirstStop) {
-      originCount++;
+      firstStop++;
     }
     if (entry.patternPosition.isLastStop) {
-      terminalCount++;
+      lastStopCount++;
     }
     if (!entry.patternPosition.isFirstStop && !entry.patternPosition.isLastStop) {
       passingCount++;
     }
 
     if (isBoardableForPassenger(entry)) {
-      boardableCount++;
+      boardableForPassengerCount++;
     } else {
-      nonBoardableCount++;
+      nonBoardableForPassengerCount++;
     }
-    if (entry.boarding.pickupType === 1) {
-      noPickupCount++;
-    }
-    if (entry.boarding.dropOffType === 1) {
-      noDropOffCount++;
-    }
+    pickupTypeCounts[entry.boarding.pickupType]++;
+    dropOffTypeCounts[entry.boarding.dropOffType]++;
 
     const routeId = entry.routeDirection.route.route_id;
     routeIds.add(routeId);
@@ -197,17 +204,17 @@ export function computeTimetableEntryStats(
   return {
     totalCount: entries.length,
     position: {
-      originCount,
-      terminalCount,
+      originCount: firstStop,
+      terminalCount: lastStopCount,
       passingCount,
     },
-    signal: {
-      noPickupCount,
-      noDropOffCount,
+    boarding: {
+      pickupTypeCounts,
+      dropOffTypeCounts,
     },
     passenger: {
-      boardableCount,
-      nonBoardableCount,
+      boardableCount: boardableForPassengerCount,
+      nonBoardableCount: nonBoardableForPassengerCount,
     },
     routeDirection: {
       routeCount: routeIds.size,

--- a/src/domain/transit/timetable-stats.ts
+++ b/src/domain/transit/timetable-stats.ts
@@ -1,6 +1,6 @@
 import type { StopServiceType, TimetableEntry } from '@/types/app/transit-composed';
 import { getHeadsignDisplayNames } from './name-resolver/get-headsign-display-names';
-import { isBoardableForPassenger } from './timetable-entry-for-passenger';
+import { isAlightableForPassenger, isBoardableForPassenger } from './timetable-entry-for-passenger';
 import type { Agency } from '@/types/app/transit';
 import { resolveAgencyLang } from '@/config/transit-defaults';
 // import { createLogger } from '../../lib/logger';
@@ -30,8 +30,10 @@ import { resolveAgencyLang } from '@/config/transit-defaults';
  *   `boarding.pickupType` / `boarding.dropOffType` values (0/1/2/3). No
  *   interpretation; each value's meaning follows the GTFS spec.
  * - **`passenger`** (interpreted, value for passenger): `boardableCount`
- *   / `nonBoardableCount`, judged by {@link isBoardableForPassenger}.
- *   The pair partitions all entries (sum equals `totalCount`).
+ *   / `nonBoardableCount` (judged by {@link isBoardableForPassenger}) and
+ *   `alightableCount` / `nonAlightableCount` (judged by
+ *   {@link isAlightableForPassenger}). Each pair partitions all entries
+ *   (sum equals `totalCount`).
  * - **`routeDirection`** (identity): unique counts of `route_id`,
  *   observed `direction` values, resolved trip/stop headsigns (the
  *   user-facing strings from {@link getHeadsignDisplayNames}).
@@ -74,6 +76,10 @@ export interface TimetableEntryStats {
     boardableCount: number;
     /** Entries where boarding is NOT available (= `!isBoardableForPassenger`). */
     nonBoardableCount: number;
+    /** Entries where alighting is available (= `isAlightableForPassenger`). */
+    alightableCount: number;
+    /** Entries where alighting is NOT available (= `!isAlightableForPassenger`). */
+    nonAlightableCount: number;
   };
 
   /** Identity: route / direction / headsign uniqueness. */
@@ -137,6 +143,9 @@ export function computeTimetableEntryStats(
   // boardability for passenger is a derived interpretation of the raw GTFS signals,
   let boardableForPassengerCount = 0;
   let nonBoardableForPassengerCount = 0;
+  // alightability for passenger (symmetric to boardability)
+  let alightableForPassengerCount = 0;
+  let nonAlightableForPassengerCount = 0;
 
   const routeIds = new Set<string>();
   const tripsHeadsigns = new Set<string>();
@@ -163,6 +172,11 @@ export function computeTimetableEntryStats(
       boardableForPassengerCount++;
     } else {
       nonBoardableForPassengerCount++;
+    }
+    if (isAlightableForPassenger(entry)) {
+      alightableForPassengerCount++;
+    } else {
+      nonAlightableForPassengerCount++;
     }
     pickupTypeCounts[entry.boarding.pickupType]++;
     dropOffTypeCounts[entry.boarding.dropOffType]++;
@@ -215,6 +229,8 @@ export function computeTimetableEntryStats(
     passenger: {
       boardableCount: boardableForPassengerCount,
       nonBoardableCount: nonBoardableForPassengerCount,
+      alightableCount: alightableForPassengerCount,
+      nonAlightableCount: nonAlightableForPassengerCount,
     },
     routeDirection: {
       routeCount: routeIds.size,

--- a/src/domain/transit/timetable-stats.ts
+++ b/src/domain/transit/timetable-stats.ts
@@ -10,37 +10,14 @@ import { resolveAgencyLang } from '@/config/transit-defaults';
 /**
  * Aggregated statistics computed from a list of {@link TimetableEntry}.
  *
- * Counts are grouped into sub-objects by axis. Each axis answers a
- * single kind of question; counts on different axes are independent, so
- * summing across them is meaningless (e.g. one entry can be counted in
- * both `position.originCount` and `passenger.boardableCount`).
+ * Counts are grouped into sub-objects by axis. Axes are independent, so
+ * summing across them is meaningless (one entry can be counted in both
+ * `position.originCount` and `passenger.boardableCount`).
  *
- * The grouping keeps two semantic layers from being mixed under one
- * heading (Issue #162): faithful counts read straight from the source
- * (`position`, `signal`) vs interpreted counts that combine the signal
- * with the pattern position for the passenger (`passenger`).
- *
- * - **`position`** (faithful, pattern role): `originCount` /
- *   `terminalCount` / `passingCount`. `originCount` and `terminalCount`
- *   are NOT mutually exclusive — a single-stop pattern (= `totalStops
- *   === 1`) increments both. `passingCount` is strictly mid-route
- *   (= `!isFirstStop && !isLastStop`).
- * - **`boarding`** (faithful, `TimetableEntry.boarding`): per-value
- *   distributions `pickupTypeCounts` / `dropOffTypeCounts` over the
- *   `boarding.pickupType` / `boarding.dropOffType` values (0/1/2/3). No
- *   interpretation; each value's meaning follows the GTFS spec.
- * - **`passenger`** (interpreted, value for passenger): `boardableCount`
- *   / `nonBoardableCount` (judged by {@link isBoardableForPassenger}) and
- *   `alightableCount` / `nonAlightableCount` (judged by
- *   {@link isAlightableForPassenger}). Each pair partitions all entries
- *   (sum equals `totalCount`).
- * - **`routeDirection`** (identity): unique counts of `route_id`,
- *   observed `direction` values, resolved trip/stop headsigns (the
- *   user-facing strings from {@link getHeadsignDisplayNames}).
- * - **`tripLocator`** (identity): unique counts of `patternId`,
- *   `serviceId`, and `(patternId, serviceId, tripIndex)` triples.
- *   `uniqueTripCount` can be lower than `totalCount` for 6-shape /
- *   circular patterns where the same trip visits the same stop twice.
+ * Two semantic layers are kept apart (Issue #162): faithful counts read
+ * straight from the source (`position`, `boarding`) vs interpreted
+ * counts that judge the value for the passenger (`passenger`). See each
+ * field for per-axis details.
  *
  * @see computeTimetableEntryStats
  */
@@ -48,7 +25,11 @@ export interface TimetableEntryStats {
   /** Total number of entries (= input length). */
   totalCount: number;
 
-  /** Faithful: pattern role of the stop event. */
+  /**
+   * Faithful: pattern role of the stop event. `originCount` and
+   * `terminalCount` are NOT mutually exclusive -- a single-stop pattern
+   * increments both.
+   */
   position: {
     /** Entries where this stop is the trip's origin (= `isFirstStop === true`). */
     originCount: number;
@@ -70,7 +51,11 @@ export interface TimetableEntryStats {
     dropOffTypeCounts: Record<StopServiceType, number>;
   };
 
-  /** Interpreted: value for the passenger. */
+  /**
+   * Interpreted: value for the passenger. Each pair
+   * (boardable/nonBoardable, alightable/nonAlightable) partitions all
+   * entries, so each sums to `totalCount`.
+   */
   passenger: {
     /** Entries where boarding is available (= `isBoardableForPassenger`). */
     boardableCount: number;
@@ -88,7 +73,9 @@ export interface TimetableEntryStats {
     routeCount: number;
     /** Number of unique `direction` values observed (`undefined` is one value). */
     directionCount: number;
+    /** Number of unique resolved (user-facing) trip headsigns. */
     tripHeadsignCount: number;
+    /** Number of unique resolved (user-facing) stop headsigns. */
     stopHeadsignCount: number;
   };
 
@@ -130,7 +117,7 @@ export function computeTimetableEntryStats(
   agencies: readonly Agency[],
   preferredDisplayLangs: readonly string[],
 ): TimetableEntryStats {
-  // stop position in the trip pattern (origin/terminal/passing) is a fundamental structural
+  // faithful structural axis: stop position (origin/terminal/passing)
   let firstStop = 0;
   let lastStopCount = 0;
   let passingCount = 0;
@@ -140,7 +127,7 @@ export function computeTimetableEntryStats(
   const pickupTypeCounts: Record<StopServiceType, number> = { 0: 0, 1: 0, 2: 0, 3: 0 };
   const dropOffTypeCounts: Record<StopServiceType, number> = { 0: 0, 1: 0, 2: 0, 3: 0 };
 
-  // boardability for passenger is a derived interpretation of the raw GTFS signals,
+  // interpreted axis: boardability for passenger
   let boardableForPassengerCount = 0;
   let nonBoardableForPassengerCount = 0;
   // alightability for passenger (symmetric to boardability)
@@ -200,8 +187,6 @@ export function computeTimetableEntryStats(
     ).resolved.name;
     stopHeadsigns.add(stopHeadsign);
 
-    // console.debug({ stopHeadsign, tripHeadsign });
-
     directions.add(String(entry.routeDirection.direction));
 
     const tl = entry.tripLocator;
@@ -209,11 +194,6 @@ export function computeTimetableEntryStats(
     serviceIds.add(tl.serviceId);
     trips.add(`${tl.patternId}|${tl.serviceId}|${tl.tripIndex}`);
   }
-
-  // if (logger.isEnabled('debug')) {
-  //   logger.debug('tripsHeadsigns', [...tripsHeadsigns]);
-  //   logger.debug('stopHeadsigns', [...stopHeadsigns]);
-  // }
 
   return {
     totalCount: entries.length,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -112,7 +112,7 @@
   },
   "stop": {
     "serviceState": {
-      "boardable": "In service",
+      "inService": "In service",
       "dropOffOnly": "Drop-off only",
       "noService": "No service",
       "serviceEnded": "No more service today"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -141,14 +141,27 @@
     "set": "🧙 Time, freeze!"
   },
   "stopTimeView": {
-    "soon": "Soon",
-    "in": "",
-    "minutes": "min",
-    "arriving": "",
-    "arrivingAbsolute": "Arr",
-    "departingAbsolute": "Dep",
-    "terminal": "Terminal",
-    "noBoarding": "No boarding"
+    "relativeTime": {
+      "soon": "Soon",
+      "in": "",
+      "minutes": "min"
+    },
+    "absoluteTime": {
+      "arrivingMarker": "Arr",
+      "departingMarker": "Dep"
+    },
+    "passenger": {
+      "boardable": "Boardable",
+      "nonBoardable": "Not boardable",
+      "alightable": "Alightable",
+      "nonAlightable": "Not alightable"
+    },
+    "endpoint": {
+      "realOrigin": "Origin",
+      "realTerminus": "Terminal",
+      "throughOrigin": "Through Origin",
+      "throughTerminus": "Through Terminal"
+    }
   },
   "transitDisplay": {
     "recentCount": "Latest {{count}} ({{radius}}m)",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -112,7 +112,7 @@
   },
   "stop": {
     "serviceState": {
-      "boardable": "運行中",
+      "inService": "運行中",
       "dropOffOnly": "降車専用",
       "noService": "運行便なし",
       "serviceEnded": "本日の運行は終了しました"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -141,14 +141,27 @@
     "set": "🧙 とまれ!"
   },
   "stopTimeView": {
-    "soon": "まもなく",
-    "in": "あと",
-    "minutes": "分",
-    "arriving": "",
-    "arrivingAbsolute": "着",
-    "departingAbsolute": "発",
-    "terminal": "終点",
-    "noBoarding": "乗車不可"
+    "relativeTime": {
+      "soon": "まもなく",
+      "in": "あと",
+      "minutes": "分"
+    },
+    "absoluteTime": {
+      "arrivingMarker": "着",
+      "departingMarker": "発"
+    },
+    "passenger": {
+      "boardable": "乗車可",
+      "nonBoardable": "乗車不可",
+      "alightable": "降車可",
+      "nonAlightable": "降車不可"
+    },
+    "endpoint": {
+      "realOrigin": "始発",
+      "realTerminus": "終点",
+      "throughOrigin": "経由始発(直通)",
+      "throughTerminus": "経由終点(直通)"
+    }
   },
   "transitDisplay": {
     "recentCount": "直近 {{count}} 件 ({{radius}}m)",


### PR DESCRIPTION
## Summary

Clean up the stats aggregation axes and resolve the **#298 badge axis mixing** in `TimetableMetadata`, plus restructure the related i18n. Builds on the signal-trust work (#297) by giving its faithful/interpreted split a consistent vocabulary in stats, badges, and translation keys (#162).

## What changed

**`TimetableEntryStats` (domain)**
- Rename the faithful axis `signal` -> `boarding` (it aggregates `TimetableEntry.boarding`; "signal" wrongly implied raw GTFS, but the data is `(GTFS / ODPT JSON) -> V2 JSON`).
- Hold `pickupType` / `dropOffType` as **full per-value distributions** (`pickupTypeCounts` / `dropOffTypeCounts`, `Record<StopServiceType, number>`, 0/1/2/3) instead of only the "1" (unavailable) count -- faithful, no interpretation.
- Add **alightable** to the `passenger` axis (`alightableCount` / `nonAlightableCount`), symmetric to boardable.

**`TimetableMetadata` (#298)**
- Split the axis-mixed `BoardingAxisBadges` into `BoardingAxisBadges` (faithful: no-pickup / no-drop-off markers) and a new `PassengerAxisBadges` (interpreted: boardable / nonBoardable / alightable / nonAlightable). The no-pickup badge no longer pairs a signal label with `passenger.nonBoardableCount` -- every badge's label and count share one axis.
- Show `PassengerAxisBadges` only at the **verbose** info level.
- Remove the dead `*AxisStats` span functions; the same data is shown by `VerboseTimetableSummary`.

**i18n**
- Rename unused `stop.serviceState.boardable` ("運行中") -> `inService` (avoids confusion with `passenger.boardableCount` = "乗車可").
- Restructure flat `stopTimeView` into `relativeTime` / `absoluteTime` / `passenger` / `endpoint` subgroups; update all call sites (relative-time, absolute-stop-time, tests, stories).
- Add an `endpoint` translation-only scaffold (`realOrigin` / `realTerminus` / `throughOrigin` / `throughTerminus`) for future "real endpoint vs through boundary" display (#145); no code references it yet.

## Verification

- typecheck / prettier / eslint: clean
- vitest: **4,513 passed**
- build: green

## Notes

- `Closes #298`.
- Display-side scaffolding for endpoint reality relates to #145; behaviour is unchanged for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
