### PR TITLE
transit-display: per-route boards + UI sort hardening (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- TransitDisplay (rail / subway / tram / monorail): per-route board (1 board = 1 route) を導入した。渋谷 subway 等の多 line 駅で銀座線 / 半蔵門線 / 副都心線が個別 board として並ぶようになった (#296, #300)。
+- TransitDisplay: per-route 用の row cap (`transitDisplayMaxEntriesPerRouteFor`) を追加した (simple: 3 / normal: 5 / detailed: 10 / verbose: 10、1 route board が冗長にならないように multi-route 用より少なく) (#296, #300)。
+- TransitDisplay2: Header band を 2 columns 構成 (Title + Routes / stats badges) に再構成し、`RouteBadge` を Title 行に表示するようにした (#296, #300)。
+
 ### Changed
 
 - Boardability: 他社直通の境界となる last stop (フィード境界) を乗車可として扱う per-source endpoint-signal-trust を導入した。信頼対象は東京メトロ (`tome`) / りんかい線 (`twrr`) / 都営地下鉄 (`toaran`) で、これらでは last stop / first stop の乗降可否を pickup_type / drop_off_type の signal のみで判定する。従来 last stop として発着案内・乗車可フィルタから除外されていた直通便 (例: 千代田線→JR 常磐線の綾瀬、りんかい線→JR 埼京線の大崎) が乗車可として表示されるようになった (東京メトロ 約 3,211 / 都営地下鉄 約 1,339 / りんかい線 大崎 152 行)。横浜市営地下鉄のように真の終点に pickup_type=0 を残す事業者は対象外 (#297, #145)。
@@ -16,6 +22,13 @@ and this project adheres to [CalVer](https://calver.org/).
 - TimetableEntryStats: faithful な集計軸 `signal` を `boarding` にリネームし、pickup_type / drop_off_type を「不可」だけでなく全値 (0/1/2/3) の分布 (`pickupTypeCounts` / `dropOffTypeCounts`) として持つようにした。利用者観点の `passenger` 軸には降車側 (`alightableCount` / `nonAlightableCount`) を対称に追加した (#298, #162)。
 - TimetableMetadata: 時刻表ダイアログの集計バッジで faithful (signal) と interpreted (passenger) の軸が混在していた問題を解消し、position / boarding (faithful) / passenger (interpreted) のバッジに分離した。passenger バッジは verbose 情報レベルでのみ表示し、デバッグ用の集計 span は `VerboseTimetableSummary` に集約した (#298)。
 - i18n: 未使用だった `stop.serviceState.boardable` ("運行中") を `inService` にリネームした (`passenger.boardableCount` ("乗車可") との混同を回避)。`stopTimeView` を `relativeTime` / `absoluteTime` / `passenger` / `endpoint` のサブグループに構造化し、将来の発着可否・端点種別 (現実の起終点 vs 直通境界) 表示用キーを足場として追加した (#162)。
+- transit-display: UI 表示用のヘルパー (`sortTransitDisplayDataWithMetaData` / `resolveTransitDisplayState` / `transitDisplayMaxEntriesFor` ほか) を `transit-display-ui.ts` に分離した。builder (`build-transit-display-data.ts`) は board データ生成のみ、UI 配慮 (並び順 / row 上限 / empty-state) は専用 module に集約 (#296, #300)。
+- TransitDisplaysContainer: 鉄道系 (`DIRECTION_SPLIT_ROUTE_TYPES`) は per-route board (`splitByRoute: true`) で構築し、bus / trolleybus / ferry (`NO_SPLIT_ROUTE_TYPES`) は multi-route のまま維持する per-mode policy を採用した。group-by の runtime toggle は意図的に追加しない (#296, #300)。
+- TransitDisplay: multi-route board の row cap (`simple` / `normal`) を 10 に下げた (per-route と数を揃え、過剰な行数を抑制) (#296, #300)。
+
+### Fixed
+
+- TransitDisplay: 多 route 停留所 (都営バス渋谷駅前 / 伊予鉄バス大街道等) で「到着」 board が「出発」 board より先に並んでしまうバグを修正した。multi-route 板の `meta.routes` / `meta.directions` は boardCandidates ベースで計算されるため dep / arr 間で `routes[0]` / `directions[0]` がズレることがあり、sort key として信頼できない。sort 関数で multi-value のときは route 軸 / direction 軸を skip し、category 軸で確実に departures → arrivals 順になるようにした (#296, #300)。
 
 ## [2026.06.11]
 

--- a/src/components/transit-display/transit-display-2.stories.tsx
+++ b/src/components/transit-display/transit-display-2.stories.tsx
@@ -88,6 +88,7 @@ function makeDisplay(
   const meta: TransitDisplayMeta = {
     category: 'departures',
     routeTypes: [3],
+    routes: [],
     directions: [0],
     max: 20,
     radius: 100,
@@ -97,6 +98,7 @@ function makeDisplay(
     meta,
     data: {
       routeTypes: meta.routeTypes,
+      routes: meta.routes,
       directions: meta.directions,
       category: meta.category,
       data: [...rows],

--- a/src/components/transit-display/transit-display-entry-2.stories.tsx
+++ b/src/components/transit-display/transit-display-entry-2.stories.tsx
@@ -88,6 +88,7 @@ function makeMeta(overrides: Partial<TransitDisplayMeta> = {}): TransitDisplayMe
   return {
     category: 'departures',
     routeTypes: [3],
+    routes: [],
     directions: [0],
     max: 20,
     radius: 100,

--- a/src/components/transit-display/transit-display.stories.tsx
+++ b/src/components/transit-display/transit-display.stories.tsx
@@ -94,6 +94,7 @@ function makeDisplay(
     meta: {
       category: 'departures',
       routeTypes: [3],
+      routes: [],
       directions: ['none'],
       max: 12,
       radius: 100,

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -497,8 +497,9 @@ export function TransitDisplay2({
       {infoLevelFlag.isVerboseEnabled && (
         <div className="flex flex-col items-end gap-0.5 text-[8px]">
           <p className="m-0 w-full min-w-0 text-right">
-            [{meta.category} / rt {meta.routeTypes.join(',')} / dir {meta.directions.join(',')} /
-            (max:{meta.max}/{meta.radius}m)]
+            [{meta.category} / rt {meta.routeTypes.join(',')} / r{' '}
+            {meta.routes.map((e) => e.route_id).length} / dir {meta.directions.join(',')} / (max:
+            {meta.max}/{meta.radius}m)]
           </p>
           {/* <p className="m-0 w-full min-w-0 text-right">
             [withinRadius: {stats.stopsInRadius.stopCount} stops / {stats.stopsInRadius.routeCount}{' '}
@@ -511,9 +512,10 @@ export function TransitDisplay2({
             {stats.qualifying.routeTypeCount} types]
           </p> */}
           <p className="m-0 w-full min-w-0 text-right">
-            [shown: {displayedStats.entryCount} entries / {displayedStats.stopCount} stops /{' '}
-            {displayedStats.routeCount} routes / {displayedStats.agencyCount} agencies /{' '}
-            {displayedStats.routeTypeCount} types]
+            [shown:
+            {displayedStats.entryCount} entries / {displayedStats.routeTypeCount} types /{' '}
+            {displayedStats.agencyCount} agencies / {displayedStats.routeCount} routes /{' '}
+            {displayedStats.stopCount} stops ]
           </p>
         </div>
       )}
@@ -555,6 +557,21 @@ export function TransitDisplay2({
             {routeTypeIcon}
             <span className="truncate">{title}</span>
           </h3>
+
+          {/* Routes  */}
+          {/* {meta.routes.map((route) => {
+            return (
+              <RouteBadge
+                route={route}
+                dataLang={dataLangs}
+                // agencyLangs={stopAgencyLangs}
+                // agencyLangs={route.agency_id}
+                infoLevel={infoLevel}
+                size={DISTANCE_BADGE_SIZE_BY_SIZE[size]}
+                showBorder={true}
+              />
+            );
+          })} */}
 
           {/* Right side: stats badges + radius, grouped and right-aligned. */}
           <div className="flex shrink-0 items-center gap-1">

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -486,6 +486,7 @@ export function TransitDisplay2({
     () => [...meta.routes].sort((a, b) => a.route_id.localeCompare(b.route_id)),
     [meta.routes],
   );
+  // const sortedRoutes = meta.routes; // Keep original order.
 
   const hasMultiRoutes = meta.routes.length >= 2;
 

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -480,6 +480,13 @@ export function TransitDisplay2({
     [transitDisplayData.data],
   );
 
+  // Routes shown in the header band, ordered by route_id alphabetical so the
+  // badge order is stable across renders and matches sortTransitDisplayDataWithMetaData.
+  const sortedRoutes = useMemo(
+    () => [...meta.routes].sort((a, b) => a.route_id.localeCompare(b.route_id)),
+    [meta.routes],
+  );
+
   // A board that mixes route types: rows then show their own trip route-type emoji.
   // const hasMultiRoutes = meta.routeTypes.length >= 2;
   return (
@@ -533,7 +540,7 @@ export function TransitDisplay2({
         )}
       >
         <div className="flex items-center justify-between gap-3 border-0">
-          {/* Title — board basis arrow (up = departures, right = arrivals) + mode + phrase.
+          {/* Left side:  Title — board basis arrow (up = departures, right = arrivals) + mode + phrase.
               The arrow is decorative; the phrase already states departures/arrivals. */}
           <h3
             className={cn(
@@ -558,21 +565,6 @@ export function TransitDisplay2({
             <span className="truncate">{title}</span>
           </h3>
 
-          {/* Routes  */}
-          {/* {meta.routes.map((route) => {
-            return (
-              <RouteBadge
-                route={route}
-                dataLang={dataLangs}
-                // agencyLangs={stopAgencyLangs}
-                // agencyLangs={route.agency_id}
-                infoLevel={infoLevel}
-                size={DISTANCE_BADGE_SIZE_BY_SIZE[size]}
-                showBorder={true}
-              />
-            );
-          })} */}
-
           {/* Right side: stats badges + radius, grouped and right-aligned. */}
           <div className="flex shrink-0 items-center gap-1">
             <IconTextBadge
@@ -584,7 +576,7 @@ export function TransitDisplay2({
               frameClassName="p-1 border-none"
               aria-label="radius"
             />
-            {infoLevelFlag.isDetailedEnabled && (
+            {infoLevelFlag.isNormalEnabled && (
               <StatsBadges
                 size={size}
                 entryCount={stats.qualifying.entryCount}
@@ -595,6 +587,31 @@ export function TransitDisplay2({
             )}
           </div>
         </div>
+
+        {/* Routes  */}
+        {infoLevelFlag.isDetailedEnabled && (
+          <div className="flex flex-wrap items-center gap-1">
+            {sortedRoutes.map((route) => {
+              // Find the agency that runs this route. board scope may span multiple
+              // stops, so flatten all agencies present and match by agency_id.
+              const agency = transitDisplayData.data
+                .flatMap((c) => c.stop.agencies)
+                .find((a) => a.agency_id === route.agency_id);
+              const agencyLangs = agency ? [agency.agency_lang] : undefined;
+              return (
+                <RouteBadge
+                  route={route}
+                  dataLang={dataLangs}
+                  agencyLangs={agencyLangs}
+                  infoLevel={infoLevel}
+                  // size={DISTANCE_BADGE_SIZE_BY_SIZE[size]}
+                  size={HEADER_STATS_ICONS_BY_SIZE[size].large.size}
+                  showBorder={true}
+                />
+              );
+            })}
+          </div>
+        )}
       </div>
       {/* Body: the rows (or the empty fallback). */}
       <div
@@ -706,9 +723,10 @@ export function TransitDisplayEntry2({
     const inspectTarget = buildTripInspectionTarget(entry, entry.serviceDate);
     return {
       routeAgency,
+      routeAgencyLangs,
       routeColor,
       headsign,
-      stopAgencyLangs,
+      // stopAgencyLangs,
       stopName,
       distanceRounded,
       inspectTarget,
@@ -716,9 +734,10 @@ export function TransitDisplayEntry2({
   }, [data, dataLangs]);
   const {
     routeAgency,
+    routeAgencyLangs,
     routeColor,
     headsign,
-    stopAgencyLangs,
+    // stopAgencyLangs,
     stopName,
     distanceRounded,
     inspectTarget,
@@ -787,7 +806,7 @@ export function TransitDisplayEntry2({
           <RouteBadge
             route={timetableEntry.routeDirection.route}
             dataLang={dataLangs}
-            agencyLangs={stopAgencyLangs}
+            agencyLangs={routeAgencyLangs}
             infoLevel={infoLevel}
             size={DISTANCE_BADGE_SIZE_BY_SIZE[size]}
             showBorder={true}

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -16,8 +16,8 @@ import {
   type TransitDisplayDataWithMetaData,
   type TransitDisplayDatum,
   type TransitDisplayMeta,
-  type TransitDisplayStatus,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
+import type { TransitDisplayStatus } from '@/domain/transit/transit-info-display/transit-display-ui';
 import { computeTransitDisplayDatumStats } from '@/domain/transit/compute-transit-display-datum-stats';
 import { getBearingDeg } from '@/domain/transit/distance';
 import { resolveRouteColors } from '@/domain/transit/color-resolver/route-colors';
@@ -487,6 +487,8 @@ export function TransitDisplay2({
     [meta.routes],
   );
 
+  const hasMultiRoutes = meta.routes.length >= 2;
+
   // A board that mixes route types: rows then show their own trip route-type emoji.
   // const hasMultiRoutes = meta.routeTypes.length >= 2;
   return (
@@ -563,6 +565,31 @@ export function TransitDisplay2({
             )}
             {routeTypeIcon}
             <span className="truncate">{title}</span>
+
+            {/* Routes (show when only a single route) */}
+            {/* {!hasMultiRoutes && (
+              <div className="flex flex-wrap items-center gap-1">
+                {sortedRoutes.map((route) => {
+                  // Find the agency that runs this route. board scope may span multiple
+                  // stops, so flatten all agencies present and match by agency_id.
+                  const agency = transitDisplayData.data
+                    .flatMap((c) => c.stop.agencies)
+                    .find((a) => a.agency_id === route.agency_id);
+                  const agencyLangs = agency ? [agency.agency_lang] : undefined;
+                  return (
+                    <RouteBadge
+                      route={route}
+                      dataLang={dataLangs}
+                      agencyLangs={agencyLangs}
+                      infoLevel={infoLevel}
+                      size={DISTANCE_BADGE_SIZE_BY_SIZE[size]}
+                      // size={HEADER_STATS_ICONS_BY_SIZE[size].large.size}
+                      showBorder={true}
+                    />
+                  );
+                })}
+              </div>
+            )} */}
           </h3>
 
           {/* Right side: stats badges + radius, grouped and right-aligned. */}
@@ -588,8 +615,8 @@ export function TransitDisplay2({
           </div>
         </div>
 
-        {/* Routes  */}
-        {infoLevelFlag.isDetailedEnabled && (
+        {/* Routes (show only multiple routes) */}
+        {hasMultiRoutes && infoLevelFlag.isDetailedEnabled && (
           <div className="flex flex-wrap items-center gap-1">
             {sortedRoutes.map((route) => {
               // Find the agency that runs this route. board scope may span multiple

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -371,10 +371,10 @@ export interface TransitDisplay2Props {
 }
 
 /**
- * Verbose-only badge row that renders a stats scope as icon badges. Icon choices
- * follow the data-source group summary convention: Signpost = stops, Route =
- * routes, Building2 = agencies, Shapes = route types, Clock = entries.
- * `entryCount` is omitted for the stop-set scope (which has no entry count).
+ * Badge row that renders a stats scope as icon badges. Icon choices follow the
+ * data-source group summary convention: Signpost = stops, Route = routes,
+ * Building2 = agencies, Shapes = route types, Clock = entries. `entryCount` is
+ * omitted for the stop-set scope (which has no entry count).
  */
 function StatsBadges({
   size,
@@ -507,20 +507,10 @@ export function TransitDisplay2({
       {infoLevelFlag.isVerboseEnabled && (
         <div className="flex flex-col items-end gap-0.5 text-[8px]">
           <p className="m-0 w-full min-w-0 text-right">
-            [{meta.category} / rt {meta.routeTypes.join(',')} / r{' '}
-            {meta.routes.map((e) => e.route_id).length} / dir {meta.directions.join(',')} / (max:
+            [{meta.category} / rt {meta.routeTypes.join(',')} / r {meta.routes.length} / dir{' '}
+            {meta.directions.join(',')} / (max:
             {meta.max}/{meta.radius}m)]
           </p>
-          {/* <p className="m-0 w-full min-w-0 text-right">
-            [withinRadius: {stats.stopsInRadius.stopCount} stops / {stats.stopsInRadius.routeCount}{' '}
-            routes / {stats.stopsInRadius.agencyCount} agencies /{' '}
-            {stats.stopsInRadius.routeTypeCount} types]
-          </p> */}
-          {/* <p className="m-0 w-full min-w-0 text-right">
-            [qualifying: {stats.qualifying.entryCount} entries / {stats.qualifying.stopCount} stops
-            / {stats.qualifying.routeCount} routes / {stats.qualifying.agencyCount} agencies /{' '}
-            {stats.qualifying.routeTypeCount} types]
-          </p> */}
           <p className="m-0 w-full min-w-0 text-right">
             [shown:
             {displayedStats.entryCount} entries / {displayedStats.routeTypeCount} types /{' '}

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -148,6 +148,17 @@ export function TransitDisplaysContainer({
       ...directionUnsplitRaw,
       ...directionSplitRaw,
     ]);
+
+    // data.forEach((e) => {
+    //   console.info(
+    //     'debug-x',
+    //     `e.meta.category: ${e.meta.category}`,
+    //     `e.meta.routeTypes.length: ${e.meta.routeTypes.length}`,
+    //     `e.meta.routes.length: ${e.meta.routes.length}`,
+    //     `e.meta.directions.length: ${e.meta.directions.length}`,
+    //   );
+    // });
+    // return data;
   }, [infoLevel, nearbyStops, transitDisplayStatus.state]);
 
   return (

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -19,6 +19,7 @@ import {
   resolveTransitDisplayState,
   sortTransitDisplayDataWithMetaData,
   transitDisplayMaxEntriesFor,
+  transitDisplayMaxEntriesPerRouteFor,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
 
 import type { ExtendedDisplaySize } from '@/components/shared/display-size';
@@ -111,7 +112,9 @@ export function TransitDisplaysContainer({
       return [];
     }
 
-    const maxEntries = transitDisplayMaxEntriesFor(infoLevel);
+    // const maxEntries = transitDisplayMaxEntriesFor(infoLevel);
+    const maxEntriesMultiRoute = transitDisplayMaxEntriesFor(infoLevel);
+    const maxEntriesPerRoute = transitDisplayMaxEntriesPerRouteFor(infoLevel);
 
     // Per-mode direction policy is composed here rather than inside the builder:
     // NO_SPLIT_ROUTE_TYPES keep both directions on one board, everything else
@@ -124,16 +127,19 @@ export function TransitDisplaysContainer({
     // order). Rows stay raw here; TransitDisplays resolves them into UI data.
 
     const directionUnsplitRaw = buildTransitDisplayDataSet(nearbyStops, NEARBY_RADIUS_M, {
-      maxEntries,
+      maxEntries: maxEntriesMultiRoute,
       routeTypeGrouping: { kind: 'custom', groups: NO_SPLIT_ROUTE_TYPES.map((t) => [t]) },
       splitByRoute: false,
+      // splitByRoute: true,
       splitByDirection: false,
+      // splitByDirection: true,
     });
     const directionSplitRaw = buildTransitDisplayDataSet(nearbyStops, NEARBY_RADIUS_M, {
-      maxEntries,
+      maxEntries: maxEntriesPerRoute,
       routeTypeGrouping: { kind: 'custom', groups: DIRECTION_SPLIT_ROUTE_TYPES.map((t) => [t]) },
-      splitByRoute: false,
-      // splitByRoute: true,
+      // splitByRoute: false,
+      splitByRoute: true,
+      // splitByDirection: false,
       splitByDirection: true,
     });
 

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -14,13 +14,13 @@ import { useScrollOverflow } from '@/hooks/use-scroll-overflow';
 import { ROUTE_TYPE_DISPLAY_ORDER } from '@/domain/transit/route-type-display-order';
 import { filterStopsWithinDistance } from '@/domain/transit/stop-meta-filter';
 import type { StopTimeViewId } from '@/domain/transit/stop-time-views';
+import { buildTransitDisplayDataSet } from '@/domain/transit/transit-info-display/build-transit-display-data';
 import {
-  buildTransitDisplayDataSet,
   resolveTransitDisplayState,
   sortTransitDisplayDataWithMetaData,
   transitDisplayMaxEntriesFor,
   transitDisplayMaxEntriesPerRouteFor,
-} from '@/domain/transit/transit-info-display/build-transit-display-data';
+} from '@/domain/transit/transit-info-display/transit-display-ui';
 
 import type { ExtendedDisplaySize } from '@/components/shared/display-size';
 import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -125,12 +125,15 @@ export function TransitDisplaysContainer({
 
     const directionUnsplitRaw = buildTransitDisplayDataSet(nearbyStops, NEARBY_RADIUS_M, {
       maxEntries,
-      routeGrouping: { kind: 'custom', groups: NO_SPLIT_ROUTE_TYPES.map((t) => [t]) },
+      routeTypeGrouping: { kind: 'custom', groups: NO_SPLIT_ROUTE_TYPES.map((t) => [t]) },
+      splitByRoute: false,
       splitByDirection: false,
     });
     const directionSplitRaw = buildTransitDisplayDataSet(nearbyStops, NEARBY_RADIUS_M, {
       maxEntries,
-      routeGrouping: { kind: 'custom', groups: DIRECTION_SPLIT_ROUTE_TYPES.map((t) => [t]) },
+      routeTypeGrouping: { kind: 'custom', groups: DIRECTION_SPLIT_ROUTE_TYPES.map((t) => [t]) },
+      splitByRoute: false,
+      // splitByRoute: true,
       splitByDirection: true,
     });
 

--- a/src/components/transit-display/transit-displays.tsx
+++ b/src/components/transit-display/transit-displays.tsx
@@ -13,8 +13,8 @@ import { Button } from '@/components/ui/button';
 import {
   type TransitDisplayCategory,
   type TransitDisplayDataWithMetaData,
-  type TransitDisplayStatus,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
+import type { TransitDisplayStatus } from '@/domain/transit/transit-info-display/transit-display-ui';
 import {
   buildTransitDisplayDatumForUi,
   type TransitDisplayDataWithMetaDataForUi,

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -243,7 +243,7 @@ describe('clusterCandidatesByRouteType', () => {
     const subway = candidateOf(subwayRoute); // route_type 1
     const bus = candidateOf(busRoute); // route_type 3
 
-    const clusters = clusterCandidatesByRouteType([subway, bus], { kind: 'route' }, [1, 3]);
+    const clusters = clusterCandidatesByRouteType([subway, bus], { kind: 'routeType' }, [1, 3]);
 
     // One single-type cluster per eligible type, in display order.
     const eligible = ROUTE_TYPE_DISPLAY_ORDER.filter((t) => t === 1 || t === 3);
@@ -259,7 +259,7 @@ describe('clusterCandidatesByRouteType', () => {
   it("'route': an eligible route type with no candidates yields an empty cluster", () => {
     const bus = candidateOf(busRoute); // 3; route_type 2 is eligible but has no candidate
 
-    const clusters = clusterCandidatesByRouteType([bus], { kind: 'route' }, [2, 3]);
+    const clusters = clusterCandidatesByRouteType([bus], { kind: 'routeType' }, [2, 3]);
 
     const railCluster = clusters.find((c) => c.routeTypes[0] === railRoute.route_type);
     expect(railCluster?.candidates).toEqual([]);
@@ -268,7 +268,7 @@ describe('clusterCandidatesByRouteType', () => {
   it("'route': ignores route types not in effectiveRouteTypes", () => {
     const bus = candidateOf(busRoute); // 3
 
-    const clusters = clusterCandidatesByRouteType([bus], { kind: 'route' }, [3]);
+    const clusters = clusterCandidatesByRouteType([bus], { kind: 'routeType' }, [3]);
 
     expect(clusters.map((c) => c.routeTypes)).toEqual([[3]]);
   });
@@ -335,14 +335,14 @@ describe('clusterCandidatesByRouteType', () => {
     const bus1 = candidateOf(busRoute); // 3
     const bus2 = candidateOf(busRoute); // 3
 
-    const clusters = clusterCandidatesByRouteType([bus1, bus2], { kind: 'route' }, [3]);
+    const clusters = clusterCandidatesByRouteType([bus1, bus2], { kind: 'routeType' }, [3]);
 
     const busCluster = clusters.find((c) => c.routeTypes[0] === busRoute.route_type);
     expect(busCluster?.candidates).toEqual([bus1, bus2]);
   });
 
   it("'route': returns a cluster per eligible type even with no candidates (all empty)", () => {
-    const clusters = clusterCandidatesByRouteType([], { kind: 'route' }, [1, 2, 3]);
+    const clusters = clusterCandidatesByRouteType([], { kind: 'routeType' }, [1, 2, 3]);
 
     const eligible = ROUTE_TYPE_DISPLAY_ORDER.filter((t) => t === 1 || t === 2 || t === 3);
     expect(clusters.map((c) => c.routeTypes)).toEqual(eligible.map((t) => [t]));
@@ -350,7 +350,7 @@ describe('clusterCandidatesByRouteType', () => {
   });
 
   it('returns no eligible clusters when effectiveRouteTypes is empty', () => {
-    expect(clusterCandidatesByRouteType([], { kind: 'route' }, [])).toEqual([]);
+    expect(clusterCandidatesByRouteType([], { kind: 'routeType' }, [])).toEqual([]);
     // 'none' still returns its single cluster, but with no route types.
     expect(clusterCandidatesByRouteType([], { kind: 'none' }, [])).toEqual([
       { routeTypes: [], candidates: [] },
@@ -388,7 +388,8 @@ describe('groupCandidatesIntoBoards', () => {
 
   const notSplit: TransitDisplayCondition = {
     maxEntries: 100,
-    routeGrouping: { kind: 'none' },
+    routeTypeGrouping: { kind: 'none' },
+    splitByRoute: false,
     splitByDirection: false,
   };
   const split: TransitDisplayCondition = { ...notSplit, splitByDirection: true };
@@ -479,13 +480,18 @@ describe('groupCandidatesIntoBoards', () => {
     );
   });
 
-  it("respects the route grouping: 'route' yields per-route-type boards in display order", () => {
+  it("respects the route-type grouping: 'routeType' yields per-route-type boards in display order", () => {
     const bus = cand({ route: busRoute }); // 3
     const subway = cand({ route: subwayRoute }); // 1
 
     const boards = groupCandidatesIntoBoards(
       [bus, subway],
-      { maxEntries: 100, routeGrouping: { kind: 'route' }, splitByDirection: false },
+      {
+        maxEntries: 100,
+        routeTypeGrouping: { kind: 'routeType' },
+        splitByRoute: false,
+        splitByDirection: false,
+      },
       busAndSubwayStops,
     );
 
@@ -497,6 +503,110 @@ describe('groupCandidatesIntoBoards', () => {
       { routeTypes: [1], category: 'departures' },
       { routeTypes: [1], category: 'arrivals' },
     ]);
+  });
+
+  // splitByRoute: subdivides each route-type cluster so that one board carries
+  // trips of exactly one route. Models the Shibuya subway case (Issue #296):
+  // route_type 1 contains multiple lines (e.g. Ginza / Hanzomon), and folding
+  // them into one direction bucket reads poorly because `direction_id` is
+  // route-local.
+  const ginzaLine = makeRoute('ginza', 1);
+  const hanzomonLine = makeRoute('hanzomon', 1);
+  const subwayStops: readonly StopWithContext[] = [{ ...STUB_STOP, routeTypes: [1] }];
+
+  it('splitByRoute: subdivides a single route-type cluster into one board per route, in first-appearance order', () => {
+    const ginza = cand({ route: ginzaLine });
+    const hanzomon = cand({ route: hanzomonLine });
+
+    const boards = groupCandidatesIntoBoards(
+      [ginza, hanzomon],
+      {
+        maxEntries: 100,
+        routeTypeGrouping: { kind: 'none' }, // one cluster covering route_type 1
+        splitByRoute: true,
+        splitByDirection: false,
+      },
+      subwayStops,
+    );
+
+    // Two routes -> two route-buckets per category; first-appearance order is
+    // ginza, then hanzomon. Category-major: all departures before all arrivals.
+    expect(
+      boards.map((bd) => ({
+        category: bd.category,
+        routeIds: bd.data.map((c) => c.timetableEntry.routeDirection.route.route_id),
+      })),
+    ).toEqual([
+      { category: 'departures', routeIds: ['ginza'] },
+      { category: 'departures', routeIds: ['hanzomon'] },
+      { category: 'arrivals', routeIds: ['ginza'] },
+      { category: 'arrivals', routeIds: ['hanzomon'] },
+    ]);
+    // routeTypes stays at the cluster level (the route_type is still 1 on every board).
+    for (const bd of boards) {
+      expect(bd.routeTypes).toEqual([1]);
+    }
+  });
+
+  it('splitByRoute + splitByDirection: cross-product of route x direction within a cluster', () => {
+    // Each route runs both directions; route-local direction_id 0/1 has no
+    // shared meaning across routes, but per-route boards keep each direction
+    // self-consistent.
+    const ginza0 = cand({ route: ginzaLine, direction: 0 });
+    const ginza1 = cand({ route: ginzaLine, direction: 1 });
+    const hanzomon0 = cand({ route: hanzomonLine, direction: 0 });
+    const hanzomon1 = cand({ route: hanzomonLine, direction: 1 });
+
+    const boards = groupCandidatesIntoBoards(
+      [ginza0, ginza1, hanzomon0, hanzomon1],
+      {
+        maxEntries: 100,
+        routeTypeGrouping: { kind: 'none' },
+        splitByRoute: true,
+        splitByDirection: true,
+      },
+      subwayStops,
+    );
+
+    // route-major within category: ginza (dir 0, dir 1), then hanzomon (dir 0, dir 1).
+    expect(
+      boards
+        .filter((bd) => bd.category === 'departures')
+        .map((bd) => ({
+          routeId: bd.data[0]?.timetableEntry.routeDirection.route.route_id,
+          directions: bd.directions,
+        })),
+    ).toEqual([
+      { routeId: 'ginza', directions: [0] },
+      { routeId: 'ginza', directions: [1] },
+      { routeId: 'hanzomon', directions: [0] },
+      { routeId: 'hanzomon', directions: [1] },
+    ]);
+  });
+
+  it('splitByRoute: false keeps routes folded into one cluster board (current behaviour)', () => {
+    const ginza = cand({ route: ginzaLine });
+    const hanzomon = cand({ route: hanzomonLine });
+
+    const boards = groupCandidatesIntoBoards(
+      [ginza, hanzomon],
+      {
+        maxEntries: 100,
+        routeTypeGrouping: { kind: 'none' },
+        splitByRoute: false,
+        splitByDirection: false,
+      },
+      subwayStops,
+    );
+
+    // One departures + one arrivals board, each carrying both routes mixed.
+    expect(boards).toHaveLength(2);
+    for (const bd of boards) {
+      expect(bd.data.map((c) => c.timetableEntry.routeDirection.route.route_id)).toEqual([
+        'ginza',
+        'hanzomon',
+      ]);
+    }
   });
 });
 
@@ -518,7 +628,7 @@ describe('sortAndCapTransitDisplayData', () => {
     category: TransitDisplayCategory,
     candidates: TransitDisplayCandidate[],
   ): TransitDisplayData {
-    return { routeTypes: [3], directions: ['none'], category, data: candidates };
+    return { routeTypes: [3], routes: [], directions: ['none'], category, data: candidates };
   }
 
   it("sorts each board's candidates by its own category's time", () => {
@@ -550,6 +660,7 @@ describe('sortAndCapTransitDisplayData', () => {
   it('preserves board metadata (routeTypes, directions, category)', () => {
     const board: TransitDisplayData = {
       routeTypes: [2, 1],
+      routes: [],
       directions: [0, 'none'],
       category: 'departures',
       data: [candWithTimes(800)],
@@ -630,21 +741,23 @@ describe('toTransitDisplayCandidates', () => {
 });
 
 describe('sortTransitDisplayDataWithMetaData', () => {
-  /** A display whose only meaningful fields for ordering are route type, category, direction. */
+  /** A display whose only meaningful fields for ordering are route type, route, category, direction. */
   function display(
     routeType: AppRouteTypeValue,
     category: TransitDisplayCategory,
     directions: readonly (0 | 1 | 'none')[] = ['none'],
+    routes: readonly Route[] = [],
   ): TransitDisplayDataWithMetaData {
     return {
       meta: {
         category,
         routeTypes: [routeType],
+        routes,
         directions,
         max: 10,
         radius: 100,
       },
-      data: { routeTypes: [routeType], directions, category, data: [] },
+      data: { routeTypes: [routeType], routes, directions, category, data: [] },
       stats: {
         stopsInRadius: { stopCount: 0, agencyCount: 0, routeCount: 0, routeTypeCount: 0 },
         qualifying: {
@@ -720,6 +833,75 @@ describe('sortTransitDisplayDataWithMetaData', () => {
     ]);
   });
 
+  // route_id alphabetical sort: within the same route type, boards are ordered
+  // by `meta.routes[0].route_id`. In v2 sources the id is agency-prefixed
+  // (e.g. `eidan:ginza`), so agency clustering falls out naturally. Independent
+  // of builder input order -- ordering is fully derivable from meta.
+  it('within a route type, orders by routes[0].route_id alphabetical', () => {
+    const ginza = makeRoute('eidan:ginza', 1);
+    const hanzomon = makeRoute('eidan:hanzomon', 1);
+    const fukutoshin = makeRoute('eidan:fukutoshin', 1);
+
+    // Pass in an order different from the alphabetical one to prove the sort
+    // is driven by the key, not by input order.
+    const sorted = sortTransitDisplayDataWithMetaData([
+      display(1, 'departures', ['none'], [ginza]),
+      display(1, 'departures', ['none'], [hanzomon]),
+      display(1, 'departures', ['none'], [fukutoshin]),
+    ]);
+
+    expect(sorted.map((d) => d.meta.routes[0]?.route_id)).toEqual([
+      'eidan:fukutoshin',
+      'eidan:ginza',
+      'eidan:hanzomon',
+    ]);
+  });
+
+  it('applies all four levels: route type -> route -> category -> direction', () => {
+    const ginza = makeRoute('eidan:ginza', 1);
+    const hanzomon = makeRoute('eidan:hanzomon', 1);
+
+    // Two routes within one route type, each with both directions and both
+    // categories. Sorted result keeps every board of the same route adjacent.
+    const sorted = sortTransitDisplayDataWithMetaData([
+      display(1, 'arrivals', [1], [hanzomon]),
+      display(1, 'departures', [0], [hanzomon]),
+      display(1, 'arrivals', [0], [ginza]),
+      display(1, 'departures', [1], [ginza]),
+      display(1, 'departures', [0], [ginza]),
+      display(1, 'departures', [1], [hanzomon]),
+      display(1, 'arrivals', [0], [hanzomon]),
+      display(1, 'arrivals', [1], [ginza]),
+    ]);
+
+    expect(
+      sorted.map((d) => ({
+        routeId: d.meta.routes[0]?.route_id,
+        category: d.meta.category,
+        dir: d.meta.directions[0],
+      })),
+    ).toEqual([
+      { routeId: 'eidan:ginza', category: 'departures', dir: 0 },
+      { routeId: 'eidan:ginza', category: 'departures', dir: 1 },
+      { routeId: 'eidan:ginza', category: 'arrivals', dir: 0 },
+      { routeId: 'eidan:ginza', category: 'arrivals', dir: 1 },
+      { routeId: 'eidan:hanzomon', category: 'departures', dir: 0 },
+      { routeId: 'eidan:hanzomon', category: 'departures', dir: 1 },
+      { routeId: 'eidan:hanzomon', category: 'arrivals', dir: 0 },
+      { routeId: 'eidan:hanzomon', category: 'arrivals', dir: 1 },
+    ]);
+  });
+
+  it('falls back to no route comparison when meta.routes is empty (boards with same routeType/category/direction keep stable order)', () => {
+    // Empty routes -> routeId compares as '' for all, so route axis is a no-op.
+    // Stable sort preserves the input order within the same key.
+    const a = display(2, 'departures', [0]);
+    const b = display(2, 'departures', [0]);
+    const c = display(2, 'departures', [0]);
+    const sorted = sortTransitDisplayDataWithMetaData([a, b, c]);
+    expect(sorted).toEqual([a, b, c]);
+  });
+
   it('does not mutate the input array', () => {
     const a = display(2, 'departures');
     const b = display(3, 'departures');
@@ -741,7 +923,8 @@ describe('buildTransitDisplayDataSet', () => {
   it('returns no displays for an empty stop set', () => {
     const result = buildTransitDisplayDataSet([], 100, {
       maxEntries: 20,
-      routeGrouping: { kind: 'none' },
+      routeTypeGrouping: { kind: 'none' },
+      splitByRoute: false,
       splitByDirection: false,
     });
     expect(result).toEqual([]);

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -25,6 +25,7 @@ import {
   sortTransitDisplayDataWithMetaData,
   toTransitDisplayCandidates,
   transitDisplayMaxEntriesFor,
+  transitDisplayMaxEntriesPerRouteFor,
   type TransitDisplayData,
   type TransitDisplayCandidate,
   type TransitDisplayCategory,
@@ -34,8 +35,8 @@ import {
 
 describe('transitDisplayMaxEntriesFor', () => {
   it('returns the configured row cap for each info level', () => {
-    expect(transitDisplayMaxEntriesFor('simple')).toBe(20);
-    expect(transitDisplayMaxEntriesFor('normal')).toBe(20);
+    expect(transitDisplayMaxEntriesFor('simple')).toBe(10);
+    expect(transitDisplayMaxEntriesFor('normal')).toBe(10);
     expect(transitDisplayMaxEntriesFor('detailed')).toBe(20);
     expect(transitDisplayMaxEntriesFor('verbose')).toBe(20);
   });
@@ -44,6 +45,22 @@ describe('transitDisplayMaxEntriesFor', () => {
     const levels: InfoLevel[] = ['simple', 'normal', 'detailed', 'verbose'];
     for (const level of levels) {
       expect(transitDisplayMaxEntriesFor(level)).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('transitDisplayMaxEntriesPerRouteFor', () => {
+  it('returns the configured per-route row cap for each info level', () => {
+    expect(transitDisplayMaxEntriesPerRouteFor('simple')).toBe(3);
+    expect(transitDisplayMaxEntriesPerRouteFor('normal')).toBe(5);
+    expect(transitDisplayMaxEntriesPerRouteFor('detailed')).toBe(10);
+    expect(transitDisplayMaxEntriesPerRouteFor('verbose')).toBe(10);
+  });
+
+  it('returns a positive cap for every info level', () => {
+    const levels: InfoLevel[] = ['simple', 'normal', 'detailed', 'verbose'];
+    for (const level of levels) {
+      expect(transitDisplayMaxEntriesPerRouteFor(level)).toBeGreaterThan(0);
     }
   });
 });

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -7,8 +7,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { makeContextualEntry, makeRoute, makeStop } from '../../../../__tests__/helpers';
-import type { InfoLevel } from '../../../../types/app/settings';
-import type { AppRouteTypeValue, Route } from '../../../../types/app/transit';
+import type { Route } from '../../../../types/app/transit';
 import type {
   ContextualTimetableEntry,
   StopWithContext,
@@ -22,48 +21,12 @@ import {
   groupCandidatesIntoBoards,
   sortAndCapTransitDisplayData,
   sortByCategory,
-  sortTransitDisplayDataWithMetaData,
   toTransitDisplayCandidates,
-  transitDisplayMaxEntriesFor,
-  transitDisplayMaxEntriesPerRouteFor,
   type TransitDisplayData,
   type TransitDisplayCandidate,
   type TransitDisplayCategory,
   type TransitDisplayCondition,
-  type TransitDisplayDataWithMetaData,
 } from '../build-transit-display-data';
-
-describe('transitDisplayMaxEntriesFor', () => {
-  it('returns the configured row cap for each info level', () => {
-    expect(transitDisplayMaxEntriesFor('simple')).toBe(10);
-    expect(transitDisplayMaxEntriesFor('normal')).toBe(10);
-    expect(transitDisplayMaxEntriesFor('detailed')).toBe(20);
-    expect(transitDisplayMaxEntriesFor('verbose')).toBe(20);
-  });
-
-  it('returns a positive cap for every info level', () => {
-    const levels: InfoLevel[] = ['simple', 'normal', 'detailed', 'verbose'];
-    for (const level of levels) {
-      expect(transitDisplayMaxEntriesFor(level)).toBeGreaterThan(0);
-    }
-  });
-});
-
-describe('transitDisplayMaxEntriesPerRouteFor', () => {
-  it('returns the configured per-route row cap for each info level', () => {
-    expect(transitDisplayMaxEntriesPerRouteFor('simple')).toBe(3);
-    expect(transitDisplayMaxEntriesPerRouteFor('normal')).toBe(5);
-    expect(transitDisplayMaxEntriesPerRouteFor('detailed')).toBe(10);
-    expect(transitDisplayMaxEntriesPerRouteFor('verbose')).toBe(10);
-  });
-
-  it('returns a positive cap for every info level', () => {
-    const levels: InfoLevel[] = ['simple', 'normal', 'detailed', 'verbose'];
-    for (const level of levels) {
-      expect(transitDisplayMaxEntriesPerRouteFor(level)).toBeGreaterThan(0);
-    }
-  });
-});
 
 const busRoute = makeRoute('bus', 3); // route_type 3
 const railRoute = makeRoute('rail', 2); // route_type 2
@@ -754,183 +717,6 @@ describe('toTransitDisplayCandidates', () => {
 
   it('returns an empty array for empty input', () => {
     expect(toTransitDisplayCandidates([])).toEqual([]);
-  });
-});
-
-describe('sortTransitDisplayDataWithMetaData', () => {
-  /** A display whose only meaningful fields for ordering are route type, route, category, direction. */
-  function display(
-    routeType: AppRouteTypeValue,
-    category: TransitDisplayCategory,
-    directions: readonly (0 | 1 | 'none')[] = ['none'],
-    routes: readonly Route[] = [],
-  ): TransitDisplayDataWithMetaData {
-    return {
-      meta: {
-        category,
-        routeTypes: [routeType],
-        routes,
-        directions,
-        max: 10,
-        radius: 100,
-      },
-      data: { routeTypes: [routeType], routes, directions, category, data: [] },
-      stats: {
-        stopsInRadius: { stopCount: 0, agencyCount: 0, routeCount: 0, routeTypeCount: 0 },
-        qualifying: {
-          entryCount: 0,
-          stopCount: 0,
-          agencyCount: 0,
-          routeCount: 0,
-          routeTypeCount: 0,
-        },
-      },
-    };
-  }
-
-  it('orders by route type in ROUTE_TYPE_DISPLAY_ORDER (ferry not hoisted)', () => {
-    // display order is [3, 11, 0, 2, 1, 12, 4, ...]: bus(3) < rail(2) < subway(1) < ferry(4)
-    const bus = display(3, 'departures');
-    const rail = display(2, 'departures');
-    const subway = display(1, 'departures');
-    const ferry = display(4, 'departures');
-
-    const sorted = sortTransitDisplayDataWithMetaData([subway, ferry, rail, bus]);
-
-    expect(sorted.map((d) => d.meta.routeTypes[0])).toEqual([3, 2, 1, 4]);
-  });
-
-  it('within a route type, departures come before arrivals', () => {
-    const arr = display(2, 'arrivals');
-    const dep = display(2, 'departures');
-
-    expect(sortTransitDisplayDataWithMetaData([arr, dep]).map((d) => d.meta.category)).toEqual([
-      'departures',
-      'arrivals',
-    ]);
-  });
-
-  it('within a category, orders by direction (none, 0, 1)', () => {
-    const d1 = display(2, 'departures', [1]);
-    const d0 = display(2, 'departures', [0]);
-    const dn = display(2, 'departures', ['none']);
-
-    expect(
-      sortTransitDisplayDataWithMetaData([d1, d0, dn]).map((d) => d.meta.directions[0]),
-    ).toEqual(['none', 0, 1]);
-  });
-
-  it('applies the three levels together: route type -> category -> direction', () => {
-    const railArr0 = display(2, 'arrivals', [0]);
-    const busDep = display(3, 'departures', ['none']);
-    const railDep1 = display(2, 'departures', [1]);
-    const railDep0 = display(2, 'departures', [0]);
-    const busArr = display(3, 'arrivals', ['none']);
-
-    const sorted = sortTransitDisplayDataWithMetaData([
-      railArr0,
-      busDep,
-      railDep1,
-      railDep0,
-      busArr,
-    ]);
-
-    expect(
-      sorted.map((d) => ({
-        rt: d.meta.routeTypes[0],
-        category: d.meta.category,
-        dir: d.meta.directions[0],
-      })),
-    ).toEqual([
-      { rt: 3, category: 'departures', dir: 'none' },
-      { rt: 3, category: 'arrivals', dir: 'none' },
-      { rt: 2, category: 'departures', dir: 0 },
-      { rt: 2, category: 'departures', dir: 1 },
-      { rt: 2, category: 'arrivals', dir: 0 },
-    ]);
-  });
-
-  // route_id alphabetical sort: within the same route type, boards are ordered
-  // by `meta.routes[0].route_id`. In v2 sources the id is agency-prefixed
-  // (e.g. `eidan:ginza`), so agency clustering falls out naturally. Independent
-  // of builder input order -- ordering is fully derivable from meta.
-  it('within a route type, orders by routes[0].route_id alphabetical', () => {
-    const ginza = makeRoute('eidan:ginza', 1);
-    const hanzomon = makeRoute('eidan:hanzomon', 1);
-    const fukutoshin = makeRoute('eidan:fukutoshin', 1);
-
-    // Pass in an order different from the alphabetical one to prove the sort
-    // is driven by the key, not by input order.
-    const sorted = sortTransitDisplayDataWithMetaData([
-      display(1, 'departures', ['none'], [ginza]),
-      display(1, 'departures', ['none'], [hanzomon]),
-      display(1, 'departures', ['none'], [fukutoshin]),
-    ]);
-
-    expect(sorted.map((d) => d.meta.routes[0]?.route_id)).toEqual([
-      'eidan:fukutoshin',
-      'eidan:ginza',
-      'eidan:hanzomon',
-    ]);
-  });
-
-  it('applies all four levels: route type -> route -> category -> direction', () => {
-    const ginza = makeRoute('eidan:ginza', 1);
-    const hanzomon = makeRoute('eidan:hanzomon', 1);
-
-    // Two routes within one route type, each with both directions and both
-    // categories. Sorted result keeps every board of the same route adjacent.
-    const sorted = sortTransitDisplayDataWithMetaData([
-      display(1, 'arrivals', [1], [hanzomon]),
-      display(1, 'departures', [0], [hanzomon]),
-      display(1, 'arrivals', [0], [ginza]),
-      display(1, 'departures', [1], [ginza]),
-      display(1, 'departures', [0], [ginza]),
-      display(1, 'departures', [1], [hanzomon]),
-      display(1, 'arrivals', [0], [hanzomon]),
-      display(1, 'arrivals', [1], [ginza]),
-    ]);
-
-    expect(
-      sorted.map((d) => ({
-        routeId: d.meta.routes[0]?.route_id,
-        category: d.meta.category,
-        dir: d.meta.directions[0],
-      })),
-    ).toEqual([
-      { routeId: 'eidan:ginza', category: 'departures', dir: 0 },
-      { routeId: 'eidan:ginza', category: 'departures', dir: 1 },
-      { routeId: 'eidan:ginza', category: 'arrivals', dir: 0 },
-      { routeId: 'eidan:ginza', category: 'arrivals', dir: 1 },
-      { routeId: 'eidan:hanzomon', category: 'departures', dir: 0 },
-      { routeId: 'eidan:hanzomon', category: 'departures', dir: 1 },
-      { routeId: 'eidan:hanzomon', category: 'arrivals', dir: 0 },
-      { routeId: 'eidan:hanzomon', category: 'arrivals', dir: 1 },
-    ]);
-  });
-
-  it('falls back to no route comparison when meta.routes is empty (boards with same routeType/category/direction keep stable order)', () => {
-    // Empty routes -> routeId compares as '' for all, so route axis is a no-op.
-    // Stable sort preserves the input order within the same key.
-    const a = display(2, 'departures', [0]);
-    const b = display(2, 'departures', [0]);
-    const c = display(2, 'departures', [0]);
-    const sorted = sortTransitDisplayDataWithMetaData([a, b, c]);
-    expect(sorted).toEqual([a, b, c]);
-  });
-
-  it('does not mutate the input array', () => {
-    const a = display(2, 'departures');
-    const b = display(3, 'departures');
-    const input = [a, b];
-
-    sortTransitDisplayDataWithMetaData(input);
-
-    expect(input).toEqual([a, b]);
-  });
-
-  it('returns an empty array for empty input', () => {
-    expect(sortTransitDisplayDataWithMetaData([])).toEqual([]);
   });
 });
 

--- a/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/build-transit-display-data.test.ts
@@ -219,7 +219,7 @@ describe('categoryQualifies', () => {
 });
 
 describe('clusterCandidatesByRouteType', () => {
-  it("'route': one cluster per eligible route type in display order, candidates placed by type", () => {
+  it("'routeType': one cluster per eligible route type in display order, candidates placed by type", () => {
     const subway = candidateOf(subwayRoute); // route_type 1
     const bus = candidateOf(busRoute); // route_type 3
 
@@ -236,7 +236,7 @@ describe('clusterCandidatesByRouteType', () => {
     ]);
   });
 
-  it("'route': an eligible route type with no candidates yields an empty cluster", () => {
+  it("'routeType': an eligible route type with no candidates yields an empty cluster", () => {
     const bus = candidateOf(busRoute); // 3; route_type 2 is eligible but has no candidate
 
     const clusters = clusterCandidatesByRouteType([bus], { kind: 'routeType' }, [2, 3]);
@@ -245,7 +245,7 @@ describe('clusterCandidatesByRouteType', () => {
     expect(railCluster?.candidates).toEqual([]);
   });
 
-  it("'route': ignores route types not in effectiveRouteTypes", () => {
+  it("'routeType': ignores route types not in effectiveRouteTypes", () => {
     const bus = candidateOf(busRoute); // 3
 
     const clusters = clusterCandidatesByRouteType([bus], { kind: 'routeType' }, [3]);
@@ -311,7 +311,7 @@ describe('clusterCandidatesByRouteType', () => {
     expect(dropped).toEqual([]); // whole group ineligible -> no cluster
   });
 
-  it("'route': keeps the input order of candidates within a single type's cluster", () => {
+  it("'routeType': keeps the input order of candidates within a single type's cluster", () => {
     const bus1 = candidateOf(busRoute); // 3
     const bus2 = candidateOf(busRoute); // 3
 
@@ -321,7 +321,7 @@ describe('clusterCandidatesByRouteType', () => {
     expect(busCluster?.candidates).toEqual([bus1, bus2]);
   });
 
-  it("'route': returns a cluster per eligible type even with no candidates (all empty)", () => {
+  it("'routeType': returns a cluster per eligible type even with no candidates (all empty)", () => {
     const clusters = clusterCandidatesByRouteType([], { kind: 'routeType' }, [1, 2, 3]);
 
     const eligible = ROUTE_TYPE_DISPLAY_ORDER.filter((t) => t === 1 || t === 2 || t === 3);

--- a/src/domain/transit/transit-info-display/__tests__/transit-display-ui.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/transit-display-ui.test.ts
@@ -117,7 +117,7 @@ describe('sortTransitDisplayDataWithMetaData', () => {
     ).toEqual(['none', 0, 1]);
   });
 
-  it('applies the three levels together: route type -> category -> direction', () => {
+  it('applies the three levels together: route type -> direction -> category', () => {
     const railArr0 = display(2, 'arrivals', [0]);
     const busDep = display(3, 'departures', ['none']);
     const railDep1 = display(2, 'departures', [1]);
@@ -132,6 +132,9 @@ describe('sortTransitDisplayDataWithMetaData', () => {
       busArr,
     ]);
 
+    // routeType 3 (bus) before 2 (rail) per ROUTE_TYPE_DISPLAY_ORDER; within
+    // a route type, direction (none -> 0 -> 1) groups dep / arr pairs together,
+    // then category (dep -> arr) decides inside one direction.
     expect(
       sorted.map((d) => ({
         rt: d.meta.routeTypes[0],
@@ -142,8 +145,8 @@ describe('sortTransitDisplayDataWithMetaData', () => {
       { rt: 3, category: 'departures', dir: 'none' },
       { rt: 3, category: 'arrivals', dir: 'none' },
       { rt: 2, category: 'departures', dir: 0 },
-      { rt: 2, category: 'departures', dir: 1 },
       { rt: 2, category: 'arrivals', dir: 0 },
+      { rt: 2, category: 'departures', dir: 1 },
     ]);
   });
 
@@ -171,12 +174,13 @@ describe('sortTransitDisplayDataWithMetaData', () => {
     ]);
   });
 
-  it('applies all four levels: route type -> route -> category -> direction', () => {
+  it('applies all four levels: route type -> route -> direction -> category', () => {
     const ginza = makeRoute('eidan:ginza', 1);
     const hanzomon = makeRoute('eidan:hanzomon', 1);
 
-    // Two routes within one route type, each with both directions and both
-    // categories. Sorted result keeps every board of the same route adjacent.
+    // Two single-route boards (one per route) for each (direction, category)
+    // combination. Sort groups by route first, then by direction with dep / arr
+    // paired inside each direction.
     const sorted = sortTransitDisplayDataWithMetaData([
       display(1, 'arrivals', [1], [hanzomon]),
       display(1, 'departures', [0], [hanzomon]),
@@ -196,14 +200,73 @@ describe('sortTransitDisplayDataWithMetaData', () => {
       })),
     ).toEqual([
       { routeId: 'eidan:ginza', category: 'departures', dir: 0 },
-      { routeId: 'eidan:ginza', category: 'departures', dir: 1 },
       { routeId: 'eidan:ginza', category: 'arrivals', dir: 0 },
+      { routeId: 'eidan:ginza', category: 'departures', dir: 1 },
       { routeId: 'eidan:ginza', category: 'arrivals', dir: 1 },
       { routeId: 'eidan:hanzomon', category: 'departures', dir: 0 },
-      { routeId: 'eidan:hanzomon', category: 'departures', dir: 1 },
       { routeId: 'eidan:hanzomon', category: 'arrivals', dir: 0 },
+      { routeId: 'eidan:hanzomon', category: 'departures', dir: 1 },
       { routeId: 'eidan:hanzomon', category: 'arrivals', dir: 1 },
     ]);
+  });
+
+  // Multi-route boards (routes.length > 1) have `meta.routes` derived from
+  // filtered boardCandidates, so the cluster's dep board and arr board can
+  // land on different routes[0]. Sort skips the route axis for those, letting
+  // direction / category decide -- so dep stays before arr.
+  it('skips route axis for boards with multiple routes (multi-route bus cluster keeps dep before arr)', () => {
+    const route76 = makeRoute('iyotetsu:76', 3);
+    const routeExpress = makeRoute('iyotetsu:express', 3);
+    // dep board only sees route76 first; arr board only sees express first
+    // (the opposite picks would otherwise win on alphabetical route_id).
+    const dep = display(3, 'departures', ['none'], [route76, routeExpress]);
+    const arr = display(3, 'arrivals', ['none'], [routeExpress, route76]);
+
+    // Even if `routes[0]` differs between dep and arr (express < 76 in route_id
+    // alphabetical), the multi-route detection skips the route axis so
+    // category decides: dep before arr.
+    expect(sortTransitDisplayDataWithMetaData([arr, dep]).map((d) => d.meta.category)).toEqual([
+      'departures',
+      'arrivals',
+    ]);
+  });
+
+  // Direction axis is skipped independently (per-axis), with the same reasoning
+  // as the route axis. Real-world trigger: a bus cluster where one route has
+  // no direction_id (e.g. long-distance express) only appears as an arrival --
+  // arr board's directions[0] = 'none', dep board's directions[0] = 0. Without
+  // skipping, direction would mis-order arr before dep.
+  it('skips direction axis for boards with multiple directions (multi-direction bus cluster keeps dep before arr)', () => {
+    const route76 = makeRoute('iyotetsu:76', 3);
+    const routeExpress = makeRoute('iyotetsu:express', 3);
+    // Multi-route AND multi-direction. dep has directions [0, 1], arr has
+    // ['none', 0, 1] (because the express route only appears in arrivals and
+    // has no direction_id). DIRECTIONS index of 'none' (0) < 0 (1), so
+    // without the direction-axis skip, arr would sort before dep.
+    const dep = display(3, 'departures', [0, 1], [route76, routeExpress]);
+    const arr = display(3, 'arrivals', ['none', 0, 1], [route76, routeExpress]);
+
+    expect(sortTransitDisplayDataWithMetaData([arr, dep]).map((d) => d.meta.category)).toEqual([
+      'departures',
+      'arrivals',
+    ]);
+  });
+
+  // Composition: `splitByDirection: true` + `splitByRoute: false` is a possible
+  // future call shape (multi-route boards split by direction). For those, the
+  // route axis is skipped but the direction axis remains usable because
+  // `directions.length === 1` (each board carries a single split direction).
+  it('keeps direction axis usable when routes are multiple but directions are split (single-direction multi-route boards)', () => {
+    const route76 = makeRoute('iyotetsu:76', 3);
+    const routeA = makeRoute('iyotetsu:a', 3);
+    // Two boards, both multi-route, both single-direction. dep / arr aside;
+    // dir 0 < dir 1 must hold.
+    const dep0 = display(3, 'departures', [0], [route76, routeA]);
+    const dep1 = display(3, 'departures', [1], [route76, routeA]);
+
+    expect(
+      sortTransitDisplayDataWithMetaData([dep1, dep0]).map((d) => d.meta.directions[0]),
+    ).toEqual([0, 1]);
   });
 
   it('falls back to no route comparison when meta.routes is empty (boards with same routeType/category/direction keep stable order)', () => {

--- a/src/domain/transit/transit-info-display/__tests__/transit-display-ui.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/transit-display-ui.test.ts
@@ -252,21 +252,45 @@ describe('sortTransitDisplayDataWithMetaData', () => {
     ]);
   });
 
-  // Composition: `splitByDirection: true` + `splitByRoute: false` is a possible
-  // future call shape (multi-route boards split by direction). For those, the
-  // route axis is skipped but the direction axis remains usable because
-  // `directions.length === 1` (each board carries a single split direction).
-  it('keeps direction axis usable when routes are multiple but directions are split (single-direction multi-route boards)', () => {
+  // Multi-route boards skip the direction axis as well (skipDirectionAxis is
+  // OR-ed with skipRouteAxis). Reason: even a "single-direction multi-route"
+  // board can have a direction value that differs between dep and arr inside
+  // the cluster (the offending case is multi-route + single-direction with
+  // a per-category direction shift). Trusting direction here would mis-order
+  // arrivals before departures, so we skip it whenever the route axis is.
+  // Same-category multi-route boards that share routeType keep their input
+  // order via stable sort.
+  it('skips direction axis when multi-route (single-direction multi-route boards keep input order via stable sort)', () => {
     const route76 = makeRoute('iyotetsu:76', 3);
     const routeA = makeRoute('iyotetsu:a', 3);
-    // Two boards, both multi-route, both single-direction. dep / arr aside;
-    // dir 0 < dir 1 must hold.
     const dep0 = display(3, 'departures', [0], [route76, routeA]);
     const dep1 = display(3, 'departures', [1], [route76, routeA]);
 
-    expect(
-      sortTransitDisplayDataWithMetaData([dep1, dep0]).map((d) => d.meta.directions[0]),
-    ).toEqual([0, 1]);
+    // Direction is no longer a sort key for multi-route boards, so the two
+    // are equal under (routeType, category) and stable sort preserves input
+    // order regardless of direction values.
+    expect(sortTransitDisplayDataWithMetaData([dep1, dep0])).toEqual([dep1, dep0]);
+    expect(sortTransitDisplayDataWithMetaData([dep0, dep1])).toEqual([dep0, dep1]);
+  });
+
+  // The minkuru:0636-06 (Tokyo bus stop) regression: multi-route + single-
+  // direction where dep's directions[0] differs from arr's directions[0]
+  // (because the present-direction set diverges across categories). Without
+  // OR-ing skipDirectionAxis with skipRouteAxis, this case would mis-order
+  // arrivals before departures.
+  it('skips direction axis for multi-route single-direction with category-shifted directions[0] (minkuru regression)', () => {
+    const routeT01 = makeRoute('toei:t01', 3);
+    const routeMt87 = makeRoute('toei:t87', 3);
+    // dep has directions [1] only, arr has ['none'] only -- both length 1
+    // but different values. DIRECTIONS.indexOf('none') = 0 < indexOf(1) = 2,
+    // so without the OR skip, arr would sort before dep.
+    const dep = display(3, 'departures', [1], [routeT01, routeMt87]);
+    const arr = display(3, 'arrivals', ['none'], [routeT01, routeMt87]);
+
+    expect(sortTransitDisplayDataWithMetaData([arr, dep]).map((d) => d.meta.category)).toEqual([
+      'departures',
+      'arrivals',
+    ]);
   });
 
   it('falls back to no route comparison when meta.routes is empty (boards with same routeType/category/direction keep stable order)', () => {

--- a/src/domain/transit/transit-info-display/__tests__/transit-display-ui.test.ts
+++ b/src/domain/transit/transit-info-display/__tests__/transit-display-ui.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for transit-display-ui.ts -- UI presentation helpers
+ * (row caps, sort ordering, empty-state resolution).
+ *
+ * @vitest-environment node
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { makeRoute, makeStop } from '../../../../__tests__/helpers';
+import type { InfoLevel } from '../../../../types/app/settings';
+import type { AppRouteTypeValue, Route } from '../../../../types/app/transit';
+import type { StopWithContext } from '../../../../types/app/transit-composed';
+import {
+  type TransitDisplayCategory,
+  type TransitDisplayDataWithMetaData,
+} from '../build-transit-display-data';
+import {
+  resolveTransitDisplayState,
+  sortTransitDisplayDataWithMetaData,
+  transitDisplayMaxEntriesFor,
+  transitDisplayMaxEntriesPerRouteFor,
+} from '../transit-display-ui';
+
+describe('transitDisplayMaxEntriesFor', () => {
+  it('returns the configured row cap for each info level', () => {
+    expect(transitDisplayMaxEntriesFor('simple')).toBe(10);
+    expect(transitDisplayMaxEntriesFor('normal')).toBe(10);
+    expect(transitDisplayMaxEntriesFor('detailed')).toBe(20);
+    expect(transitDisplayMaxEntriesFor('verbose')).toBe(20);
+  });
+
+  it('returns a positive cap for every info level', () => {
+    const levels: InfoLevel[] = ['simple', 'normal', 'detailed', 'verbose'];
+    for (const level of levels) {
+      expect(transitDisplayMaxEntriesFor(level)).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('transitDisplayMaxEntriesPerRouteFor', () => {
+  it('returns the configured per-route row cap for each info level', () => {
+    expect(transitDisplayMaxEntriesPerRouteFor('simple')).toBe(3);
+    expect(transitDisplayMaxEntriesPerRouteFor('normal')).toBe(5);
+    expect(transitDisplayMaxEntriesPerRouteFor('detailed')).toBe(10);
+    expect(transitDisplayMaxEntriesPerRouteFor('verbose')).toBe(10);
+  });
+
+  it('returns a positive cap for every info level', () => {
+    const levels: InfoLevel[] = ['simple', 'normal', 'detailed', 'verbose'];
+    for (const level of levels) {
+      expect(transitDisplayMaxEntriesPerRouteFor(level)).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('sortTransitDisplayDataWithMetaData', () => {
+  /** A display whose only meaningful fields for ordering are route type, route, category, direction. */
+  function display(
+    routeType: AppRouteTypeValue,
+    category: TransitDisplayCategory,
+    directions: readonly (0 | 1 | 'none')[] = ['none'],
+    routes: readonly Route[] = [],
+  ): TransitDisplayDataWithMetaData {
+    return {
+      meta: {
+        category,
+        routeTypes: [routeType],
+        routes,
+        directions,
+        max: 10,
+        radius: 100,
+      },
+      data: { routeTypes: [routeType], routes, directions, category, data: [] },
+      stats: {
+        stopsInRadius: { stopCount: 0, agencyCount: 0, routeCount: 0, routeTypeCount: 0 },
+        qualifying: {
+          entryCount: 0,
+          stopCount: 0,
+          agencyCount: 0,
+          routeCount: 0,
+          routeTypeCount: 0,
+        },
+      },
+    };
+  }
+
+  it('orders by route type in ROUTE_TYPE_DISPLAY_ORDER (ferry not hoisted)', () => {
+    // display order is [3, 11, 0, 2, 1, 12, 4, ...]: bus(3) < rail(2) < subway(1) < ferry(4)
+    const bus = display(3, 'departures');
+    const rail = display(2, 'departures');
+    const subway = display(1, 'departures');
+    const ferry = display(4, 'departures');
+
+    const sorted = sortTransitDisplayDataWithMetaData([subway, ferry, rail, bus]);
+
+    expect(sorted.map((d) => d.meta.routeTypes[0])).toEqual([3, 2, 1, 4]);
+  });
+
+  it('within a route type, departures come before arrivals', () => {
+    const arr = display(2, 'arrivals');
+    const dep = display(2, 'departures');
+
+    expect(sortTransitDisplayDataWithMetaData([arr, dep]).map((d) => d.meta.category)).toEqual([
+      'departures',
+      'arrivals',
+    ]);
+  });
+
+  it('within a category, orders by direction (none, 0, 1)', () => {
+    const d1 = display(2, 'departures', [1]);
+    const d0 = display(2, 'departures', [0]);
+    const dn = display(2, 'departures', ['none']);
+
+    expect(
+      sortTransitDisplayDataWithMetaData([d1, d0, dn]).map((d) => d.meta.directions[0]),
+    ).toEqual(['none', 0, 1]);
+  });
+
+  it('applies the three levels together: route type -> category -> direction', () => {
+    const railArr0 = display(2, 'arrivals', [0]);
+    const busDep = display(3, 'departures', ['none']);
+    const railDep1 = display(2, 'departures', [1]);
+    const railDep0 = display(2, 'departures', [0]);
+    const busArr = display(3, 'arrivals', ['none']);
+
+    const sorted = sortTransitDisplayDataWithMetaData([
+      railArr0,
+      busDep,
+      railDep1,
+      railDep0,
+      busArr,
+    ]);
+
+    expect(
+      sorted.map((d) => ({
+        rt: d.meta.routeTypes[0],
+        category: d.meta.category,
+        dir: d.meta.directions[0],
+      })),
+    ).toEqual([
+      { rt: 3, category: 'departures', dir: 'none' },
+      { rt: 3, category: 'arrivals', dir: 'none' },
+      { rt: 2, category: 'departures', dir: 0 },
+      { rt: 2, category: 'departures', dir: 1 },
+      { rt: 2, category: 'arrivals', dir: 0 },
+    ]);
+  });
+
+  // route_id alphabetical sort: within the same route type, boards are ordered
+  // by `meta.routes[0].route_id`. In v2 sources the id is agency-prefixed
+  // (e.g. `eidan:ginza`), so agency clustering falls out naturally. Independent
+  // of builder input order -- ordering is fully derivable from meta.
+  it('within a route type, orders by routes[0].route_id alphabetical', () => {
+    const ginza = makeRoute('eidan:ginza', 1);
+    const hanzomon = makeRoute('eidan:hanzomon', 1);
+    const fukutoshin = makeRoute('eidan:fukutoshin', 1);
+
+    // Pass in an order different from the alphabetical one to prove the sort
+    // is driven by the key, not by input order.
+    const sorted = sortTransitDisplayDataWithMetaData([
+      display(1, 'departures', ['none'], [ginza]),
+      display(1, 'departures', ['none'], [hanzomon]),
+      display(1, 'departures', ['none'], [fukutoshin]),
+    ]);
+
+    expect(sorted.map((d) => d.meta.routes[0]?.route_id)).toEqual([
+      'eidan:fukutoshin',
+      'eidan:ginza',
+      'eidan:hanzomon',
+    ]);
+  });
+
+  it('applies all four levels: route type -> route -> category -> direction', () => {
+    const ginza = makeRoute('eidan:ginza', 1);
+    const hanzomon = makeRoute('eidan:hanzomon', 1);
+
+    // Two routes within one route type, each with both directions and both
+    // categories. Sorted result keeps every board of the same route adjacent.
+    const sorted = sortTransitDisplayDataWithMetaData([
+      display(1, 'arrivals', [1], [hanzomon]),
+      display(1, 'departures', [0], [hanzomon]),
+      display(1, 'arrivals', [0], [ginza]),
+      display(1, 'departures', [1], [ginza]),
+      display(1, 'departures', [0], [ginza]),
+      display(1, 'departures', [1], [hanzomon]),
+      display(1, 'arrivals', [0], [hanzomon]),
+      display(1, 'arrivals', [1], [ginza]),
+    ]);
+
+    expect(
+      sorted.map((d) => ({
+        routeId: d.meta.routes[0]?.route_id,
+        category: d.meta.category,
+        dir: d.meta.directions[0],
+      })),
+    ).toEqual([
+      { routeId: 'eidan:ginza', category: 'departures', dir: 0 },
+      { routeId: 'eidan:ginza', category: 'departures', dir: 1 },
+      { routeId: 'eidan:ginza', category: 'arrivals', dir: 0 },
+      { routeId: 'eidan:ginza', category: 'arrivals', dir: 1 },
+      { routeId: 'eidan:hanzomon', category: 'departures', dir: 0 },
+      { routeId: 'eidan:hanzomon', category: 'departures', dir: 1 },
+      { routeId: 'eidan:hanzomon', category: 'arrivals', dir: 0 },
+      { routeId: 'eidan:hanzomon', category: 'arrivals', dir: 1 },
+    ]);
+  });
+
+  it('falls back to no route comparison when meta.routes is empty (boards with same routeType/category/direction keep stable order)', () => {
+    // Empty routes -> routeId compares as '' for all, so route axis is a no-op.
+    // Stable sort preserves the input order within the same key.
+    const a = display(2, 'departures', [0]);
+    const b = display(2, 'departures', [0]);
+    const c = display(2, 'departures', [0]);
+    const sorted = sortTransitDisplayDataWithMetaData([a, b, c]);
+    expect(sorted).toEqual([a, b, c]);
+  });
+
+  it('does not mutate the input array', () => {
+    const a = display(2, 'departures');
+    const b = display(3, 'departures');
+    const input = [a, b];
+
+    sortTransitDisplayDataWithMetaData(input);
+
+    expect(input).toEqual([a, b]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(sortTransitDisplayDataWithMetaData([])).toEqual([]);
+  });
+});
+
+describe('resolveTransitDisplayState', () => {
+  function stop(
+    stopServiceState: StopWithContext['stopServiceState'] = 'boardable',
+  ): StopWithContext {
+    return {
+      stop: makeStop('s'),
+      agencies: [],
+      routes: [],
+      routeTypes: [],
+      stopTimes: [],
+      stopServiceState,
+    };
+  }
+
+  it("returns 'no-stops' for an empty stop set", () => {
+    expect(resolveTransitDisplayState([])).toBe('no-stops');
+  });
+
+  it("returns 'no-service' when every stop is out of service today", () => {
+    expect(resolveTransitDisplayState([stop('no-service'), stop('no-service')])).toBe('no-service');
+  });
+
+  it("returns 'ready' when at least one stop has service", () => {
+    expect(resolveTransitDisplayState([stop('no-service'), stop('boardable')])).toBe('ready');
+    expect(resolveTransitDisplayState([stop('boardable')])).toBe('ready');
+  });
+});

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -20,8 +20,8 @@ import { isArrival, isDeparture } from '../timetable-entry-for-transit-display';
  * {@link buildTransitDisplayDataSet}.
  */
 const MAX_ENTRIES_BY_INFO_LEVEL: Record<InfoLevel, number> = {
-  simple: 20,
-  normal: 20,
+  simple: 10,
+  normal: 10,
   detailed: 20,
   verbose: 20,
   // verbose: 10,
@@ -30,6 +30,18 @@ const MAX_ENTRIES_BY_INFO_LEVEL: Record<InfoLevel, number> = {
 /** Resolves the per-board row cap for the given info level. */
 export function transitDisplayMaxEntriesFor(infoLevel: InfoLevel): number {
   return MAX_ENTRIES_BY_INFO_LEVEL[infoLevel];
+}
+
+const MAX_ENTRIES_PER_ROUTE_BY_INFO_LEVEL: Record<InfoLevel, number> = {
+  simple: 3,
+  normal: 5,
+  detailed: 10,
+  verbose: 10,
+  // verbose: 10,
+};
+
+export function transitDisplayMaxEntriesPerRouteFor(infoLevel: InfoLevel): number {
+  return MAX_ENTRIES_PER_ROUTE_BY_INFO_LEVEL[infoLevel];
 }
 
 /**

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -1,4 +1,3 @@
-import type { InfoLevel } from '../../../types/app/settings';
 import type { AppRouteTypeValue, Route } from '../../../types/app/transit';
 import type {
   ContextualTimetableEntry,
@@ -13,36 +12,6 @@ import {
   type TransitDisplayDatumStats,
 } from '../compute-transit-display-datum-stats';
 import { isArrival, isDeparture } from '../timetable-entry-for-transit-display';
-
-/**
- * Per-board row cap by info level: terser levels show fewer departures, the
- * more detailed levels show more. Used as the `maxEntries` passed to
- * {@link buildTransitDisplayDataSet}.
- */
-const MAX_ENTRIES_BY_INFO_LEVEL: Record<InfoLevel, number> = {
-  simple: 10,
-  normal: 10,
-  detailed: 20,
-  verbose: 20,
-  // verbose: 10,
-};
-
-/** Resolves the per-board row cap for the given info level. */
-export function transitDisplayMaxEntriesFor(infoLevel: InfoLevel): number {
-  return MAX_ENTRIES_BY_INFO_LEVEL[infoLevel];
-}
-
-const MAX_ENTRIES_PER_ROUTE_BY_INFO_LEVEL: Record<InfoLevel, number> = {
-  simple: 3,
-  normal: 5,
-  detailed: 10,
-  verbose: 10,
-  // verbose: 10,
-};
-
-export function transitDisplayMaxEntriesPerRouteFor(infoLevel: InfoLevel): number {
-  return MAX_ENTRIES_PER_ROUTE_BY_INFO_LEVEL[infoLevel];
-}
 
 /**
  * How a display is classified: a departures board or an arrivals board. The
@@ -285,8 +254,12 @@ export function sortByCategory(
   );
 }
 
-/** Board categories, in the order they appear within a route type (departures then arrivals). */
-const CATEGORIES: readonly TransitDisplayCategory[] = ['departures', 'arrivals'];
+/**
+ * Board categories, in the order they appear within a route type (departures
+ * then arrivals). Exported because the UI presentation layer reuses the same
+ * order as the sort axis for boards.
+ */
+export const CATEGORIES: readonly TransitDisplayCategory[] = ['departures', 'arrivals'];
 
 /**
  * Direction buckets used to split a board by direction of travel. The values
@@ -294,9 +267,10 @@ const CATEGORIES: readonly TransitDisplayCategory[] = ['departures', 'arrivals']
  * `0` and `1` (the route's two opposite directions). `direction` mirrors GTFS
  * `direction_id` where the source provides it, and is `undefined` otherwise
  * (e.g. non-GTFS / ODPT sources). Empty buckets are dropped downstream, so trips
- * without a direction collapse to one group.
+ * without a direction collapse to one group. Exported because the UI
+ * presentation layer reuses the same order as the sort axis for boards.
  */
-const DIRECTIONS: readonly (0 | 1 | undefined)[] = [undefined, 0, 1];
+export const DIRECTIONS: readonly (0 | 1 | undefined)[] = [undefined, 0, 1];
 
 /**
  * Directions actually present among the candidates, in `DIRECTIONS` order, with
@@ -599,65 +573,4 @@ export function buildTransitDisplayDataSet(
     },
   }));
   return dataWithMetaData;
-}
-
-/**
- * UI ordering for the raw displays (sorted on `meta`, before rows are resolved),
- * independent of how they were built or merged (the container concatenates a
- * no-split and a split call, so the raw order is not canonical). Four levels:
- *   1. route type, by `ROUTE_TYPE_DISPLAY_ORDER`
- *   2. within a route type: route, by `meta.routes[0].route_id` alphabetical.
- *      Boards spanning multiple routes are evaluated by `routes[0]`. The id is
- *      agency-prefixed in v2 sources (e.g. `kobus:9`), so this naturally keeps
- *      every route under the same agency adjacent. This groups boards of the
- *      same route together -- its departures / arrivals and both directions
- *      stay adjacent rather than getting interleaved with other routes' boards
- *      at multi-route stops (Issue #296). Alphabetical sort is independent of
- *      builder input order so the final ordering is fully derivable from meta.
- *   3. within a route: category, departures before arrivals
- *   4. within a category: direction, in `DIRECTIONS` order (none, 0, 1)
- *
- * A full comparator (not a stable sort on one key), so reordering by route type
- * can never disturb the route/category/direction order set up earlier.
- */
-export function sortTransitDisplayDataWithMetaData(
-  rawDisplays: readonly TransitDisplayDataWithMetaData[],
-): TransitDisplayDataWithMetaData[] {
-  const orderKey = (d: TransitDisplayDataWithMetaData) => {
-    const direction = d.meta.directions[0];
-    return {
-      routeType: ROUTE_TYPE_DISPLAY_ORDER.indexOf(d.meta.routeTypes[0]),
-      routeId: d.meta.routes[0]?.route_id ?? '',
-      category: CATEGORIES.indexOf(d.meta.category),
-      direction: DIRECTIONS.indexOf(direction === 'none' ? undefined : direction),
-    };
-  };
-  return [...rawDisplays].sort((a, b) => {
-    const ka = orderKey(a);
-    const kb = orderKey(b);
-    return (
-      ka.routeType - kb.routeType ||
-      ka.routeId.localeCompare(kb.routeId) ||
-      ka.category - kb.category ||
-      ka.direction - kb.direction
-    );
-  });
-}
-
-export type TransitDisplayStopsState = 'ready' | 'no-stops' | 'no-service';
-export type TransitDisplayStatus = {
-  radius: number;
-  state: TransitDisplayStopsState;
-};
-
-export function resolveTransitDisplayState(
-  stops: readonly StopWithContext[],
-): TransitDisplayStopsState {
-  if (stops.length === 0) {
-    return 'no-stops';
-  }
-  if (stops.every((stop) => stop.stopServiceState === 'no-service')) {
-    return 'no-service';
-  }
-  return 'ready';
 }

--- a/src/domain/transit/transit-info-display/build-transit-display-data.ts
+++ b/src/domain/transit/transit-info-display/build-transit-display-data.ts
@@ -1,5 +1,5 @@
 import type { InfoLevel } from '../../../types/app/settings';
-import type { AppRouteTypeValue } from '../../../types/app/transit';
+import type { AppRouteTypeValue, Route } from '../../../types/app/transit';
 import type {
   ContextualTimetableEntry,
   StopWithContext,
@@ -55,6 +55,12 @@ export interface TransitDisplayMeta {
    */
   routeTypes: readonly AppRouteTypeValue[];
   /**
+   * Route(s) this board covers. One element when split by route; several (the
+   * routes actually present in the board's entries) when not. Mirrors how
+   * `directions` is structured.
+   */
+  routes: readonly Route[];
+  /**
    * Direction(s) of travel this board covers. `0` / `1` are GTFS `direction_id`
    * (where the source provides it) and `'none'` is "no direction_id". One element
    * when split by direction; several (the directions actually present) when not.
@@ -75,6 +81,8 @@ export interface TransitDisplayMeta {
  */
 export interface TransitDisplayData {
   routeTypes: readonly AppRouteTypeValue[];
+  /** Route(s) this board covers (see {@link TransitDisplayMeta.routes}). */
+  routes: readonly Route[];
   /** Direction(s) this board covers (see {@link TransitDisplayMeta.directions}). */
   directions: readonly (0 | 1 | 'none')[];
   category: TransitDisplayCategory;
@@ -132,16 +140,20 @@ export interface TransitDisplayCandidate {
 export type TransitDisplayDatum = TransitDisplayCandidate;
 
 /**
- * How route types are grouped into boards:
+ * How route types are grouped into boards. Note: this controls clustering by
+ * `route_type` (the mode, e.g. bus / subway / train), NOT by individual routes
+ * (e.g. 銀座線 / 半蔵門線). For per-route splitting within a route-type cluster
+ * see {@link TransitDisplayCondition.splitByRoute}.
+ *
  * - `none`: all route types combined into one board (per category)
- * - `route`: one board per route type
+ * - `routeType`: one board per route type
  * - `custom`: one board per caller-supplied group (each group = the route types
  *   on that board); e.g. pass the values of `ROUTE_TYPE_CATEGORY_GROUPS` to group
  *   by bus / subway / train / others.
  */
-export type TransitDisplayRouteGrouping =
+export type TransitDisplayRouteTypeGrouping =
   | { kind: 'none' }
-  | { kind: 'route' }
+  | { kind: 'routeType' }
   | { kind: 'custom'; groups: readonly (readonly AppRouteTypeValue[])[] };
 
 /**
@@ -152,8 +164,18 @@ export type TransitDisplayRouteGrouping =
 export interface TransitDisplayCondition {
   /** Per-display (per-board) row cap. */
   maxEntries: number;
-  /** How route types are grouped into boards. */
-  routeGrouping: TransitDisplayRouteGrouping;
+  /** How route types (modes) are grouped into boards. */
+  routeTypeGrouping: TransitDisplayRouteTypeGrouping;
+  /**
+   * Whether to also split each board by individual route (e.g. 銀座線 vs
+   * 半蔵門線 within the subway cluster). Applied AFTER {@link routeTypeGrouping}:
+   * each route-type cluster is further divided so that one board carries trips
+   * of exactly one route. When `false`, all routes within a cluster share one
+   * board (the legacy behaviour). Useful for rail at multi-line stations, where
+   * `direction_id` alone reads poorly because it is route-local / arbitrary
+   * across routes -- see Issue #296.
+   */
+  splitByRoute: boolean;
   /**
    * Whether to also split each board by direction of travel. When true, every
    * route type is split by each trip's `routeDirection.direction` (`0` | `1` |
@@ -279,6 +301,25 @@ function presentDirections(
 }
 
 /**
+ * Routes actually present among the candidates, in first-appearance order
+ * (no explicit display order exists for individual routes), deduped by
+ * `route_id`. Used to enumerate route buckets when {@link
+ * TransitDisplayCondition.splitByRoute} is on.
+ */
+function presentRoutesInOrder(candidates: readonly TransitDisplayCandidate[]): Route[] {
+  const seen = new Set<string>();
+  const routes: Route[] = [];
+  for (const c of candidates) {
+    const route = c.timetableEntry.routeDirection.route;
+    if (!seen.has(route.route_id)) {
+      seen.add(route.route_id);
+      routes.push(route);
+    }
+  }
+  return routes;
+}
+
+/**
  * One direction bucket for {@link groupCandidatesIntoBoards}: which candidates
  * belong to it (`matches`) and how to label the resulting board's `directions`
  * (`directionsOf`). Not split = a single bucket spanning all present directions;
@@ -291,13 +332,26 @@ interface DirectionGroup {
 }
 
 /**
- * Clusters candidates by route type, per the grouping strategy. `effectiveRouteTypes`
- * is the set of route types eligible to appear -- typically the route types served
- * by the nearby stops -- so a board's `routeTypes` reflect what the stops offer. It
- * is intersected with `ROUTE_TYPE_DISPLAY_ORDER` for ordering and dedup.
+ * One route bucket for {@link groupCandidatesIntoBoards}: which candidates
+ * belong to it (`matches`) and how to label the resulting board's `routes`
+ * (`routesOf`). Not split = a single bucket spanning all routes in the
+ * cluster; split = one bucket per `route_id` present in the cluster. Mirrors
+ * {@link DirectionGroup} so the per-cell loop can fold both axes the same way.
+ */
+interface RouteGroup {
+  matches: (candidate: TransitDisplayCandidate) => boolean;
+  routesOf: (selected: readonly TransitDisplayCandidate[]) => readonly Route[];
+}
+
+/**
+ * Clusters candidates by route type (mode), per the grouping strategy.
+ * `effectiveRouteTypes` is the set of route types eligible to appear -- typically
+ * the route types served by the nearby stops -- so a board's `routeTypes` reflect
+ * what the stops offer. It is intersected with `ROUTE_TYPE_DISPLAY_ORDER` for
+ * ordering and dedup.
  *
- * - `route`: one cluster per eligible route type (display order); an eligible type
- *   with no candidates yields an empty cluster.
+ * - `routeType`: one cluster per eligible route type (display order); an eligible
+ *   type with no candidates yields an empty cluster.
  * - `none`: a single cluster of all candidates; its `routeTypes` are the eligible
  *   types in display order.
  * - `custom`: one cluster per caller-supplied group, in the given order. Each
@@ -314,7 +368,7 @@ interface DirectionGroup {
  */
 export function clusterCandidatesByRouteType(
   candidates: readonly TransitDisplayCandidate[],
-  grouping: TransitDisplayRouteGrouping,
+  groupingByRouteType: TransitDisplayRouteTypeGrouping,
   effectiveRouteTypes: readonly AppRouteTypeValue[],
 ): RouteTypeCluster[] {
   // Eligible route types in display order (those served by the stops).
@@ -322,21 +376,21 @@ export function clusterCandidatesByRouteType(
     effectiveRouteTypes.includes(rt),
   );
 
-  if (grouping.kind === 'route') {
+  if (groupingByRouteType.kind === 'routeType') {
     return eligibleRouteTypes.map((routeType) => ({
       routeTypes: [routeType],
       candidates: selectByRouteType(candidates, routeType),
     }));
   }
 
-  if (grouping.kind === 'none') {
+  if (groupingByRouteType.kind === 'none') {
     return [{ routeTypes: eligibleRouteTypes, candidates: [...candidates] }];
   }
 
   // 'custom': one cluster per group (groups may overlap). Keep each group's own
   // order for routeTypes (eligible types only), so the caller's order is honored.
   const eligibleSet = new Set<number>(eligibleRouteTypes);
-  return grouping.groups
+  return groupingByRouteType.groups
     .map((group) => {
       const groupSet = new Set<number>(group);
       return {
@@ -352,9 +406,10 @@ export function clusterCandidatesByRouteType(
 /**
  * Groups candidates into boards: derives the eligible route types from `stops`
  * (each stop's `routeTypes`, independent of whether trips remain), clusters
- * candidates by route type (per `routeGrouping`), optionally by direction of
- * travel (when `splitByDirection`), then by category, yielding one board per
- * non-empty cell.
+ * candidates by route type (per `routeTypeGrouping`), optionally subdivides each
+ * cluster by individual route (when `splitByRoute`) and by direction of travel
+ * (when `splitByDirection`), then by category, yielding one board per non-empty
+ * cell.
  *
  * `stops` are the (already distance-filtered) nearby stops. As a guard it returns
  * no boards when there are no stops, or none are in service today -- the same
@@ -363,9 +418,9 @@ export function clusterCandidatesByRouteType(
  * A trip's `routeDirection.direction` (which mirrors GTFS `direction_id` where
  * the source provides it) is route-local and arbitrary across routes, so a
  * caller that wants direction split for some modes but not others (e.g. trains
- * yes, buses no) composes it by calling with different `routeGrouping` /
- * `splitByDirection` and merging the results, rather than having a per-mode rule
- * baked in here.
+ * yes, buses no) composes it by calling with different `routeTypeGrouping` /
+ * `splitByRoute` / `splitByDirection` and merging the results, rather than
+ * having a per-mode rule baked in here.
  *
  * Grouping only: it does not sort / cap ({@link sortAndCapTransitDisplayData}) or resolve
  * display names ({@link buildTransitDisplayDatumForUi}). Empty cells are dropped, so the
@@ -390,7 +445,7 @@ export function groupCandidatesIntoBoards(
 
   const clusters = clusterCandidatesByRouteType(
     candidates,
-    condition.routeGrouping,
+    condition.routeTypeGrouping,
     effectiveRouteTypes,
   );
 
@@ -409,22 +464,39 @@ export function groupCandidatesIntoBoards(
     : [{ matches: () => true, directionsOf: presentDirections }];
 
   for (const cluster of clusters) {
+    // Route buckets are cluster-scoped (the present routes depend on which
+    // candidates fell into this cluster), so they are built inside the loop.
+    // Not split = a single bucket spanning all routes in the cluster; split =
+    // one bucket per `route_id`, in first-appearance order.
+    const routeGroups: readonly RouteGroup[] = condition.splitByRoute
+      ? presentRoutesInOrder(cluster.candidates).map((route) => ({
+          matches: (c) => c.timetableEntry.routeDirection.route.route_id === route.route_id,
+          routesOf: () => [route],
+        }))
+      : [{ matches: () => true, routesOf: presentRoutesInOrder }];
+
     for (const category of CATEGORIES) {
-      for (const group of directionGroups) {
-        const boardCandidates = cluster.candidates.filter(
-          (c) => group.matches(c) && categoryQualifies(c.timetableEntry, category),
-        );
+      for (const routeGroup of routeGroups) {
+        for (const directionGroup of directionGroups) {
+          const boardCandidates = cluster.candidates.filter(
+            (c) =>
+              routeGroup.matches(c) &&
+              directionGroup.matches(c) &&
+              categoryQualifies(c.timetableEntry, category),
+          );
 
-        if (boardCandidates.length === 0) {
-          continue;
+          if (boardCandidates.length === 0) {
+            continue;
+          }
+
+          boards.push({
+            routeTypes: cluster.routeTypes,
+            routes: routeGroup.routesOf(boardCandidates),
+            directions: directionGroup.directionsOf(boardCandidates),
+            category,
+            data: boardCandidates,
+          });
         }
-
-        boards.push({
-          routeTypes: cluster.routeTypes,
-          directions: group.directionsOf(boardCandidates),
-          category,
-          data: boardCandidates,
-        });
       }
     }
   }
@@ -503,6 +575,7 @@ export function buildTransitDisplayDataSet(
     meta: {
       category: data.category,
       routeTypes: data.routeTypes,
+      routes: data.routes,
       directions: data.directions,
       max: condition.maxEntries,
       radius: radiusMeters,
@@ -519,29 +592,43 @@ export function buildTransitDisplayDataSet(
 /**
  * UI ordering for the raw displays (sorted on `meta`, before rows are resolved),
  * independent of how they were built or merged (the container concatenates a
- * no-split and a split call, so the raw order is not canonical). Three levels:
+ * no-split and a split call, so the raw order is not canonical). Four levels:
  *   1. route type, by `ROUTE_TYPE_DISPLAY_ORDER`
- *   2. within a route type: category, departures before arrivals
- *   3. within a category: direction, in `DIRECTIONS` order (none, 0, 1)
+ *   2. within a route type: route, by `meta.routes[0].route_id` alphabetical.
+ *      Boards spanning multiple routes are evaluated by `routes[0]`. The id is
+ *      agency-prefixed in v2 sources (e.g. `kobus:9`), so this naturally keeps
+ *      every route under the same agency adjacent. This groups boards of the
+ *      same route together -- its departures / arrivals and both directions
+ *      stay adjacent rather than getting interleaved with other routes' boards
+ *      at multi-route stops (Issue #296). Alphabetical sort is independent of
+ *      builder input order so the final ordering is fully derivable from meta.
+ *   3. within a route: category, departures before arrivals
+ *   4. within a category: direction, in `DIRECTIONS` order (none, 0, 1)
  *
  * A full comparator (not a stable sort on one key), so reordering by route type
- * can never disturb the departures/arrivals or direction order set up earlier.
+ * can never disturb the route/category/direction order set up earlier.
  */
 export function sortTransitDisplayDataWithMetaData(
   rawDisplays: readonly TransitDisplayDataWithMetaData[],
 ): TransitDisplayDataWithMetaData[] {
-  const orderKey = (d: TransitDisplayDataWithMetaData): [number, number, number] => {
+  const orderKey = (d: TransitDisplayDataWithMetaData) => {
     const direction = d.meta.directions[0];
-    return [
-      ROUTE_TYPE_DISPLAY_ORDER.indexOf(d.meta.routeTypes[0]),
-      CATEGORIES.indexOf(d.meta.category),
-      DIRECTIONS.indexOf(direction === 'none' ? undefined : direction),
-    ];
+    return {
+      routeType: ROUTE_TYPE_DISPLAY_ORDER.indexOf(d.meta.routeTypes[0]),
+      routeId: d.meta.routes[0]?.route_id ?? '',
+      category: CATEGORIES.indexOf(d.meta.category),
+      direction: DIRECTIONS.indexOf(direction === 'none' ? undefined : direction),
+    };
   };
   return [...rawDisplays].sort((a, b) => {
     const ka = orderKey(a);
     const kb = orderKey(b);
-    return ka[0] - kb[0] || ka[1] - kb[1] || ka[2] - kb[2];
+    return (
+      ka.routeType - kb.routeType ||
+      ka.routeId.localeCompare(kb.routeId) ||
+      ka.category - kb.category ||
+      ka.direction - kb.direction
+    );
   });
 }
 

--- a/src/domain/transit/transit-info-display/transit-display-ui.ts
+++ b/src/domain/transit/transit-info-display/transit-display-ui.ts
@@ -101,8 +101,7 @@ export function sortTransitDisplayDataWithMetaData(
     // `directions[0]`), so trusting it would mis-order arrivals before
     // departures. `hasMultipleDirections` covers the case where `splitByRoute`
     // is true but `splitByDirection` is false (rare but possible).
-    const skipDirectionAxis =
-      skipRouteAxis || ka.hasMultipleDirections || kb.hasMultipleDirections;
+    const skipDirectionAxis = skipRouteAxis || ka.hasMultipleDirections || kb.hasMultipleDirections;
     return (
       ka.routeType - kb.routeType ||
       (skipRouteAxis ? 0 : ka.routeId.localeCompare(kb.routeId)) ||

--- a/src/domain/transit/transit-info-display/transit-display-ui.ts
+++ b/src/domain/transit/transit-info-display/transit-display-ui.ts
@@ -46,21 +46,32 @@ export function transitDisplayMaxEntriesPerRouteFor(infoLevel: InfoLevel): numbe
 /**
  * UI ordering for the raw displays (sorted on `meta`, before rows are resolved),
  * independent of how they were built or merged (the container concatenates a
- * no-split and a split call, so the raw order is not canonical). Four levels:
+ * no-split and a split call, so the raw order is not canonical). Axes:
  *   1. route type, by `ROUTE_TYPE_DISPLAY_ORDER`
- *   2. within a route type: route, by `meta.routes[0].route_id` alphabetical.
- *      Boards spanning multiple routes are evaluated by `routes[0]`. The id is
- *      agency-prefixed in v2 sources (e.g. `kobus:9`), so this naturally keeps
- *      every route under the same agency adjacent. This groups boards of the
- *      same route together -- its departures / arrivals and both directions
- *      stay adjacent rather than getting interleaved with other routes' boards
- *      at multi-route stops (Issue #296). Alphabetical sort is independent of
- *      builder input order so the final ordering is fully derivable from meta.
- *   3. within a route: category, departures before arrivals
- *   4. within a category: direction, in `DIRECTIONS` order (none, 0, 1)
+ *   2. route, by `meta.routes[0].route_id` alphabetical -- ONLY when both
+ *      boards have a single route (`routes.length === 1`). Single-route boards
+ *      have a stable `routes[0]` shared across the cluster's dep / arr, so
+ *      comparing by route keeps every board of the same route adjacent (Issue
+ *      #296). The id is agency-prefixed in v2 sources (e.g. `kobus:9`), so
+ *      agency clustering falls out naturally. For multi-route boards
+ *      (`routes.length > 1`) the route axis is skipped: `meta.routes` is
+ *      derived from filtered boardCandidates, so dep / arr from the same
+ *      cluster can land on different `routes[0]`; using it as a sort key
+ *      would mis-order arrivals before departures.
+ *   3. direction, in `DIRECTIONS` order (none, 0, 1) -- ONLY when both boards
+ *      have a single direction (`directions.length === 1`). Same reasoning as
+ *      the route axis: a single direction means split-by-direction was applied
+ *      and dep / arr share `directions[0]`; multi-direction boards have a
+ *      shifted `directions[0]` between dep and arr (whether a no-direction
+ *      route appears in only one category etc.), so the axis is skipped.
+ *      Skipping route and direction is decided per axis (not jointly), so a
+ *      future "splitByDirection: true + splitByRoute: false" composition
+ *      keeps the direction axis usable while route is skipped.
+ *   4. category, departures before arrivals -- the final tiebreaker, and the
+ *      only inner axis when both route and direction are skipped.
  *
- * A full comparator (not a stable sort on one key), so reordering by route type
- * can never disturb the route/category/direction order set up earlier.
+ * A full comparator (not a stable sort on one key), so reordering by route
+ * type can never disturb the inner-axis order set up earlier.
  */
 export function sortTransitDisplayDataWithMetaData(
   rawDisplays: readonly TransitDisplayDataWithMetaData[],
@@ -69,19 +80,29 @@ export function sortTransitDisplayDataWithMetaData(
     const direction = d.meta.directions[0];
     return {
       routeType: ROUTE_TYPE_DISPLAY_ORDER.indexOf(d.meta.routeTypes[0]),
+      // Per-axis skip flags. When the board carries multiple values on an
+      // axis (routes or directions), `meta` is derived from filtered
+      // boardCandidates, so dep / arr from the same cluster can land on
+      // different head values for that axis; comparing by it would mis-order
+      // arrivals before departures. Evaluated independently so each axis can
+      // remain usable on its own merit.
+      hasMultipleRoutes: d.meta.routes.length > 1,
+      hasMultipleDirections: d.meta.directions.length > 1,
       routeId: d.meta.routes[0]?.route_id ?? '',
-      category: CATEGORIES.indexOf(d.meta.category),
       direction: DIRECTIONS.indexOf(direction === 'none' ? undefined : direction),
+      category: CATEGORIES.indexOf(d.meta.category),
     };
   };
   return [...rawDisplays].sort((a, b) => {
     const ka = orderKey(a);
     const kb = orderKey(b);
+    const skipRouteAxis = ka.hasMultipleRoutes || kb.hasMultipleRoutes;
+    const skipDirectionAxis = ka.hasMultipleDirections || kb.hasMultipleDirections;
     return (
       ka.routeType - kb.routeType ||
-      ka.routeId.localeCompare(kb.routeId) ||
-      ka.category - kb.category ||
-      ka.direction - kb.direction
+      (skipRouteAxis ? 0 : ka.routeId.localeCompare(kb.routeId)) ||
+      (skipDirectionAxis ? 0 : ka.direction - kb.direction) ||
+      ka.category - kb.category
     );
   });
 }

--- a/src/domain/transit/transit-info-display/transit-display-ui.ts
+++ b/src/domain/transit/transit-info-display/transit-display-ui.ts
@@ -1,0 +1,105 @@
+import type { InfoLevel } from '../../../types/app/settings';
+import type { StopWithContext } from '../../../types/app/transit-composed';
+import { ROUTE_TYPE_DISPLAY_ORDER } from '../route-type-display-order';
+import {
+  CATEGORIES,
+  DIRECTIONS,
+  type TransitDisplayDataWithMetaData,
+} from './build-transit-display-data';
+
+/**
+ * Per-board row cap by info level: terser levels show fewer departures, the
+ * more detailed levels show more. Used as the `maxEntries` passed to
+ * {@link buildTransitDisplayDataSet}.
+ */
+const MAX_ENTRIES_BY_INFO_LEVEL: Record<InfoLevel, number> = {
+  simple: 10,
+  normal: 10,
+  detailed: 20,
+  verbose: 20,
+  // verbose: 10,
+};
+
+/** Resolves the per-board row cap for the given info level. */
+export function transitDisplayMaxEntriesFor(infoLevel: InfoLevel): number {
+  return MAX_ENTRIES_BY_INFO_LEVEL[infoLevel];
+}
+
+/**
+ * Per-board row cap for per-route boards (1 route per board, produced by
+ * `splitByRoute: true`). Smaller than the multi-route default since a long
+ * list dilutes the "next several departures of THIS line" intent.
+ */
+const MAX_ENTRIES_PER_ROUTE_BY_INFO_LEVEL: Record<InfoLevel, number> = {
+  simple: 3,
+  normal: 5,
+  detailed: 10,
+  verbose: 10,
+  // verbose: 10,
+};
+
+/** Resolves the per-route per-board row cap for the given info level. */
+export function transitDisplayMaxEntriesPerRouteFor(infoLevel: InfoLevel): number {
+  return MAX_ENTRIES_PER_ROUTE_BY_INFO_LEVEL[infoLevel];
+}
+
+/**
+ * UI ordering for the raw displays (sorted on `meta`, before rows are resolved),
+ * independent of how they were built or merged (the container concatenates a
+ * no-split and a split call, so the raw order is not canonical). Four levels:
+ *   1. route type, by `ROUTE_TYPE_DISPLAY_ORDER`
+ *   2. within a route type: route, by `meta.routes[0].route_id` alphabetical.
+ *      Boards spanning multiple routes are evaluated by `routes[0]`. The id is
+ *      agency-prefixed in v2 sources (e.g. `kobus:9`), so this naturally keeps
+ *      every route under the same agency adjacent. This groups boards of the
+ *      same route together -- its departures / arrivals and both directions
+ *      stay adjacent rather than getting interleaved with other routes' boards
+ *      at multi-route stops (Issue #296). Alphabetical sort is independent of
+ *      builder input order so the final ordering is fully derivable from meta.
+ *   3. within a route: category, departures before arrivals
+ *   4. within a category: direction, in `DIRECTIONS` order (none, 0, 1)
+ *
+ * A full comparator (not a stable sort on one key), so reordering by route type
+ * can never disturb the route/category/direction order set up earlier.
+ */
+export function sortTransitDisplayDataWithMetaData(
+  rawDisplays: readonly TransitDisplayDataWithMetaData[],
+): TransitDisplayDataWithMetaData[] {
+  const orderKey = (d: TransitDisplayDataWithMetaData) => {
+    const direction = d.meta.directions[0];
+    return {
+      routeType: ROUTE_TYPE_DISPLAY_ORDER.indexOf(d.meta.routeTypes[0]),
+      routeId: d.meta.routes[0]?.route_id ?? '',
+      category: CATEGORIES.indexOf(d.meta.category),
+      direction: DIRECTIONS.indexOf(direction === 'none' ? undefined : direction),
+    };
+  };
+  return [...rawDisplays].sort((a, b) => {
+    const ka = orderKey(a);
+    const kb = orderKey(b);
+    return (
+      ka.routeType - kb.routeType ||
+      ka.routeId.localeCompare(kb.routeId) ||
+      ka.category - kb.category ||
+      ka.direction - kb.direction
+    );
+  });
+}
+
+export type TransitDisplayStopsState = 'ready' | 'no-stops' | 'no-service';
+export type TransitDisplayStatus = {
+  radius: number;
+  state: TransitDisplayStopsState;
+};
+
+export function resolveTransitDisplayState(
+  stops: readonly StopWithContext[],
+): TransitDisplayStopsState {
+  if (stops.length === 0) {
+    return 'no-stops';
+  }
+  if (stops.every((stop) => stop.stopServiceState === 'no-service')) {
+    return 'no-service';
+  }
+  return 'ready';
+}

--- a/src/domain/transit/transit-info-display/transit-display-ui.ts
+++ b/src/domain/transit/transit-info-display/transit-display-ui.ts
@@ -58,15 +58,13 @@ export function transitDisplayMaxEntriesPerRouteFor(infoLevel: InfoLevel): numbe
  *      derived from filtered boardCandidates, so dep / arr from the same
  *      cluster can land on different `routes[0]`; using it as a sort key
  *      would mis-order arrivals before departures.
- *   3. direction, in `DIRECTIONS` order (none, 0, 1) -- ONLY when both boards
- *      have a single direction (`directions.length === 1`). Same reasoning as
- *      the route axis: a single direction means split-by-direction was applied
- *      and dep / arr share `directions[0]`; multi-direction boards have a
- *      shifted `directions[0]` between dep and arr (whether a no-direction
- *      route appears in only one category etc.), so the axis is skipped.
- *      Skipping route and direction is decided per axis (not jointly), so a
- *      future "splitByDirection: true + splitByRoute: false" composition
- *      keeps the direction axis usable while route is skipped.
+ *   3. direction, in `DIRECTIONS` order (none, 0, 1) -- ONLY when the route
+ *      axis is also being used (both boards single-route) AND both boards
+ *      have a single direction. Reasoning: a single direction value can still
+ *      differ between dep and arr inside a multi-route cluster (a route
+ *      present only in one category can shift `directions[0]`), so the
+ *      direction axis is trusted only alongside single-route, where `routes`
+ *      and `directions` are both stable across the cluster's dep / arr.
  *   4. category, departures before arrivals -- the final tiebreaker, and the
  *      only inner axis when both route and direction are skipped.
  *
@@ -97,7 +95,14 @@ export function sortTransitDisplayDataWithMetaData(
     const ka = orderKey(a);
     const kb = orderKey(b);
     const skipRouteAxis = ka.hasMultipleRoutes || kb.hasMultipleRoutes;
-    const skipDirectionAxis = ka.hasMultipleDirections || kb.hasMultipleDirections;
+    // Direction axis is also skipped whenever the route axis is skipped:
+    // multi-route boards may have a single direction value that still differs
+    // between dep and arr (a route present only in one category can shift
+    // `directions[0]`), so trusting it would mis-order arrivals before
+    // departures. `hasMultipleDirections` covers the case where `splitByRoute`
+    // is true but `splitByDirection` is false (rare but possible).
+    const skipDirectionAxis =
+      skipRouteAxis || ka.hasMultipleDirections || kb.hasMultipleDirections;
     return (
       ka.routeType - kb.routeType ||
       (skipRouteAxis ? 0 : ka.routeId.localeCompare(kb.routeId)) ||


### PR DESCRIPTION
## Summary

- Adds per-route board splitting (`splitByRoute`) to the transit display
  builder, enabling rail-style "one board per route" layouts (Issue #296)
- Container now uses per-route boards for rail / subway / tram /
  monorail / ... while bus / trolleybus / ferry stay as multi-route
- Splits UI presentation helpers into a new
  `transit-display-ui.ts` module (sort / row caps / empty-state),
  separating UI concerns from the pure builder
- Hardens `sortTransitDisplayDataWithMetaData` to skip the route and
  direction axes when those values are not stable across the cluster's
  dep / arr (multi-value boards have meta derived from filtered
  boardCandidates, so dep / arr can land on different `routes[0]` /
  `directions[0]`)

### Commits

1. `feat(transit-display): split boards by route` -- domain layer
2. `feat(transit-display): enable per-route boards in container` -- container switch + per-route row cap
3. `refactor(transit-display): split UI helpers into transit-display-ui.ts` -- file split
4. `fix(transit-display): skip route/direction sort axes for multi-value boards` -- initial bus sort fix
5. `fix(transit-display): skip direction axis whenever route axis is skipped` -- minkuru regression follow-up

### Sort key shape (final)

- single-route + single-direction boards (rail / subway):
  `routeType -> route_id -> direction -> category`
- multi-route boards (bus / trolleybus / ferry, any direction count):
  `routeType -> category`

The route and direction axes are evaluated only when both compared
boards expose stable values for them; otherwise they are skipped and
`category` decides (departures before arrivals).

## Test plan

- [x] Rail / subway stop (e.g. Shibuya subway) shows per-route boards
      grouped together (Ginza / Hanzomon / Fukutoshin each get their
      own dep / arr / dir blocks)
- [x] Bus stop with arrivals-only express routes
      (e.g. \`?stop=iyt2:bus_oogaidou\`, \`?stop=minkuru:0636-06\`)
      shows departures before arrivals
- [x] No regressions on other stops (mixed routeType, single-route
      bus, etc.)
- [x] Existing `transit-displays-2.tsx` header layout (2 columns:
      Title + Routes vs stats badges) is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)