### PR TITLE
feat: route-grouped view + display-names shared components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [CalVer](https://calver.org/).
 - TransitDisplay (rail / subway / tram / monorail): per-route board (1 board = 1 route) を導入した。渋谷 subway 等の多 line 駅で銀座線 / 半蔵門線 / 副都心線が個別 board として並ぶようになった (#296, #300)。
 - TransitDisplay: per-route 用の row cap (`transitDisplayMaxEntriesPerRouteFor`) を追加した (simple: 3 / normal: 5 / detailed: 10 / verbose: 10、1 route board が冗長にならないように multi-route 用より少なく) (#296, #300)。
 - TransitDisplay2: Header band を 2 columns 構成 (Title + Routes / stats badges) に再構成し、`RouteBadge` を Title 行に表示するようにした (#296, #300)。
+- StopTime views: 新しい `route` view (per-route card) を導入し、view picker の並びでも `route` を `transit-display` より先に置いた。bus / trolleybus / ferry を含む全 route_type で per-route card を表示する (#302)。
+- Shared components: 多言語 sub-names を inline / 縦 stack でレンダリングする `InlineDisplayNames` / `StackedDisplayNames` を `src/components/shared/` に追加した。必須 `size` (`ExtendedDisplaySize`) / `showSubNames` / (Stacked のみ) `subNamesPosition` を受け取り、default 色 (`text-[#333]` / `text-[#888]` + dark variants) を内蔵する。caller-provided `nameClassName` / `subNamesClassName` は twMerge で text-\* を override 可能 (#302)。
+- Storybook: `DisplayNames/StackedDisplayNames` / `DisplayNames/InlineDisplayNames` の stories を追加した (#302)。
 
 ### Changed
 
@@ -25,10 +28,14 @@ and this project adheres to [CalVer](https://calver.org/).
 - transit-display: UI 表示用のヘルパー (`sortTransitDisplayDataWithMetaData` / `resolveTransitDisplayState` / `transitDisplayMaxEntriesFor` ほか) を `transit-display-ui.ts` に分離した。builder (`build-transit-display-data.ts`) は board データ生成のみ、UI 配慮 (並び順 / row 上限 / empty-state) は専用 module に集約 (#296, #300)。
 - TransitDisplaysContainer: 鉄道系 (`DIRECTION_SPLIT_ROUTE_TYPES`) は per-route board (`splitByRoute: true`) で構築し、bus / trolleybus / ferry (`NO_SPLIT_ROUTE_TYPES`) は multi-route のまま維持する per-mode policy を採用した。group-by の runtime toggle は意図的に追加しない (#296, #300)。
 - TransitDisplay: multi-route board の row cap (`simple` / `normal`) を 10 に下げた (per-route と数を揃え、過剰な行数を抑制) (#296, #300)。
+- TripInfo: ヘッドサインのレンダーをローカル `HeadsignInfo` から shared `StackedDisplayNames` に置き換えた (#302)。
+- TransitDisplayPerRoute: route info row に `flex-wrap` を入れ、RouteBadge が長文のとき Route names を次の行へ折り返して表示するようにした (#302)。
+- `hasDisplayContent`: truthy/falsy collapse を strict empty-string check (`!== ''`) に書き換えた (テスト追加、挙動は不変) (#302)。
 
 ### Fixed
 
 - TransitDisplay: 多 route 停留所 (都営バス渋谷駅前 / 伊予鉄バス大街道等) で「到着」 board が「出発」 board より先に並んでしまうバグを修正した。multi-route 板の `meta.routes` / `meta.directions` は boardCandidates ベースで計算されるため dep / arr 間で `routes[0]` / `directions[0]` がズレることがあり、sort key として信頼できない。sort 関数で multi-value のときは route 軸 / direction 軸を skip し、category 軸で確実に departures → arrivals 順になるようにした (#296, #300)。
+- StackedDisplayNames / InlineDisplayNames: `subNames` に空文字 / whitespace-only エントリが混入した際に空 span や leading separator (例: `' / Nakano'`) が描画される問題を、`map(trim).filter(non-empty)` で正規化して防ぐようにした (#302)。
 
 ## [2026.06.11]
 

--- a/src/components/absolute-stop-time.tsx
+++ b/src/components/absolute-stop-time.tsx
@@ -42,6 +42,7 @@ export function AbsoluteStopTime({
   return (
     <div
       className={cn(
+        // 'font-dotgothic16',
         weight === 'bold' ? 'font-bold' : 'font-normal',
         'text-[#333] dark:text-gray-100',
         variant.time,

--- a/src/components/shared/inline-display-names.stories.tsx
+++ b/src/components/shared/inline-display-names.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import type { ResolvedDisplayNames } from '@/domain/transit/name-resolver/get-display-names';
+
+import type { ExtendedDisplaySize } from './display-size';
+import { InlineDisplayNames } from './inline-display-names';
+
+const kyotoArashiyamaNames: ResolvedDisplayNames = {
+  name: '京都駅前〜阪急嵐山駅前',
+  subNames: [
+    'Kyoto Sta.〜Hankyu Arashiyama Sta.',
+    '京都站前〜阪急岚山站前',
+    '京都站前〜阪急嵐山站前',
+    '교토에키마에〜한큐아라시야마에키마에',
+  ],
+};
+
+const nakanoNames: ResolvedDisplayNames = {
+  name: '中野駅',
+  subNames: ['Nakano Sta.'],
+};
+
+const nameOnlyNames: ResolvedDisplayNames = {
+  name: '中野駅',
+  subNames: [],
+};
+
+const meta = {
+  title: 'DisplayNames/InlineDisplayNames',
+  component: InlineDisplayNames,
+  args: {
+    names: kyotoArashiyamaNames,
+    size: 'md',
+    ellipsis: false,
+    showSubNames: true,
+  },
+  argTypes: {
+    size: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
+    showSubNames: { control: 'boolean' },
+    ellipsis: { control: 'boolean' },
+    nameClassName: { control: 'text' },
+    subNamesClassName: { control: 'text' },
+  },
+} satisfies Meta<typeof InlineDisplayNames>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default: Kyoto-Arashiyama, name followed by 4-language sub-names, md size. */
+export const Default: Story = {};
+
+/** Sub-names hidden via `showSubNames=false`. */
+export const WithoutSubNames: Story = {
+  args: { showSubNames: false },
+};
+
+/** Single sub-name (English only). */
+export const SingleSubName: Story = {
+  args: { names: nakanoNames },
+};
+
+/** No sub-names at all (primary name only). */
+export const NameOnly: Story = {
+  args: { names: nameOnlyNames },
+};
+
+const ALL_SIZES: readonly ExtendedDisplaySize[] = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+/** All five sizes side-by-side for comparison (sub-names = 1 step smaller). */
+export const SizeComparison: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-6 p-4">
+      {ALL_SIZES.map((size) => (
+        <div key={size} className="flex items-baseline gap-3">
+          <span className="w-8 text-xs text-gray-500">{size}</span>
+          <InlineDisplayNames
+            names={args.names}
+            size={size}
+            ellipsis={args.ellipsis}
+            showSubNames={args.showSubNames}
+            nameClassName={args.nameClassName}
+            subNamesClassName={args.subNamesClassName}
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** Long content with `ellipsis` enabled in a narrow container. */
+export const Truncated: Story = {
+  args: { ellipsis: true },
+  render: (args) => (
+    <div className="w-48 border border-dashed p-2">
+      <InlineDisplayNames
+        names={args.names}
+        size={args.size}
+        ellipsis={args.ellipsis}
+        showSubNames={args.showSubNames}
+        nameClassName={args.nameClassName}
+        subNamesClassName={args.subNamesClassName}
+      />
+    </div>
+  ),
+};

--- a/src/components/shared/inline-display-names.tsx
+++ b/src/components/shared/inline-display-names.tsx
@@ -1,6 +1,22 @@
 import type { ResolvedDisplayNames } from '@/domain/transit/name-resolver/get-display-names';
 import { cn } from '@/lib/utils';
-import type { InfoLevelFlags } from '@/utils/create-info-level';
+import type { ExtendedDisplaySize } from './display-size';
+
+const NAME_TEXT_BY_SIZE: Record<ExtendedDisplaySize, string> = {
+  xs: 'text-xs',
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+  xl: 'text-xl',
+};
+
+const SUB_TEXT_BY_SIZE: Record<ExtendedDisplaySize, string> = {
+  xs: 'text-[8px]',
+  sm: 'text-[10px]',
+  md: 'text-xs',
+  lg: 'text-sm',
+  xl: 'text-base',
+};
 
 /**
  * Props for {@link InlineDisplayNames}.
@@ -8,36 +24,51 @@ import type { InfoLevelFlags } from '@/utils/create-info-level';
 export interface InlineDisplayNamesProps {
   /** Names to render. */
   names: ResolvedDisplayNames;
-  /** Controls whether sub-names are shown (only shown when normal info is enabled and at least one sub-name is non-empty). */
-  infoLevel: InfoLevelFlags;
-  /** Class names applied to the primary-name span. */
-  nameClass: string;
-  /** Class names applied to the sub-names span. */
-  subNameClass: string;
+
+  /**
+   * Base text size for the primary name. The sub-names get one step smaller.
+   * Caller-provided `nameClassName` / `subNamesClassName` win over this
+   * baseline (twMerge resolves `text-*` collisions with the later argument).
+   */
+  size: ExtendedDisplaySize;
+
   /** When `true`, each span is allowed to truncate with an ellipsis. */
   ellipsis: boolean;
+
+  /** When `true`, the sub-names are rendered (still requires at least one non-empty sub-name). */
+  showSubNames: boolean;
+
+  /** Extra class names applied to the primary-name span. */
+  nameClassName?: string | undefined;
+
+  /** Extra class names applied to the sub-names span. */
+  subNamesClassName?: string | undefined;
 }
 
 /**
  * Render a {@link ResolvedDisplayNames} as an inline pair: primary name
- * followed by sub-names (when present and `infoLevel` allows).
+ * followed by sub-names (when `showSubNames` and at least one sub-name is
+ * non-empty).
  *
  * Children use `inline-block` so each span gets its own line box and
  * `leading-tight` applies to its line-height.
  */
 export function InlineDisplayNames({
   names,
-  infoLevel,
-  nameClass,
-  subNameClass,
+  size,
   ellipsis,
+  showSubNames,
+  nameClassName,
+  subNamesClassName,
 }: InlineDisplayNamesProps) {
   return (
     <span className="">
       <span
         className={cn(
           //
-          nameClass,
+          NAME_TEXT_BY_SIZE[size],
+          'text-[#333] dark:text-gray-200',
+          nameClassName,
           ellipsis && 'truncate',
           'inline-block',
           'leading-tight',
@@ -45,11 +76,13 @@ export function InlineDisplayNames({
       >
         {names.name}
       </span>
-      {infoLevel.isNormalEnabled && names.subNames.length > 0 && (
+      {showSubNames && names.subNames.length > 0 && (
         <span
           className={cn(
             //
-            subNameClass,
+            SUB_TEXT_BY_SIZE[size],
+            'text-[#888] dark:text-gray-400',
+            subNamesClassName,
             ellipsis && 'truncate',
             'inline-block',
             'leading-tight',

--- a/src/components/shared/inline-display-names.tsx
+++ b/src/components/shared/inline-display-names.tsx
@@ -61,6 +61,8 @@ export function InlineDisplayNames({
   nameClassName,
   subNamesClassName,
 }: InlineDisplayNamesProps) {
+  const { name, subNames } = names;
+  const normalizedSubNames = subNames.map((e) => e.trim()).filter((s) => s !== '');
   return (
     <span className="">
       <span
@@ -74,9 +76,9 @@ export function InlineDisplayNames({
           'leading-tight',
         )}
       >
-        {names.name}
+        {name}
       </span>
-      {showSubNames && names.subNames.length > 0 && (
+      {showSubNames && normalizedSubNames.length > 0 && (
         <span
           className={cn(
             //
@@ -88,7 +90,7 @@ export function InlineDisplayNames({
             'leading-tight',
           )}
         >
-          {names.subNames.join(' / ')}
+          {normalizedSubNames.join(' / ')}
         </span>
       )}
     </span>

--- a/src/components/shared/inline-display-names.tsx
+++ b/src/components/shared/inline-display-names.tsx
@@ -1,0 +1,63 @@
+import type { ResolvedDisplayNames } from '@/domain/transit/name-resolver/get-display-names';
+import { cn } from '@/lib/utils';
+import type { InfoLevelFlags } from '@/utils/create-info-level';
+
+/**
+ * Props for {@link InlineDisplayNames}.
+ */
+export interface InlineDisplayNamesProps {
+  /** Names to render. */
+  names: ResolvedDisplayNames;
+  /** Controls whether sub-names are shown (only shown when normal info is enabled and at least one sub-name is non-empty). */
+  infoLevel: InfoLevelFlags;
+  /** Class names applied to the primary-name span. */
+  nameClass: string;
+  /** Class names applied to the sub-names span. */
+  subNameClass: string;
+  /** When `true`, each span is allowed to truncate with an ellipsis. */
+  ellipsis: boolean;
+}
+
+/**
+ * Render a {@link ResolvedDisplayNames} as an inline pair: primary name
+ * followed by sub-names (when present and `infoLevel` allows).
+ *
+ * Children use `inline-block` so each span gets its own line box and
+ * `leading-tight` applies to its line-height.
+ */
+export function InlineDisplayNames({
+  names,
+  infoLevel,
+  nameClass,
+  subNameClass,
+  ellipsis,
+}: InlineDisplayNamesProps) {
+  return (
+    <span className="">
+      <span
+        className={cn(
+          //
+          nameClass,
+          ellipsis && 'truncate',
+          'inline-block',
+          'leading-tight',
+        )}
+      >
+        {names.name}
+      </span>
+      {infoLevel.isNormalEnabled && names.subNames.length > 0 && (
+        <span
+          className={cn(
+            //
+            subNameClass,
+            ellipsis && 'truncate',
+            'inline-block',
+            'leading-tight',
+          )}
+        >
+          {names.subNames.join(' / ')}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/shared/stacked-display-names.stories.tsx
+++ b/src/components/shared/stacked-display-names.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import type { ResolvedDisplayNames } from '@/domain/transit/name-resolver/get-display-names';
+
+import type { ExtendedDisplaySize } from './display-size';
+import { StackedDisplayNames } from './stacked-display-names';
+
+const kyotoArashiyamaNames: ResolvedDisplayNames = {
+  name: '京都駅前〜阪急嵐山駅前',
+  subNames: [
+    'Kyoto Sta.〜Hankyu Arashiyama Sta.',
+    '京都站前〜阪急岚山站前',
+    '京都站前〜阪急嵐山站前',
+    '교토에키마에〜한큐아라시야마에키마에',
+  ],
+};
+
+const nakanoNames: ResolvedDisplayNames = {
+  name: '中野駅',
+  subNames: ['Nakano Sta.'],
+};
+
+const nameOnlyNames: ResolvedDisplayNames = {
+  name: '中野駅',
+  subNames: [],
+};
+
+const meta = {
+  title: 'DisplayNames/StackedDisplayNames',
+  component: StackedDisplayNames,
+  args: {
+    names: kyotoArashiyamaNames,
+    size: 'md',
+    ellipsis: false,
+    showSubNames: true,
+    subNamesPosition: 'top',
+  },
+  argTypes: {
+    size: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
+    subNamesPosition: { control: 'inline-radio', options: ['top', 'bottom'] },
+    showSubNames: { control: 'boolean' },
+    ellipsis: { control: 'boolean' },
+    nameClassName: { control: 'text' },
+    subNamesClassName: { control: 'text' },
+  },
+} satisfies Meta<typeof StackedDisplayNames>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default: Kyoto-Arashiyama with sub-names on top, md size. */
+export const Default: Story = {};
+
+/** Sub-names placed below the primary name. */
+export const SubNamesBottom: Story = {
+  args: { subNamesPosition: 'bottom' },
+};
+
+/** Sub-names hidden via `showSubNames=false`. */
+export const WithoutSubNames: Story = {
+  args: { showSubNames: false },
+};
+
+/** Single sub-name (English only). */
+export const SingleSubName: Story = {
+  args: { names: nakanoNames },
+};
+
+/** No sub-names at all (primary name only). */
+export const NameOnly: Story = {
+  args: { names: nameOnlyNames },
+};
+
+const ALL_SIZES: readonly ExtendedDisplaySize[] = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+/** All five sizes side-by-side for comparison (sub-names = 1 step smaller). */
+export const SizeComparison: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-6 p-4">
+      {ALL_SIZES.map((size) => (
+        <div key={size} className="flex items-baseline gap-3">
+          <span className="w-8 text-xs text-gray-500">{size}</span>
+          <StackedDisplayNames
+            names={args.names}
+            size={size}
+            ellipsis={args.ellipsis}
+            showSubNames={args.showSubNames}
+            subNamesPosition={args.subNamesPosition}
+            nameClassName={args.nameClassName}
+            subNamesClassName={args.subNamesClassName}
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** Long content with `ellipsis` enabled in a narrow container. */
+export const Truncated: Story = {
+  args: { ellipsis: true },
+  render: (args) => (
+    <div className="w-48 border border-dashed p-2">
+      <StackedDisplayNames
+        names={args.names}
+        size={args.size}
+        ellipsis={args.ellipsis}
+        showSubNames={args.showSubNames}
+        subNamesPosition={args.subNamesPosition}
+        nameClassName={args.nameClassName}
+        subNamesClassName={args.subNamesClassName}
+      />
+    </div>
+  ),
+};

--- a/src/components/shared/stacked-display-names.tsx
+++ b/src/components/shared/stacked-display-names.tsx
@@ -1,6 +1,22 @@
 import type { ResolvedDisplayNames } from '@/domain/transit/name-resolver/get-display-names';
 import { cn } from '@/lib/utils';
-import type { InfoLevelFlags } from '@/utils/create-info-level';
+import type { ExtendedDisplaySize } from './display-size';
+
+const NAME_TEXT_BY_SIZE: Record<ExtendedDisplaySize, string> = {
+  xs: 'text-xs',
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+  xl: 'text-xl',
+};
+
+const SUB_TEXT_BY_SIZE: Record<ExtendedDisplaySize, string> = {
+  xs: 'text-[8px]',
+  sm: 'text-[10px]',
+  md: 'text-xs',
+  lg: 'text-sm',
+  xl: 'text-base',
+};
 
 /**
  * Props for {@link StackedDisplayNames}.
@@ -8,47 +24,90 @@ import type { InfoLevelFlags } from '@/utils/create-info-level';
 export interface StackedDisplayNamesProps {
   /** Names to render. */
   names: ResolvedDisplayNames;
-  /** Controls whether sub-names are shown (only shown when normal info is enabled). */
-  infoLevel: InfoLevelFlags;
-  /** Class names applied to the primary-name span. */
-  nameClass: string;
-  /** Class names applied to the sub-names span. */
-  subNameClass: string;
+
+  /**
+   * Base text size for the primary name. The sub-names get one step smaller.
+   * Caller-provided `nameClassName` / `subNamesClassName` win over this
+   * baseline (twMerge resolves `text-*` collisions with the later argument).
+   */
+  size: ExtendedDisplaySize;
+
   /** When `true`, each span is allowed to truncate with an ellipsis. */
   ellipsis: boolean;
+
+  /** When `true`, the sub-names are rendered. */
+  showSubNames: boolean;
+
+  /** Where the sub-names sit relative to the primary name. */
+  subNamesPosition: 'top' | 'bottom';
+
+  /** Extra class names applied to the primary-name span. */
+  nameClassName?: string | undefined;
+
+  /** Extra class names applied to the sub-names span. */
+  subNamesClassName?: string | undefined;
 }
 
 /**
- * Render a {@link ResolvedDisplayNames} as a vertical stack: sub-names on
- * top (when `infoLevel` allows), primary name on the bottom.
+ * Render a {@link ResolvedDisplayNames} as a vertical stack of the primary
+ * name and sub-names. The order is controlled by `subNamesPosition`:
+ * `'top'` puts sub-names above the name, `'bottom'` puts them below.
  *
  * The wrapper is an `inline-flex` column so the block participates in
  * surrounding inline layout while keeping its children stacked.
  */
 export function StackedDisplayNames({
   names,
-  infoLevel,
-  nameClass,
-  subNameClass,
+  size,
   ellipsis,
+  showSubNames,
+  subNamesPosition,
+  nameClassName,
+  subNamesClassName,
 }: StackedDisplayNamesProps) {
   const { name, subNames } = names;
+  const hasSubNames = subNames.some((s) => s !== '');
+  const subElement =
+    showSubNames && hasSubNames ? (
+      <span
+        className={cn(
+          //
+          SUB_TEXT_BY_SIZE[size],
+          'text-[#888] dark:text-gray-400',
+          subNamesClassName,
+          ellipsis && 'truncate',
+          'inline-block',
+          'leading-tight',
+        )}
+      >
+        {subNames.join(' / ')}
+      </span>
+    ) : null;
+  const nameElement = (
+    <span
+      className={cn(
+        NAME_TEXT_BY_SIZE[size],
+        'text-[#333] dark:text-gray-200',
+        nameClassName,
+        ellipsis && 'truncate',
+      )}
+    >
+      {name}
+    </span>
+  );
   return (
     <span className="inline-flex min-w-0 flex-col">
-      {infoLevel.isNormalEnabled && (
-        <span
-          className={cn(
-            //
-            subNameClass,
-            ellipsis && 'truncate',
-            'inline-block',
-            'leading-tight',
-          )}
-        >
-          {subNames.join(' / ')}
-        </span>
+      {subNamesPosition === 'top' ? (
+        <>
+          {subElement}
+          {nameElement}
+        </>
+      ) : (
+        <>
+          {nameElement}
+          {subElement}
+        </>
       )}
-      <span className={cn(nameClass, ellipsis && 'truncate')}>{name}</span>
     </span>
   );
 }

--- a/src/components/shared/stacked-display-names.tsx
+++ b/src/components/shared/stacked-display-names.tsx
@@ -1,0 +1,54 @@
+import type { ResolvedDisplayNames } from '@/domain/transit/name-resolver/get-display-names';
+import { cn } from '@/lib/utils';
+import type { InfoLevelFlags } from '@/utils/create-info-level';
+
+/**
+ * Props for {@link StackedDisplayNames}.
+ */
+export interface StackedDisplayNamesProps {
+  /** Names to render. */
+  names: ResolvedDisplayNames;
+  /** Controls whether sub-names are shown (only shown when normal info is enabled). */
+  infoLevel: InfoLevelFlags;
+  /** Class names applied to the primary-name span. */
+  nameClass: string;
+  /** Class names applied to the sub-names span. */
+  subNameClass: string;
+  /** When `true`, each span is allowed to truncate with an ellipsis. */
+  ellipsis: boolean;
+}
+
+/**
+ * Render a {@link ResolvedDisplayNames} as a vertical stack: sub-names on
+ * top (when `infoLevel` allows), primary name on the bottom.
+ *
+ * The wrapper is an `inline-flex` column so the block participates in
+ * surrounding inline layout while keeping its children stacked.
+ */
+export function StackedDisplayNames({
+  names,
+  infoLevel,
+  nameClass,
+  subNameClass,
+  ellipsis,
+}: StackedDisplayNamesProps) {
+  const { name, subNames } = names;
+  return (
+    <span className="inline-flex min-w-0 flex-col">
+      {infoLevel.isNormalEnabled && (
+        <span
+          className={cn(
+            //
+            subNameClass,
+            ellipsis && 'truncate',
+            'inline-block',
+            'leading-tight',
+          )}
+        >
+          {subNames.join(' / ')}
+        </span>
+      )}
+      <span className={cn(nameClass, ellipsis && 'truncate')}>{name}</span>
+    </span>
+  );
+}

--- a/src/components/shared/stacked-display-names.tsx
+++ b/src/components/shared/stacked-display-names.tsx
@@ -66,9 +66,9 @@ export function StackedDisplayNames({
   subNamesClassName,
 }: StackedDisplayNamesProps) {
   const { name, subNames } = names;
-  const hasSubNames = subNames.some((s) => s !== '');
+  const normalizedSubNames = subNames.map((e) => e.trim()).filter((s) => s !== '');
   const subElement =
-    showSubNames && hasSubNames ? (
+    showSubNames && normalizedSubNames.length > 0 ? (
       <span
         className={cn(
           //
@@ -80,7 +80,7 @@ export function StackedDisplayNames({
           'leading-tight',
         )}
       >
-        {subNames.join(' / ')}
+        {normalizedSubNames.join(' / ')}
       </span>
     ) : null;
   const nameElement = (

--- a/src/components/stop-browser.tsx
+++ b/src/components/stop-browser.tsx
@@ -25,6 +25,7 @@ import type { StopWithContext, TripInspectionTarget } from '../types/app/transit
 import { resolveContainerDisplaySize } from './shared/display-size';
 import { StopBrowserHeader } from './stop-browser-header';
 import { StopGrid } from './stop-grid';
+import { TRANSIT_DISPLAY_VIEW_IDS } from './transit-display/transit-display-view-policy';
 import { TransitDisplaysContainer } from './transit-display/transit-displays-container';
 
 export interface StopBrowserProps {
@@ -239,7 +240,7 @@ export function StopBrowser({
       return;
     }
 
-    if (viewId === 'transit-display' || viewId === 'transit-display-2') {
+    if (TRANSIT_DISPLAY_VIEW_IDS.includes(viewId)) {
       // The transit-display (board) view is not stop-oriented: the same stop id can
       // appear in multiple rows (one stop shows up across several boards), so a stop
       // cannot be targeted for scrolling. Leave its scroll position alone -- do not
@@ -287,7 +288,7 @@ export function StopBrowser({
         onToggleRouteType={toggleRouteType}
         onToggleAgency={toggleAgency}
       />
-      {viewId === 'transit-display' || viewId === 'transit-display-2' ? (
+      {TRANSIT_DISPLAY_VIEW_IDS.includes(viewId) ? (
         <TransitDisplaysContainer
           stopTimes={trimmedStopTimes}
           viewId={viewId}

--- a/src/components/transit-display/transit-display-per-route.tsx
+++ b/src/components/transit-display/transit-display-per-route.tsx
@@ -3,11 +3,13 @@ import { useMemo } from 'react';
 import { DEFAULT_AGENCY_LANG } from '@/config/transit-defaults';
 import { resolveRouteColors } from '@/domain/transit/color-resolver/route-colors';
 import type { TransitDisplayDataWithMetaData } from '@/domain/transit/transit-info-display/build-transit-display-data';
-import type { Route } from '@/types/app/transit';
+import type { Agency, Route } from '@/types/app/transit';
 
 import { RouteBadge } from '../badge/route-badge';
 import { TransitDisplay2, type TransitDisplay2Props } from './transit-displays-2';
 import { AgencyBadge } from '../badge/agency-badge';
+import { cn } from '@/lib/utils';
+import { resolveAgencyColors } from '@/domain/transit/color-resolver/agency-colors';
 
 /**
  * A group of boards that belong to the same route, paired with the route
@@ -55,7 +57,7 @@ export function TransitDisplayPerRoute({
   onStopSelected,
   onInspectTrip,
 }: TransitDisplayPerRouteProps) {
-  const routeAgency = useMemo(() => {
+  const routeAgency: Agency | undefined = useMemo(() => {
     for (const board of group.data) {
       for (const candidate of board.data.data) {
         const found = candidate.stop.agencies.find((a) => a.agency_id === group.route.agency_id);
@@ -71,17 +73,51 @@ export function TransitDisplayPerRoute({
     return null;
   }
 
+  const { agencyColor } =
+    routeAgency !== undefined
+      ? resolveAgencyColors(routeAgency, 'css-hex')
+      : { agencyColor: undefined };
+
   const route = group.route;
   const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : DEFAULT_AGENCY_LANG;
   const { routeColor } = resolveRouteColors(route, 'css-hex');
 
   return (
     <section
-      className="my-2 overflow-hidden rounded border-2"
-      style={{ borderColor: routeColor ?? undefined }}
+      className={cn(
+        //
+        'overflow-hidden',
+        // 'rounded border-2',
+      )}
+      style={
+        //
+        {
+          // borderColor: routeColor ?? undefined,
+          borderColor: agencyColor ?? undefined,
+        }
+      }
     >
-      <div className="flex items-center gap-2 p-2">
-        <span className="truncate">{route.route_long_name}</span>
+      {/* Route info */}
+      <div
+        className={cn(
+          //
+          'my-0 overflow-hidden p-2',
+          'rounded border-2',
+        )}
+        style={
+          //
+          {
+            borderColor: routeColor ?? undefined,
+            // borderColor: agencyColor ?? undefined,
+          }
+        }
+      >
+        <span
+          className="truncate"
+          // style={{ color: routeTextColor ?? undefined }}
+        >
+          {route.route_long_name}
+        </span>
         <RouteBadge
           route={route}
           dataLang={dataLangs}
@@ -100,19 +136,22 @@ export function TransitDisplayPerRoute({
           />
         )}
       </div>
+
+      {/* Panels  */}
       <div>
         {group.data.map((d, i) => (
-          <TransitDisplay2
-            key={i}
-            transitDisplayDataWithMetaData={d}
-            dataLangs={dataLangs}
-            now={now}
-            mapCenter={mapCenter}
-            infoLevel={infoLevel}
-            size={size}
-            onStopSelected={onStopSelected}
-            onInspectTrip={onInspectTrip}
-          />
+          <div key={i} className="mt-4">
+            <TransitDisplay2
+              transitDisplayDataWithMetaData={d}
+              dataLangs={dataLangs}
+              now={now}
+              mapCenter={mapCenter}
+              infoLevel={infoLevel}
+              size={size}
+              onStopSelected={onStopSelected}
+              onInspectTrip={onInspectTrip}
+            />
+          </div>
         ))}
       </div>
     </section>

--- a/src/components/transit-display/transit-display-per-route.tsx
+++ b/src/components/transit-display/transit-display-per-route.tsx
@@ -10,6 +10,13 @@ import { TransitDisplay2, type TransitDisplay2Props } from './transit-displays-2
 import { AgencyBadge } from '../badge/agency-badge';
 import { cn } from '@/lib/utils';
 import { resolveAgencyColors } from '@/domain/transit/color-resolver/agency-colors';
+import { getRouteDisplayNames } from '@/domain/transit/name-resolver/get-route-display-names';
+import { VerboseRoutes } from '../verbose/verbose-routes';
+import { hasDisplayContent } from '@/domain/transit/name-resolver/get-display-names';
+import { useInfoLevel } from '@/hooks/use-info-level';
+import { InlineDisplayNames } from '../shared/inline-display-names';
+import { routeTypesEmoji } from '@/utils/route-type-emoji';
+import { StackedDisplayNames } from '../shared/stacked-display-names';
 
 /**
  * A group of boards that belong to the same route, paired with the route
@@ -24,6 +31,8 @@ export interface TransitDisplayRouteGroup {
   /** Boards for this route (typically the cluster's dep / arr boards across both directions). */
   data: readonly TransitDisplayDataWithMetaData[];
 }
+
+
 
 /**
  * Props for {@link TransitDisplayPerRoute}.
@@ -57,6 +66,7 @@ export function TransitDisplayPerRoute({
   onStopSelected,
   onInspectTrip,
 }: TransitDisplayPerRouteProps) {
+  const infoLevelFlag = useInfoLevel(infoLevel);
   const routeAgency: Agency | undefined = useMemo(() => {
     for (const board of group.data) {
       for (const candidate of board.data.data) {
@@ -79,8 +89,15 @@ export function TransitDisplayPerRoute({
       : { agencyColor: undefined };
 
   const route = group.route;
-  const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : DEFAULT_AGENCY_LANG;
   const { routeColor } = resolveRouteColors(route, 'css-hex');
+
+  // Route name
+  const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : DEFAULT_AGENCY_LANG;
+  const routeNames = getRouteDisplayNames(route, dataLangs, routeAgencyLangs, 'short');
+  const resolvedRouteNames = routeNames.resolved;
+  const otherRouteNames =
+    routeNames.resolvedSource === 'short' ? routeNames.longName : routeNames.shortName;
+  const hasOtherNames = hasDisplayContent(otherRouteNames);
 
   return (
     <section
@@ -97,43 +114,88 @@ export function TransitDisplayPerRoute({
         }
       }
     >
+      {infoLevelFlag.isVerboseEnabled && (
+        <VerboseRoutes
+          routes={[route]}
+          infoLevel={infoLevel}
+          dataLang={dataLangs}
+          agencies={routeAgency ? [routeAgency] : []}
+        />
+      )}
+
       {/* Route info */}
       <div
-        className={cn(
-          //
-          'my-0 overflow-hidden p-2',
-          'rounded border-2',
-        )}
-        style={
-          //
-          {
-            borderColor: routeColor ?? undefined,
-            // borderColor: agencyColor ?? undefined,
-          }
-        }
+        className={cn('flex items-center gap-2', 'my-0 overflow-hidden p-2', 'rounded border-2')}
+        style={{ borderColor: routeColor ?? undefined }}
       >
-        <span
-          className="truncate"
-          // style={{ color: routeTextColor ?? undefined }}
-        >
-          {route.route_long_name}
-        </span>
-        <RouteBadge
-          route={route}
-          dataLang={dataLangs}
-          agencyLangs={routeAgencyLangs}
-          infoLevel={infoLevel}
-          size="sm"
-          showBorder={true}
-        />
-        {routeAgency && (
-          <AgencyBadge
-            agency={routeAgency}
-            size="sm"
-            infoLevel={infoLevel}
+        {/* Left: route info */}
+        <div className="flex min-w-0 items-center gap-2">
+          {routeTypesEmoji([route.route_type])}
+          <RouteBadge
+            route={route}
             dataLang={dataLangs}
+            agencyLangs={routeAgencyLangs}
+            infoLevel={infoLevel}
+            size="sm"
             showBorder={true}
           />
+          {/* Route names */}
+          <div className="flex min-w-0 flex-col">
+            <div>
+              {/* <RouteBadge
+                route={route}
+                dataLang={dataLangs}
+                agencyLangs={routeAgencyLangs}
+                infoLevel={infoLevel}
+                size="sm"
+                showBorder={true}
+              /> */}
+              <InlineDisplayNames
+                names={resolvedRouteNames}
+                size="md"
+                ellipsis={false}
+                showSubNames={infoLevelFlag.isNormalEnabled}
+              />
+              <StackedDisplayNames
+                names={resolvedRouteNames}
+                size="md"
+                ellipsis={false}
+                showSubNames={infoLevelFlag.isNormalEnabled}
+                subNamesPosition="top"
+              />
+            </div>
+            {hasOtherNames && (
+              <div>
+                <hr />
+                <InlineDisplayNames
+                  names={otherRouteNames}
+                  size="xs"
+                  ellipsis={false}
+                  showSubNames={infoLevelFlag.isNormalEnabled}
+                />
+                <hr />
+                <StackedDisplayNames
+                  names={otherRouteNames}
+                  size="xs"
+                  ellipsis={false}
+                  showSubNames={infoLevelFlag.isNormalEnabled}
+                  subNamesPosition="top"
+                />
+              </div>
+            )}
+          </div>
+        </div>
+        {/* Right: agency */}
+        {routeAgency && (
+          <div className="ml-auto flex items-center">
+            <AgencyBadge
+              agency={routeAgency}
+              size="sm"
+              infoLevel={infoLevel}
+              dataLang={dataLangs}
+              showBorder={true}
+            />
+          </div>
         )}
       </div>
 

--- a/src/components/transit-display/transit-display-per-route.tsx
+++ b/src/components/transit-display/transit-display-per-route.tsx
@@ -3,20 +3,22 @@ import { useMemo } from 'react';
 import { DEFAULT_AGENCY_LANG } from '@/config/transit-defaults';
 import { resolveRouteColors } from '@/domain/transit/color-resolver/route-colors';
 import type { TransitDisplayDataWithMetaData } from '@/domain/transit/transit-info-display/build-transit-display-data';
-import type { Agency, Route } from '@/types/app/transit';
-
-import { RouteBadge } from '../badge/route-badge';
-import { TransitDisplay2, type TransitDisplay2Props } from './transit-displays-2';
-import { AgencyBadge } from '../badge/agency-badge';
-import { cn } from '@/lib/utils';
-import { resolveAgencyColors } from '@/domain/transit/color-resolver/agency-colors';
-import { getRouteDisplayNames } from '@/domain/transit/name-resolver/get-route-display-names';
-import { VerboseRoutes } from '../verbose/verbose-routes';
-import { hasDisplayContent } from '@/domain/transit/name-resolver/get-display-names';
 import { useInfoLevel } from '@/hooks/use-info-level';
-import { InlineDisplayNames } from '../shared/inline-display-names';
+import { cn } from '@/lib/utils';
+import type { Agency, Route } from '@/types/app/transit';
 import { routeTypesEmoji } from '@/utils/route-type-emoji';
-import { StackedDisplayNames } from '../shared/stacked-display-names';
+
+import { AgencyBadge } from '@/components/badge/agency-badge';
+import { RouteBadge } from '@/components/badge/route-badge';
+import { InlineDisplayNames } from '@/components/shared/inline-display-names';
+import {
+  TransitDisplay2,
+  type TransitDisplay2Props,
+} from '@/components/transit-display/transit-displays-2';
+import { VerboseRoutes } from '@/components/verbose/verbose-routes';
+import { resolveAgencyColors } from '@/domain/transit/color-resolver/agency-colors';
+import { hasDisplayContent } from '@/domain/transit/name-resolver/get-display-names';
+import { getRouteDisplayNames } from '@/domain/transit/name-resolver/get-route-display-names';
 
 /**
  * A group of boards that belong to the same route, paired with the route
@@ -31,8 +33,6 @@ export interface TransitDisplayRouteGroup {
   /** Boards for this route (typically the cluster's dep / arr boards across both directions). */
   data: readonly TransitDisplayDataWithMetaData[];
 }
-
-
 
 /**
  * Props for {@link TransitDisplayPerRoute}.
@@ -129,7 +129,7 @@ export function TransitDisplayPerRoute({
         style={{ borderColor: routeColor ?? undefined }}
       >
         {/* Left: route info */}
-        <div className="flex min-w-0 items-center gap-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
           {routeTypesEmoji([route.route_type])}
           <RouteBadge
             route={route}
@@ -142,46 +142,25 @@ export function TransitDisplayPerRoute({
           {/* Route names */}
           <div className="flex min-w-0 flex-col">
             <div>
-              {/* <RouteBadge
-                route={route}
-                dataLang={dataLangs}
-                agencyLangs={routeAgencyLangs}
-                infoLevel={infoLevel}
-                size="sm"
-                showBorder={true}
-              /> */}
               <InlineDisplayNames
                 names={resolvedRouteNames}
                 size="md"
                 ellipsis={false}
                 showSubNames={infoLevelFlag.isNormalEnabled}
               />
-              <StackedDisplayNames
-                names={resolvedRouteNames}
-                size="md"
-                ellipsis={false}
-                showSubNames={infoLevelFlag.isNormalEnabled}
-                subNamesPosition="top"
-              />
             </div>
             {hasOtherNames && (
-              <div>
+              <>
                 <hr />
-                <InlineDisplayNames
-                  names={otherRouteNames}
-                  size="xs"
-                  ellipsis={false}
-                  showSubNames={infoLevelFlag.isNormalEnabled}
-                />
-                <hr />
-                <StackedDisplayNames
-                  names={otherRouteNames}
-                  size="xs"
-                  ellipsis={false}
-                  showSubNames={infoLevelFlag.isNormalEnabled}
-                  subNamesPosition="top"
-                />
-              </div>
+                <div>
+                  <InlineDisplayNames
+                    names={otherRouteNames}
+                    size="xs"
+                    ellipsis={false}
+                    showSubNames={infoLevelFlag.isNormalEnabled}
+                  />
+                </div>
+              </>
             )}
           </div>
         </div>

--- a/src/components/transit-display/transit-display-per-route.tsx
+++ b/src/components/transit-display/transit-display-per-route.tsx
@@ -1,0 +1,120 @@
+import { useMemo } from 'react';
+
+import { DEFAULT_AGENCY_LANG } from '@/config/transit-defaults';
+import { resolveRouteColors } from '@/domain/transit/color-resolver/route-colors';
+import type { TransitDisplayDataWithMetaData } from '@/domain/transit/transit-info-display/build-transit-display-data';
+import type { Route } from '@/types/app/transit';
+
+import { RouteBadge } from '../badge/route-badge';
+import { TransitDisplay2, type TransitDisplay2Props } from './transit-displays-2';
+import { AgencyBadge } from '../badge/agency-badge';
+
+/**
+ * A group of boards that belong to the same route, paired with the route
+ * itself. Produced by upstream grouping in `TransitDisplays2` and consumed by
+ * {@link TransitDisplayPerRoute}. The caller is responsible for the
+ * shared-route invariant (all `data[i].meta.routes[0]` equal `route`); this
+ * shape does not re-check it.
+ */
+export interface TransitDisplayRouteGroup {
+  /** The route every board in `data` belongs to. */
+  route: Route;
+  /** Boards for this route (typically the cluster's dep / arr boards across both directions). */
+  data: readonly TransitDisplayDataWithMetaData[];
+}
+
+/**
+ * Props for {@link TransitDisplayPerRoute}.
+ *
+ * Reuses {@link TransitDisplay2Props} for every prop except the data, which is
+ * a {@link TransitDisplayRouteGroup} (route + its boards) rather than a
+ * single board. `Omit` ensures any future change to {@link TransitDisplay2Props}
+ * flows here automatically.
+ */
+export interface TransitDisplayPerRouteProps extends Omit<
+  TransitDisplay2Props,
+  'transitDisplayDataWithMetaData'
+> {
+  /** Route + its boards. */
+  group: TransitDisplayRouteGroup;
+}
+
+/**
+ * Renders a group of boards that belong to the same route as one cohesive
+ * card-like section. Currently a thin wrapper that stacks {@link TransitDisplay2}
+ * for each board; a dedicated Route header (using `group.route`) and an outer
+ * card frame can be layered on later without touching the call sites.
+ */
+export function TransitDisplayPerRoute({
+  group,
+  dataLangs,
+  now,
+  mapCenter,
+  infoLevel,
+  size,
+  onStopSelected,
+  onInspectTrip,
+}: TransitDisplayPerRouteProps) {
+  const routeAgency = useMemo(() => {
+    for (const board of group.data) {
+      for (const candidate of board.data.data) {
+        const found = candidate.stop.agencies.find((a) => a.agency_id === group.route.agency_id);
+        if (found) {
+          return found;
+        }
+      }
+    }
+    return undefined;
+  }, [group.data, group.route.agency_id]);
+
+  if (group.data.length < 1) {
+    return null;
+  }
+
+  const route = group.route;
+  const routeAgencyLangs = routeAgency ? [routeAgency.agency_lang] : DEFAULT_AGENCY_LANG;
+  const { routeColor } = resolveRouteColors(route, 'css-hex');
+
+  return (
+    <section
+      className="my-2 overflow-hidden rounded border-2"
+      style={{ borderColor: routeColor ?? undefined }}
+    >
+      <div className="flex items-center gap-2 p-2">
+        <span className="truncate">{route.route_long_name}</span>
+        <RouteBadge
+          route={route}
+          dataLang={dataLangs}
+          agencyLangs={routeAgencyLangs}
+          infoLevel={infoLevel}
+          size="sm"
+          showBorder={true}
+        />
+        {routeAgency && (
+          <AgencyBadge
+            agency={routeAgency}
+            size="sm"
+            infoLevel={infoLevel}
+            dataLang={dataLangs}
+            showBorder={true}
+          />
+        )}
+      </div>
+      <div>
+        {group.data.map((d, i) => (
+          <TransitDisplay2
+            key={i}
+            transitDisplayDataWithMetaData={d}
+            dataLangs={dataLangs}
+            now={now}
+            mapCenter={mapCenter}
+            infoLevel={infoLevel}
+            size={size}
+            onStopSelected={onStopSelected}
+            onInspectTrip={onInspectTrip}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/transit-display/transit-display-per-route.tsx
+++ b/src/components/transit-display/transit-display-per-route.tsx
@@ -16,7 +16,6 @@ import {
   type TransitDisplay2Props,
 } from '@/components/transit-display/transit-displays-2';
 import { VerboseRoutes } from '@/components/verbose/verbose-routes';
-import { resolveAgencyColors } from '@/domain/transit/color-resolver/agency-colors';
 import { hasDisplayContent } from '@/domain/transit/name-resolver/get-display-names';
 import { getRouteDisplayNames } from '@/domain/transit/name-resolver/get-route-display-names';
 
@@ -83,11 +82,6 @@ export function TransitDisplayPerRoute({
     return null;
   }
 
-  const { agencyColor } =
-    routeAgency !== undefined
-      ? resolveAgencyColors(routeAgency, 'css-hex')
-      : { agencyColor: undefined };
-
   const route = group.route;
   const { routeColor } = resolveRouteColors(route, 'css-hex');
 
@@ -110,7 +104,6 @@ export function TransitDisplayPerRoute({
         //
         {
           // borderColor: routeColor ?? undefined,
-          borderColor: agencyColor ?? undefined,
         }
       }
     >

--- a/src/components/transit-display/transit-display-view-policy.ts
+++ b/src/components/transit-display/transit-display-view-policy.ts
@@ -1,0 +1,119 @@
+import { ROUTE_TYPE_DISPLAY_ORDER } from '@/domain/transit/route-type-display-order';
+import type { StopTimeViewId } from '@/domain/transit/stop-time-views';
+import { buildTransitDisplayDataSet } from '@/domain/transit/transit-info-display/build-transit-display-data';
+import {
+  sortTransitDisplayDataWithMetaData,
+  transitDisplayMaxEntriesFor,
+  transitDisplayMaxEntriesPerRouteFor,
+} from '@/domain/transit/transit-info-display/transit-display-ui';
+import type { InfoLevel } from '@/types/app/settings';
+import type { AppRouteTypeValue } from '@/types/app/transit';
+import type { StopWithContext } from '@/types/app/transit-composed';
+
+/**
+ * Route types whose boards are NOT split by direction: bus, trolleybus, and
+ * ferry. Their `direction_id` is route-local / arbitrary, and at a shared stop
+ * many routes converge (ferries especially fan out hub-and-spoke across several
+ * pontoons), so a per-direction split would mix unrelated routes; the headsign
+ * carries the destination instead. Everything else (rail / subway / tram /
+ * monorail / ...) is split, where a line's direction is the meaningful axis.
+ */
+const NO_SPLIT_ROUTE_TYPES: readonly AppRouteTypeValue[] = [3, 11, 4];
+
+/** Every other route type is split by direction, kept in display order. */
+const DIRECTION_SPLIT_ROUTE_TYPES: readonly AppRouteTypeValue[] = ROUTE_TYPE_DISPLAY_ORDER.filter(
+  (routeType) => !NO_SPLIT_ROUTE_TYPES.includes(routeType),
+);
+
+/**
+ * Per-view build policy: which route types are rendered as multi-route boards
+ * vs. per-route boards, and whether each side splits by direction.
+ * Declarative so adding a new view is one entry instead of an if-else chain.
+ * Two builder calls are issued -- one for `multiRoute` route types and one for
+ * `perRoute` route types -- and their outputs are concatenated and re-sorted.
+ */
+export interface ViewPolicy {
+  /** Multi-route boards (1 board can carry multiple routes; bus-style). */
+  multiRoute: {
+    /** Route types to build as multi-route boards. Empty = no multi-route boards. */
+    routeTypes: readonly AppRouteTypeValue[];
+    /** Whether to additionally split each multi-route board by direction. */
+    splitByDirection: boolean;
+  };
+  /** Per-route boards (1 board = 1 route). */
+  perRoute: {
+    /** Route types to build as per-route boards. Empty = no per-route boards. */
+    routeTypes: readonly AppRouteTypeValue[];
+    /** Whether to additionally split each per-route board by direction. */
+    splitByDirection: boolean;
+  };
+}
+
+/**
+ * Default transit-display / transit-display-2 policy: bus / trolleybus / ferry
+ * as multi-route (folded), everything else as per-route + per-direction.
+ */
+export const TRANSIT_DISPLAY_POLICY: ViewPolicy = {
+  multiRoute: { routeTypes: NO_SPLIT_ROUTE_TYPES, splitByDirection: false },
+  perRoute: { routeTypes: DIRECTION_SPLIT_ROUTE_TYPES, splitByDirection: true },
+};
+
+/** Route-grouped view: every route type rendered per-route + per-direction. */
+export const ROUTE_VIEW_POLICY: ViewPolicy = {
+  multiRoute: { routeTypes: [], splitByDirection: false },
+  perRoute: { routeTypes: ROUTE_TYPE_DISPLAY_ORDER, splitByDirection: true },
+};
+
+/**
+ * View-id -> policy table. Views whose layout is owned by `TransitDisplaysContainer`
+ * live here; views handled elsewhere (e.g. the stop-list view) are absent and
+ * the container then renders nothing for the active board.
+ * {@link TRANSIT_DISPLAY_VIEW_IDS} exposes the keys so callers (e.g.
+ * `StopBrowser`) can ask "is this view owned by the container?" without
+ * duplicating the list.
+ */
+export const VIEW_POLICY: Partial<Record<StopTimeViewId, ViewPolicy>> = {
+  'transit-display': TRANSIT_DISPLAY_POLICY,
+  'transit-display-2': TRANSIT_DISPLAY_POLICY,
+  route: ROUTE_VIEW_POLICY,
+};
+
+/**
+ * View IDs this container is responsible for (= keys of {@link VIEW_POLICY}).
+ * Use this in upstream dispatch to decide whether to render
+ * `TransitDisplaysContainer` vs a different surface (e.g. `StopGrid`).
+ */
+export const TRANSIT_DISPLAY_VIEW_IDS: readonly StopTimeViewId[] = Object.keys(
+  VIEW_POLICY,
+) as StopTimeViewId[];
+
+/**
+ * Run the two builder calls for one policy and merge their output in the UI
+ * order. Pure function so it can be called from `useMemo` hooks with stable
+ * dependencies (the result depends only on `nearbyStops`, `radiusMeters`,
+ * `policy`, and `infoLevel`).
+ */
+export function buildBoardsForPolicy(
+  nearbyStops: readonly StopWithContext[],
+  radiusMeters: number,
+  policy: ViewPolicy,
+  infoLevel: InfoLevel,
+) {
+  const maxEntriesMultiRoute = transitDisplayMaxEntriesFor(infoLevel);
+  const maxEntriesPerRoute = transitDisplayMaxEntriesPerRouteFor(infoLevel);
+
+  const multiRouteRaw = buildTransitDisplayDataSet(nearbyStops, radiusMeters, {
+    maxEntries: maxEntriesMultiRoute,
+    routeTypeGrouping: { kind: 'custom', groups: policy.multiRoute.routeTypes.map((t) => [t]) },
+    splitByRoute: false,
+    splitByDirection: policy.multiRoute.splitByDirection,
+  });
+  const perRouteRaw = buildTransitDisplayDataSet(nearbyStops, radiusMeters, {
+    maxEntries: maxEntriesPerRoute,
+    routeTypeGrouping: { kind: 'custom', groups: policy.perRoute.routeTypes.map((t) => [t]) },
+    splitByRoute: true,
+    splitByDirection: policy.perRoute.splitByDirection,
+  });
+
+  return sortTransitDisplayDataWithMetaData([...multiRouteRaw, ...perRouteRaw]);
+}

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -254,7 +254,8 @@ export function TransitDisplays2({
 
   return (
     // <div className="font-dotgothic16 px-4 pb-0">
-    <div className="px-4 pb-0">
+    <div className="px-4">
+      {/* Filter */}
       {presentCategories.length > 0 && (
         <TransitDisplayCategoryFilter
           categories={presentCategories}
@@ -263,6 +264,7 @@ export function TransitDisplays2({
           onToggleCategory={toggleCategory}
         />
       )}
+      {/* Panels */}
       {groupedDisplays.map((item, index) => {
         if (item.kind === 'single') {
           return (
@@ -553,7 +555,7 @@ export function TransitDisplay2({
     // boards are separated by their own surface and margin.
     <section
       className={cn(
-        'mb-4 overflow-hidden',
+        'overfl0w-hidden mb-0',
         'rounded-sm border-0',
         BOARD_PANEL_BG,
         // BOARD_FRAME_COLOR,

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -17,7 +17,10 @@ import {
   type TransitDisplayDatum,
   type TransitDisplayMeta,
 } from '@/domain/transit/transit-info-display/build-transit-display-data';
-import type { TransitDisplayStatus } from '@/domain/transit/transit-info-display/transit-display-ui';
+import {
+  hasMultipleRoutes,
+  type TransitDisplayStatus,
+} from '@/domain/transit/transit-info-display/transit-display-ui';
 import { computeTransitDisplayDatumStats } from '@/domain/transit/compute-transit-display-datum-stats';
 import { getBearingDeg } from '@/domain/transit/distance';
 import { resolveRouteColors } from '@/domain/transit/color-resolver/route-colors';
@@ -33,6 +36,10 @@ import { getStopDisplayNames } from '@/domain/transit/name-resolver/get-stop-dis
 import { RouteBadge } from '../badge/route-badge';
 import { AgencyBadge } from '../badge/agency-badge';
 import { StopTimeTimeInfo } from '../stop-time-time-info';
+import {
+  TransitDisplayPerRoute,
+  type TransitDisplayRouteGroup,
+} from './transit-display-per-route';
 import { Separator } from '../ui/separator';
 import { PlatformCodeLabel } from '../stop/platform-code-label';
 import { DEFAULT_AGENCY_LANG } from '@/config/transit-defaults';
@@ -210,6 +217,37 @@ export function TransitDisplays2({
 
   const visibleData = dataWithMeta.filter((display) => shownCategories[display.meta.category]);
 
+  // Group single-route boards by their route (collapses the cluster's dep / arr
+  // boards for one route into a single TransitDisplayPerRoute card) and keep
+  // multi-route boards as standalone TransitDisplay2 renders. Map-based
+  // aggregation so we do not rely on sort-order continuity of same-route boards.
+  type GroupedItem =
+    | { kind: 'single'; group: TransitDisplayRouteGroup }
+    | { kind: 'multi'; board: TransitDisplayDataWithMetaData };
+  const singleBoardsByRouteId = new Map<string, TransitDisplayDataWithMetaData[]>();
+  const groupedDisplays: GroupedItem[] = [];
+  for (const d of visibleData) {
+    if (hasMultipleRoutes(d)) {
+      groupedDisplays.push({ kind: 'multi', board: d });
+      continue;
+    }
+    const route = d.meta.routes[0];
+    if (!route) {
+      // No route metadata to group by; render as a standalone board.
+      groupedDisplays.push({ kind: 'multi', board: d });
+      continue;
+    }
+    let boards = singleBoardsByRouteId.get(route.route_id);
+    if (!boards) {
+      boards = [];
+      singleBoardsByRouteId.set(route.route_id, boards);
+      // Push once with the live boards reference; subsequent boards.push(d)
+      // is visible through groupedDisplays as well.
+      groupedDisplays.push({ kind: 'single', group: { route, data: boards } });
+    }
+    boards.push(d);
+  }
+
   const toggleCategory = (category: TransitDisplayCategory) => {
     setShownCategories((prev) => ({ ...prev, [category]: !prev[category] }));
   };
@@ -225,23 +263,41 @@ export function TransitDisplays2({
           onToggleCategory={toggleCategory}
         />
       )}
-      {visibleData.map((dataWithMeta, index) => (
-        // Key from the board's identity (category + its route types), with the
-        // map index as a disambiguator: a `custom` route grouping can collapse
-        // two groups to the same present route types, so identity alone is not
-        // guaranteed unique.
-        <TransitDisplay2
-          key={`${dataWithMeta.meta.category}__${dataWithMeta.meta.routeTypes.join('-')}__${index}`}
-          transitDisplayDataWithMetaData={dataWithMeta}
-          dataLangs={dataLangs}
-          now={now}
-          mapCenter={mapCenter}
-          infoLevel={infoLevel}
-          size={size}
-          onStopSelected={onStopSelected}
-          onInspectTrip={onInspectTrip}
-        />
-      ))}
+      {groupedDisplays.map((item, index) => {
+        if (item.kind === 'single') {
+          return (
+            <TransitDisplayPerRoute
+              key={`single__${item.group.route.route_id}__${index}`}
+              group={item.group}
+              dataLangs={dataLangs}
+              now={now}
+              mapCenter={mapCenter}
+              infoLevel={infoLevel}
+              size={size}
+              onStopSelected={onStopSelected}
+              onInspectTrip={onInspectTrip}
+            />
+          );
+        }
+        // Multi-route board: rendered standalone with the existing TransitDisplay2.
+        // Key combines board identity (category + route types) with the map
+        // index, since a `custom` route grouping can collapse two groups to
+        // the same present route types.
+        const board = item.board;
+        return (
+          <TransitDisplay2
+            key={`multi__${board.meta.category}__${board.meta.routeTypes.join('-')}__${index}`}
+            transitDisplayDataWithMetaData={board}
+            dataLangs={dataLangs}
+            now={now}
+            mapCenter={mapCenter}
+            infoLevel={infoLevel}
+            size={size}
+            onStopSelected={onStopSelected}
+            onInspectTrip={onInspectTrip}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -253,24 +253,63 @@ export function TransitDisplays2({
   };
 
   return (
-    // <div className="font-dotgothic16 px-4 pb-0">
-    <div className="px-4">
-      {/* Filter */}
-      {presentCategories.length > 0 && (
-        <TransitDisplayCategoryFilter
-          categories={presentCategories}
-          shownCategories={shownCategories}
-          size={size}
-          onToggleCategory={toggleCategory}
-        />
+    <div
+      className={cn(
+        // 'font-dotgothic16',
+        'px-4',
       )}
+    >
+      {/* Filter */}
+      <div
+        className={cn(
+          //
+          'px-0',
+        )}
+      >
+        {presentCategories.length > 0 && (
+          <TransitDisplayCategoryFilter
+            categories={presentCategories}
+            shownCategories={shownCategories}
+            size={size}
+            onToggleCategory={toggleCategory}
+          />
+        )}
+      </div>
+
       {/* Panels */}
-      {groupedDisplays.map((item, index) => {
-        if (item.kind === 'single') {
+      <div
+        className={cn(
+          //
+          // 'font-dotgothic16',
+          'space-y-4',
+          // 'px-0',
+        )}
+      >
+        {groupedDisplays.map((item, index) => {
+          if (item.kind === 'single') {
+            return (
+              <TransitDisplayPerRoute
+                key={`single__${item.group.route.route_id}__${index}`}
+                group={item.group}
+                dataLangs={dataLangs}
+                now={now}
+                mapCenter={mapCenter}
+                infoLevel={infoLevel}
+                size={size}
+                onStopSelected={onStopSelected}
+                onInspectTrip={onInspectTrip}
+              />
+            );
+          }
+          // Multi-route board: rendered standalone with the existing TransitDisplay2.
+          // Key combines board identity (category + route types) with the map
+          // index, since a `custom` route grouping can collapse two groups to
+          // the same present route types.
+          const board = item.board;
           return (
-            <TransitDisplayPerRoute
-              key={`single__${item.group.route.route_id}__${index}`}
-              group={item.group}
+            <TransitDisplay2
+              key={`multi__${board.meta.category}__${board.meta.routeTypes.join('-')}__${index}`}
+              transitDisplayDataWithMetaData={board}
               dataLangs={dataLangs}
               now={now}
               mapCenter={mapCenter}
@@ -280,26 +319,8 @@ export function TransitDisplays2({
               onInspectTrip={onInspectTrip}
             />
           );
-        }
-        // Multi-route board: rendered standalone with the existing TransitDisplay2.
-        // Key combines board identity (category + route types) with the map
-        // index, since a `custom` route grouping can collapse two groups to
-        // the same present route types.
-        const board = item.board;
-        return (
-          <TransitDisplay2
-            key={`multi__${board.meta.category}__${board.meta.routeTypes.join('-')}__${index}`}
-            transitDisplayDataWithMetaData={board}
-            dataLangs={dataLangs}
-            now={now}
-            mapCenter={mapCenter}
-            infoLevel={infoLevel}
-            size={size}
-            onStopSelected={onStopSelected}
-            onInspectTrip={onInspectTrip}
-          />
-        );
-      })}
+        })}
+      </div>
     </div>
   );
 }
@@ -555,7 +576,7 @@ export function TransitDisplay2({
     // boards are separated by their own surface and margin.
     <section
       className={cn(
-        'overfl0w-hidden mb-0',
+        'overfl0w-hidden',
         'rounded-sm border-0',
         BOARD_PANEL_BG,
         // BOARD_FRAME_COLOR,

--- a/src/components/transit-display/transit-displays-2.tsx
+++ b/src/components/transit-display/transit-displays-2.tsx
@@ -576,7 +576,7 @@ export function TransitDisplay2({
     // boards are separated by their own surface and margin.
     <section
       className={cn(
-        'overfl0w-hidden',
+        'overflow-hidden',
         'rounded-sm border-0',
         BOARD_PANEL_BG,
         // BOARD_FRAME_COLOR,

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -4,48 +4,31 @@ import { useTranslation } from 'react-i18next';
 
 import type { LatLng } from '@/types/app/map';
 import type { InfoLevel } from '@/types/app/settings';
-import type { AppRouteTypeValue } from '@/types/app/transit';
 import type { StopWithContext, TripInspectionTarget } from '@/types/app/transit-composed';
 
 import { createLogger } from '@/lib/logger';
 
 import { useScrollOverflow } from '@/hooks/use-scroll-overflow';
 
-import { ROUTE_TYPE_DISPLAY_ORDER } from '@/domain/transit/route-type-display-order';
 import { filterStopsWithinDistance } from '@/domain/transit/stop-meta-filter';
 import type { StopTimeViewId } from '@/domain/transit/stop-time-views';
-import { buildTransitDisplayDataSet } from '@/domain/transit/transit-info-display/build-transit-display-data';
-import {
-  resolveTransitDisplayState,
-  sortTransitDisplayDataWithMetaData,
-  transitDisplayMaxEntriesFor,
-  transitDisplayMaxEntriesPerRouteFor,
-} from '@/domain/transit/transit-info-display/transit-display-ui';
+import { resolveTransitDisplayState } from '@/domain/transit/transit-info-display/transit-display-ui';
 
 import type { ExtendedDisplaySize } from '@/components/shared/display-size';
 import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
 import { ScrollToTopButton } from '@/components/shared/scroll-to-top-button';
+import {
+  buildBoardsForPolicy,
+  ROUTE_VIEW_POLICY,
+  TRANSIT_DISPLAY_POLICY,
+  VIEW_POLICY,
+} from '@/components/transit-display/transit-display-view-policy';
 import { TransitDisplays } from '@/components/transit-display/transit-displays';
 import { TransitDisplays2 } from '@/components/transit-display/transit-displays-2';
 
 const logger = createLogger('TransitDisplaysContainer');
 
 export const NEARBY_RADIUS_M = 100;
-
-/**
- * Route types whose boards are NOT split by direction: bus, trolleybus, and
- * ferry. Their `direction_id` is route-local / arbitrary, and at a shared stop
- * many routes converge (ferries especially fan out hub-and-spoke across several
- * pontoons), so a per-direction split would mix unrelated routes; the headsign
- * carries the destination instead. Everything else (rail / subway / tram /
- * monorail / ...) is split, where a line's direction is the meaningful axis.
- */
-const NO_SPLIT_ROUTE_TYPES: readonly AppRouteTypeValue[] = [3, 11, 4];
-
-/** Every other route type is split by direction, kept in display order. */
-const DIRECTION_SPLIT_ROUTE_TYPES: readonly AppRouteTypeValue[] = ROUTE_TYPE_DISPLAY_ORDER.filter(
-  (routeType) => !NO_SPLIT_ROUTE_TYPES.includes(routeType),
-);
 
 export interface TransitDisplaysContainerProps {
   /**
@@ -104,62 +87,38 @@ export function TransitDisplaysContainer({
     );
   }, [transitDisplayStatus.radius, transitDisplayStatus.state]);
 
+  // Per-policy memos: data depends only on (nearbyStops, infoLevel, ready
+  // state), so switching the view does not invalidate either one. Both are
+  // computed eagerly because the per-stop dataset is small (NEARBY_RADIUS_M)
+  // and the cost is dominated by the active view's render anyway.
+  const memoizedTransitDisplayBoards = useMemo(
+    () =>
+      transitDisplayStatus.state === 'ready'
+        ? buildBoardsForPolicy(nearbyStops, NEARBY_RADIUS_M, TRANSIT_DISPLAY_POLICY, infoLevel)
+        : [],
+    [nearbyStops, infoLevel, transitDisplayStatus.state],
+  );
+  const memoizedRouteViewBoards = useMemo(
+    () =>
+      transitDisplayStatus.state === 'ready'
+        ? buildBoardsForPolicy(nearbyStops, NEARBY_RADIUS_M, ROUTE_VIEW_POLICY, infoLevel)
+        : [],
+    [nearbyStops, infoLevel, transitDisplayStatus.state],
+  );
+
+  // Select the memo for the active view via VIEW_POLICY lookup (identity
+  // compare on the policy reference -- adding a new view = new memo + new
+  // VIEW_POLICY entry + a new branch here, all explicit).
   const transitDisplayData = useMemo(() => {
-    // Build boards only when there is something to show; `no-stops` / `no-service`
-    // produce no boards, so skip the work and let TransitDisplays2 render the
-    // reason from `transitDisplayStatus`.
-    if (transitDisplayStatus.state !== 'ready') {
-      return [];
+    const policy = VIEW_POLICY[viewId];
+    if (policy === ROUTE_VIEW_POLICY) {
+      return memoizedRouteViewBoards;
     }
-
-    // const maxEntries = transitDisplayMaxEntriesFor(infoLevel);
-    const maxEntriesMultiRoute = transitDisplayMaxEntriesFor(infoLevel);
-    const maxEntriesPerRoute = transitDisplayMaxEntriesPerRouteFor(infoLevel);
-
-    // Per-mode direction policy is composed here rather than inside the builder:
-    // NO_SPLIT_ROUTE_TYPES keep both directions on one board, everything else
-    // splits by direction. The builder takes a single splitByDirection flag, so
-    // this is two calls (each scoped to its route types via a custom grouping).
-    // buildTransitDisplayDataSet attaches each display's meta but leaves rows raw.
-    // The concatenated result is re-ordered into the canonical UI order by
-    // sortTransitDisplayDataWithMetaData (so the order is correct
-    // regardless of which modes share a stop -- the raw concat is not in display
-    // order). Rows stay raw here; TransitDisplays resolves them into UI data.
-
-    const directionUnsplitRaw = buildTransitDisplayDataSet(nearbyStops, NEARBY_RADIUS_M, {
-      maxEntries: maxEntriesMultiRoute,
-      routeTypeGrouping: { kind: 'custom', groups: NO_SPLIT_ROUTE_TYPES.map((t) => [t]) },
-      splitByRoute: false,
-      // splitByRoute: true,
-      splitByDirection: false,
-      // splitByDirection: true,
-    });
-    const directionSplitRaw = buildTransitDisplayDataSet(nearbyStops, NEARBY_RADIUS_M, {
-      maxEntries: maxEntriesPerRoute,
-      routeTypeGrouping: { kind: 'custom', groups: DIRECTION_SPLIT_ROUTE_TYPES.map((t) => [t]) },
-      // splitByRoute: false,
-      splitByRoute: true,
-      // splitByDirection: false,
-      splitByDirection: true,
-    });
-
-    return sortTransitDisplayDataWithMetaData([
-      //
-      ...directionUnsplitRaw,
-      ...directionSplitRaw,
-    ]);
-
-    // data.forEach((e) => {
-    //   console.info(
-    //     'debug-x',
-    //     `e.meta.category: ${e.meta.category}`,
-    //     `e.meta.routeTypes.length: ${e.meta.routeTypes.length}`,
-    //     `e.meta.routes.length: ${e.meta.routes.length}`,
-    //     `e.meta.directions.length: ${e.meta.directions.length}`,
-    //   );
-    // });
-    // return data;
-  }, [infoLevel, nearbyStops, transitDisplayStatus.state]);
+    if (policy === TRANSIT_DISPLAY_POLICY) {
+      return memoizedTransitDisplayBoards;
+    }
+    return [];
+  }, [viewId, memoizedTransitDisplayBoards, memoizedRouteViewBoards]);
 
   return (
     <div
@@ -168,34 +127,63 @@ export function TransitDisplaysContainer({
       onScroll={scrollOverflow.update}
     >
       {scrollOverflow.hasContentAbove && <ScrollFadeEdge position="top" />}
-      {/* transit-display: the classic split-flap board. */}
-      {/* transit-display-2: the modern design board. */}
-      {viewId === 'transit-display' ? (
-        <TransitDisplays
-          dataWithMeta={transitDisplayData}
-          status={transitDisplayStatus}
-          dataLangs={dataLangs}
-          emptyMessage={t('stop.timetable.allFilteredOut')}
-          now={now}
-          mapCenter={mapCenter}
-          infoLevel={infoLevel}
-          size={size}
-          onStopSelected={onStopSelected}
-          onInspectTrip={onInspectTrip}
-        />
-      ) : (
-        <TransitDisplays2
-          dataWithMeta={transitDisplayData}
-          status={transitDisplayStatus}
-          dataLangs={dataLangs}
-          now={now}
-          mapCenter={mapCenter}
-          infoLevel={infoLevel}
-          size={size}
-          onStopSelected={onStopSelected}
-          onInspectTrip={onInspectTrip}
-        />
-      )}
+      {/*
+        Each viewId is listed explicitly so new views render through a fresh
+        branch instead of falling through a catch-all. Currently:
+        - 'transit-display'    -> classic split-flap board
+        - 'transit-display-2'  -> modern design board
+        - 'route'              -> uses the modern design board for now (will
+                                  switch to a dedicated component if needed)
+      */}
+      {(() => {
+        switch (viewId) {
+          case 'transit-display':
+            return (
+              <TransitDisplays
+                dataWithMeta={transitDisplayData}
+                status={transitDisplayStatus}
+                dataLangs={dataLangs}
+                emptyMessage={t('stop.timetable.allFilteredOut')}
+                now={now}
+                mapCenter={mapCenter}
+                infoLevel={infoLevel}
+                size={size}
+                onStopSelected={onStopSelected}
+                onInspectTrip={onInspectTrip}
+              />
+            );
+          case 'transit-display-2':
+            return (
+              <TransitDisplays2
+                dataWithMeta={transitDisplayData}
+                status={transitDisplayStatus}
+                dataLangs={dataLangs}
+                now={now}
+                mapCenter={mapCenter}
+                infoLevel={infoLevel}
+                size={size}
+                onStopSelected={onStopSelected}
+                onInspectTrip={onInspectTrip}
+              />
+            );
+          case 'route':
+            return (
+              <TransitDisplays2
+                dataWithMeta={transitDisplayData}
+                status={transitDisplayStatus}
+                dataLangs={dataLangs}
+                now={now}
+                mapCenter={mapCenter}
+                infoLevel={infoLevel}
+                size={size}
+                onStopSelected={onStopSelected}
+                onInspectTrip={onInspectTrip}
+              />
+            );
+          default:
+            return null;
+        }
+      })()}
       {scrollOverflow.hasContentBelow && <ScrollFadeEdge position="bottom" />}
       <ScrollToTopButton
         visible={scrollOverflow.hasContentAbove}

--- a/src/components/trip-info.tsx
+++ b/src/components/trip-info.tsx
@@ -1,43 +1,36 @@
 import { DEFAULT_AGENCY_LANG } from '../config/transit-defaults';
-import { getHeadsignDisplayNames } from '../domain/transit/name-resolver/get-headsign-display-names';
 import { headsignSourceEmoji } from '../domain/transit/headsign-source-emoji';
-import {
-  type ResolvedDisplayNames,
-  hasDisplayContent,
-} from '../domain/transit/name-resolver/get-display-names';
+import { hasDisplayContent } from '../domain/transit/name-resolver/get-display-names';
+import { getHeadsignDisplayNames } from '../domain/transit/name-resolver/get-headsign-display-names';
 import { useInfoLevel } from '../hooks/use-info-level';
-import { cn } from '../lib/utils';
 import type { InfoLevel } from '../types/app/settings';
 import type { Agency, TimetableEntryAttributes } from '../types/app/transit';
 import type { RouteDirection } from '../types/app/transit-composed';
-import type { InfoLevelFlags } from '../utils/create-info-level';
 import { routeTypeEmoji } from '../utils/route-type-emoji';
 import { AgencyBadge } from './badge/agency-badge';
 import { RouteBadge } from './badge/route-badge';
 import type { BaseLabelSize } from './label/base-label';
 import { TimetableEntryAttributesLabels } from './label/timetable-entry-attributes-labels';
+import { StackedDisplayNames } from './shared/stacked-display-names';
 
 const sizeVariants = {
   // Standard variant for StopTimeItem / StopTimesItem.
   md: {
     emoji: 'text-[1.2rem]',
-    headsign: 'text-[1.0rem]',
-    headsignSub: 'text-[0.7rem]',
     label: 'text-[0.7rem]',
+    sizeForNames: 'md',
   },
   // Compact variant for StopSummary tooltips. Small text sizes are
   // intentional — secondary info must stay subordinate in limited space.
   sm: {
     emoji: 'text-[1.0rem]',
-    headsign: 'text-[0.8rem]',
-    headsignSub: 'text-[0.6rem]',
     label: 'text-[0.6rem]',
+    sizeForNames: 'sm',
   },
   xs: {
     emoji: 'text-[1.0rem]',
-    headsign: 'text-[0.7rem]',
-    headsignSub: 'text-[0.5rem]',
     label: 'text-[0.5rem]',
+    sizeForNames: 'xs',
   },
 } as const;
 
@@ -50,36 +43,6 @@ const ATTRIBUTES_LABELS_SIZE_BY_SIZE: Record<keyof typeof sizeVariants, BaseLabe
   sm: 'sm',
   md: 'sm',
 };
-
-/**
- * Headsign display within TripInfo.
- *
- * - simple: resolved name only
- * - normal+: resolved subNames + resolved name
- */
-function HeadsignInfo({
-  names,
-  info,
-  headsignClass,
-  subClass,
-  ellipsis,
-}: {
-  names: ResolvedDisplayNames;
-  info: InfoLevelFlags;
-  headsignClass: string;
-  subClass: string;
-  ellipsis: boolean;
-}) {
-  return (
-    <span className="inline-flex min-w-0 flex-col">
-      {info.isNormalEnabled && names.subNames.length > 0 && (
-        <span className={cn(subClass, ellipsis && 'truncate')}>{names.subNames.join(' / ')}</span>
-      )}
-      <span className={cn(headsignClass, ellipsis && 'truncate')}>{names.name}</span>
-    </span>
-  );
-}
-
 interface TripInfoProps {
   /** Agency operating this trip. Rendered only when `showAgency` is true. */
   agency?: Agency;
@@ -141,53 +104,52 @@ export function TripInfo({
   ellipsisHeadsign = false,
 }: TripInfoProps) {
   const { route } = routeDirection;
-  const info = useInfoLevel(infoLevel);
+  const infoLevelFlag = useInfoLevel(infoLevel);
   const v = sizeVariants[size];
   const agencyLang = agency?.agency_lang ? [agency.agency_lang] : DEFAULT_AGENCY_LANG;
   const headsignNames = getHeadsignDisplayNames(routeDirection, dataLangs, agencyLang, 'stop');
 
-  const headsignClass = cn(v.headsign, 'font-medium text-[#333] dark:text-gray-200');
-  const subClass = cn(v.headsignSub, 'font-normal text-[#888] dark:text-gray-400');
-
-  const headSignInfos = info.isVerboseEnabled ? (
+  const headSignInfos = infoLevelFlag.isVerboseEnabled ? (
     <>
       {hasDisplayContent(headsignNames.tripName) && (
         <>
-          <HeadsignInfo
+          <StackedDisplayNames
             names={{
               ...headsignNames.tripName,
               name: headsignSourceEmoji('trip') + ' ' + headsignNames.tripName.name,
             }}
-            info={info}
-            headsignClass={headsignClass}
-            subClass={subClass}
+            size={v.sizeForNames}
             ellipsis={ellipsisHeadsign}
+            showSubNames={infoLevelFlag.isNormalEnabled}
+            subNamesPosition="top"
           />
         </>
       )}
       {headsignNames.stopName && hasDisplayContent(headsignNames.stopName) && (
         <>
-          <HeadsignInfo
+          <StackedDisplayNames
             names={{
               ...headsignNames.stopName,
               name: headsignSourceEmoji('stop') + ' ' + headsignNames.stopName.name,
             }}
-            info={info}
-            headsignClass={headsignClass}
-            subClass={subClass}
+            size={v.sizeForNames}
             ellipsis={ellipsisHeadsign}
+            showSubNames={infoLevelFlag.isNormalEnabled}
+            subNamesPosition="top"
           />
         </>
       )}
     </>
   ) : (
-    <HeadsignInfo
-      names={headsignNames.resolved}
-      info={info}
-      headsignClass={headsignClass}
-      subClass={subClass}
-      ellipsis={ellipsisHeadsign}
-    />
+    <>
+      <StackedDisplayNames
+        names={headsignNames.resolved}
+        size={v.sizeForNames}
+        ellipsis={ellipsisHeadsign}
+        showSubNames={infoLevelFlag.isNormalEnabled}
+        subNamesPosition="top"
+      />
+    </>
   );
 
   return (
@@ -203,7 +165,7 @@ export function TripInfo({
         infoLevel={infoLevel}
         showBorder={true}
       />
-      {info.isDetailedEnabled && agency && showAgency && (
+      {infoLevelFlag.isDetailedEnabled && agency && showAgency && (
         <AgencyBadge
           size={size}
           agency={agency}

--- a/src/domain/transit/name-resolver/__tests__/get-display-names.test.ts
+++ b/src/domain/transit/name-resolver/__tests__/get-display-names.test.ts
@@ -10,6 +10,18 @@ describe('hasDisplayContent', () => {
     expect(hasDisplayContent({ name: '', subNames: ['Nakano Sta.'] })).toBe(true);
   });
 
+  it('returns true when both name and subNames have content', () => {
+    expect(hasDisplayContent({ name: '中野駅', subNames: ['Nakano Sta.'] })).toBe(true);
+  });
+
+  it('returns true when subNames has multiple non-empty values', () => {
+    expect(hasDisplayContent({ name: '', subNames: ['Nakano Sta.', '中野站'] })).toBe(true);
+  });
+
+  it('returns true when name is empty but one subName is non-empty', () => {
+    expect(hasDisplayContent({ name: '', subNames: ['', 'Nakano'] })).toBe(true);
+  });
+
   it('returns false when name is empty and subNames is empty', () => {
     expect(hasDisplayContent({ name: '', subNames: [] })).toBe(false);
   });
@@ -18,7 +30,11 @@ describe('hasDisplayContent', () => {
     expect(hasDisplayContent({ name: '', subNames: ['', ''] })).toBe(false);
   });
 
-  it('returns true when name is empty but one subName is non-empty', () => {
-    expect(hasDisplayContent({ name: '', subNames: ['', 'Nakano'] })).toBe(true);
+  it('treats a whitespace-only name as content (strict empty-string check)', () => {
+    expect(hasDisplayContent({ name: ' ', subNames: [] })).toBe(true);
+  });
+
+  it('treats a whitespace-only subName as content (strict empty-string check)', () => {
+    expect(hasDisplayContent({ name: '', subNames: [' '] })).toBe(true);
   });
 });

--- a/src/domain/transit/name-resolver/get-display-names.ts
+++ b/src/domain/transit/name-resolver/get-display-names.ts
@@ -21,5 +21,5 @@ export interface ResolvedDisplayNames {
  * Returns `false` when `name` is empty and all `subNames` are empty strings.
  */
 export function hasDisplayContent(names: ResolvedDisplayNames): boolean {
-  return !!names.name || names.subNames.some(Boolean);
+  return names.name !== '' || names.subNames.some((s) => s !== '');
 }

--- a/src/domain/transit/stop-time-views.ts
+++ b/src/domain/transit/stop-time-views.ts
@@ -65,6 +65,23 @@ export const STOP_TIMES_VIEWS = [
   },
 
   /**
+   * Route grouped view.
+   *
+   * Display unit: multiple stops.
+   *
+   * Shows service events in timeline order across a route cluster.
+   */
+  {
+    id: 'route',
+    icon: '🚏',
+    labelKey: 'view.route.label',
+    titleKey: 'view.route.title',
+    descriptionKey: 'view.route.description',
+    enabled: true,
+    visible: true,
+  },
+
+  /**
    * Transit display view -- classic design.
    *
    * Display unit: multiple stops.
@@ -83,22 +100,6 @@ export const STOP_TIMES_VIEWS = [
     visible: true,
   },
 
-  /**
-   * Route grouped view.
-   *
-   * Display unit: multiple stops.
-   *
-   * Shows service events in timeline order across a route cluster.
-   */
-  {
-    id: 'route',
-    icon: '🚏',
-    labelKey: 'view.route.label',
-    titleKey: 'view.route.title',
-    descriptionKey: 'view.route.description',
-    enabled: true,
-    visible: true,
-  },
   /**
    * Headsign grouped view.
    *

--- a/src/domain/transit/stop-time-views.ts
+++ b/src/domain/transit/stop-time-views.ts
@@ -86,9 +86,9 @@ export const STOP_TIMES_VIEWS = [
   /**
    * Route grouped view.
    *
-   * Display unit: stop.
+   * Display unit: multiple stops.
    *
-   * Groups upcoming service events within a stop by route.
+   * Shows service events in timeline order across a route cluster.
    */
   {
     id: 'route',

--- a/src/domain/transit/stop-time-views.ts
+++ b/src/domain/transit/stop-time-views.ts
@@ -96,7 +96,7 @@ export const STOP_TIMES_VIEWS = [
     labelKey: 'view.route.label',
     titleKey: 'view.route.title',
     descriptionKey: 'view.route.description',
-    enabled: false,
+    enabled: true,
     visible: true,
   },
   /**

--- a/src/domain/transit/transit-info-display/transit-display-ui.ts
+++ b/src/domain/transit/transit-info-display/transit-display-ui.ts
@@ -84,8 +84,8 @@ export function sortTransitDisplayDataWithMetaData(
       // different head values for that axis; comparing by it would mis-order
       // arrivals before departures. Evaluated independently so each axis can
       // remain usable on its own merit.
-      hasMultipleRoutes: d.meta.routes.length > 1,
-      hasMultipleDirections: d.meta.directions.length > 1,
+      hasMultipleRoutes: hasMultipleRoutes(d),
+      hasMultipleDirections: hasMultipleDirections(d),
       routeId: d.meta.routes[0]?.route_id ?? '',
       direction: DIRECTIONS.indexOf(direction === 'none' ? undefined : direction),
       category: CATEGORIES.indexOf(d.meta.category),
@@ -127,4 +127,24 @@ export function resolveTransitDisplayState(
     return 'no-service';
   }
   return 'ready';
+}
+
+/**
+ * Whether the given display covers multiple routes on its single board
+ * (i.e. a multi-route board, built with `splitByRoute: false` and serving
+ * more than one route at this stop). Implementation reads `meta.routes`
+ * (O(1)); the same count could be derived from `data.data` but with O(n).
+ */
+export function hasMultipleRoutes(d: TransitDisplayDataWithMetaData): boolean {
+  return d.meta.routes.length > 1;
+}
+
+/**
+ * Whether the given display covers multiple directions on its single board
+ * (i.e. a multi-direction board, built with `splitByDirection: false` and
+ * carrying trips of more than one direction at this stop). Implementation
+ * reads `meta.directions` (O(1)).
+ */
+export function hasMultipleDirections(d: TransitDisplayDataWithMetaData): boolean {
+  return d.meta.directions.length > 1;
 }


### PR DESCRIPTION
## Summary

- Add the new `route` view in the stop browser: per-route cards that group boards by route, applied to all route types. The picker now lists `route` ahead of the classic `transit-display` board.
- Introduce two shared display-names components (`StackedDisplayNames`, `InlineDisplayNames`) under `src/components/shared/`. Both take an `ExtendedDisplaySize` size, a `showSubNames` toggle, default text colors, and (Stacked only) a `subNamesPosition: 'top' | 'bottom'`. Caller-provided `nameClassName` / `subNamesClassName` win over the baseline via twMerge ordering.
- Migrate `trip-info` to `StackedDisplayNames` and drop the now-redundant local `HeadsignInfo` helper.
- Tighten `hasDisplayContent` (strict empty-string check) with extra test coverage.
- Layout fix: per-route header now uses `flex-wrap` so a long RouteBadge no longer squeezes the Route names area.

## Test plan

- [x] `npm run typecheck` + `npm run lint` + `npm run test` pass.
- [x] In the stop browser, switch to the new `route` view and confirm per-route cards render for stops served by multiple routes (real GTFS + `?repo=mock`).
- [x] Confirm the per-route card shows the route color border, RouteBadge, AgencyBadge, and the inline name display.
- [x] With a long RouteBadge (e.g. a long route_short_name), confirm the Route names wrap to the next line instead of overflowing.
- [x] In the picker, confirm `route` appears before the classic `transit-display` view.
- [x] Open `trip-info` callers (StopTimeItem / StopSummary tooltip) and confirm headsign rendering is visually unchanged.
- [x] Storybook: open `DisplayNames/StackedDisplayNames` and `DisplayNames/InlineDisplayNames`; exercise size comparison, sub-name visibility toggle, and (Stacked) sub-name position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)