### PR TITLE
refactor(transit-display): rename classic to SplitFlap*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - TripInfo: ヘッドサインのレンダーをローカル `HeadsignInfo` から shared `StackedDisplayNames` に置き換えた (#302)。
 - TransitDisplayPerRoute: route info row に `flex-wrap` を入れ、RouteBadge が長文のとき Route names を次の行へ折り返して表示するようにした (#302)。
 - `hasDisplayContent`: truthy/falsy collapse を strict empty-string check (`!== ''`) に書き換えた (テスト追加、挙動は不変) (#302)。
+- TransitDisplay: classic split-flap signage board の components / Props / ファイル名を `SplitFlap*` prefix に rename した (新方式 `TransitDisplay2` 系との視覚的区別を明確化、メタファー prefix で時期非依存)。`TransitDisplays` -> `SplitFlapTransitDisplays`、`TransitDisplay` -> `SplitFlapTransitDisplay`、`TransitDisplayEntry` -> `SplitFlapTransitDisplayEntry` および各 Props 型。ファイル: `transit-displays.tsx` -> `split-flap-transit-display.tsx`、stories 2 ファイルも `split-flap-` prefix。Storybook category (`TransitDisplay/`) はそのままで component 名のみ更新。
 
 ### Fixed
 

--- a/src/components/transit-display/split-flap-transit-display-entry.stories.tsx
+++ b/src/components/transit-display/split-flap-transit-display-entry.stories.tsx
@@ -11,7 +11,7 @@ import {
 import type { AppRouteTypeValue, TimetableEntryAttributes } from '../../types/app/transit';
 import type { StopWithContext } from '../../types/app/transit-composed';
 import { routeTypesEmoji } from '../../utils/route-type-emoji';
-import { TransitDisplayEntry } from './transit-displays';
+import { SplitFlapTransitDisplayEntry } from './split-flap-transit-display';
 
 /** Flat override knobs for {@link makeRow}, assembled into the nested row shape. */
 interface MakeRowOverrides {
@@ -92,8 +92,8 @@ function makeRow(overrides: MakeRowOverrides = {}): TransitDisplayDatumForUi {
 }
 
 const meta = {
-  title: 'TransitDisplay/TransitDisplayEntry',
-  component: TransitDisplayEntry,
+  title: 'TransitDisplay/SplitFlapTransitDisplayEntry',
+  component: SplitFlapTransitDisplayEntry,
   args: {
     dataWithMeta: makeRow(),
     infoLevel: 'normal' as const,
@@ -109,8 +109,8 @@ const meta = {
     size: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
     hasMultiRoutes: { control: 'boolean' },
   },
-  // TransitDisplayEntry renders an <li>; wrap in a <ul> mirroring the
-  // parent TransitDisplays list so layout and semantics match production.
+  // SplitFlapTransitDisplayEntry renders an <li>; wrap in a <ul> mirroring the
+  // parent SplitFlapTransitDisplays list so layout and semantics match production.
   decorators: [
     (Story) => (
       <div className="max-w-sm rounded-lg bg-[#f5f7fa] p-3 dark:bg-gray-800">
@@ -120,7 +120,7 @@ const meta = {
       </div>
     ),
   ],
-} satisfies Meta<typeof TransitDisplayEntry>;
+} satisfies Meta<typeof SplitFlapTransitDisplayEntry>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -197,7 +197,7 @@ export const SizeComparison: Story = {
     return (
       <>
         {rows.map(({ size, data }) => (
-          <TransitDisplayEntry
+          <SplitFlapTransitDisplayEntry
             key={data.key}
             dataWithMeta={data}
             infoLevel={args.infoLevel}
@@ -313,7 +313,7 @@ export const KitchenSink: Story = {
   render: (args) => (
     <>
       {kitchenSinkRows.map((row) => (
-        <TransitDisplayEntry
+        <SplitFlapTransitDisplayEntry
           key={row.key}
           dataWithMeta={row}
           infoLevel={args.infoLevel}

--- a/src/components/transit-display/split-flap-transit-display.stories.tsx
+++ b/src/components/transit-display/split-flap-transit-display.stories.tsx
@@ -15,7 +15,7 @@ import {
 import type { AppRouteTypeValue, TimetableEntryAttributes } from '../../types/app/transit';
 import type { StopWithContext } from '../../types/app/transit-composed';
 import { routeTypesEmoji } from '../../utils/route-type-emoji';
-import { TransitDisplay } from './transit-displays';
+import { SplitFlapTransitDisplay } from './split-flap-transit-display';
 
 /** Flat override knobs for {@link makeEntry}, assembled into the nested row shape. */
 interface MakeEntryOverrides {
@@ -173,8 +173,8 @@ const trainRows: TransitDisplayDatumForUi[] = [
 ];
 
 const meta = {
-  title: 'TransitDisplay/TransitDisplay',
-  component: TransitDisplay,
+  title: 'TransitDisplay/SplitFlapTransitDisplay',
+  component: SplitFlapTransitDisplay,
   args: {
     dataWithMeta: makeDisplay(),
     emptyMessage: 'Hidden by filter',
@@ -190,7 +190,7 @@ const meta = {
     infoLevel: { control: 'inline-radio', options: ['simple', 'normal', 'detailed', 'verbose'] },
     size: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
   },
-  // Mirror the parent TransitDisplays wrapper (px-4) so framing/spacing match production.
+  // Mirror the parent SplitFlapTransitDisplays wrapper (px-4) so framing/spacing match production.
   decorators: [
     (Story) => (
       <div className="max-w-sm bg-white px-4 py-2 dark:bg-gray-900">
@@ -198,7 +198,7 @@ const meta = {
       </div>
     ),
   ],
-} satisfies Meta<typeof TransitDisplay>;
+} satisfies Meta<typeof SplitFlapTransitDisplay>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -229,7 +229,7 @@ export const SizeComparison: Story = {
   render: (args) => (
     <div className="space-y-2">
       {(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
-        <TransitDisplay
+        <SplitFlapTransitDisplay
           key={size}
           dataWithMeta={args.dataWithMeta}
           emptyMessage={args.emptyMessage}

--- a/src/components/transit-display/split-flap-transit-display.tsx
+++ b/src/components/transit-display/split-flap-transit-display.tsx
@@ -107,7 +107,7 @@ const HEADSIGN_WIDTH_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
   xl: 'max-w-[32ch] min-w-[32ch]',
 };
 
-export interface TransitDisplaysProps {
+export interface SplitFlapTransitDisplaysProps {
   /** Raw displays (meta + unresolved board); rows are resolved here for rendering. */
   dataWithMeta: readonly TransitDisplayDataWithMetaData[];
   /** Build state + radius, for the empty-state message (no stops / no service). */
@@ -144,7 +144,7 @@ const DEFAULT_CATEGORIES: Record<TransitDisplayCategory, boolean> = {
  * presentation-only local state: it narrows the rendered displays, it does not
  * change how they are built or fetched.
  */
-export function TransitDisplays({
+export function SplitFlapTransitDisplays({
   dataWithMeta,
   status,
   dataLangs,
@@ -155,13 +155,13 @@ export function TransitDisplays({
   size,
   onStopSelected,
   onInspectTrip,
-}: TransitDisplaysProps) {
+}: SplitFlapTransitDisplaysProps) {
   const { t } = useTranslation();
 
   const [shownCategories, setShownCategories] =
     useState<Record<TransitDisplayCategory, boolean>>(DEFAULT_CATEGORIES);
 
-  // Resolve every raw display's rows into UI data here -- TransitDisplays is the
+  // Resolve every raw display's rows into UI data here -- SplitFlapTransitDisplays is the
   // only consumer that needs the resolved rows. Resolve all up front, then let
   // the category filter below narrow the already-resolved list.
   const resolvedDataWithMeta = useMemo<readonly TransitDisplayDataWithMetaDataForUi[]>(
@@ -214,7 +214,7 @@ export function TransitDisplays({
         // map index as a disambiguator: a `custom` route grouping can collapse
         // two groups to the same present route types, so identity alone is not
         // guaranteed unique.
-        <TransitDisplay
+        <SplitFlapTransitDisplay
           key={`${dataWithMeta.meta.category}__${dataWithMeta.meta.routeTypes.join('-')}__${index}`}
           dataWithMeta={dataWithMeta}
           emptyMessage={emptyMessage}
@@ -335,7 +335,7 @@ function TransitDisplayCategoryFilter({
   );
 }
 
-export interface TransitDisplayProps {
+export interface SplitFlapTransitDisplayProps {
   dataWithMeta: TransitDisplayDataWithMetaDataForUi;
   emptyMessage: string;
   now: Date;
@@ -359,7 +359,7 @@ export interface TransitDisplayProps {
  * Layout: a header band (title on the left, recent-count / radius on the right)
  * above the rows, or an empty fallback when the board has no entries.
  */
-export function TransitDisplay({
+export function SplitFlapTransitDisplay({
   dataWithMeta,
   emptyMessage,
   mapCenter,
@@ -367,7 +367,7 @@ export function TransitDisplay({
   size,
   onStopSelected,
   onInspectTrip,
-}: TransitDisplayProps) {
+}: SplitFlapTransitDisplayProps) {
   const { t } = useTranslation();
   // Airport-board-style title: mode emoji + departures/arrivals phrase. The
   // route type and basis are structured meta; the UI composes the localized text.
@@ -448,7 +448,7 @@ export function TransitDisplay({
         ) : (
           <ul className="m-0 list-none p-0">
             {dataWithMeta.data.map((row) => (
-              <TransitDisplayEntry
+              <SplitFlapTransitDisplayEntry
                 key={row.key}
                 dataWithMeta={row}
                 mapCenter={mapCenter}
@@ -514,7 +514,7 @@ function TimeInfo({
   );
 }
 
-export interface TransitDisplayEntryProps {
+export interface SplitFlapTransitDisplayEntryProps {
   dataWithMeta: TransitDisplayDatumForUi;
   mapCenter: LatLng | null;
   infoLevel: InfoLevel;
@@ -531,7 +531,7 @@ export interface TransitDisplayEntryProps {
 }
 
 /** A single departure-board row (one stop event). */
-export function TransitDisplayEntry({
+export function SplitFlapTransitDisplayEntry({
   dataWithMeta,
   mapCenter,
   infoLevel,
@@ -539,7 +539,7 @@ export function TransitDisplayEntry({
   hasMultiRoutes,
   onStopSelected,
   onInspectTrip,
-}: TransitDisplayEntryProps) {
+}: SplitFlapTransitDisplayEntryProps) {
   const infoLevelFlag = useInfoLevel(infoLevel);
 
   // Distance is baked on the row (query-time); bearing is computed live from the

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -23,7 +23,7 @@ import {
   TRANSIT_DISPLAY_POLICY,
   VIEW_POLICY,
 } from '@/components/transit-display/transit-display-view-policy';
-import { TransitDisplays } from '@/components/transit-display/transit-displays';
+import { SplitFlapTransitDisplays } from '@/components/transit-display/split-flap-transit-display';
 import { TransitDisplays2 } from '@/components/transit-display/transit-displays-2';
 
 const logger = createLogger('TransitDisplaysContainer');
@@ -139,7 +139,7 @@ export function TransitDisplaysContainer({
         switch (viewId) {
           case 'transit-display':
             return (
-              <TransitDisplays
+              <SplitFlapTransitDisplays
                 dataWithMeta={transitDisplayData}
                 status={transitDisplayStatus}
                 dataLangs={dataLangs}

--- a/src/stories/fixtures.ts
+++ b/src/stories/fixtures.ts
@@ -1303,7 +1303,7 @@ export const headsignLong: TranslatableText = {
 };
 
 /**
- * Default radius-scope stop stats for TransitDisplay meta in stories.
+ * Default radius-scope stop stats for SplitFlapTransitDisplay meta in stories.
  * Mirrors a small multi-agency cluster (the exact figures are illustrative).
  */
 export const storyStopStats: StopWithMetaStats = {
@@ -1313,7 +1313,7 @@ export const storyStopStats: StopWithMetaStats = {
   routeTypeCount: 1,
 };
 
-/** Default derived stats bundle for a TransitDisplay (radius-scope + per-board). */
+/** Default derived stats bundle for a SplitFlapTransitDisplay (radius-scope + per-board). */
 export const storyTransitDisplayStats: TransitDisplayStats = {
   stopsInRadius: storyStopStats,
   qualifying: { entryCount: 8, stopCount: 6, routeCount: 3, agencyCount: 2, routeTypeCount: 1 },


### PR DESCRIPTION
## Summary

- Rename the classic split-flap signage board components (`TransitDisplays` / `TransitDisplay` / `TransitDisplayEntry`) + their Props types + 3 files to the `SplitFlap*` prefix.
- The visual metaphor (old station departure board) is encoded in the name, removing the unqualified `TransitDisplay*` namespace clash with the newer `TransitDisplay2` family.
- Storybook title keeps the `TransitDisplay/` category; only the component name is updated.
- `TransitDisplay2` family and other `TransitDisplay*` tokens (data types, helpers, Container, PerRoute) are intentionally left for follow-up PRs.

## Test plan

- [x] `npm run typecheck` + `npm run lint` + `npm run test` pass.
- [x] `npm run build` pass.
- [x] In the stop browser, the classic transit-display view still renders correctly (rename should be behavior-neutral).
- [x] Storybook: `TransitDisplay/SplitFlapTransitDisplay` and `TransitDisplay/SplitFlapTransitDisplayEntry` open and render.
- [x] No `SplitFlapSplitFlap` double-prefix remains anywhere in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)