### PR TITLE
feat(map): view-aware highlight circle via map overlay store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - 5 つのコンポーネントに size 駆動の nested style table を導入した: `TRANSIT_DISPLAY_STYLE_BY_SIZE` / `TRANSIT_DISPLAY_DASHBOARD_STYLE_BY_SIZE` / `TRANSIT_DISPLAY_ENTRY_STYLE_BY_SIZE` / `PER_ROUTE_STYLE_BY_SIZE` (`TransitDisplayPerRoute`) / `ROUTE_FILTER_STYLE_BY_SIZE`。 `xs` / `sm` / `md` / `lg` / `xl` の `ExtendedDisplaySize` 毎に text size / border 太さ / 余白 / 子 component の size を 1 ヶ所で lookup する。 `md` は従来のハードコード値と一致 (#304)。
 - StopsSummary: `infoLevel === 'verbose'` のとき解決済み `size` を表す debug badge を表示するようにした。 container 駆動 sizing の挙動確認用 (#304)。
 - MapView: `showDistanceRings?: boolean` (既定 true、 既存距離参照同心円の on/off) と `highlightedCircles?: HighlightedCircle[]` (= 新規 export interface `{ center: LatLng; radius: number; color: string }` の配列、 内部 `AdditionalCircles` で fill-tinted Circle として描画) を追加した。 center は固定で map drag に追従せず、 color / radius は free-form (`DISTANCE_BANDS` 非依存)。 既存 call site は未変更 (#306)。
+- Map overlay store `useMapOverlay` を追加した (`useSyncExternalStore` ベース): hoisted な MapView の overlay を任意の component が prop-drill / context なしで制御できる (`useHighlightedCircles` / `useShowDistanceRings` read hook + `useMapOverlayControls` write hook)。 `HighlightedCircle` 型は `types/app/map.ts` へ移動。 `TransitDisplaysContainer` が active view の近接半径を circle として publish (半径 + 色は per-view `TRANSIT_DISPLAY_VIEW_SETTINGS`、 board filter と同一半径)。 `AdditionalCircles` の fill は dark で濃くする (fillOpacity 0.4 / 0.2) (#307)。
 
 ### Changed
 
@@ -34,6 +35,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - i18n: 未使用だった `stop.serviceState.boardable` ("運行中") を `inService` にリネームした (`passenger.boardableCount` ("乗車可") との混同を回避)。`stopTimeView` を `relativeTime` / `absoluteTime` / `passenger` / `endpoint` のサブグループに構造化し、将来の発着可否・端点種別 (現実の起終点 vs 直通境界) 表示用キーを足場として追加した (#162)。
 - transit-display: UI 表示用のヘルパー (`sortTransitDisplayDataWithMetaData` / `resolveTransitDisplayState` / `transitDisplayMaxEntriesFor` ほか) を `transit-display-ui.ts` に分離した。builder (`build-transit-display-data.ts`) は board データ生成のみ、UI 配慮 (並び順 / row 上限 / empty-state) は専用 module に集約 (#296, #300)。
 - TransitDisplaysContainer: 鉄道系 (`DIRECTION_SPLIT_ROUTE_TYPES`) は per-route board (`splitByRoute: true`) で構築し、bus / trolleybus / ferry (`NO_SPLIT_ROUTE_TYPES`) は multi-route のまま維持する per-mode policy を採用した。group-by の runtime toggle は意図的に追加しない (#296, #300)。
+- TransitDisplaysContainer: 近接半径を固定 `NEARBY_RADIUS_M` から per-view (`TRANSIT_DISPLAY_VIEW_SETTINGS`) 駆動に変更し、 board の構築を eager dual-policy memo から active view のみの lazy build に切り替えた (= view 毎に半径が異なり得るため。 inactive policy の毎レンダー構築も解消) (#307)。
 - TransitDisplay: multi-route board の row cap (`simple` / `normal`) を 10 に下げた (per-route と数を揃え、過剰な行数を抑制) (#296, #300)。
 - TripInfo: ヘッドサインのレンダーをローカル `HeadsignInfo` から shared `StackedDisplayNames` に置き換えた (#302)。
 - TransitDisplayPerRoute: route info row に `flex-wrap` を入れ、RouteBadge が長文のとき Route names を次の行へ折り返して表示するようにした (#302)。

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -56,6 +56,7 @@ import { useDateTime } from './hooks/use-date-time';
 import { useGlobalFilter } from './hooks/use-global-filter';
 import { useKeyboardShortcuts } from './hooks/use-keyboard-shortcuts';
 import { useLoadResult } from './hooks/use-load-result';
+import { useHighlightedCircles, useShowDistanceRings } from './hooks/use-map-overlay';
 import { useNearbyStopTimes } from './hooks/use-nearby-stop-times';
 import { useRouteShapes } from './hooks/use-route-shapes';
 import { useRouteStops } from './hooks/use-route-stops';
@@ -194,6 +195,13 @@ export default function App() {
       perfProfile,
       onStopsCommitted: handleStopsCommitted,
     });
+  // Map overlay state published by any component via the shared store (e.g.
+  // TransitDisplaysContainer draws the active view's nearby radius circle).
+  // MapView stays a generic prop-driven renderer; App only bridges the store
+  // to its props.
+  const highlightedCircles = useHighlightedCircles();
+  const showDistanceRings = useShowDistanceRings();
+
   const routeShapes = useRouteShapes(repo);
   // Auto-tracking flag is intentionally not persisted: a tracking
   // permission/intent shouldn't silently survive a reload, so it always
@@ -896,6 +904,8 @@ export default function App() {
             userLocation={userLocation}
             onLocated={handleLocated}
             onMapInstance={setMapInstance}
+            highlightedCircles={highlightedCircles}
+            showDistanceRings={showDistanceRings}
             heightClassName="h-full"
           />
           {/* All chrome that overlays the map: corner panels, locate

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -4,7 +4,7 @@ import { MapContainer, TileLayer, Marker, Circle, useMap, useMapEvents } from 'r
 import L from 'leaflet';
 import { toast } from 'sonner';
 import type { AutoLocateOffReason } from '../../types/app/auto-locate';
-import type { Bounds, LatLng, RouteShape } from '../../types/app/map';
+import type { Bounds, HighlightedCircle, LatLng, RouteShape } from '../../types/app/map';
 import type { InfoLevel, RenderMode, Theme } from '../../types/app/settings';
 import type { Agency, AppRouteTypeValue, Stop } from '../../types/app/transit';
 import type { StopWithContext, StopWithMeta } from '../../types/app/transit-composed';
@@ -233,32 +233,14 @@ function AdditionalCircles({ circles }: { circles: readonly HighlightedCircle[] 
           pathOptions={{
             color: c.color,
             fillColor: c.color,
-            fillOpacity: 0.12,
-            weight: 6,
-            opacity: 0.85,
+            fillOpacity: 0.15,
+            weight: 2,
+            opacity: 0.8,
           }}
         />
       ))}
     </>
   );
-}
-
-/**
- * Specification for one extra Circle rendered on top of the always-on
- * `DistanceRings`. The caller decides everything: where the circle is
- * anchored, how large it is, and what color it gets. Color is required
- * (and intentionally an opaque CSS color string) so the MapView never
- * has to know about `DISTANCE_BANDS` -- caller-side helpers in
- * `utils/distance-style.ts` etc. can be used to look one up if the
- * caller wants band-consistent colors.
- */
-export interface HighlightedCircle {
-  /** Anchor point. Does NOT follow the user dragging the map. */
-  center: LatLng;
-  /** Radius in meters. Free-form; not restricted to `DISTANCE_BANDS.max`. */
-  radius: number;
-  /** CSS color string used for both stroke and fill. */
-  color: string;
 }
 
 export interface MapViewProps {

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -221,7 +221,15 @@ function DistanceRings() {
  * about" (e.g. the most recently committed stops-fetch center) rather
  * than the live viewport.
  */
-function AdditionalCircles({ circles }: { circles: readonly HighlightedCircle[] }) {
+function AdditionalCircles({
+  circles,
+  theme,
+}: {
+  circles: readonly HighlightedCircle[];
+  theme: Theme;
+}) {
+  // Dark map tiles need a stronger fill for the same color to read.
+  const fillOpacity = theme === 'dark' ? 0.4 : 0.2;
   return (
     <>
       {circles.map((c) => (
@@ -233,7 +241,7 @@ function AdditionalCircles({ circles }: { circles: readonly HighlightedCircle[] 
           pathOptions={{
             color: c.color,
             fillColor: c.color,
-            fillOpacity: 0.15,
+            fillOpacity,
             weight: 2,
             opacity: 0.8,
           }}
@@ -608,7 +616,7 @@ export function MapView({
         <RouteShapePanes />
         {showDistanceRings && <DistanceRings />}
         {highlightedCircles && highlightedCircles.length > 0 && (
-          <AdditionalCircles circles={highlightedCircles} />
+          <AdditionalCircles circles={highlightedCircles} theme={theme} />
         )}
         {infoLevel === 'verbose' && <ZoomDisplay />}
         <PanToFocus position={focusPosition} />

--- a/src/components/transit-display/transit-display-view-policy.ts
+++ b/src/components/transit-display/transit-display-view-policy.ts
@@ -87,6 +87,42 @@ export const TRANSIT_DISPLAY_VIEW_IDS: readonly StopTimeViewId[] = Object.keys(
   VIEW_POLICY,
 ) as StopTimeViewId[];
 
+/** Per-view nearby radius + map highlight circle appearance. */
+export interface TransitDisplayViewSettings {
+  /** Nearby radius (m): filters the boards AND sizes the map's highlight circle. */
+  nearbyRadiusMeters: number;
+  /** Color of the map's highlight circle drawn at the nearby radius. */
+  highlightCircleColor: string;
+}
+
+/**
+ * Per-view settings for the transit-display views. Single source of truth for
+ * both the board filtering in `TransitDisplaysContainer` and the map's
+ * highlight circle (published from the same component), so the two agree.
+ */
+const TRANSIT_DISPLAY_VIEW_SETTINGS: Partial<Record<StopTimeViewId, TransitDisplayViewSettings>> = {
+  'transit-display': {
+    nearbyRadiusMeters: 150,
+    highlightCircleColor: '#009688', // teal
+  },
+  'transit-display-2': {
+    nearbyRadiusMeters: 100,
+    highlightCircleColor: '#009688', // teal
+  },
+  route: {
+    nearbyRadiusMeters: 150,
+    // highlightCircleColor: '#1e88e5'
+    highlightCircleColor: '#1e88e5', // DISTANCE_BANDS[1].color // 100m = blue
+  },
+};
+
+/** Settings for a view, or null for a view this container does not own. */
+export function transitDisplayViewSettings(
+  viewId: StopTimeViewId,
+): TransitDisplayViewSettings | null {
+  return TRANSIT_DISPLAY_VIEW_SETTINGS[viewId] ?? null;
+}
+
 /**
  * Run the two builder calls for one policy and merge their output in the UI
  * order. Pure function so it can be called from `useMemo` hooks with stable

--- a/src/components/transit-display/transit-display-view-policy.ts
+++ b/src/components/transit-display/transit-display-view-policy.ts
@@ -111,7 +111,6 @@ const TRANSIT_DISPLAY_VIEW_SETTINGS: Partial<Record<StopTimeViewId, TransitDispl
   },
   route: {
     nearbyRadiusMeters: 150,
-    // highlightCircleColor: '#1e88e5'
     highlightCircleColor: '#1e88e5', // DISTANCE_BANDS[1].color // 100m = blue
   },
 };

--- a/src/components/transit-display/transit-display-view-policy.ts
+++ b/src/components/transit-display/transit-display-view-policy.ts
@@ -111,7 +111,7 @@ const TRANSIT_DISPLAY_VIEW_SETTINGS: Partial<Record<StopTimeViewId, TransitDispl
   },
   route: {
     nearbyRadiusMeters: 150,
-    highlightCircleColor: '#1e88e5', // DISTANCE_BANDS[1].color // 100m = blue
+    highlightCircleColor: '#1e88e5', // blue (DISTANCE_BANDS[1].color)
   },
 };
 

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -109,7 +109,7 @@ export function TransitDisplaysContainer({
           color: settings.highlightCircleColor,
         },
       ]);
-      // setShowDistanceRings(false);
+      setShowDistanceRings(false);
     }
     return () => {
       clearHighlightedCircles();

--- a/src/components/transit-display/transit-displays-container.tsx
+++ b/src/components/transit-display/transit-displays-container.tsx
@@ -8,6 +8,7 @@ import type { StopWithContext, TripInspectionTarget } from '@/types/app/transit-
 
 import { createLogger } from '@/lib/logger';
 
+import { useMapOverlayControls } from '@/hooks/use-map-overlay';
 import { useScrollOverflow } from '@/hooks/use-scroll-overflow';
 
 import { filterStopsWithinDistance } from '@/domain/transit/stop-meta-filter';
@@ -19,8 +20,7 @@ import { ScrollFadeEdge } from '@/components/shared/scroll-fade-edge';
 import { ScrollToTopButton } from '@/components/shared/scroll-to-top-button';
 import {
   buildBoardsForPolicy,
-  ROUTE_VIEW_POLICY,
-  TRANSIT_DISPLAY_POLICY,
+  transitDisplayViewSettings,
   VIEW_POLICY,
 } from '@/components/transit-display/transit-display-view-policy';
 import { SplitFlapTransitDisplays } from '@/components/transit-display/split-flap-transit-display';
@@ -64,20 +64,27 @@ export function TransitDisplaysContainer({
   onInspectTrip,
 }: TransitDisplaysContainerProps) {
   const { t } = useTranslation();
+  const { setHighlightedCircles, clearHighlightedCircles, setShowDistanceRings } =
+    useMapOverlayControls();
   const stopIdsKey = useMemo(() => stopTimes.map((swc) => swc.stop.stop_id).join(','), [stopTimes]);
   const scrollOverflow = useScrollOverflow(contentRef, stopIdsKey);
 
-  // distance filter: stops within radiusMeters of the center. Memoized so its
-  // reference is stable while stopTimes are unchanged -- otherwise the
+  // Per-view nearby radius (the value this view's boards are filtered within
+  // and the map's highlight circle is drawn at). Container-owned views always
+  // have settings; the fallback is defensive only.
+  const radiusMeters = transitDisplayViewSettings(viewId)?.nearbyRadiusMeters ?? NEARBY_RADIUS_M;
+
+  // Distance filter: stops within `radiusMeters` of the center. Memoized so its
+  // reference is stable while stopTimes / radius are unchanged -- otherwise the
   // transitDisplayData useMemo below (which depends on it) would rebuild every render.
   const nearbyStops = useMemo(
-    () => filterStopsWithinDistance(stopTimes, NEARBY_RADIUS_M),
-    [stopTimes],
+    () => filterStopsWithinDistance(stopTimes, radiusMeters),
+    [stopTimes, radiusMeters],
   );
 
   const transitDisplayStatus = useMemo(
-    () => ({ radius: NEARBY_RADIUS_M, state: resolveTransitDisplayState(nearbyStops) }),
-    [nearbyStops],
+    () => ({ radius: radiusMeters, state: resolveTransitDisplayState(nearbyStops) }),
+    [nearbyStops, radiusMeters],
   );
 
   // Log only when the status value (radius / state) changes, not every render.
@@ -87,38 +94,42 @@ export function TransitDisplaysContainer({
     );
   }, [transitDisplayStatus.radius, transitDisplayStatus.state]);
 
-  // Per-policy memos: data depends only on (nearbyStops, infoLevel, ready
-  // state), so switching the view does not invalidate either one. Both are
-  // computed eagerly because the per-stop dataset is small (NEARBY_RADIUS_M)
-  // and the cost is dominated by the active view's render anyway.
-  const memoizedTransitDisplayBoards = useMemo(
-    () =>
-      transitDisplayStatus.state === 'ready'
-        ? buildBoardsForPolicy(nearbyStops, NEARBY_RADIUS_M, TRANSIT_DISPLAY_POLICY, infoLevel)
-        : [],
-    [nearbyStops, infoLevel, transitDisplayStatus.state],
-  );
-  const memoizedRouteViewBoards = useMemo(
-    () =>
-      transitDisplayStatus.state === 'ready'
-        ? buildBoardsForPolicy(nearbyStops, NEARBY_RADIUS_M, ROUTE_VIEW_POLICY, infoLevel)
-        : [],
-    [nearbyStops, infoLevel, transitDisplayStatus.state],
-  );
+  // Draw the active view's nearby radius as a highlight circle on the hoisted
+  // map via the shared store. Anchored to the fetched-stops center
+  // (`mapCenter`); radius + color come from the same per-view settings the
+  // boards are filtered by, so circle and boards agree. The cleanup clears it,
+  // so leaving this view (or unmounting to a non-board view) removes the circle.
+  useEffect(() => {
+    const settings = transitDisplayViewSettings(viewId);
+    if (mapCenter != null && settings != null) {
+      setHighlightedCircles([
+        {
+          center: mapCenter,
+          radius: settings.nearbyRadiusMeters,
+          color: settings.highlightCircleColor,
+        },
+      ]);
+      // setShowDistanceRings(false);
+    }
+    return () => {
+      clearHighlightedCircles();
+      setShowDistanceRings(true);
+    };
+  }, [mapCenter, viewId, setHighlightedCircles, clearHighlightedCircles, setShowDistanceRings]);
 
-  // Select the memo for the active view via VIEW_POLICY lookup (identity
-  // compare on the policy reference -- adding a new view = new memo + new
-  // VIEW_POLICY entry + a new branch here, all explicit).
+  // Build only the active view's boards. Each view carries its own radius (= its
+  // own `nearbyStops`), so a view switch recomputes here -- cheap for the small
+  // in-radius dataset and avoids building the inactive policy every render.
   const transitDisplayData = useMemo(() => {
+    if (transitDisplayStatus.state !== 'ready') {
+      return [];
+    }
     const policy = VIEW_POLICY[viewId];
-    if (policy === ROUTE_VIEW_POLICY) {
-      return memoizedRouteViewBoards;
+    if (!policy) {
+      return [];
     }
-    if (policy === TRANSIT_DISPLAY_POLICY) {
-      return memoizedTransitDisplayBoards;
-    }
-    return [];
-  }, [viewId, memoizedTransitDisplayBoards, memoizedRouteViewBoards]);
+    return buildBoardsForPolicy(nearbyStops, radiusMeters, policy, infoLevel);
+  }, [viewId, nearbyStops, radiusMeters, infoLevel, transitDisplayStatus.state]);
 
   return (
     <div

--- a/src/hooks/__tests__/use-map-overlay.test.ts
+++ b/src/hooks/__tests__/use-map-overlay.test.ts
@@ -1,0 +1,110 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { HighlightedCircle } from '@/types/app/map';
+
+import {
+  useHighlightedCircles,
+  useMapOverlayControls,
+  useShowDistanceRings,
+} from '../use-map-overlay';
+
+/**
+ * Render the read hooks + the controls together so a single result exposes the
+ * current overlay state and the mutators.
+ */
+function renderStore() {
+  return renderHook(() => ({
+    circles: useHighlightedCircles(),
+    showDistanceRings: useShowDistanceRings(),
+    controls: useMapOverlayControls(),
+  }));
+}
+
+const CIRCLE: HighlightedCircle = { center: { lat: 35, lng: 139 }, radius: 100, color: '#009688' };
+
+// The store is module-global state, so reset it to defaults after each test
+// to keep cases independent.
+afterEach(() => {
+  const { result, unmount } = renderHook(() => useMapOverlayControls());
+  act(() => {
+    result.current.clearHighlightedCircles();
+    result.current.setShowDistanceRings(true);
+  });
+  unmount();
+});
+
+describe('useMapOverlay store', () => {
+  it('defaults to no circles and distance rings shown', () => {
+    const { result } = renderStore();
+    expect(result.current.circles).toEqual([]);
+    expect(result.current.showDistanceRings).toBe(true);
+  });
+
+  it('re-renders subscribers when highlighted circles are set', () => {
+    const { result } = renderStore();
+    act(() => {
+      result.current.controls.setHighlightedCircles([CIRCLE]);
+    });
+    expect(result.current.circles).toEqual([CIRCLE]);
+  });
+
+  it('clears highlighted circles back to empty', () => {
+    const { result } = renderStore();
+    act(() => {
+      result.current.controls.setHighlightedCircles([CIRCLE]);
+    });
+    act(() => {
+      result.current.controls.clearHighlightedCircles();
+    });
+    expect(result.current.circles).toEqual([]);
+  });
+
+  it('toggles distance rings visibility', () => {
+    const { result } = renderStore();
+    act(() => {
+      result.current.controls.setShowDistanceRings(false);
+    });
+    expect(result.current.showDistanceRings).toBe(false);
+  });
+
+  it('keeps the two slots independent', () => {
+    const { result } = renderStore();
+    act(() => {
+      result.current.controls.setHighlightedCircles([CIRCLE]);
+    });
+    // Setting circles must not flip the rings flag.
+    expect(result.current.showDistanceRings).toBe(true);
+
+    act(() => {
+      result.current.controls.setShowDistanceRings(false);
+    });
+    // Toggling rings must not drop the circles.
+    expect(result.current.circles).toEqual([CIRCLE]);
+  });
+
+  it('returns a stable controls reference across renders', () => {
+    const { result, rerender } = renderHook(() => useMapOverlayControls());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it('stops notifying a subscriber after it unmounts', () => {
+    const { result: stateResult, unmount } = renderHook(() => useHighlightedCircles());
+    const { result: controlsResult } = renderHook(() => useMapOverlayControls());
+
+    act(() => {
+      controlsResult.current.setHighlightedCircles([CIRCLE]);
+    });
+    expect(stateResult.current).toEqual([CIRCLE]);
+
+    unmount();
+    // Updating after unmount must not throw (listener was removed on cleanup).
+    expect(() => {
+      act(() => {
+        controlsResult.current.clearHighlightedCircles();
+      });
+    }).not.toThrow();
+  });
+});

--- a/src/hooks/use-map-overlay.ts
+++ b/src/hooks/use-map-overlay.ts
@@ -21,8 +21,14 @@ import type { HighlightedCircle } from '@/types/app/map';
  * single global slot per value suffices and avoids provider wiring. Each slot
  * is single-writer in effect -- the most recent writer wins.
  */
-let highlightedCircles: readonly HighlightedCircle[] = [];
-let showDistanceRings = true;
+// Defaults, also returned as the SSR / hydration snapshot by the `use*` hooks.
+// `getServerSnapshot` must return a cached value, so these are stable
+// references rather than fresh literals.
+const DEFAULT_HIGHLIGHTED_CIRCLES: readonly HighlightedCircle[] = [];
+const DEFAULT_SHOW_DISTANCE_RINGS = true;
+
+let highlightedCircles: readonly HighlightedCircle[] = DEFAULT_HIGHLIGHTED_CIRCLES;
+let showDistanceRings = DEFAULT_SHOW_DISTANCE_RINGS;
 const listeners = new Set<() => void>();
 
 function emit(): void {
@@ -71,7 +77,11 @@ export function useMapOverlayControls(): typeof controls {
  * consumer (App passes the result to {@link MapView}).
  */
 export function useHighlightedCircles(): readonly HighlightedCircle[] {
-  return useSyncExternalStore(subscribe, () => highlightedCircles);
+  return useSyncExternalStore(
+    subscribe,
+    () => highlightedCircles,
+    () => DEFAULT_HIGHLIGHTED_CIRCLES,
+  );
 }
 
 /**
@@ -79,5 +89,9 @@ export function useHighlightedCircles(): readonly HighlightedCircle[] {
  * consumer (App passes the result to {@link MapView}).
  */
 export function useShowDistanceRings(): boolean {
-  return useSyncExternalStore(subscribe, () => showDistanceRings);
+  return useSyncExternalStore(
+    subscribe,
+    () => showDistanceRings,
+    () => DEFAULT_SHOW_DISTANCE_RINGS,
+  );
 }

--- a/src/hooks/use-map-overlay.ts
+++ b/src/hooks/use-map-overlay.ts
@@ -1,0 +1,83 @@
+import { useSyncExternalStore } from 'react';
+
+import type { HighlightedCircle } from '@/types/app/map';
+
+/**
+ * Tiny global store for map overlay state that any caller can control.
+ *
+ * The map's {@link MapView} is hoisted to the App root (always-mounted so
+ * Leaflet survives layout-mode swaps), so a component that wants to change
+ * what the map draws usually lives in a different subtree and cannot reach it
+ * through props. This module is a single shared channel: ANY code can set
+ * these values from anywhere, and the map (App subscribes via the `use*`
+ * hooks and passes the values to {@link MapView}) re-renders.
+ *
+ * Each value is an INDEPENDENT slot with its own setter -- a caller changes
+ * only what it needs. Nothing is coupled here: drawing highlighted circles
+ * does not force the distance rings on or off; whether to do both together
+ * is entirely the caller's decision.
+ *
+ * Plain module state (not a React context): there is exactly one map, so a
+ * single global slot per value suffices and avoids provider wiring. Each slot
+ * is single-writer in effect -- the most recent writer wins.
+ */
+let highlightedCircles: readonly HighlightedCircle[] = [];
+let showDistanceRings = true;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// Raw mutators -- module-private. Exposed only through useMapOverlayControls
+// so this hooks/ module exports hooks only.
+function setHighlightedCircles(next: readonly HighlightedCircle[]): void {
+  highlightedCircles = next;
+  emit();
+}
+function clearHighlightedCircles(): void {
+  setHighlightedCircles([]);
+}
+function setShowDistanceRings(show: boolean): void {
+  showDistanceRings = show;
+  emit();
+}
+
+// Stable bundle: the mutators never change, so one object is reused for every
+// caller (safe to list in effect dependency arrays).
+const controls = { setHighlightedCircles, clearHighlightedCircles, setShowDistanceRings };
+
+/**
+ * Map overlay mutators for producers (any component drawing on the hoisted
+ * map). Each is independent -- a caller changes only what it needs; drawing
+ * circles does not force the distance rings on or off.
+ */
+export function useMapOverlayControls(): typeof controls {
+  return controls;
+}
+
+/**
+ * Subscribe to the highlighted circles. Returns the current list and
+ * re-renders the caller whenever it changes. Intended for the single map
+ * consumer (App passes the result to {@link MapView}).
+ */
+export function useHighlightedCircles(): readonly HighlightedCircle[] {
+  return useSyncExternalStore(subscribe, () => highlightedCircles);
+}
+
+/**
+ * Subscribe to the distance-rings visibility. Intended for the single map
+ * consumer (App passes the result to {@link MapView}).
+ */
+export function useShowDistanceRings(): boolean {
+  return useSyncExternalStore(subscribe, () => showDistanceRings);
+}

--- a/src/hooks/use-map-overlay.ts
+++ b/src/hooks/use-map-overlay.ts
@@ -18,8 +18,16 @@ import type { HighlightedCircle } from '@/types/app/map';
  * is entirely the caller's decision.
  *
  * Plain module state (not a React context): there is exactly one map, so a
- * single global slot per value suffices and avoids provider wiring. Each slot
- * is single-writer in effect -- the most recent writer wins.
+ * single global slot per value suffices and avoids provider wiring.
+ *
+ * SINGLE active producer assumed. Each slot is single-slot and cleanup clears
+ * it UNCONDITIONALLY (a producer's effect cleanup resets to the default), so
+ * two producers writing at the same time would clobber each other -- e.g. A
+ * sets, B sets, then A unmounts and its cleanup wipes B's overlay. Today there
+ * is exactly one producer (`TransitDisplaysContainer`, rendered once in the
+ * single mounted stop-browser surface), so this never happens. If multiple
+ * concurrent producers are ever needed, switch to owned writes (a lease/token
+ * so clear only clears the current owner) or a keyed registry.
  */
 // Defaults, also returned as the SSR / hydration snapshot by the `use*` hooks.
 // `getServerSnapshot` must return a cached value, so these are stable

--- a/src/types/app/map.ts
+++ b/src/types/app/map.ts
@@ -23,6 +23,24 @@ export interface LatLng {
 }
 
 /**
+ * Specification for one extra Circle rendered on top of the always-on
+ * `DistanceRings`. The caller decides everything: where the circle is
+ * anchored, how large it is, and what color it gets. Color is required
+ * (and intentionally an opaque CSS color string) so the MapView never
+ * has to know about `DISTANCE_BANDS` -- caller-side helpers in
+ * `utils/distance-style.ts` etc. can be used to look one up if the
+ * caller wants band-consistent colors.
+ */
+export interface HighlightedCircle {
+  /** Anchor point. Does NOT follow the user dragging the map. */
+  center: LatLng;
+  /** Radius in meters. Free-form; not restricted to `DISTANCE_BANDS.max`. */
+  radius: number;
+  /** CSS color string used for both stroke and fill. */
+  color: string;
+}
+
+/**
  * A marker displayed at the screen edge pointing toward an off-screen stop.
  *
  * Position (x, y) is in screen pixels, clamped to the viewport boundary.


### PR DESCRIPTION
## Summary

Draw the active stop-time view's nearby radius as a **highlight circle** on the hoisted map, driven by a small shared **map overlay store** that any component can use to control the map's overlay from anywhere -- without prop-drilling or context.

### Map overlay store (`src/hooks/use-map-overlay.ts`)

`MapView` is hoisted to the App root (always-mounted so Leaflet survives layout-mode swaps), so a component that wants to draw on it lives in a different subtree and can't reach it via props. A tiny `useSyncExternalStore`-based module bridges this:

- `useHighlightedCircles()` / `useShowDistanceRings()` -- read hooks; App subscribes and passes the values to `MapView` (which stays a generic, prop-driven renderer).
- `useMapOverlayControls()` -- write hook returning **independent** setters (`setHighlightedCircles` / `clearHighlightedCircles` / `setShowDistanceRings`). Callers couple them or not as they wish (drawing a circle does not force the distance rings on/off -- that's the caller's decision).

`HighlightedCircle` moved to `types/app/map.ts` (shared by `MapView` and the store; no store→component dependency).

### Per-view circle + filtering

- `TRANSIT_DISPLAY_VIEW_SETTINGS` (in `transit-display-view-policy.ts`) is the single source of truth for each view's **nearby radius + highlight circle color**.
- `TransitDisplaysContainer` filters its boards at the per-view radius AND publishes the matching circle (center = fetched-stops center, same radius + color), so the boards and the on-map circle always agree. Board build is now active-view-only (was eager dual-policy).

### Theme-aware fill

`AdditionalCircles` uses a stronger fill on dark map tiles (`fillOpacity` 0.4 dark / 0.2 light) so the same circle color stays readable in both themes.

## Not final (provisional in this PR)

- **Per-view colors / radii in `TRANSIT_DISPLAY_VIEW_SETTINGS` are still being tuned** (current values are experimental; e.g. one view uses white, another blue). To be finalized.
- A couple of **commented-out alternative color lines** remain in the settings table (to be cleaned).
- The `setShowDistanceRings(false)` coupling in the container (hide rings while a circle is shown) is still under evaluation -- may stay or be removed.

## Test plan

- [x] `npm run typecheck` / `lint` / `format:check` pass.
- [x] `npm run test` / `npm run build`.
- [x] Switch stop-time views (`transit-display` / `transit-display-2` / `route`): the highlight circle redraws at that view's radius/color, anchored to the fetched-stops center; leaving to a non-board view (stop list) removes it.
- [x] Toggle dark theme: the circle fill stays readable (stronger fill on dark).
- [x] Confirm the displayed boards and the circle cover the same radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)