### PR TITLE
fix(transit-display): keep radius selector reachable in empty state

### DIFF
--- a/src/components/transit-display/radius-toggle-button.tsx
+++ b/src/components/transit-display/radius-toggle-button.tsx
@@ -7,13 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Radio } from 'lucide-react';
 import { distanceStyle } from '@/utils/distance-style';
 
-/**
- * Per-`size` style bundle for `RadiusToggleButton`. Looked up via
- * {@link RADIUS_TOGGLE_BUTTON_STYLE_BY_SIZE} so the text / icon scale with
- * `size`. Height is NOT set here: the button stretches (`h-auto` + the row's
- * `items-stretch`) to match the height-scaling category filter beside it,
- * which differs between the dashboard and split-flap views.
- */
+/** Per-`size` style bundle for `RadiusToggleButton`. */
 interface RadiusToggleButtonSizeStyle {
   /** Button label text size. */
   textClass: string;
@@ -22,15 +16,17 @@ interface RadiusToggleButtonSizeStyle {
    * ui/button base `[&_svg:not([class*='size-'])]:size-4`.
    */
   iconClass: string;
+  /** Vertical padding; sets the button height. */
+  paddingClass: string;
 }
 
 const RADIUS_TOGGLE_BUTTON_STYLE_BY_SIZE: Record<ExtendedDisplaySize, RadiusToggleButtonSizeStyle> =
   {
-    xs: { textClass: 'text-[10px]', iconClass: 'size-2.5' },
-    sm: { textClass: 'text-xs', iconClass: 'size-3' },
-    md: { textClass: 'text-base', iconClass: 'size-4' },
-    lg: { textClass: 'text-2xl', iconClass: 'size-9' },
-    xl: { textClass: 'text-4xl', iconClass: 'size-15' },
+    xs: { textClass: 'text-[10px]', iconClass: 'size-2.5', paddingClass: 'py-px' },
+    sm: { textClass: 'text-xs', iconClass: 'size-3', paddingClass: 'py-0.5' },
+    md: { textClass: 'text-base', iconClass: 'size-4', paddingClass: 'py-1' },
+    lg: { textClass: 'text-2xl', iconClass: 'size-9', paddingClass: 'py-1.5' },
+    xl: { textClass: 'text-4xl', iconClass: 'size-15', paddingClass: 'py-2' },
   };
 
 interface RadiusToggleButtonProps {
@@ -82,6 +78,7 @@ export function RadiusToggleButton({
         'h-auto w-fit shrink-0 cursor-pointer px-2 has-[>svg]:px-2',
         // 'border-0',
         style.textClass,
+        style.paddingClass,
         className,
       )}
       style={{

--- a/src/components/transit-display/split-flap-transit-display.tsx
+++ b/src/components/transit-display/split-flap-transit-display.tsx
@@ -80,6 +80,15 @@ const ROW_TEXT_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
   xl: 'text-2xl',
 };
 
+/** Empty-state message text size per display size (no-stops / no-service). */
+const MESSAGE_TEXT_CLASS_BY_SIZE: Record<ExtendedDisplaySize, string> = {
+  xs: 'text-[10px]',
+  sm: 'text-xs',
+  md: 'text-base',
+  lg: 'text-2xl',
+  xl: 'text-4xl',
+};
+
 const TIMETABLE_ENTRY_ATTRIBUTES_LABELS_SIZE_BY_SIZE: Record<
   ExtendedDisplaySize,
   ExtendedDisplaySize
@@ -193,19 +202,6 @@ export function SplitFlapTransitDisplays({
     [dataWithMeta, dataLangs],
   );
 
-  // No boards to show because the dataset itself is empty: either no stops within
-  // the radius (`no-stops`) or stops exist but none have service today
-  // (`no-service`). Show the reason instead of a blank view.
-  if (status.state === 'no-stops' || status.state === 'no-service') {
-    return (
-      <div className="text-muted-foreground px-4 py-6 text-center text-sm">
-        {t(status.state === 'no-service' ? 'transitDisplay2.noService' : 'transitDisplay2.empty', {
-          radius: status.radius,
-        })}
-      </div>
-    );
-  }
-
   // Only offer toggles for categories that actually have a board, so the bar
   // mirrors what is on screen rather than always showing both.
   const presentCategories = FILTERABLE_CATEGORIES.filter((category) =>
@@ -241,23 +237,38 @@ export function SplitFlapTransitDisplays({
           </div>
         )}
       </div>
-      {visibleData.map((dataWithMeta, index) => (
-        // Key from the board's identity (category + its route types), with the
-        // map index as a disambiguator: a `custom` route grouping can collapse
-        // two groups to the same present route types, so identity alone is not
-        // guaranteed unique.
-        <SplitFlapTransitDisplay
-          key={`${dataWithMeta.meta.category}__${dataWithMeta.meta.routeTypes.join('-')}__${index}`}
-          dataWithMeta={dataWithMeta}
-          emptyMessage={emptyMessage}
-          now={now}
-          mapCenter={mapCenter}
-          infoLevel={infoLevel}
-          size={size}
-          onStopSelected={onStopSelected}
-          onInspectTrip={onInspectTrip}
-        />
-      ))}
+      {status.state === 'no-stops' && (
+        <div
+          className={cn('text-muted-foreground py-6 text-center', MESSAGE_TEXT_CLASS_BY_SIZE[size])}
+        >
+          {t('transitDisplay.noStop', { radius: status.radius })}
+        </div>
+      )}
+      {status.state === 'no-service' && (
+        <div
+          className={cn('text-muted-foreground py-6 text-center', MESSAGE_TEXT_CLASS_BY_SIZE[size])}
+        >
+          {t('transitDisplay.noService')}
+        </div>
+      )}
+      {status.state === 'ready' &&
+        visibleData.map((dataWithMeta, index) => (
+          // Key from the board's identity (category + its route types), with the
+          // map index as a disambiguator: a `custom` route grouping can collapse
+          // two groups to the same present route types, so identity alone is not
+          // guaranteed unique.
+          <SplitFlapTransitDisplay
+            key={`${dataWithMeta.meta.category}__${dataWithMeta.meta.routeTypes.join('-')}__${index}`}
+            dataWithMeta={dataWithMeta}
+            emptyMessage={emptyMessage}
+            now={now}
+            mapCenter={mapCenter}
+            infoLevel={infoLevel}
+            size={size}
+            onStopSelected={onStopSelected}
+            onInspectTrip={onInspectTrip}
+          />
+        ))}
     </div>
   );
 }

--- a/src/components/transit-display/transit-display-dashboard.tsx
+++ b/src/components/transit-display/transit-display-dashboard.tsx
@@ -37,6 +37,9 @@ interface TransitDisplayDashboardSizeStyle {
       padding: string;
     };
   };
+  message: {
+    textClass: string;
+  };
 }
 
 const TRANSIT_DISPLAY_DASHBOARD_STYLE_BY_SIZE: Record<
@@ -45,18 +48,23 @@ const TRANSIT_DISPLAY_DASHBOARD_STYLE_BY_SIZE: Record<
 > = {
   xs: {
     controls: { padding: 'pb-2', categoryFilter: { padding: 'px-1 py-0' } },
+    message: { textClass: 'text-[10px]' },
   },
   sm: {
     controls: { padding: 'pb-2', categoryFilter: { padding: 'px-1.5 py-0' } },
+    message: { textClass: 'text-xs' },
   },
   md: {
     controls: { padding: 'pb-2', categoryFilter: { padding: 'px-2 py-0' } },
+    message: { textClass: 'text-base' },
   },
   lg: {
     controls: { padding: 'pb-2', categoryFilter: { padding: 'px-0 py-0' } },
+    message: { textClass: 'text-2xl' },
   },
   xl: {
     controls: { padding: 'pb-2', categoryFilter: { padding: 'px-8 py-0' } },
+    message: { textClass: 'text-4xl' },
   },
 };
 
@@ -211,19 +219,8 @@ export function TransitDisplayDashboard({
     });
   }, [categoryFilteredData, activeRouteFilters]);
 
-  // No boards to show because the dataset itself is empty: either no stops within
-  // the radius (`no-stops`) or stops exist but none have service today
-  // (`no-service`). Show the reason instead of a blank view.
-  if (status.state === 'no-stops' || status.state === 'no-service') {
-    return (
-      <div className="text-muted-foreground px-4 py-6 text-center text-sm">
-        {t(status.state === 'no-service' ? 'transitDisplay2.noService' : 'transitDisplay2.empty', {
-          radius: status.radius,
-        })}
-      </div>
-    );
-  }
-
+  // Only offer toggles for categories that actually have a board, so the bar
+  // mirrors what is on screen rather than always showing both.
   const presentCategories = FILTERABLE_CATEGORIES.filter((category) =>
     dataWithMeta.some((display) => display.meta.category === category),
   );
@@ -329,15 +326,49 @@ export function TransitDisplayDashboard({
           // 'bg-pink-100',
         )}
       >
-        {groupedDisplays.map((item) => {
-          if (item.kind === 'single') {
-            // Single-route group: keyed by route_id alone. `singleBoardsByRouteId`
-            // already deduped by route_id when groupedDisplays was built, so this
-            // is unique within the rendered list and stable across filter changes.
+        {status.state === 'no-stops' && (
+          <div className={cn('text-muted-foreground py-6 text-center', style.message.textClass)}>
+            {t('transitDisplay2.noStop', { radius: status.radius })}
+          </div>
+        )}
+        {status.state === 'no-service' && (
+          <div className={cn('text-muted-foreground py-6 text-center', style.message.textClass)}>
+            {t('transitDisplay2.noService')}
+          </div>
+        )}
+        {status.state === 'ready' &&
+          groupedDisplays.map((item) => {
+            if (item.kind === 'single') {
+              // Single-route group: keyed by route_id alone. `singleBoardsByRouteId`
+              // already deduped by route_id when groupedDisplays was built, so this
+              // is unique within the rendered list and stable across filter changes.
+              return (
+                <TransitDisplayPerRoute
+                  key={`single__${item.group.route.route_id}`}
+                  group={item.group}
+                  dataLangs={dataLangs}
+                  now={now}
+                  mapCenter={mapCenter}
+                  infoLevel={infoLevel}
+                  size={size}
+                  onStopSelected={onStopSelected}
+                  onInspectTrip={onInspectTrip}
+                />
+              );
+            }
+            // Multi-route board: keyed by (category, sorted route_id set). Distinct
+            // groupings always carry a distinct route_id set, so this stays unique
+            // even if a `custom` policy collapses two groupings to the same
+            // route_type set. Stable across filter-driven reorderings.
+            const board = item.board;
+            const routeIdsKey = board.meta.routes
+              .map((r) => r.route_id)
+              .sort()
+              .join('-');
             return (
-              <TransitDisplayPerRoute
-                key={`single__${item.group.route.route_id}`}
-                group={item.group}
+              <TransitDisplayMultiRoutes
+                key={`multi__${board.meta.category}__${routeIdsKey}`}
+                transitDisplayDataWithMetaData={board}
                 dataLangs={dataLangs}
                 now={now}
                 mapCenter={mapCenter}
@@ -347,30 +378,7 @@ export function TransitDisplayDashboard({
                 onInspectTrip={onInspectTrip}
               />
             );
-          }
-          // Multi-route board: keyed by (category, sorted route_id set). Distinct
-          // groupings always carry a distinct route_id set, so this stays unique
-          // even if a `custom` policy collapses two groupings to the same
-          // route_type set. Stable across filter-driven reorderings.
-          const board = item.board;
-          const routeIdsKey = board.meta.routes
-            .map((r) => r.route_id)
-            .sort()
-            .join('-');
-          return (
-            <TransitDisplayMultiRoutes
-              key={`multi__${board.meta.category}__${routeIdsKey}`}
-              transitDisplayDataWithMetaData={board}
-              dataLangs={dataLangs}
-              now={now}
-              mapCenter={mapCenter}
-              infoLevel={infoLevel}
-              size={size}
-              onStopSelected={onStopSelected}
-              onInspectTrip={onInspectTrip}
-            />
-          );
-        })}
+          })}
       </div>
     </div>
   );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -167,6 +167,8 @@
     "recentCount": "Latest {{count}} ({{radius}}m)",
     "entryCount": "{{count}} ({{radius}}m)",
     "stopCount": "{{count}} stops",
+    "noStop": "No stops within {{radius}}m",
+    "noService": "No service at stops",
     "departures": "DEPARTURES",
     "arrivals": "ARRIVALS",
     "filter": {
@@ -179,8 +181,8 @@
     "recentCount": "Latest {{count}} ({{radius}}m)",
     "entryCount": "{{count}} ({{radius}}m)",
     "stopCount": "{{count}} stops",
-    "empty": "Transit display covers stops within {{radius}}m",
-    "noService": "No service today at stops",
+    "noStop": "No stops within {{radius}}m",
+    "noService": "No service at stops",
     "departures": "DEPARTURES",
     "arrivals": "ARRIVALS",
     "filter": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -167,6 +167,8 @@
     "recentCount": "直近 {{count}} 件 ({{radius}}m)",
     "entryCount": "{{count}} 件 ({{radius}}m)",
     "stopCount": "{{count}} のりば",
+    "noStop": "{{radius}}m 以内にのりばがありません",
+    "noService": "運行便はありません",
     "departures": "出発 Departures",
     "arrivals": "到着 Arrivals",
     "filter": {
@@ -179,8 +181,8 @@
     "recentCount": "直近 {{count}} 件 ({{radius}}m)",
     "entryCount": "{{count}} 件 ({{radius}}m)",
     "stopCount": "{{count}} のりば",
-    "empty": "{{radius}}m 以内にのりばがありません",
-    "noService": "本日の運行便はありません",
+    "noStop": "{{radius}}m 以内にのりばがありません",
+    "noService": "運行便はありません",
     "departures": "出発",
     "arrivals": "到着",
     "filter": {


### PR DESCRIPTION
## 概要

TransitDisplay (split-flap / dashboard 両 view) で、 対象半径 (coverage radius) を絞った結果のりばが 0 件になると、 空状態メッセージの early-return によって **controls 行ごと非表示**になっていた。 その結果 `RadiusToggleButton` も消え、 半径を広げ直す手段が無くなる行き止まりが発生していた。

この PR では early-return を廃し、 controls 行を常に描画したうえで、 panel を state 別の flat なガード (`no-stops` / `no-service` / `ready`) に分離する。 これにより 0 件でも `RadiusToggleButton` が残り、 半径を再選択できる。

あわせて空状態メッセージのテキストを size 対応にした。

## 変更点

- **split-flap / dashboard**: `no-stops` / `no-service` の early-return を削除し、 controls 行を常時描画。 panel は `status.state` ごとの独立した `&&` ガードに分離 (chained ternary は使わない)。
- **dashboard**: 空状態メッセージを `style.message.textClass` (size 駆動) に。
- **split-flap**: 同等の `MESSAGE_TEXT_CLASS_BY_SIZE` を新設して適用 (`text-[10px]` / `text-xs` / `text-base` / `text-2xl` / `text-4xl`、 dashboard と同スケール)。
- **RadiusToggleButton**: 空状態で他コントロールが消えても高さが潰れないよう、 padding (`py-*`) で per-size の確定高さを与えた。 category filter の高さと一致するよう padding 幅を border 幅に合わせている。
- **i18n**: `noStop` / `noService` メッセージを ja / en で更新。

## 検証

- `npm run typecheck` / `npm run lint` / `npm run test` (4557 passed) / `npm run build` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)