### PR TITLE
chore(pipeline): update GTFS resources for 3 bus sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Data: nishi-tokyo-bus の GTFS resource を 20260622 版へ更新。
+- Data: kyoto-bus の GTFS resource を 20260617 版へ更新。
+- Data: kanto-bus の GTFS resource を 20260507 版へ更新。
+
 ## [2026.06.19]
 
 ### Added

--- a/pipeline/config/resources/gtfs/kanto-bus.ts
+++ b/pipeline/config/resources/gtfs/kanto-bus.ts
@@ -16,8 +16,8 @@ const kantoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/kanto_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/kanto_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/kanto_bus_all_lines/resource/06a61379-b448-4e49-9e3c-77a858551f16',
-      resourceId: '06a61379-b448-4e49-9e3c-77a858551f16',
+        'https://ckan.odpt.org/dataset/kanto_bus_all_lines/resource/982b26b9-c57d-4d2a-beca-4b88e6fb2c81',
+      resourceId: '982b26b9-c57d-4d2a-beca-4b88e6fb2c81',
     },
     provider: {
       name: {
@@ -43,7 +43,7 @@ const kantoBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KantoBus/AllLines.zip?date=20260401',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KantoBus/AllLines.zip?date=20260507',
   },
   pipeline: {
     outDir: 'kanto-bus',

--- a/pipeline/config/resources/gtfs/kyoto-bus.ts
+++ b/pipeline/config/resources/gtfs/kyoto-bus.ts
@@ -17,8 +17,8 @@ const kyotoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/kyoto_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/kyoto_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/586d66a4-1562-49bc-92d1-5b1e50cc13bd',
-      resourceId: '586d66a4-1562-49bc-92d1-5b1e50cc13bd',
+        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/b1c3c6f7-80fe-4508-84fd-5ddda8474031',
+      resourceId: 'b1c3c6f7-80fe-4508-84fd-5ddda8474031',
     },
     provider: {
       name: {
@@ -38,7 +38,7 @@ const kyotoBus: GtfsSourceDefinition = {
     routeTypes: ['bus'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260613',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260617',
   },
   pipeline: {
     outDir: 'kyoto-bus',

--- a/pipeline/config/resources/gtfs/nishi-tokyo-bus.ts
+++ b/pipeline/config/resources/gtfs/nishi-tokyo-bus.ts
@@ -17,8 +17,8 @@ const nishiTokyoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/nishi_tokyo_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus/resource/557cfca7-c73b-4dd4-9858-488808bff051',
-      resourceId: '557cfca7-c73b-4dd4-9858-488808bff051',
+        'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus/resource/c2a57a1b-73d5-424f-ac8e-ab05900fad35',
+      resourceId: 'c2a57a1b-73d5-424f-ac8e-ab05900fad35',
     },
     provider: {
       name: {
@@ -41,7 +41,7 @@ const nishiTokyoBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/NishiTokyoBus/NTBus.zip?date=20260324',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/NishiTokyoBus/NTBus.zip?date=20260622',
   },
   pipeline: {
     outDir: 'nishi-tokyo-bus',


### PR DESCRIPTION
## Summary

Refresh ODPT GTFS resource definitions to their latest published versions, triggered by the `Check Transit Resources` run ([27934708798](https://github.com/F88/athenai-transit/actions/runs/27934708798)). Each source has its three-field set updated (`downloadUrl` `date=` / `resourceUrl` / `resourceId`).

| source | date= | feed validity | note |
|---|---|---|---|
| `nishi-tokyo-bus` | 20260324 → **20260622** | 2026-06-22 – 2026-08-31 | previous adopted resource was removed from remote (ADOPTED_MISSING); 20260622 is the only currently-valid revision (20260626 is not yet effective) |
| `kyoto-bus` | 20260613 → **20260617** | 2026-06-17 – 2026-09-30 | |
| `kanto-bus` | 20260401 → **20260507** | 2026-05-07 – 2026-11-03 | |

## Notes

- Config-only change. The pipeline (download / build / sync) is handled by CI after merge.
- `tsc -b --noEmit` passes.
- CHANGELOG updated under `[Unreleased]` → `### Changed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)