### PR TITLE
chore(ci): bump actions/checkout from v6 to v7

### DIFF
--- a/.github/workflows/check-transit-resources.yml
+++ b/.github/workflows/check-transit-resources.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Required: actions/checkout checks out the commit that triggered
       # the run. On rerun, this is the OLD commit — the previous run's

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/update-transit-data.yml
+++ b/.github/workflows/update-transit-data.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # ── Setup ──────────────────────────────────────────────
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Required: actions/checkout checks out the commit that triggered
       # the run. On rerun, this is the OLD commit — the previous run's


### PR DESCRIPTION
## Summary

Update `actions/checkout` from `v6` to `v7` across all GitHub Actions workflows.

## Changes

- `.github/workflows/claude.yml`
- `.github/workflows/claude-code-review.yml`
- `.github/workflows/check-transit-resources.yml`
- `.github/workflows/update-transit-data.yml`

## Impact assessment

The only breaking change in v7.0.0 is that fork PR checkout is now blocked for the `pull_request_target` and `workflow_run` triggers (a security hardening). None of these workflows use those triggers (they use `schedule`, `workflow_dispatch`, `issue_comment`, `issues`, `pull_request_review*`), so the change is safe. The Node.js 24 runtime was already in place since v6.0.0, so there are no additional runner requirements.

## References

- https://github.com/actions/checkout/releases
- https://github.com/actions/checkout/blob/main/CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)