### PR TITLE
fix(pipeline): update ODPT GTFS sources for 2026-07 feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - アプリアイコンを新ロゴ (bus / train / ferry / map / clock / walk のモチーフ) に刷新した。generator 出力 (`pwa-64x64.png` / `pwa-192x192.png` / `pwa-512x512.png` / `maskable-icon-512x512.png` / `apple-touch-icon-180x180.png` / `favicon.ico`) を採用し、アプリは `public/icons/v1/` を参照する。
 - アイコンのソース画像と非アクティブなリビジョンを Service Worker の precache 対象から除外した (`vite.config.ts` の `globIgnores`)。
+- Data: kanto-bus の GTFS resource を 20260701 版へ更新。
+- Data: kawasaki-city-bus の GTFS resource を 20260701 版へ更新。
+- Data: oshima-bus の GTFS resource を 20260701 版へ更新。
+- Data: uwajima-unyu の GTFS resource を 20260701 版へ更新。
+- Data: tokai-kisen の GTFS resource を 20260701 版へ更新。
+- Data: kyoto-city-bus の GTFS resource を 20260630 版へ更新。
+- Data: meimon-taiyo-ferry の GTFS resource を 20260701 版へ更新。
+- Data: nishi-tokyo-bus の GTFS resource を 20260626 版へ更新。
+- Data: kyoto-bus の GTFS resource を 20260701 版へ更新。
 
 ## [2026.06.22]
 

--- a/pipeline/config/resources/gtfs/kanto-bus.ts
+++ b/pipeline/config/resources/gtfs/kanto-bus.ts
@@ -16,8 +16,8 @@ const kantoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/kanto_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/kanto_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/kanto_bus_all_lines/resource/982b26b9-c57d-4d2a-beca-4b88e6fb2c81',
-      resourceId: '982b26b9-c57d-4d2a-beca-4b88e6fb2c81',
+        'https://ckan.odpt.org/dataset/kanto_bus_all_lines/resource/f3a5465c-1994-482b-8393-2adeb785fac4',
+      resourceId: 'f3a5465c-1994-482b-8393-2adeb785fac4',
     },
     provider: {
       name: {
@@ -43,7 +43,7 @@ const kantoBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KantoBus/AllLines.zip?date=20260507',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KantoBus/AllLines.zip?date=20260701',
   },
   pipeline: {
     outDir: 'kanto-bus',

--- a/pipeline/config/resources/gtfs/kawasaki-city-bus.ts
+++ b/pipeline/config/resources/gtfs/kawasaki-city-bus.ts
@@ -17,8 +17,8 @@ const kawasakiCityBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/transportation_bureau_city_of_kawasaki',
       datasetUrl: 'https://ckan.odpt.org/dataset/transportation_bureau_city_of_kawasaki_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/transportation_bureau_city_of_kawasaki_all_lines/resource/a0aeeac5-93fe-4529-9fbb-2de7f28a1546',
-      resourceId: 'a0aeeac5-93fe-4529-9fbb-2de7f28a1546',
+        'https://ckan.odpt.org/dataset/transportation_bureau_city_of_kawasaki_all_lines/resource/139a9c5f-e7dd-46ad-8f92-fba6b7ed5ad5',
+      resourceId: '139a9c5f-e7dd-46ad-8f92-fba6b7ed5ad5',
     },
     provider: {
       name: {
@@ -45,7 +45,7 @@ const kawasakiCityBus: GtfsSourceDefinition = {
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
     downloadUrl:
-      'https://api.odpt.org/api/v4/files/odpt/TransportationBureau_CityOfKawasaki/AllLines.zip?date=20260528',
+      'https://api.odpt.org/api/v4/files/odpt/TransportationBureau_CityOfKawasaki/AllLines.zip?date=20260701',
   },
   pipeline: {
     outDir: 'kawasaki-city-bus',

--- a/pipeline/config/resources/gtfs/kyoto-bus.ts
+++ b/pipeline/config/resources/gtfs/kyoto-bus.ts
@@ -17,8 +17,8 @@ const kyotoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/kyoto_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/kyoto_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/b1c3c6f7-80fe-4508-84fd-5ddda8474031',
-      resourceId: 'b1c3c6f7-80fe-4508-84fd-5ddda8474031',
+        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/63d2d764-6f96-4857-ad9d-d64d260dd0de',
+      resourceId: '63d2d764-6f96-4857-ad9d-d64d260dd0de',
     },
     provider: {
       name: {
@@ -38,7 +38,7 @@ const kyotoBus: GtfsSourceDefinition = {
     routeTypes: ['bus'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260617',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260701',
   },
   pipeline: {
     outDir: 'kyoto-bus',

--- a/pipeline/config/resources/gtfs/kyoto-city-bus.ts
+++ b/pipeline/config/resources/gtfs/kyoto-city-bus.ts
@@ -17,8 +17,8 @@ const kyotoCityBus: GtfsSourceDefinition = {
       datasetUrl:
         'https://ckan.odpt.org/dataset/kyoto_municipal_transportation_kyoto_city_bus_gtfs',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/kyoto_municipal_transportation_kyoto_city_bus_gtfs/resource/21d8f3ec-6546-446e-a2b3-95df1ba36387',
-      resourceId: '21d8f3ec-6546-446e-a2b3-95df1ba36387',
+        'https://ckan.odpt.org/dataset/kyoto_municipal_transportation_kyoto_city_bus_gtfs/resource/12faf6c6-3341-4edd-90fe-3a0ebe956d05',
+      resourceId: '12faf6c6-3341-4edd-90fe-3a0ebe956d05',
     },
     provider: {
       name: {
@@ -37,7 +37,7 @@ const kyotoCityBus: GtfsSourceDefinition = {
     /** GtfsResource */
     routeTypes: ['bus'],
     downloadUrl:
-      'https://api.odpt.org/api/v4/files/odpt/KyotoMunicipalTransportation/Kyoto_City_Bus_GTFS.zip?date=20260525',
+      'https://api.odpt.org/api/v4/files/odpt/KyotoMunicipalTransportation/Kyoto_City_Bus_GTFS.zip?date=20260630',
   },
   pipeline: {
     outDir: 'kyoto-city-bus',

--- a/pipeline/config/resources/gtfs/meimon-taiyo-ferry.ts
+++ b/pipeline/config/resources/gtfs/meimon-taiyo-ferry.ts
@@ -17,8 +17,8 @@ const meimonTaiyoFerry: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/meimon_taiyo_ferry',
       datasetUrl: 'https://ckan.odpt.org/dataset/meimon_taiyo_ferry_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/meimon_taiyo_ferry_all_lines/resource/af0e0550-8e8e-48da-8fca-274b091cccb7',
-      resourceId: 'af0e0550-8e8e-48da-8fca-274b091cccb7',
+        'https://ckan.odpt.org/dataset/meimon_taiyo_ferry_all_lines/resource/73dece57-1c35-4588-9a27-bb91a53afeff',
+      resourceId: '73dece57-1c35-4588-9a27-bb91a53afeff',
     },
     provider: {
       name: {
@@ -40,7 +40,7 @@ const meimonTaiyoFerry: GtfsSourceDefinition = {
     // Update this value when a new version is published — feeds are rotated
     // every 3 months.
     downloadUrl:
-      'https://api.odpt.org/api/v4/files/odpt/MeimonTaiyoFerry/AllLines.zip?date=20260401',
+      'https://api.odpt.org/api/v4/files/odpt/MeimonTaiyoFerry/AllLines.zip?date=20260701',
   },
   pipeline: {
     outDir: 'meimon-taiyo-ferry',

--- a/pipeline/config/resources/gtfs/nishi-tokyo-bus.ts
+++ b/pipeline/config/resources/gtfs/nishi-tokyo-bus.ts
@@ -17,8 +17,8 @@ const nishiTokyoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/nishi_tokyo_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus/resource/c2a57a1b-73d5-424f-ac8e-ab05900fad35',
-      resourceId: 'c2a57a1b-73d5-424f-ac8e-ab05900fad35',
+        'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus/resource/cbe22e32-4163-444d-8dd9-b74e8af13fe4',
+      resourceId: 'cbe22e32-4163-444d-8dd9-b74e8af13fe4',
     },
     provider: {
       name: {
@@ -41,7 +41,7 @@ const nishiTokyoBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/NishiTokyoBus/NTBus.zip?date=20260622',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/NishiTokyoBus/NTBus.zip?date=20260626',
   },
   pipeline: {
     outDir: 'nishi-tokyo-bus',

--- a/pipeline/config/resources/gtfs/oshima-bus.ts
+++ b/pipeline/config/resources/gtfs/oshima-bus.ts
@@ -16,8 +16,8 @@ const oshimaBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/oshima_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/oshima_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/oshima_bus_all_lines/resource/ef2e0472-f50f-4a8e-b4b4-df9002dd219a',
-      resourceId: 'ef2e0472-f50f-4a8e-b4b4-df9002dd219a',
+        'https://ckan.odpt.org/dataset/oshima_bus_all_lines/resource/6794ea21-b93d-4625-9246-d72b067a694c',
+      resourceId: '6794ea21-b93d-4625-9246-d72b067a694c',
     },
     provider: {
       name: {
@@ -35,7 +35,7 @@ const oshimaBus: GtfsSourceDefinition = {
 
     /** GtfsResource */
     routeTypes: ['bus'],
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/OshimaBus/AllLines.zip?date=20260328',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/OshimaBus/AllLines.zip?date=20260701',
   },
   pipeline: {
     outDir: 'oshima-bus',

--- a/pipeline/config/resources/gtfs/tokai-kisen.ts
+++ b/pipeline/config/resources/gtfs/tokai-kisen.ts
@@ -17,8 +17,8 @@ const tokaiKisen: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/tokai_kisen',
       datasetUrl: 'https://ckan.odpt.org/dataset/tokai_kisen_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/tokai_kisen_all_lines/resource/30516ce5-9fcc-4bc3-ac9b-baa3e6f531ee',
-      resourceId: '30516ce5-9fcc-4bc3-ac9b-baa3e6f531ee',
+        'https://ckan.odpt.org/dataset/tokai_kisen_all_lines/resource/f579de09-8c4d-40c7-82a7-344c7f8ed5fe',
+      resourceId: 'f579de09-8c4d-40c7-82a7-344c7f8ed5fe',
     },
     provider: {
       name: {
@@ -41,7 +41,7 @@ const tokaiKisen: GtfsSourceDefinition = {
     routeTypes: ['ferry'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/TokaiKisen/AllLines.zip?date=20260401',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/TokaiKisen/AllLines.zip?date=20260701',
     // All 15 routes have empty route_color in the source GTFS — fallback applied.
     routeColorFallbacks: {
       '*': '294DA5',

--- a/pipeline/config/resources/gtfs/uwajima-unyu.ts
+++ b/pipeline/config/resources/gtfs/uwajima-unyu.ts
@@ -17,8 +17,8 @@ const uwajimaUnyu: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/uwajima_unyu',
       datasetUrl: 'https://ckan.odpt.org/dataset/uwajima_unyu_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/uwajima_unyu_all_lines/resource/55e14d2f-0f14-41a2-80c7-de1c343ec94a',
-      resourceId: '55e14d2f-0f14-41a2-80c7-de1c343ec94a',
+        'https://ckan.odpt.org/dataset/uwajima_unyu_all_lines/resource/d2ada078-e357-40f5-8c0c-eae269c3d59b',
+      resourceId: 'd2ada078-e357-40f5-8c0c-eae269c3d59b',
     },
     provider: {
       name: {
@@ -39,7 +39,7 @@ const uwajimaUnyu: GtfsSourceDefinition = {
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published — feeds are rotated
     // every 3 months.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/UwajimaUnyu/AllLines.zip?date=20260401',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/UwajimaUnyu/AllLines.zip?date=20260701',
   },
   pipeline: {
     outDir: 'uwajima-unyu',


### PR DESCRIPTION
## Summary

Update 9 ODPT GTFS source definitions to their newest currently-valid published versions. The adopted versions expired or were removed from the ODPT Members Portal API at the 2026-07-01 boundary, breaking the scheduled `Update Transit Data` pipeline (HTTP 404 downloads + v2 bundle validation failure).

## Root cause

The daily `Update Transit Data` run failed because two adopted resources returned HTTP 404 (removed upstream), and several more expired on 2026-07-01:

- `kanto-bus` (date=20260507) and `kawasaki-city-bus` (date=20260528) were removed from the API (`ADOPTED_MISSING`), so their downloads 404'd and v2 validation failed on the missing sources.
- Multiple ferry/bus feeds expired at the 2026-07-01 boundary with a newer valid revision available.

## Changes

Each source updates the coupled `resourceUrl` + `resourceId` + `downloadUrl` three-field set (each ODPT CKAN version is a separate resource). All values verified against CKAN.

| Source | New version | Feed window |
| --- | --- | --- |
| kanto-bus | date=20260701 | 2026-07-01 - 2026-12-28 |
| kawasaki-city-bus | date=20260701 | 2026-07-01 - 2027-07-01 |
| oshima-bus | date=20260701 | 2026-07-01 - 2026-09-30 |
| uwajima-unyu | date=20260701 | 2026-07-01 - 2026-09-30 |
| tokai-kisen | date=20260701 | 2026-07-01 - 2026-09-30 |
| kyoto-city-bus | date=20260630 | 2026-06-29 - 2027-03-31 |
| meimon-taiyo-ferry | date=20260701 | 2026-07-01 - 2026-07-31 |
| nishi-tokyo-bus | date=20260626 | 2026-06-26 - 2026-08-31 |
| kyoto-bus | date=20260701 | 2026-07-01 - 2026-09-30 |

`meimon-taiyo-ferry` only publishes a one-month feed window, so it will need another bump for the August feed.

## Left as-is (no upstream replacement)

These sources have an expired adopted feed and no currently-valid replacement in the API, so they are intentionally left unchanged (expired-data UX shows an empty timetable):

- `chuo-bus` (feed_end 2025-11-30) - upstream still only publishes the old version
- `suginami-gsm` (feed_end 2026-05-31) - upstream still only publishes the old version
- `iyotetsu-bus` (feed_end 2026-06-30) - currently absent from the Members Portal API, assumed transient

## Notes

Generated app data (`public/data-v2/**`) is not committed; the `Update Transit Data` GitHub Action regenerates and pushes it after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)