### PR TITLE
Serve built transit data from Vercel Blob (out of git)

### DIFF
--- a/.github/workflows/update-transit-data.yml
+++ b/.github/workflows/update-transit-data.yml
@@ -269,7 +269,7 @@ jobs:
       - name: Sync to public/
         run: npm run data:sync
 
-      # ── Report & Deploy ────────────────────────────────────
+      # ── Report & Commit ────────────────────────────────────
       - name: Detect changes
         id: changes
         run: |

--- a/.github/workflows/upload-transit-data-to-vercel-blob.yml
+++ b/.github/workflows/upload-transit-data-to-vercel-blob.yml
@@ -273,6 +273,10 @@ jobs:
           echo "::error::V2 bundle validation failed. See Job Summary for details."
           exit 1
 
+      #  disabled: replaced by Vercel Blob upload below
+      # - name: Sync to public/
+      #   run: npm run data:sync
+
       # ── Upload to Vercel Blob ──────────────────────────────
       # Replaces "Sync to public/" and committing public/<data dir> to git:
       # instead, upload the build output straight to a Vercel Blob store. The

--- a/.github/workflows/upload-transit-data-to-vercel-blob.yml
+++ b/.github/workflows/upload-transit-data-to-vercel-blob.yml
@@ -1,9 +1,18 @@
-name: Update Transit Data
+name: Upload Transit Data (Vercel Blob)
+
+# Same pipeline as update-transit-data.yml, except the built data-v2 is
+# uploaded to Vercel Blob instead of being committed to git. Only the small
+# download metadata under pipeline/workspace/state/ is still committed. The app
+# fetches the data via the same-origin /data-v3/* rewrite in vercel.json.
+#
+# Manual trigger for now (schedule commented out); enable at cutover.
+#
+# Required secrets: ODPT_ACCESS_TOKEN, VERCEL_V3_BLOB_READ_WRITE_TOKEN
 
 on:
-  schedule:
-    # JST 13:00 (UTC 04:00)
-    - cron: '0 4 * * *'
+  # schedule:
+  #   # JST 13:00 (UTC 04:00)
+  #   - cron: '0 4 * * *'
   workflow_dispatch:
     inputs:
       skip_download:
@@ -22,8 +31,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
-    env:
-      PIPELINE_TRANSIT_DATA_DIR: ${{ vars.PIPELINE_TRANSIT_DATA_DIR || 'data-v2' }}
 
     steps:
       # ── Setup ──────────────────────────────────────────────
@@ -266,22 +273,48 @@ jobs:
           echo "::error::V2 bundle validation failed. See Job Summary for details."
           exit 1
 
-      - name: Sync to public/
-        run: npm run data:sync
+      # ── Upload to Vercel Blob ──────────────────────────────
+      # Replaces "Sync to public/" and committing public/<data dir> to git:
+      # instead, upload the build output straight to a Vercel Blob store. The
+      # app fetches it via the same-origin /data-v3/* rewrite in vercel.json.
+      # Reads the build output directly, so no data:sync is needed.
+      #
+      # Exit codes: 0=OK, 1=partial failure or other error, 2=all failed.
+      # npx tsx direct: the npm script contains --env-file-if-exists which could
+      # load a local .env and override CI secrets.
+      - name: Upload v2 data to Vercel Blob
+        id: upload-blob
+        env:
+          VERCEL_V3_BLOB_READ_WRITE_TOKEN: ${{ secrets.VERCEL_V3_BLOB_READ_WRITE_TOKEN }}
+        run: |
+          set +e
+          npx tsx pipeline/scripts/pipeline/vercel-blob/upload-data-to-blob.ts --dir pipeline/workspace/_build/data-v2 --all
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
-      # ── Report & Deploy ────────────────────────────────────
+      - name: Warn on Blob upload partial failure
+        if: steps.upload-blob.outputs.exit_code == '1'
+        run: echo "::warning::Some data files failed to upload to Blob (partial failure or other error)."
+
+      - name: Fail on Blob upload failure
+        if: steps.upload-blob.outputs.exit_code == '2'
+        run: |
+          echo "::error::All Blob uploads failed."
+          exit 1
+
+      # ── Report & Commit ────────────────────────────────────
       - name: Detect changes
         id: changes
         run: |
-          # Commit targets: the generated data (public/<PIPELINE_TRANSIT_DATA_DIR>)
-          # and the pipeline state (download metadata under workspace/state/).
-          git add "public/${PIPELINE_TRANSIT_DATA_DIR}/" pipeline/workspace/state/
+          # Commit target: only the pipeline state (download metadata under
+          # workspace/state/). The data itself is uploaded to Vercel Blob, not
+          # committed to git.
+          git add pipeline/workspace/state/
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No data changes detected."
+            echo "::notice::No metadata changes detected."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Data changes detected. Will commit and push."
+            echo "::notice::Metadata changes detected. Will commit and push."
           fi
 
       - name: Job Summary
@@ -307,10 +340,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Commit targets: the generated data (public/<PIPELINE_TRANSIT_DATA_DIR>)
-          # and the pipeline state (download metadata under workspace/state/).
-          git add "public/${PIPELINE_TRANSIT_DATA_DIR}/" pipeline/workspace/state/
-          git commit -m "chore(data): update transit data"
+          # Commit target: only the pipeline state (download metadata under
+          # workspace/state/). The data itself is uploaded to Vercel Blob, not
+          # committed to git.
+          git add pipeline/workspace/state/
+          git commit -m "chore(pipeline): update download metadata"
           git push
 
       # ── Notify ────────────────────────────────────────────
@@ -321,13 +355,8 @@ jobs:
         run: |
           PARTS=()
           HAS_WARN=false
-          # Data change status
-          CHANGED="${{ steps.changes.outputs.changed }}"
-          if [ "$CHANGED" = "true" ]; then
-            PARTS+=("Data updated")
-          elif [ "$CHANGED" = "false" ]; then
-            PARTS+=("No data changes")
-          fi
+          # Primary action
+          PARTS+=("Uploaded to Vercel Blob")
           # Partial failures (exit code 1)
           WARN=""
           if [ "${{ steps.download-gtfs.outputs.exit_code }}" = "1" ]; then WARN="${WARN}GTFS download, "; fi
@@ -340,6 +369,7 @@ jobs:
           if [ "${{ steps.build-v2-insights.outputs.exit_code }}" = "1" ]; then WARN="${WARN}v2 insights, "; fi
           if [ "${{ steps.build-v2-global-insights.outputs.exit_code }}" = "1" ]; then WARN="${WARN}v2 global insights, "; fi
           if [ "${{ steps.build-v2-data-source-catalog.outputs.exit_code }}" = "1" ]; then WARN="${WARN}v2 data source catalog, "; fi
+          if [ "${{ steps.upload-blob.outputs.exit_code }}" = "1" ]; then WARN="${WARN}Blob upload, "; fi
           if [ -n "$WARN" ]; then
             PARTS+=("Partial failure: ${WARN%, }")
             HAS_WARN=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@types/node": "^24.13.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@vercel/blob": "^2.6.1",
         "@vite-pwa/assets-generator": "^1.0.2",
         "@vitejs/plugin-react": "^6.0.3",
         "@vitest/browser-playwright": "^4.1.9",
@@ -68,7 +69,8 @@
         "typescript-eslint": "^8.62.1",
         "vite": "^8.1.2",
         "vite-plugin-pwa": "^1.3.0",
-        "vitest": "^4.1.9"
+        "vitest": "^4.1.9",
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=24"
@@ -7648,6 +7650,183 @@
       "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
       "license": "ISC"
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.6.1.tgz",
+      "integrity": "sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "^3.6.1",
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
+      "integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+      "integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vercel/cli-exec/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.0.tgz",
+      "integrity": "sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.0",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/oidc/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@vite-pwa/assets-generator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@vite-pwa/assets-generator/-/assets-generator-1.0.2.tgz",
@@ -8231,6 +8410,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/at-least-node": {
@@ -11560,6 +11749,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -11812,6 +12025,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -14168,6 +14388,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -15653,6 +15883,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -17008,6 +17248,19 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -18710,6 +18963,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "pipeline:build:v2-global-insights": "npx tsx pipeline/scripts/pipeline/app-data-v2/build-global-insights.ts --targets pipeline/config/targets/build-global-insights.ts",
     "pipeline:build:v2-data-source-catalog": "npx tsx pipeline/scripts/pipeline/app-data-v2/build-data-source-catalog.ts --targets pipeline/config/targets/build-data-source-catalog.ts",
     "pipeline:validate:v2": "npx tsx pipeline/scripts/pipeline/app-data-v2/validate-v2-bundles.ts --targets pipeline/config/targets/validate.ts",
+    "pipeline:upload:blob": "npx tsx --env-file-if-exists=pipeline/.env.pipeline.local pipeline/scripts/pipeline/vercel-blob/upload-data-to-blob.ts",
+    "pipeline:delete:blob": "npx tsx --env-file-if-exists=pipeline/.env.pipeline.local pipeline/scripts/pipeline/vercel-blob/delete-data-from-blob.ts",
+    "pipeline:list:blob": "npx tsx --env-file-if-exists=pipeline/.env.pipeline.local pipeline/scripts/pipeline/vercel-blob/list-data-in-blob.ts",
     "pipeline:check:odpt-resources": "npx tsx pipeline/scripts/pipeline/check-odpt-resources.ts",
     "pipeline:describe": "npx tsx pipeline/scripts/dev/describe-resources.ts",
     "pipeline:dev-tools": "npx tsx pipeline/scripts/dev/dev-tools.ts",
@@ -93,6 +96,7 @@
     "@types/node": "^24.13.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@vercel/blob": "^2.6.1",
     "@vite-pwa/assets-generator": "^1.0.2",
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/browser-playwright": "^4.1.9",
@@ -117,6 +121,7 @@
     "typescript-eslint": "^8.62.1",
     "vite": "^8.1.2",
     "vite-plugin-pwa": "^1.3.0",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.9",
+    "zod": "^4.4.3"
   }
 }

--- a/pipeline/scripts/pipeline/vercel-blob/blob-lib.test.ts
+++ b/pipeline/scripts/pipeline/vercel-blob/blob-lib.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_CONCURRENCY,
+  blobStoreIdFromToken,
+  deleteArgsSchema,
+  deriveBlobKey,
+  formatErrorRedacted,
+  isPathInside,
+  listArgsSchema,
+  redactBlobTokens,
+  resolveDeleteTarget,
+  resolveListPrefix,
+  uploadArgsSchema,
+} from './blob-lib';
+
+describe('deriveBlobKey', () => {
+  it('strips the base dir and yields a key with no prefix', () => {
+    expect(deriveBlobKey('public/data-v2', 'public/data-v2/85b/data.json')).toBe('85b/data.json');
+  });
+
+  it('handles nested paths', () => {
+    expect(deriveBlobKey('public/data-v2', 'public/data-v2/a/b/c.json')).toBe('a/b/c.json');
+  });
+
+  it('handles a trailing slash on the base dir', () => {
+    expect(deriveBlobKey('public/data-v2/', 'public/data-v2/85b/data.json')).toBe('85b/data.json');
+  });
+});
+
+describe('isPathInside', () => {
+  it('accepts a nested path', () => {
+    expect(isPathInside('/repo', '/repo/public/data-v2')).toBe(true);
+  });
+
+  it('accepts the base itself', () => {
+    expect(isPathInside('/repo', '/repo')).toBe(true);
+  });
+
+  it('rejects an outside path', () => {
+    expect(isPathInside('/repo', '/other')).toBe(false);
+  });
+
+  it('rejects a parent path', () => {
+    expect(isPathInside('/repo/app', '/repo')).toBe(false);
+  });
+
+  it('rejects traversal that escapes the base', () => {
+    expect(isPathInside('/repo', '/repo/../etc')).toBe(false);
+  });
+});
+
+describe('uploadArgsSchema', () => {
+  it('applies defaults (with --dir and --all)', () => {
+    const r = uploadArgsSchema.parse({ dir: 'public/data-v2', all: true });
+    expect(r.dir).toBe('public/data-v2');
+    expect(r.concurrency).toBe(MAX_CONCURRENCY);
+    expect(r.dryRun).toBe(false);
+    expect(r.all).toBe(true);
+    expect(r.source).toBeUndefined();
+  });
+
+  it('accepts a single --source', () => {
+    expect(uploadArgsSchema.parse({ dir: 'd', source: ['85b'] }).source).toEqual(['85b']);
+  });
+
+  it('accepts multiple --source', () => {
+    expect(uploadArgsSchema.parse({ dir: 'd', source: ['mir', 'mtfry'] }).source).toEqual([
+      'mir',
+      'mtfry',
+    ]);
+  });
+
+  it('rejects a missing --dir', () => {
+    expect(() => uploadArgsSchema.parse({ all: true })).toThrow();
+  });
+
+  it('rejects no target', () => {
+    expect(() => uploadArgsSchema.parse({ dir: 'd' })).toThrow();
+  });
+
+  it('rejects both --source and --all', () => {
+    expect(() => uploadArgsSchema.parse({ dir: 'd', source: ['85b'], all: true })).toThrow();
+  });
+
+  it('rejects a --source containing a slash', () => {
+    expect(() => uploadArgsSchema.parse({ dir: 'd', source: ['a/b'] })).toThrow();
+  });
+
+  it('coerces a concurrency string to a number', () => {
+    expect(uploadArgsSchema.parse({ dir: 'd', all: true, concurrency: '5' }).concurrency).toBe(5);
+  });
+
+  it('rejects concurrency above the max', () => {
+    expect(() => uploadArgsSchema.parse({ dir: 'd', all: true, concurrency: '20' })).toThrow();
+  });
+
+  it('rejects a non-integer concurrency', () => {
+    expect(() => uploadArgsSchema.parse({ dir: 'd', all: true, concurrency: '2.5' })).toThrow();
+  });
+});
+
+describe('deleteArgsSchema', () => {
+  it('accepts --source as the sole target', () => {
+    expect(deleteArgsSchema.parse({ source: 'kotr' }).source).toBe('kotr');
+  });
+
+  it('accepts --prefix as the sole target', () => {
+    expect(deleteArgsSchema.parse({ prefix: 'kotr/' }).prefix).toBe('kotr/');
+  });
+
+  it('rejects no target', () => {
+    expect(() => deleteArgsSchema.parse({})).toThrow();
+  });
+
+  it('rejects both --source and --prefix', () => {
+    expect(() => deleteArgsSchema.parse({ source: 'a', prefix: 'b' })).toThrow();
+  });
+
+  it('rejects an empty --prefix (would match the whole store)', () => {
+    expect(() => deleteArgsSchema.parse({ prefix: '' })).toThrow();
+  });
+
+  it('rejects a --source containing a slash', () => {
+    expect(() => deleteArgsSchema.parse({ source: 'a/b' })).toThrow();
+  });
+});
+
+describe('resolveDeleteTarget', () => {
+  it('maps --source to a "<name>/" prefix', () => {
+    expect(resolveDeleteTarget({ source: 'kotr', yes: false })).toEqual({
+      prefix: 'kotr/',
+      label: 'prefix "kotr/"',
+    });
+  });
+
+  it('passes --prefix through unchanged', () => {
+    expect(resolveDeleteTarget({ prefix: 'foo/bar', yes: false })).toEqual({
+      prefix: 'foo/bar',
+      label: 'prefix "foo/bar"',
+    });
+  });
+});
+
+describe('listArgsSchema', () => {
+  it('accepts no filter (list everything)', () => {
+    const r = listArgsSchema.parse({});
+    expect(r.source).toBeUndefined();
+    expect(r.prefix).toBeUndefined();
+  });
+
+  it('accepts --source', () => {
+    expect(listArgsSchema.parse({ source: 'kotr' }).source).toBe('kotr');
+  });
+
+  it('accepts --prefix', () => {
+    expect(listArgsSchema.parse({ prefix: 'kotr/' }).prefix).toBe('kotr/');
+  });
+
+  it('rejects both --source and --prefix', () => {
+    expect(() => listArgsSchema.parse({ source: 'a', prefix: 'b' })).toThrow();
+  });
+
+  it('rejects a --source containing a slash', () => {
+    expect(() => listArgsSchema.parse({ source: 'a/b' })).toThrow();
+  });
+});
+
+describe('resolveListPrefix', () => {
+  it('no filter maps to an undefined prefix (entire store)', () => {
+    expect(resolveListPrefix({})).toEqual({ prefix: undefined, label: 'in the entire store' });
+  });
+
+  it('maps --source to a "<name>/" prefix', () => {
+    expect(resolveListPrefix({ source: 'kotr' })).toEqual({
+      prefix: 'kotr/',
+      label: 'under "kotr/"',
+    });
+  });
+
+  it('passes --prefix through unchanged', () => {
+    expect(resolveListPrefix({ prefix: 'foo/bar' })).toEqual({
+      prefix: 'foo/bar',
+      label: 'under "foo/bar"',
+    });
+  });
+});
+
+describe('blobStoreIdFromToken', () => {
+  // Fabricated placeholder tokens only -- NOT real credentials or store ids.
+  it('extracts the inferred store id from a rw token', () => {
+    expect(blobStoreIdFromToken('vercel_blob_rw_EXAMPLESTOREID_this-is-not-a-real-secret')).toBe(
+      'EXAMPLESTOREID',
+    );
+  });
+
+  it('never returns the secret part', () => {
+    const id = blobStoreIdFromToken('vercel_blob_rw_EXAMPLESTOREID_placeholder-do-not-use');
+    expect(id).toBe('EXAMPLESTOREID');
+    expect(id).not.toContain('placeholder');
+  });
+
+  it('returns (unknown) for an unexpected format', () => {
+    expect(blobStoreIdFromToken('this-is-not-a-blob-token')).toBe('(unknown)');
+  });
+});
+
+describe('redactBlobTokens', () => {
+  // Fabricated placeholder tokens only -- NOT real credentials.
+  it('redacts a token embedded in text', () => {
+    expect(
+      redactBlobTokens('failed with vercel_blob_rw_EXAMPLESTOREID_not-a-real-secret in url'),
+    ).toBe('failed with vercel_blob_rw_[REDACTED] in url');
+  });
+
+  it('redacts every token occurrence', () => {
+    const text = 'a vercel_blob_rw_AAA_secret1 b vercel_blob_rw_BBB_secret2 c';
+    expect(redactBlobTokens(text)).toBe(
+      'a vercel_blob_rw_[REDACTED] b vercel_blob_rw_[REDACTED] c',
+    );
+  });
+
+  it('leaves text without a token unchanged', () => {
+    expect(redactBlobTokens('a plain error message')).toBe('a plain error message');
+  });
+});
+
+describe('formatErrorRedacted', () => {
+  it('redacts a token in an Error message', () => {
+    const msg = formatErrorRedacted(
+      new Error('403 for vercel_blob_rw_EXAMPLESTOREID_not-a-real-secret'),
+    );
+    expect(msg).toContain('vercel_blob_rw_[REDACTED]');
+    expect(msg).not.toContain('not-a-real-secret');
+  });
+
+  it('stringifies a non-Error value', () => {
+    expect(formatErrorRedacted('boom')).toBe('boom');
+  });
+});

--- a/pipeline/scripts/pipeline/vercel-blob/blob-lib.ts
+++ b/pipeline/scripts/pipeline/vercel-blob/blob-lib.ts
@@ -1,0 +1,164 @@
+/**
+ * Pure helpers for the Vercel Blob upload / delete scripts:
+ * Blob key derivation, path containment, and CLI argument schemas (zod).
+ *
+ * Kept free of `fs` / network so it can be unit-tested.
+ */
+
+import { isAbsolute, relative } from 'node:path';
+
+import { z } from 'zod';
+
+export const MAX_CONCURRENCY = 10;
+
+/** A single directory-name segment (no path separators). */
+const SEGMENT = /^[^/\\]+$/;
+
+/**
+ * Derive a Blob object key from a file path.
+ *
+ * The key is `filePath` relative to `baseDir`, with POSIX separators and no
+ * leading directory prefix (e.g. `85b/data.json`). This matches the
+ * `vercel.json` rewrite `destination: <store>/:path*`.
+ */
+export function deriveBlobKey(baseDir: string, filePath: string): string {
+  return relative(baseDir, filePath).split(/[\\/]/).join('/');
+}
+
+/**
+ * Whether `target` is `base` itself or a path nested inside `base`.
+ *
+ * Both paths should be absolute (ideally realpath-resolved) for a reliable
+ * containment check that resists `..` traversal and symlink escapes.
+ */
+export function isPathInside(base: string, target: string): boolean {
+  const rel = relative(base, target);
+  return !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+/**
+ * Best-effort, INFERRED store id parsed from a Vercel Blob read-write token
+ * (`vercel_blob_rw_<storeId>_<secret>`), for display so the operator can see
+ * which store is being targeted.
+ *
+ * This relies on the token's undocumented format and will break if Vercel
+ * changes it, so the result is an estimate, not an authoritative id (the SDK
+ * exposes no store-metadata API). Callers should present it as inferred. The
+ * secret is never returned; `(unknown)` is returned for an unexpected format.
+ */
+export function blobStoreIdFromToken(token: string): string {
+  const match = /^vercel_blob_rw_([^_]+)_/.exec(token);
+  return match ? match[1] : '(unknown)';
+}
+
+/**
+ * Redact any Vercel Blob read-write token (`vercel_blob_rw_<storeId>_<secret>`)
+ * found in `text`, so a token can never leak into logs or error output. The
+ * whole token run (store id and secret) is replaced with a fixed marker.
+ */
+export function redactBlobTokens(text: string): string {
+  return text.replace(/vercel_blob_rw_[A-Za-z0-9_-]+/g, 'vercel_blob_rw_[REDACTED]');
+}
+
+/** Format an unknown thrown value as a redacted, single-string message. */
+export function formatErrorRedacted(err: unknown): string {
+  const raw = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  return redactBlobTokens(raw);
+}
+
+// ---------------------------------------------------------------------------
+// upload args
+// ---------------------------------------------------------------------------
+
+/**
+ * Requires exactly one target: one or more `--source <name>` (repeatable) or
+ * `--all`.
+ */
+export const uploadArgsSchema = z
+  .object({
+    dir: z.string(),
+    source: z
+      .array(z.string().regex(SEGMENT, 'source must be a single directory name (no slashes)'))
+      .optional(),
+    all: z.boolean().default(false),
+    concurrency: z.coerce.number().int().min(1).max(MAX_CONCURRENCY).default(MAX_CONCURRENCY),
+    dryRun: z.boolean().default(false),
+  })
+  .refine((a) => [(a.source?.length ?? 0) > 0, a.all].filter(Boolean).length === 1, {
+    message: 'Specify exactly one of --source <name> (repeatable) or --all.',
+  });
+
+export type UploadArgs = z.infer<typeof uploadArgsSchema>;
+
+// ---------------------------------------------------------------------------
+// delete args
+// ---------------------------------------------------------------------------
+
+/**
+ * Requires exactly one target: `--source <name>` or `--prefix <path>`.
+ *
+ * There is intentionally no "delete everything" option, and `--prefix` must be
+ * non-empty so it can never match (and delete) the whole store.
+ */
+export const deleteArgsSchema = z
+  .object({
+    source: z
+      .string()
+      .regex(SEGMENT, 'source must be a single directory name (no slashes)')
+      .optional(),
+    prefix: z.string().min(1, 'prefix must not be empty').optional(),
+    yes: z.boolean().default(false),
+  })
+  .refine((a) => [a.source !== undefined, a.prefix !== undefined].filter(Boolean).length === 1, {
+    message: 'Specify exactly one of --source <name> or --prefix <path>.',
+  });
+
+export type DeleteArgs = z.infer<typeof deleteArgsSchema>;
+
+/** Resolve the `list()` prefix and a human-readable label for a delete target. */
+export function resolveDeleteTarget(args: DeleteArgs): { prefix: string; label: string } {
+  if (args.source !== undefined) {
+    return { prefix: `${args.source}/`, label: `prefix "${args.source}/"` };
+  }
+  if (args.prefix !== undefined) {
+    return { prefix: args.prefix, label: `prefix "${args.prefix}"` };
+  }
+  // Unreachable: deleteArgsSchema requires exactly one target.
+  throw new Error('No delete target (--source or --prefix) provided.');
+}
+
+// ---------------------------------------------------------------------------
+// list args
+// ---------------------------------------------------------------------------
+
+/**
+ * Read-only listing. The filter is optional (omit to list the whole store);
+ * at most one of `--source` / `--prefix` may be given.
+ */
+export const listArgsSchema = z
+  .object({
+    source: z
+      .string()
+      .regex(SEGMENT, 'source must be a single directory name (no slashes)')
+      .optional(),
+    prefix: z.string().min(1, 'prefix must not be empty').optional(),
+  })
+  .refine((a) => [a.source !== undefined, a.prefix !== undefined].filter(Boolean).length <= 1, {
+    message: 'Specify at most one of --source <name> or --prefix <path>.',
+  });
+
+export type ListArgs = z.infer<typeof listArgsSchema>;
+
+/**
+ * Resolve the `list()` prefix (undefined = entire store) and a label. Listing
+ * the whole store is safe here because this operation is read-only.
+ */
+export function resolveListPrefix(args: ListArgs): { prefix: string | undefined; label: string } {
+  if (args.source !== undefined) {
+    return { prefix: `${args.source}/`, label: `under "${args.source}/"` };
+  }
+  if (args.prefix !== undefined) {
+    return { prefix: args.prefix, label: `under "${args.prefix}"` };
+  }
+  return { prefix: undefined, label: 'in the entire store' };
+}

--- a/pipeline/scripts/pipeline/vercel-blob/delete-data-from-blob.ts
+++ b/pipeline/scripts/pipeline/vercel-blob/delete-data-from-blob.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env -S npx tsx
+
+/**
+ * Delete data files from Vercel Blob (targeted, explicit).
+ *
+ * Deletes blobs by source directory or arbitrary key prefix. Intended for
+ * removing data that must not remain published -- e.g. a data source whose
+ * provider-set usage period has ended (a license deletion obligation).
+ * Companion to `upload-data-to-blob.ts`, which never deletes.
+ *
+ * SAFE BY DEFAULT: without `--yes` this is a dry run (lists what would be
+ * deleted, deletes nothing). Requires exactly one target (`--source <name>` or
+ * a non-empty `--prefix <path>`). There is intentionally no "delete
+ * everything" option.
+ *
+ * Requires `VERCEL_V3_BLOB_READ_WRITE_TOKEN`.
+ *
+ * Exit codes: 0 = ok (dry run / help / all deleted), 1 = partial failure or
+ * other error (bad usage, missing token), 2 = all deletes failed.
+ */
+
+import { parseArgs } from 'node:util';
+
+import { del, list } from '@vercel/blob';
+
+import {
+  blobStoreIdFromToken,
+  deleteArgsSchema,
+  formatErrorRedacted,
+  redactBlobTokens,
+  resolveDeleteTarget,
+} from './blob-lib';
+
+const DELETE_CHUNK_SIZE = 100;
+
+const HELP = `Delete data files from Vercel Blob (targeted, explicit).
+
+Safe by default: without --yes this is a dry run (lists matches, deletes nothing).
+There is no "delete everything" option.
+
+Usage:
+  npm run pipeline:delete:blob -- (--source <name> | --prefix <path>) [--yes]
+
+Target (exactly one required):
+  --source <name>    Delete keys under <name>/ (e.g. --source kotr)
+  --prefix <path>    Delete keys under an arbitrary (non-empty) prefix
+
+Options:
+  --yes              Actually delete (without it: dry run)
+  --help, -h         Show this help
+
+Environment:
+  VERCEL_V3_BLOB_READ_WRITE_TOKEN   Blob read-write token (required)
+
+Exit codes: 0 = ok (dry run / help / all deleted), 1 = partial failure or other error, 2 = all failed.`;
+
+/** List every blob under `prefix`. */
+async function listAll(
+  prefix: string,
+  token: string,
+): Promise<{ pathname: string; url: string }[]> {
+  const out: { pathname: string; url: string }[] = [];
+  let cursor: string | undefined;
+  do {
+    const res = await list({ prefix, cursor, limit: 1000, token });
+    for (const blob of res.blobs) {
+      out.push({ pathname: blob.pathname, url: blob.url });
+    }
+    cursor = res.hasMore ? res.cursor : undefined;
+  } while (cursor);
+  return out;
+}
+
+function parseDelete() {
+  return parseArgs({
+    options: {
+      source: { type: 'string' },
+      prefix: { type: 'string' },
+      yes: { type: 'boolean' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    strict: true,
+    allowPositionals: false,
+  }).values;
+}
+
+async function main(): Promise<void> {
+  // No args -> show help (exit 0). Common CLI behaviour.
+  if (process.argv.slice(2).length === 0) {
+    console.log(HELP);
+    return;
+  }
+
+  let raw: ReturnType<typeof parseDelete>;
+  try {
+    raw = parseDelete();
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    console.error(HELP);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (raw.help) {
+    console.log(HELP);
+    return;
+  }
+
+  const parsed = deleteArgsSchema.safeParse({
+    source: raw.source,
+    prefix: raw.prefix,
+    yes: raw.yes,
+  });
+  if (!parsed.success) {
+    console.error(`Error: ${parsed.error.issues.map((i) => i.message).join('; ')}\n`);
+    console.error(HELP);
+    process.exitCode = 1;
+    return;
+  }
+  const args = parsed.data;
+
+  const token = process.env['VERCEL_V3_BLOB_READ_WRITE_TOKEN'];
+  if (!token) {
+    console.error('Error: VERCEL_V3_BLOB_READ_WRITE_TOKEN environment variable is required.');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Target Blob store (inferred from token): ${blobStoreIdFromToken(token)}`);
+  const { prefix, label } = resolveDeleteTarget(args);
+  const blobs = await listAll(prefix, token);
+  if (blobs.length === 0) {
+    console.log(`No blobs found for ${label}. Nothing to delete.`);
+    return;
+  }
+
+  console.log(`${blobs.length} blob(s) match ${label}:`);
+  for (const blob of blobs) {
+    console.log(`  ${blob.pathname}`);
+  }
+
+  if (!args.yes) {
+    console.log('\nDry run (no --yes): nothing deleted. Re-run with --yes to delete.');
+    return;
+  }
+
+  console.log(`\nDeleting ${blobs.length} blob(s)...`);
+  const urls = blobs.map((blob) => blob.url);
+  let deleted = 0;
+  let failed = 0;
+  // del() is atomic per call, so a failing chunk fails all its urls together;
+  // the chunk size is therefore the finest failure granularity available.
+  for (let i = 0; i < urls.length; i += DELETE_CHUNK_SIZE) {
+    const chunk = urls.slice(i, i + DELETE_CHUNK_SIZE);
+    try {
+      await del(chunk, { token });
+      deleted += chunk.length;
+    } catch (err) {
+      failed += chunk.length;
+      console.error(
+        `  ERR deleting ${chunk.length} blob(s): ${redactBlobTokens(
+          err instanceof Error ? err.message : String(err),
+        )}`,
+      );
+    }
+  }
+  console.log(`Deleted ${deleted} blob(s), ${failed} failed.`);
+
+  // Exit-code contract (matches upload): 0 all deleted, 1 partial, 2 all failed.
+  if (deleted === 0 && failed > 0) {
+    process.exitCode = 2;
+  } else if (failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((err: unknown) => {
+    console.error(formatErrorRedacted(err));
+    process.exitCode = 2;
+  })
+  .finally(() => {
+    // Always print the resolved exit code on the final line (every path,
+    // including early returns and errors), matching the other pipeline scripts.
+    // Code 1 groups partial delete failure and usage/precondition errors,
+    // hence "partial failure or other error".
+    const code = process.exitCode ?? 0;
+    let label = 'ok';
+    if (code === 2) {
+      label = 'all failed';
+    } else if (code === 1) {
+      label = 'partial failure or other error';
+    }
+    console.log(`\nExit code: ${code} (${label})`);
+  });

--- a/pipeline/scripts/pipeline/vercel-blob/list-data-in-blob.ts
+++ b/pipeline/scripts/pipeline/vercel-blob/list-data-in-blob.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env -S npx tsx
+
+/**
+ * List data files in Vercel Blob (read-only).
+ *
+ * Lists blob keys and sizes in the store. With no filter it lists the whole
+ * store; `--source <name>` or `--prefix <path>` narrows it. Read-only: this
+ * never uploads or deletes.
+ *
+ * Requires `VERCEL_V3_BLOB_READ_WRITE_TOKEN`.
+ *
+ * Exit codes: 0 = ok (including help), 1 = error / bad usage.
+ */
+
+import { parseArgs } from 'node:util';
+
+import { list } from '@vercel/blob';
+
+import {
+  blobStoreIdFromToken,
+  formatErrorRedacted,
+  listArgsSchema,
+  resolveListPrefix,
+} from './blob-lib';
+
+const HELP = `List data files in Vercel Blob (read-only).
+
+Usage:
+  npm run pipeline:list:blob -- [--source <name> | --prefix <path>]
+
+Filter (optional; omit to list the entire store):
+  --source <name>    List keys under <name>/ (e.g. --source kotr)
+  --prefix <path>    List keys under an arbitrary (non-empty) prefix
+
+Options:
+  --help, -h         Show this help
+
+Environment:
+  VERCEL_V3_BLOB_READ_WRITE_TOKEN   Blob read-write token (required)
+
+Exit codes: 0 = ok (including help), 1 = error / bad usage.`;
+
+interface BlobInfo {
+  pathname: string;
+  size: number;
+  uploadedAt: Date;
+  etag: string;
+}
+
+/** List every blob under `prefix` (all blobs when `prefix` is undefined). */
+async function listAll(prefix: string | undefined, token: string): Promise<BlobInfo[]> {
+  const out: BlobInfo[] = [];
+  let cursor: string | undefined;
+  do {
+    const res = await list({ prefix, cursor, limit: 1000, token });
+    for (const blob of res.blobs) {
+      out.push({
+        pathname: blob.pathname,
+        size: blob.size,
+        uploadedAt: blob.uploadedAt,
+        etag: blob.etag,
+      });
+    }
+    cursor = res.hasMore ? res.cursor : undefined;
+  } while (cursor);
+  return out;
+}
+
+function parseList() {
+  return parseArgs({
+    options: {
+      source: { type: 'string' },
+      prefix: { type: 'string' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    strict: true,
+    allowPositionals: false,
+  }).values;
+}
+
+async function main(): Promise<void> {
+  // Read-only: no args lists the whole store; --help shows help.
+  let raw: ReturnType<typeof parseList>;
+  try {
+    raw = parseList();
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    console.error(HELP);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (raw.help) {
+    console.log(HELP);
+    return;
+  }
+
+  const parsed = listArgsSchema.safeParse({ source: raw.source, prefix: raw.prefix });
+  if (!parsed.success) {
+    console.error(`Error: ${parsed.error.issues.map((i) => i.message).join('; ')}\n`);
+    console.error(HELP);
+    process.exitCode = 1;
+    return;
+  }
+
+  const token = process.env['VERCEL_V3_BLOB_READ_WRITE_TOKEN'];
+  if (!token) {
+    console.error('Error: VERCEL_V3_BLOB_READ_WRITE_TOKEN environment variable is required.');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Target Blob store (inferred from token): ${blobStoreIdFromToken(token)}`);
+  const { prefix, label } = resolveListPrefix(parsed.data);
+  const blobs = await listAll(prefix, token);
+  if (blobs.length === 0) {
+    console.log(`No blobs found ${label}.`);
+    return;
+  }
+
+  blobs.sort((a, b) => a.pathname.localeCompare(b.pathname));
+  let totalBytes = 0;
+  for (const blob of blobs) {
+    totalBytes += blob.size;
+    console.log(
+      `  ${blob.pathname.padEnd(40)} ${String(blob.size).padStart(10)} ${blob.uploadedAt.toISOString()} ${blob.etag}`,
+    );
+  }
+  console.log(`\n${blobs.length} blob(s), ${totalBytes} bytes total ${label}.`);
+}
+
+main()
+  .catch((err: unknown) => {
+    console.error(formatErrorRedacted(err));
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    // Always print the resolved exit code on the final line (every path).
+    // list is read-only: 0 = ok, 1 = error / bad usage (no partial state).
+    const code = process.exitCode ?? 0;
+    const label = code === 0 ? 'ok' : 'error';
+    console.log(`\nExit code: ${code} (${label})`);
+  });

--- a/pipeline/scripts/pipeline/vercel-blob/upload-data-to-blob.ts
+++ b/pipeline/scripts/pipeline/vercel-blob/upload-data-to-blob.ts
@@ -1,0 +1,285 @@
+#!/usr/bin/env -S npx tsx
+
+/**
+ * Upload built v2 data files to Vercel Blob.
+ *
+ * Uploads every `.json` file under `--dir` to a Vercel Blob store, keyed by its
+ * path relative to that directory (no prefix, e.g. `85b/data.json`). This
+ * matches the `vercel.json` rewrite `destination: <store>/:path*`, so the app
+ * can fetch the data via a same-origin `/data-v3/*` route that proxies to the
+ * store.
+ *
+ * Requires `--dir` (constrained to inside the pipeline build output dir,
+ * `pipeline/workspace/_build`) and exactly one target: `--source <name>`
+ * (repeatable) or `--all`. The upload source is the build output, e.g.
+ * `pipeline/workspace/_build/data-v2`. Uploads are additive/overwriting only --
+ * this script never deletes (see
+ * `delete-data-from-blob.ts`). Cache-Control is NOT set here: it is controlled
+ * centrally by `vercel.json`, which overrides the proxied Blob response.
+ *
+ * Requires `VERCEL_V3_BLOB_READ_WRITE_TOKEN` (except for `--dry-run`).
+ *
+ * Exit codes: 0 = all uploaded (or dry run / help), 1 = partial failure or
+ * other error (unmatched --source, bad usage, no files, missing token),
+ * 2 = all failed.
+ */
+
+import { readFileSync, readdirSync, realpathSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+
+import { put } from '@vercel/blob';
+
+import { BUILD_DIR } from '../../../src/lib/paths';
+import {
+  MAX_CONCURRENCY,
+  blobStoreIdFromToken,
+  deriveBlobKey,
+  formatErrorRedacted,
+  isPathInside,
+  redactBlobTokens,
+  uploadArgsSchema,
+} from './blob-lib';
+
+const HELP = `Upload built v2 data files to Vercel Blob.
+
+Usage:
+  npm run pipeline:upload:blob -- --dir <path> (--source <name>... | --all) [options]
+
+Required:
+  --dir <path>              Base directory to upload from (must be inside the build
+                            output dir, e.g. pipeline/workspace/_build/data-v2)
+  --source <name> | --all   Upload the given source(s), or every source under --dir.
+                            --source is repeatable (e.g. --source a --source b).
+
+Options:
+  --concurrency <n>  Concurrent uploads, 1-${MAX_CONCURRENCY} (default: ${MAX_CONCURRENCY})
+  --dry-run          List files + keys that would be uploaded; upload nothing (no token needed)
+  --help, -h         Show this help
+
+Environment:
+  VERCEL_V3_BLOB_READ_WRITE_TOKEN   Blob read-write token (required unless --dry-run)
+
+Exit codes: 0 = all uploaded (or dry run / help), 1 = partial failure or other error, 2 = all failed.`;
+
+/** Recursively collect `.json` files under `dir`, never following symlinks. */
+function collectJsonFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) {
+      continue; // never follow symlinks (defence against escaping the dir)
+    }
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectJsonFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.json')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Run `worker` over `items` with at most `limit` in flight at once. */
+async function runPool<T>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  const queue = [...items];
+  const runners = Array.from({ length: Math.min(limit, queue.length) }, async () => {
+    for (let item = queue.shift(); item !== undefined; item = queue.shift()) {
+      await worker(item);
+    }
+  });
+  await Promise.all(runners);
+}
+
+function parseUpload() {
+  return parseArgs({
+    options: {
+      dir: { type: 'string' },
+      source: { type: 'string', multiple: true },
+      all: { type: 'boolean' },
+      concurrency: { type: 'string' },
+      'dry-run': { type: 'boolean' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    strict: true,
+    allowPositionals: false,
+  }).values;
+}
+
+/**
+ * Resolve `dir` to a real path and require it to be inside the pipeline build
+ * output dir (`pipeline/workspace/_build`). Returns the resolved real path, or
+ * `null` if it does not exist or escapes.
+ */
+function resolveDirWithinBuild(dir: string): string | null {
+  try {
+    const realDir = realpathSync(resolve(dir));
+    const realRoot = realpathSync(BUILD_DIR);
+    return isPathInside(realRoot, realDir) ? realDir : null;
+  } catch {
+    return null;
+  }
+}
+
+async function main(): Promise<void> {
+  // No args -> show help (exit 0). Common CLI behaviour.
+  if (process.argv.slice(2).length === 0) {
+    console.log(HELP);
+    return;
+  }
+
+  let raw: ReturnType<typeof parseUpload>;
+  try {
+    raw = parseUpload();
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    console.error(HELP);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (raw.help) {
+    console.log(HELP);
+    return;
+  }
+
+  const parsed = uploadArgsSchema.safeParse({
+    dir: raw.dir,
+    source: raw.source,
+    all: raw.all,
+    concurrency: raw.concurrency,
+    dryRun: raw['dry-run'],
+  });
+  if (!parsed.success) {
+    console.error(`Error: ${parsed.error.issues.map((i) => i.message).join('; ')}\n`);
+    console.error(HELP);
+    process.exitCode = 1;
+    return;
+  }
+  const { dir, source, concurrency, dryRun } = parsed.data;
+
+  const realDir = resolveDirWithinBuild(dir);
+  if (realDir === null) {
+    console.error(
+      `Error: --dir must be an existing directory inside pipeline/workspace/_build: ${dir}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  let files = collectJsonFiles(realDir);
+  let unmatchedSources: string[] = [];
+  if (source !== undefined) {
+    const wanted = new Set(source);
+    files = files.filter((f) => wanted.has(deriveBlobKey(realDir, f).split('/')[0]));
+    // Record requested sources that matched nothing so we can warn (after the
+    // target-store line) and exit non-zero, rather than silently dropping them
+    // when other sources did match.
+    const matched = new Set(files.map((f) => deriveBlobKey(realDir, f).split('/')[0]));
+    unmatchedSources = source.filter((name) => !matched.has(name));
+  }
+
+  if (files.length === 0) {
+    const forSources = source ? ` for source(s) "${source.join(', ')}"` : '';
+    console.error(`No .json files found under ${dir}${forSources}.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (dryRun) {
+    for (const name of unmatchedSources) {
+      console.warn(`Warning: source "${name}" matched no files under ${dir}.`);
+    }
+    console.log(`[dry-run] ${files.length} file(s) from ${dir} would be uploaded:\n`);
+    let totalBytes = 0;
+    for (const file of files) {
+      const size = statSync(file).size;
+      totalBytes += size;
+      console.log(
+        `  ${deriveBlobKey(realDir, file).padEnd(40)} ${(size / 1024).toFixed(0).padStart(6)} KB`,
+      );
+    }
+    const unmatchedNote =
+      unmatchedSources.length > 0 ? `, ${unmatchedSources.length} source(s) not found` : '';
+    console.log(
+      `\n[dry-run] total ${files.length} file(s), ${(totalBytes / 1048576).toFixed(1)} MB${unmatchedNote}. Nothing uploaded.`,
+    );
+    if (unmatchedSources.length > 0) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  const token = process.env['VERCEL_V3_BLOB_READ_WRITE_TOKEN'];
+  if (!token) {
+    console.error('Error: VERCEL_V3_BLOB_READ_WRITE_TOKEN environment variable is required.');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Target Blob store (inferred from token): ${blobStoreIdFromToken(token)}`);
+  for (const name of unmatchedSources) {
+    console.warn(`Warning: source "${name}" matched no files under ${dir}.`);
+  }
+  console.log(`Uploading ${files.length} file(s) from ${dir} (concurrency ${concurrency})...\n`);
+
+  let ok = 0;
+  let failed = 0;
+  await runPool(files, concurrency, async (file) => {
+    const key = deriveBlobKey(realDir, file);
+    try {
+      const body = readFileSync(file);
+      const { url } = await put(key, body, {
+        access: 'public',
+        addRandomSuffix: false,
+        allowOverwrite: true,
+        contentType: 'application/json',
+        token,
+      });
+      ok++;
+      console.log(
+        `  ok  ${key.padEnd(40)} ${(body.byteLength / 1024).toFixed(0).padStart(6)} KB -> ${url}`,
+      );
+    } catch (err) {
+      failed++;
+      console.error(
+        `  ERR ${key}: ${redactBlobTokens(err instanceof Error ? err.message : String(err))}`,
+      );
+    }
+  });
+
+  const unmatchedNote =
+    unmatchedSources.length > 0 ? `, ${unmatchedSources.length} source(s) not found` : '';
+  console.log(`\nDone: ${ok} uploaded, ${failed} failed${unmatchedNote}.`);
+
+  // Exit-code contract (matches the pipeline convention): 0 ok, 1 partial
+  // (some uploads failed, or a requested --source matched no files), 2 all failed.
+  if (ok === 0 && failed > 0) {
+    process.exitCode = 2;
+  } else if (failed > 0 || unmatchedSources.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((err: unknown) => {
+    console.error(formatErrorRedacted(err));
+    process.exitCode = 2;
+  })
+  .finally(() => {
+    // Always print the resolved exit code on the final line (every path,
+    // including early returns and errors), matching the other pipeline scripts.
+    // Code 1 groups partial upload failure, an unmatched --source, and
+    // usage/precondition errors, hence "partial failure or other error".
+    const code = process.exitCode ?? 0;
+    let label = 'ok';
+    if (code === 2) {
+      label = 'all failed';
+    } else if (code === 1) {
+      label = 'partial failure or other error';
+    }
+    console.log(`\nExit code: ${code} (${label})`);
+  });

--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,7 @@
     {
       "source": "/data-v3/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=86400, must-revalidate" }
+        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=300, must-revalidate" }
       ]
     },
     {


### PR DESCRIPTION
## Summary

Move the built v2 transit data (`public/data-v2`, ~148MB, committed daily) out of git and serve it from a Vercel Blob store, to stop the git repository from growing with every data update. Adds the tooling and a separate CI workflow for it; the current git-committing pipeline is left untouched for now (this is the data-delivery-separation / testing phase).

Refs #327.

## What's included

- **Blob CLI tools** (`pipeline/scripts/pipeline/vercel-blob/`): `upload` / `delete` / `list` scripts plus shared, unit-tested helpers (`blob-lib`, 42 tests). Path-traversal hardening (constrained to `pipeline/workspace/_build`, no symlink follow), zod arg validation, token redaction in error output, exit-code contract (upload/delete `0/1/2`, list `0/1`) with the resolved code printed on the final line.
- **`vercel.json`**: `/data-v3` (the Blob proxy) served with `s-maxage=300` instead of `86400`. Blob updates don't trigger a deployment, so a short shared-cache TTL lets the CDN pick up new data via ETag revalidation within ~5 min — no purge step or Vercel token needed. `/data-v2` (git-committed, changes only on deploy) keeps its 24h TTL.
- **`upload-transit-data-to-vercel-blob.yml`**: the same `download -> build -> validate` pipeline as `update-transit-data.yml`, but the built data is uploaded to Blob (`--all`) instead of committed to git. Only the small download metadata under `pipeline/workspace/state/` is still committed (provenance of the currently-published data). Shares the `gtfs-pipeline` concurrency group so it never runs concurrently with the git-committing pipelines. Manual trigger for now; the daily `schedule` is present but commented out for a future cutover.

## Design notes

- Upload is additive/overwrite-only; the `delete` script handles removal for period-limited data (e.g. license deletion obligations). Prompt removal = delete from Blob, then optionally purge the CDN from the dashboard (delete first, then purge — purging first re-caches).
- Because `data-v2` no longer lives in git, git-diff-based "did the built data change?" detection is gone (upload is unconditional `--all`). Acceptable for a once-daily update; incremental upload via etag/hash comparison is a possible future enhancement.

## Testing status

- CLI tools: `typecheck` / `eslint` / `prettier` / `vitest` green; exit codes verified with real runs; a real Blob upload was verified end-to-end locally (uploaded, then served via `/data-v3` with the expected split-cache headers).
- Workflows: YAML-valid, prettier-clean, minimal delta from `update-transit-data.yml` (no behavioral regression: `permissions`, sync-with-remote, `Detect changes`, `Job Summary`, `Commit & Push`/state commit all preserved).
- **Not yet run in CI**: the upload workflow has not been executed as a real GitHub Actions run. Needs a manual trigger to verify the full build -> Blob upload -> state commit -> Slack path before enabling on a schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)