### PR TITLE
ci: surface Blob upload result in job summary

### DIFF
--- a/.github/workflows/upload-transit-data-to-vercel-blob.yml
+++ b/.github/workflows/upload-transit-data-to-vercel-blob.yml
@@ -287,8 +287,8 @@ jobs:
           VERCEL_V3_BLOB_READ_WRITE_TOKEN: ${{ secrets.VERCEL_V3_BLOB_READ_WRITE_TOKEN }}
         run: |
           set +e
-          npx tsx pipeline/scripts/pipeline/vercel-blob/upload-data-to-blob.ts --dir pipeline/workspace/_build/data-v2 --all
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          npx tsx pipeline/scripts/pipeline/vercel-blob/upload-data-to-blob.ts --dir pipeline/workspace/_build/data-v2 --all 2>&1 | tee blob-upload-output.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Warn on Blob upload partial failure
         if: steps.upload-blob.outputs.exit_code == '1'
@@ -322,16 +322,33 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "---" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          # Primary: Blob upload result. The data is delivered to Vercel Blob,
+          # not committed to git, so the git diff further below is metadata only.
+          echo "## Blob upload" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f blob-upload-output.txt ]; then
+            # Summary line ("Done: N uploaded, M failed") + any failures ("ERR ...").
+            # The full stdout (per-file "ok" lines) is available in the job log,
+            # so only the summary and failures are surfaced here.
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            grep -E '^Done:|ERR ' blob-upload-output.txt >> "$GITHUB_STEP_SUMMARY" \
+              || echo "(no Done/ERR lines captured)" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No Blob upload output captured (upload step may have been skipped)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          # Secondary: git metadata diff (download state under workspace/state/).
           if [ "${{ steps.changes.outputs.changed }}" = "true" ]; then
-            echo "## Updated files" >> "$GITHUB_STEP_SUMMARY"
+            echo "## Updated metadata" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             git diff --cached --stat >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "## No data changes" >> "$GITHUB_STEP_SUMMARY"
+            echo "## No metadata change" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "GTFS data is already up to date. No commit created." >> "$GITHUB_STEP_SUMMARY"
+            echo "Data uploaded to Blob; download metadata unchanged. No commit created." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Commit & Push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - CI: KSJ (鉄道形状) ビルドの部分失敗を許容し、transit data 更新 workflow が KSJ 失敗で停止しないようにした (#323)。
 - Pipeline: ローカルのデータ配備を pipeline の責務 (Stage 6) として明確化した。配備スクリプトを `scripts/copy-pipeline-data.ts` から `pipeline/scripts/pipeline/copy-pipeline-data.ts` へ移動し、npm script を `data:sync` から `pipeline:deliver:local` へ改名。用途 (ローカル配信領域への配備) を名前で明示し、本番の Vercel Blob upload と対称にする。配備先ベースは `TRANSIT_DATA_DELIVERY_BASE_DIR` (既定 `public/`、`__AT_DATA__/` に切替可) で、cross-boundary import 不可 (`.vercelignore` が `pipeline/` を除外) のため dev plugin 側にも定数を意図的に複製する。重複していた `scripts/lib/sanitize-dir-name.ts` は削除し pipeline の `file-utils` を使用。
 - Scripts: Vercel 運用の npm script を `vercel:*` に整理した。Blob 操作を `pipeline:{upload,delete,list}:blob` から `vercel:blob:{upload,delete,list}` へ、deploy cleanup を `cleanup:vercel[:run]` から `vercel:deployment:cleanup[:run]` へ改名。これらは pipeline のビルドステージではなくローカル手動の Vercel 運用 util であり (CI は npm 経由で呼ばない)、`pipeline:*` と prefix で分離する。
+- CI: Blob upload workflow (`upload-transit-data-to-vercel-blob.yml`) の Job Summary を Blob upload 結果ベースに刷新した。upload script の stdout を capture し、アップロード集計 (`Done: N uploaded, M failed`) と失敗 (`ERR`) を表示する。git 配信版から流用していた git diff は download metadata 差分 (`workspace/state/`) として補助的に残す。全 upload (`--all`) のため成功ファイルの個別行は job log 側とし、summary には出さない。
 
 ## [2026.07.01]
 


### PR DESCRIPTION
## Summary

The Blob upload workflow's Job Summary was copied from the **git-delivery** workflow (`update-transit-data.yml`), where a git diff equals the data diff (data is committed to `public/data-v2`). For **Blob delivery**, the data goes to Vercel Blob and git only tracks download metadata (`workspace/state/`), so the old summary showed **no upload info** and a misleading "No data changes / GTFS data is already up to date".

## Changes

- **Capture upload stdout** via `tee blob-upload-output.txt` (`PIPESTATUS` keeps `exit_code`).
- **Job Summary** now shows:
  - `## Blob upload` (primary): the `Done: N uploaded, M failed` line + failures (`ERR ...`). Successes are NOT listed — with `--all`, every file would appear; the full list is in the job log.
  - `## Updated metadata` (secondary): the git state diff, relabeled/reworded for Blob context (kept per the "git diff も必要" requirement).

Diff detection (upload only changed files) was intentionally **not** added — high cost against the `--all` upload model.

## Test plan

- [x] yaml valid
- [x] grep extracts only `Done:` / `ERR ` (the `Exit code: ... error` line is not mis-hit)
- [x] `workflow_dispatch` run to confirm the rendered summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)