### PR TITLE
chore(pipeline): update 5 ODPT GTFS sources to 2026-07 feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Data: rinko-bus の GTFS resource を 20260716 版へ更新。
+- Data: keio-bus の GTFS resource を 20260716 版へ更新。
+- Data: odakyu-bus の GTFS resource を 20260716 版へ更新。
+- Data: nishi-tokyo-bus の GTFS resource を 20260711 版へ更新。
+- Data: iyotetsu-bus の GTFS resource を 20260720 版へ更新。
+
 ## [2026.07.09]
 
 ### Added

--- a/pipeline/config/resources/gtfs/iyotetsu-bus.ts
+++ b/pipeline/config/resources/gtfs/iyotetsu-bus.ts
@@ -16,8 +16,8 @@ const iyotetsuBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/iyotetsu_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/iyotetsu_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/iyotetsu_bus_all_lines/resource/d8ded132-ffcc-416d-b180-04fece268400',
-      resourceId: 'd8ded132-ffcc-416d-b180-04fece268400',
+        'https://ckan.odpt.org/dataset/iyotetsu_bus_all_lines/resource/1c565a07-6b6a-4f77-be81-b3ad59a3fccd',
+      resourceId: '1c565a07-6b6a-4f77-be81-b3ad59a3fccd',
     },
     provider: {
       name: {
@@ -37,7 +37,7 @@ const iyotetsuBus: GtfsSourceDefinition = {
     routeTypes: ['bus'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/IyotetsuBus/AllLines.zip?date=20260519',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/IyotetsuBus/AllLines.zip?date=20260720',
   },
   pipeline: {
     outDir: 'iyotetsu-bus',

--- a/pipeline/config/resources/gtfs/keio-bus.ts
+++ b/pipeline/config/resources/gtfs/keio-bus.ts
@@ -16,8 +16,8 @@ const keioBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/keio_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/keio_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/76ce041a-6817-4e3e-a1a3-39e33153f0e0',
-      resourceId: '76ce041a-6817-4e3e-a1a3-39e33153f0e0',
+        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/abc7b801-5c10-461d-b50b-397b660e36d0',
+      resourceId: 'abc7b801-5c10-461d-b50b-397b660e36d0',
     },
     provider: {
       name: {
@@ -43,7 +43,7 @@ const keioBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260404',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260716',
   },
   pipeline: {
     outDir: 'keio-bus',

--- a/pipeline/config/resources/gtfs/nishi-tokyo-bus.ts
+++ b/pipeline/config/resources/gtfs/nishi-tokyo-bus.ts
@@ -17,8 +17,8 @@ const nishiTokyoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/nishi_tokyo_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus/resource/cbe22e32-4163-444d-8dd9-b74e8af13fe4',
-      resourceId: 'cbe22e32-4163-444d-8dd9-b74e8af13fe4',
+        'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus/resource/3d71e5a3-da16-4f7d-9fa1-f6e43cc572ba',
+      resourceId: '3d71e5a3-da16-4f7d-9fa1-f6e43cc572ba',
     },
     provider: {
       name: {
@@ -41,7 +41,7 @@ const nishiTokyoBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/NishiTokyoBus/NTBus.zip?date=20260626',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/NishiTokyoBus/NTBus.zip?date=20260711',
   },
   pipeline: {
     outDir: 'nishi-tokyo-bus',

--- a/pipeline/config/resources/gtfs/odakyu-bus.ts
+++ b/pipeline/config/resources/gtfs/odakyu-bus.ts
@@ -17,8 +17,8 @@ const odakyuBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/odakyu_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/odakyu_bus_aii_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/odakyu_bus_aii_lines/resource/6dceccf4-7d3a-4051-a1af-7c0d89a9c582',
-      resourceId: '6dceccf4-7d3a-4051-a1af-7c0d89a9c582',
+        'https://ckan.odpt.org/dataset/odakyu_bus_aii_lines/resource/04ab391e-e650-4077-8b14-e5cb5c0ad585',
+      resourceId: '04ab391e-e650-4077-8b14-e5cb5c0ad585',
     },
     provider: {
       name: {
@@ -44,7 +44,7 @@ const odakyuBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/OdakyuBus/AIILines.zip?date=20260601',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/OdakyuBus/AIILines.zip?date=20260716',
   },
   pipeline: {
     outDir: 'odakyu-bus',

--- a/pipeline/config/resources/gtfs/rinko-bus.ts
+++ b/pipeline/config/resources/gtfs/rinko-bus.ts
@@ -17,8 +17,8 @@ const rinkoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/kawasaki_tsurumi_rinko_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/kawasaki_tsurumi_rinko_bus_allrinko',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/kawasaki_tsurumi_rinko_bus_allrinko/resource/5f074130-2fa6-4eec-a379-36d3a2530d59',
-      resourceId: '5f074130-2fa6-4eec-a379-36d3a2530d59',
+        'https://ckan.odpt.org/dataset/kawasaki_tsurumi_rinko_bus_allrinko/resource/ffc40d96-ee01-4b67-a76d-885793ad5822',
+      resourceId: 'ffc40d96-ee01-4b67-a76d-885793ad5822',
     },
     provider: {
       name: {
@@ -42,7 +42,7 @@ const rinkoBus: GtfsSourceDefinition = {
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
     downloadUrl:
-      'https://api.odpt.org/api/v4/files/odpt/KawasakiTsurumiRinkoBus/allrinko.zip?date=20260523',
+      'https://api.odpt.org/api/v4/files/odpt/KawasakiTsurumiRinkoBus/allrinko.zip?date=20260716',
   },
   pipeline: {
     outDir: 'rinko-bus',


### PR DESCRIPTION
## Summary

Bump the `resourceUrl` / `resourceId` / `downloadUrl` three-field set for 5 ODPT GTFS sources to the versions selected from CKAN, following the 2026-07-16 Check Transit Resources triage (run 29474989192).

| Source | Version | Feed validity | Note |
|---|---|---|---|
| rinko-bus | 20260523 -> 20260716 | 2026-07-16 - 2027-07-16 | Previous resource removed from remote (ADOPTED_MISSING) |
| keio-bus | 20260404 -> 20260716 | 2026-07-16 - 2026-12-31 | |
| odakyu-bus | 20260601 -> 20260716 | 2026-07-16 - (no end) | |
| nishi-tokyo-bus | 20260626 -> 20260711 | 2026-07-11 - 2026-07-25 | Short-window feed; needs another bump after 07-25 |
| iyotetsu-bus | 20260519 -> 20260720 | starts 2026-07-20 | Previous feed expired 2026-06-30 |

Not updated by decision: chuo-bus and suginami-gsm (adopted feeds expired, no valid replacement published).

## Verification

- Each downloadUrl/date was verified against the CKAN resource page for the matching resourceId.
- Full local pipeline run over all sources: download -> db -> v2 bundles -> shapes (GTFS/KSJ) -> insights -> global insights -> catalog -> validate -> deliver:local, all green.
- `pipeline:validate:v2` passes with warnings only (pre-existing expired feeds and calendar_dates-only sources; no errors).
- typecheck / lint / test (4630 passed) / build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)