### PR TITLE
chore(pipeline): update chuo-bus to 20260712 feed

### DIFF
--- a/.claude/skills/add-gtfs-source/SKILL.md
+++ b/.claude/skills/add-gtfs-source/SKILL.md
@@ -117,7 +117,7 @@ This is the canonical download (archived, with download metadata); it extracts t
 Add the **source-name** to `pipeline/config/targets/build-db.ts`, then build:
 
 ```bash
-npx tsx pipeline/scripts/pipeline/build-gtfs-db.ts --targets pipeline/config/targets/build-db.ts {source-name}
+npx tsx pipeline/scripts/pipeline/build-gtfs-db.ts {source-name}
 ```
 
 This produces `pipeline/workspace/_build/db/{source-name}.db`. The step 2 recon already established the overview; query this DB with `sqlite3` if you need exact values while finalizing details (e.g. precise per-route `route_color`, trip/stop counts, orphan stops):
@@ -249,6 +249,7 @@ Split into logical commits following Conventional Commits. **Do not commit gener
 
 ## Common Pitfalls
 
+- **Chaining pipeline steps with `&&` / trusting exit status alone**: run one command per shell call and read its full output before the next step. Pipeline scripts print usage and exit 0 on invalid arguments (e.g. `build-gtfs-db.ts --targets <file> <source>` — the two forms are mutually exclusive), so a chained run can silently skip a step and build from stale inputs.
 - **Writing the definition before the recon**: deciding `dataFormat`, `routeColorFallbacks`, or even whether to add the source at all without seeing the data leads to wrong values and wasted work. Download to a temp dir and inspect first (step 2), then write the definition (step 3).
 - **Adding an expired feed unnoticed**: check `feed_info.feed_end_date` in the recon. A past end_date means empty current-date timetables — raise it as a go/no-go before investing.
 - **`shapes.txt` present but `trips` lack `shape_id`**: shapes are linked to routes only via `trips.shape_id`; a feed can ship `shapes.txt` geometry with no `shape_id` column, so no shapes are emitted. Keep the source registered in `build-shapes-gtfs.ts` for future auto-generation.

--- a/.claude/skills/gtfs-data-build/SKILL.md
+++ b/.claude/skills/gtfs-data-build/SKILL.md
@@ -15,6 +15,13 @@ Build web app JSON data files from GTFS open data sources.
 
 Commands and execution order are documented in `CLAUDE.md` "Data preparation" section. Run steps 1-12 in order; each step depends on the previous one.
 
+## Execution rules
+
+- **One command per shell call — never chain pipeline steps with `&&`.** Judge each step from its full output before running the next.
+- **Exit status alone is NOT a success signal.** Some pipeline scripts print usage and exit 0 on invalid arguments (`parseCliArg` returns `help` for user errors), so an `&&` chain can roll past a step that did nothing — e.g. building app data from a stale DB.
+- **Per-source scripts take exactly ONE source name (or `--targets <file>`, never both).** `build-gtfs-db.ts --targets <file> <source>` is invalid and prints usage with exit 0.
+- When in doubt, verify the artifact itself (mtime / content such as `feedInfo` in `data.json`), not just the log.
+
 ## When to skip steps
 
 - **Steps 1-2 (download)**: Skip if source files are already up to date. GTFS files live in `pipeline/workspace/data/gtfs/{outDir}/`; ODPT JSON files in `pipeline/workspace/data/odpt-json/{outDir}/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [CalVer](https://calver.org/).
 - Data: odakyu-bus の GTFS resource を 20260716 版へ更新。
 - Data: nishi-tokyo-bus の GTFS resource を 20260711 版へ更新。
 - Data: iyotetsu-bus の GTFS resource を 20260720 版へ更新。
+- Data: chuo-bus の GTFS resource を 20260712 版へ更新。
 
 ## [2026.07.09]
 

--- a/pipeline/config/resources/gtfs/chuo-bus.ts
+++ b/pipeline/config/resources/gtfs/chuo-bus.ts
@@ -16,8 +16,8 @@ const chuoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/tokyo_chuo_city',
       datasetUrl: 'https://ckan.odpt.org/dataset/tokyo_chuo_city_alldata',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/tokyo_chuo_city_alldata/resource/6674c46b-d4aa-44a6-a427-0862df7b7189',
-      resourceId: '6674c46b-d4aa-44a6-a427-0862df7b7189',
+        'https://ckan.odpt.org/dataset/tokyo_chuo_city_alldata/resource/2ddf722e-78ea-448c-b148-3690e9e82633',
+      resourceId: '2ddf722e-78ea-448c-b148-3690e9e82633',
     },
     provider: {
       name: {
@@ -37,7 +37,7 @@ const chuoBus: GtfsSourceDefinition = {
     routeTypes: ['bus'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/TokyoChuoCity/Alldata.zip?date=20250108',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/TokyoChuoCity/Alldata.zip?date=20260712',
   },
   pipeline: {
     outDir: 'chuo-bus',


### PR DESCRIPTION
## Summary

Edo Bus (chuo-bus) is back. A new resource appeared on CKAN on 2026-07-17 after the adopted feed had been expired since 2025-11-30 with no replacement. This bumps the `resourceUrl` / `resourceId` / `downloadUrl` three-field set.

| Source | Version | Feed validity | Note |
|---|---|---|---|
| chuo-bus | 20250108 -> 20260712 | 2026-07-15 - 2028-06-30 | Previous resource removed from remote (ADOPTED_MISSING); new resource is the only one published on the dataset |

- CKAN resource: https://ckan.odpt.org/dataset/tokyo_chuo_city_alldata/resource/2ddf722e-78ea-448c-b148-3690e9e82633
- Resolves the chuo-bus errors in the Check Transit Resources run 29558243453.

## Verification

- downloadUrl/date verified against the CKAN resource page for the matching resourceId.
- Local single-source pipeline run: download -> db -> v2 bundles -> shapes -> insights, then global insights -> catalog -> validate -> deliver:local, all green.
- Delivered `edobus/data.json` carries the new feed period (20260715 - 20280630).
- typecheck / format / lint / test (4630 passed) / build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)