### PR TITLE
chore(pipeline): update 3 GTFS resources to newer feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Data: keio-bus の GTFS resource を 20260724 版へ更新。
+- Data: nishi-tokyo-bus の GTFS resource を 20260718 版へ更新。
+- Data: kyoto-bus の GTFS resource を 20260724 版へ更新。
+
 ## [2026.07.17]
 
 ### Changed

--- a/pipeline/config/resources/gtfs/keio-bus.ts
+++ b/pipeline/config/resources/gtfs/keio-bus.ts
@@ -16,8 +16,8 @@ const keioBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/keio_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/keio_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/abc7b801-5c10-461d-b50b-397b660e36d0',
-      resourceId: 'abc7b801-5c10-461d-b50b-397b660e36d0',
+        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/642a138c-c3d9-405b-b681-6b99e13b81a9',
+      resourceId: '642a138c-c3d9-405b-b681-6b99e13b81a9',
     },
     provider: {
       name: {
@@ -43,7 +43,7 @@ const keioBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260716',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260724',
   },
   pipeline: {
     outDir: 'keio-bus',

--- a/pipeline/config/resources/gtfs/kyoto-bus.ts
+++ b/pipeline/config/resources/gtfs/kyoto-bus.ts
@@ -17,8 +17,8 @@ const kyotoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/kyoto_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/kyoto_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/63d2d764-6f96-4857-ad9d-d64d260dd0de',
-      resourceId: '63d2d764-6f96-4857-ad9d-d64d260dd0de',
+        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/03a4087c-1ede-47b6-ac71-3ffb9f1d1f1e',
+      resourceId: '03a4087c-1ede-47b6-ac71-3ffb9f1d1f1e',
     },
     provider: {
       name: {
@@ -38,7 +38,7 @@ const kyotoBus: GtfsSourceDefinition = {
     routeTypes: ['bus'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260701',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260724',
   },
   pipeline: {
     outDir: 'kyoto-bus',

--- a/pipeline/config/resources/gtfs/nishi-tokyo-bus.ts
+++ b/pipeline/config/resources/gtfs/nishi-tokyo-bus.ts
@@ -17,8 +17,8 @@ const nishiTokyoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/nishi_tokyo_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus/resource/3d71e5a3-da16-4f7d-9fa1-f6e43cc572ba',
-      resourceId: '3d71e5a3-da16-4f7d-9fa1-f6e43cc572ba',
+        'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus/resource/aa6075ea-c746-4950-889a-1112cc330bf7',
+      resourceId: 'aa6075ea-c746-4950-889a-1112cc330bf7',
     },
     provider: {
       name: {
@@ -41,7 +41,7 @@ const nishiTokyoBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/NishiTokyoBus/NTBus.zip?date=20260711',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/NishiTokyoBus/NTBus.zip?date=20260718',
   },
   pipeline: {
     outDir: 'nishi-tokyo-bus',


### PR DESCRIPTION
## Summary

Version bumps for 3 ODPT GTFS sources, triaged from [Check Transit Resources run 30146485844](https://github.com/F88/athenai-transit/actions/runs/30146485844).

| source | date | new feed window | reason |
| --- | --- | --- | --- |
| keio-bus | 20260716 -> 20260724 | 2026-07-24 - 2026-12-31 | adopted resource removed from remote (ADOPTED_MISSING) |
| nishi-tokyo-bus | 20260711 -> 20260718 | 2026-07-18 - 2026-08-01 | adopted feed expires 2026-07-25 |
| kyoto-bus | 20260701 -> 20260724 | 2026-07-24 - 2026-09-30 | newer valid revision available |

Each source updates the three-field set together: `downloadUrl` date param, `catalog.resourceUrl`, `catalog.resourceId` (CKAN UUIDs verified against the dataset pages). CHANGELOG updated under [Unreleased].

Note: the nishi-tokyo-bus feed is another short-validity window (2 weeks, ends 2026-08-01); a follow-up bump will be needed soon.

## Verification

- `npm run typecheck` passed
- Data rebuild is CI's job after merge (Blob upload workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)