### PR TITLE
chore(pipeline): update kawasaki/yokohama bus resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Data: kawasaki-city-bus の GTFS resource を 20260801 版へ更新。
+- Data: yokohama-municipal-bus の GTFS resource を 20260727 版へ更新。
+
 ## [2026.07.25]
 
 ### Changed

--- a/pipeline/config/resources/gtfs/kawasaki-city-bus.ts
+++ b/pipeline/config/resources/gtfs/kawasaki-city-bus.ts
@@ -17,8 +17,8 @@ const kawasakiCityBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/transportation_bureau_city_of_kawasaki',
       datasetUrl: 'https://ckan.odpt.org/dataset/transportation_bureau_city_of_kawasaki_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/transportation_bureau_city_of_kawasaki_all_lines/resource/139a9c5f-e7dd-46ad-8f92-fba6b7ed5ad5',
-      resourceId: '139a9c5f-e7dd-46ad-8f92-fba6b7ed5ad5',
+        'https://ckan.odpt.org/dataset/transportation_bureau_city_of_kawasaki_all_lines/resource/6b8c28f3-c953-422f-a863-e4118db9b3c4',
+      resourceId: '6b8c28f3-c953-422f-a863-e4118db9b3c4',
     },
     provider: {
       name: {
@@ -45,7 +45,7 @@ const kawasakiCityBus: GtfsSourceDefinition = {
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
     downloadUrl:
-      'https://api.odpt.org/api/v4/files/odpt/TransportationBureau_CityOfKawasaki/AllLines.zip?date=20260701',
+      'https://api.odpt.org/api/v4/files/odpt/TransportationBureau_CityOfKawasaki/AllLines.zip?date=20260801',
   },
   pipeline: {
     outDir: 'kawasaki-city-bus',

--- a/pipeline/config/resources/gtfs/yokohama-municipal-bus.ts
+++ b/pipeline/config/resources/gtfs/yokohama-municipal-bus.ts
@@ -17,8 +17,8 @@ const yokohamaMunicipalBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/yokohama_municipal',
       datasetUrl: 'https://ckan.odpt.org/dataset/yokohama_municipal_bus',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/yokohama_municipal_bus/resource/79a66951-4934-4101-b5c0-fd58a885b9d5',
-      resourceId: '79a66951-4934-4101-b5c0-fd58a885b9d5',
+        'https://ckan.odpt.org/dataset/yokohama_municipal_bus/resource/1f099583-33d3-4017-a42f-1448571142fc',
+      resourceId: '1f099583-33d3-4017-a42f-1448571142fc',
     },
     provider: {
       name: {
@@ -41,7 +41,7 @@ const yokohamaMunicipalBus: GtfsSourceDefinition = {
     routeTypes: ['bus'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/YokohamaMunicipal/Bus.zip?date=20260601',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/YokohamaMunicipal/Bus.zip?date=20260727',
   },
   pipeline: {
     outDir: 'yokohama-municipal-bus',


### PR DESCRIPTION
## Summary

ODPT リソース定義の版更新 (2件)。 いずれも Check Transit Resources の 2026-07-29 実行 (run 30426654170) のトリアージ結果に基づく。

### kawasaki-city-bus -> date=20260801

採用中だった `date=20260701` が、 直近のデータ更新 (2026-07-29 00:38) の後に ODPT Members Portal のカタログから削除された (`ADOPTED_MISSING`)。 ファイル API は当面配信を続けるが、 参照先の CKAN リソースが実在しないため、 生き残っている `date=20260801` へ三点セット (`downloadUrl` / `resourceUrl` / `resourceId`) を再アンカーする。

- 新 UUID: `6b8c28f3-c953-422f-a863-e4118db9b3c4`
- feed 期間: 2026-07-01 - 2027-07-01 (採用中と同一 -> データ欠落・ダイヤ変更なし)

### yokohama-municipal-bus -> date=20260727

現在有効な新版へ更新。

- 新 UUID: `1f099583-33d3-4017-a42f-1448571142fc`
- feed 期間: 2026-07-27 - 2027-07-26

## Not included

- kanto-bus / suginami-gsm は `ADOPTED_EXPIRED` かつ有効な差し替え先が存在しないため、 版更新の対象外。 新 feed 提供待ち (定義変更なし)。
- keio-bus / kyoto-bus / nishi-tokyo-bus / meimon-taiyo-ferry / nagoya-srt は新版の start_at が未到来のため、 到来後に別途対応。

## Verification

- `npm run typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)