### PR TITLE
chore(pipeline): update keio/meimon/nishi-tokyo resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ### Changed
 
+- Data: keio-bus の GTFS resource を 20260731 版へ更新。
+- Data: meimon-taiyo-ferry の GTFS resource を 20260801 版へ更新。
+- Data: nishi-tokyo-bus の GTFS resource を 20260801 版へ更新。
 - Data: kawasaki-city-bus の GTFS resource を 20260801 版へ更新。
 - Data: yokohama-municipal-bus の GTFS resource を 20260727 版へ更新。
 

--- a/pipeline/config/resources/gtfs/keio-bus.ts
+++ b/pipeline/config/resources/gtfs/keio-bus.ts
@@ -16,8 +16,8 @@ const keioBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/keio_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/keio_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/642a138c-c3d9-405b-b681-6b99e13b81a9',
-      resourceId: '642a138c-c3d9-405b-b681-6b99e13b81a9',
+        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/07256457-253f-41f3-9355-cc370068885d',
+      resourceId: '07256457-253f-41f3-9355-cc370068885d',
     },
     provider: {
       name: {
@@ -43,7 +43,7 @@ const keioBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260724',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260731',
   },
   pipeline: {
     outDir: 'keio-bus',

--- a/pipeline/config/resources/gtfs/meimon-taiyo-ferry.ts
+++ b/pipeline/config/resources/gtfs/meimon-taiyo-ferry.ts
@@ -17,8 +17,8 @@ const meimonTaiyoFerry: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/meimon_taiyo_ferry',
       datasetUrl: 'https://ckan.odpt.org/dataset/meimon_taiyo_ferry_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/meimon_taiyo_ferry_all_lines/resource/73dece57-1c35-4588-9a27-bb91a53afeff',
-      resourceId: '73dece57-1c35-4588-9a27-bb91a53afeff',
+        'https://ckan.odpt.org/dataset/meimon_taiyo_ferry_all_lines/resource/fdd5c15a-6d84-4316-bfd2-3359a47e0e30',
+      resourceId: 'fdd5c15a-6d84-4316-bfd2-3359a47e0e30',
     },
     provider: {
       name: {
@@ -40,7 +40,7 @@ const meimonTaiyoFerry: GtfsSourceDefinition = {
     // Update this value when a new version is published — feeds are rotated
     // every 3 months.
     downloadUrl:
-      'https://api.odpt.org/api/v4/files/odpt/MeimonTaiyoFerry/AllLines.zip?date=20260701',
+      'https://api.odpt.org/api/v4/files/odpt/MeimonTaiyoFerry/AllLines.zip?date=20260801',
   },
   pipeline: {
     outDir: 'meimon-taiyo-ferry',

--- a/pipeline/config/resources/gtfs/nishi-tokyo-bus.ts
+++ b/pipeline/config/resources/gtfs/nishi-tokyo-bus.ts
@@ -17,8 +17,8 @@ const nishiTokyoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/nishi_tokyo_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus/resource/aa6075ea-c746-4950-889a-1112cc330bf7',
-      resourceId: 'aa6075ea-c746-4950-889a-1112cc330bf7',
+        'https://ckan.odpt.org/dataset/nishi_tokyo_bus_nt_bus/resource/c5f99d33-f9a4-4a84-b96b-494ee46a5424',
+      resourceId: 'c5f99d33-f9a4-4a84-b96b-494ee46a5424',
     },
     provider: {
       name: {
@@ -41,7 +41,7 @@ const nishiTokyoBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/NishiTokyoBus/NTBus.zip?date=20260718',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/NishiTokyoBus/NTBus.zip?date=20260801',
   },
   pipeline: {
     outDir: 'nishi-tokyo-bus',


### PR DESCRIPTION
## Summary

Bump three GTFS resource definitions to their newest currently-valid CKAN versions.

| source | date | reason |
| --- | --- | --- |
| `keio-bus` | 20260724 -> 20260731 | adopted download URL returns HTTP 404 |
| `meimon-taiyo-ferry` | 20260701 -> 20260801 | adopted resource removed from remote (404) |
| `nishi-tokyo-bus` | 20260718 -> 20260801 | feed expired (end 2026-08-01) |

All three UUIDs / download dates were verified against the CKAN dataset pages, and `npm run typecheck` passes.

## Context

The `keio-bus` and `meimon-taiyo-ferry` download failures were surfaced by the
"Update Transit Data (Vercel Blob)" run
[30725677919](https://github.com/F88/athenai-transit/actions/runs/30725677919),
which failed at v2 validation (missing `data.json`) and therefore skipped the
Blob upload entirely.

## Not fixed here: iyotetsu-bus (separate blocker)

`iyotetsu-bus` (`date=20260720`) also returns HTTP 404, but its CKAN dataset
(`iyotetsu_bus_all_lines`) currently has **zero resources**, so no version can be
adopted. Until `iyotetsu-bus` is resolved (re-published upstream, or temporarily
disabled), the Update Transit Data pipeline stays blocked at v2 validation and
no source data reaches Blob. Tracked separately.

## Out of scope (no valid replacement)

`suginami-gsm` and `kanto-bus` are expired with no in-period remote data; not a
version-bump case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
