### PR TITLE
fix(pipeline): skip missing-bundle sources in v2 validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [CalVer](https://calver.org/).
 - Data: kawasaki-city-bus の GTFS resource を 20260801 版へ更新。
 - Data: yokohama-municipal-bus の GTFS resource を 20260727 版へ更新。
 
+### Fixed
+
+- Pipeline: v2 バリデーションが、あるソースの bundle 欠落 (上流リソース削除等による未ビルド) で run 全体を失敗させないよう変更。欠落ソースは skip し他ソースは検証・配信を継続、全ソース欠落時のみ致命 (exit 2) とする。(#346)
+
 ## [2026.07.25]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,6 @@ and this project adheres to [CalVer](https://calver.org/).
 - Data: nishi-tokyo-bus の GTFS resource を 20260801 版へ更新。
 - Data: kawasaki-city-bus の GTFS resource を 20260801 版へ更新。
 - Data: yokohama-municipal-bus の GTFS resource を 20260727 版へ更新。
-
-### Fixed
-
 - Pipeline: v2 バリデーションが、あるソースの bundle 欠落 (上流リソース削除等による未ビルド) で run 全体を失敗させないよう変更。欠落ソースは skip し他ソースは検証・配信を継続、全ソース欠落時のみ致命 (exit 2) とする。(#346)
 
 ## [2026.07.25]

--- a/pipeline/docs/V2_VALIDATE.md
+++ b/pipeline/docs/V2_VALIDATE.md
@@ -6,7 +6,7 @@ v2 パイプラインが出力したバンドルファイルと global artifact 
 
 Validator の役割は**パイプライン全体の出力が揃っているかの最終確認**である。各バンドルの出力内容の正しさは builder 側のテストで担保する。
 
-- **ファイル存在チェック**: メインの検証。必須バンドルが全て出力されているか
+- **ファイル存在チェック**: メインの検証。必須バンドルが出力されているか。ソース単位で欠落を許容する (一部ソースの欠落は skip + warn で処理続行、全ソース欠落のみ致命)
 - **構造チェック**: bundle_version, kind, section versions が正しいか
 - **安全網チェック**: builder のバグで壊れたデータがアプリに渡らないための最低限の検証 (座標範囲、参照整合性、配列長一致など)
 
@@ -70,6 +70,10 @@ V1 と同じ。`--targets` モードでのみ実行。`data-v2/` 内にターゲ
 ### Step 2: File existence check
 
 必須バンドル (`data.json`, `insights.json`) の存在を確認する。任意バンドル (`shapes.json`) は存在しなければスキップ。
+
+必須バンドルを欠くソースは、**その run でビルドされなかった**ことを意味する (上流リソースの削除 / ダウンロード失敗など)。これは **skip + warn** として扱い、当該ソースを Step 3 の検証からも除外して処理を続行する。欠落ソースは Blob 上の last-good がそのまま残り (uploader は削除しない)、他のビルド済みソースは通常どおり検証・配信される。1 件の上流不調で run 全体を止めないための設計で、catalog builder の skip-tolerant 方針 (`V2_BUILD_DATA_SOURCE_CATALOG.md`) と足並みを揃えている。
+
+例外は **全ソースが欠落した場合 (total wipeout)** で、これは exit 2 (error) として停止する。ビルド系の「全失敗 = exit 2」規約と対称であり、空データの配信を防ぐ。この判定は純粋関数 `classifyExistenceOutcome` に切り出している (presentSources === 0 のときのみ fatal)。
 
 ### Step 3: Validate each bundle
 
@@ -259,37 +263,77 @@ Checked on: 2026-03-22
 Done in 42ms. (exit code: 1)
 ```
 
-### エラーありの例 (exit code: 2)
+### 一部ソース欠落の例 (exit code: 1)
+
+一部のソースが必須バンドルを欠く (上流削除等でビルドされなかった) が、他のソースはビルド済みのケース。欠落ソースは Step 2 で skip され Step 3 の検証からも除外されるが、run は warning で通過する (exit 1 なので Blob upload は継続)。
 
 ```plain
-=== Validate v2 bundles (/path/to/pipeline/workspace/_build/data-v2) ===
-
-  Validating 3 sources: minkuru, kobus, unknown
-
---- [1/5] Unvalidated directory check ---
-
-  ❌ ERROR: Unvalidated directory: broken/
-  Result: 1 unvalidated directory found.
-
 --- [2/5] File existence check ---
 
   minkuru:
     data.json ......... OK
     insights.json ..... OK
     shapes.json ....... OK
-  kobus:
-    data.json ......... OK
-    insights.json ..... ❌ MISSING (required)
+  iyt2:
+    data.json ......... ⚠️  MISSING (required - source skipped this run)
+    insights.json ..... ⚠️  MISSING (required - source skipped this run)
+    shapes.json ....... not found (optional, skipped)
+  Result: 3/6 files present (1 optional skipped).
+  ⚠️  1 source(s) skipped (required bundles missing): iyt2
+
+--- [3/5] Validate each bundle ---
+
+  minkuru:
+    [DataBundle]
+      Structure:     OK (bundle_version = 3, kind=data, 9 sections)
+      ...
+  iyt2: skipped (required bundles missing this run)
+
+... (Step 4 / 5 は通常どおり)
+
+⚠️ Validation passed with warnings.
+
+Done in 12ms. (exit code: 1)
+```
+
+### エラーありの例 (exit code: 2)
+
+必須バンドルの欠落で exit 2 になるのは **全ソースが欠落した場合 (total wipeout) のみ**。1 件でも present なら上記の一部欠落の例のとおり exit 1 (warning) となる。このほか unvalidated directory (Step 1)、構造 / データ / 参照整合性エラー (Step 3-5) も exit 2。
+
+```plain
+=== Validate v2 bundles (/path/to/pipeline/workspace/_build/data-v2) ===
+
+  Validating 2 sources: minkuru, unknown
+
+--- [1/5] Unvalidated directory check ---
+
+  Result: All directories are covered by targets.
+
+--- [2/5] File existence check ---
+
+  minkuru:
+    data.json ......... ⚠️  MISSING (required - source skipped this run)
+    insights.json ..... ⚠️  MISSING (required - source skipped this run)
     shapes.json ....... not found (optional, skipped)
   unknown:
-    data.json ......... ❌ MISSING (required)
-    insights.json ..... ❌ MISSING (required)
+    data.json ......... ⚠️  MISSING (required - source skipped this run)
+    insights.json ..... ⚠️  MISSING (required - source skipped this run)
     shapes.json ....... not found (optional, skipped)
-  Result: 4/9 files present (2 optional skipped).
+  Result: 0/6 files present (2 optional skipped).
+  ⚠️  2 source(s) skipped (required bundles missing): minkuru, unknown
 
-❌ Validation failed (required files missing).
+❌ Validation failed (no source produced its required bundles).
 
-Done in 12ms. (exit code: 2)
+Done in 8ms. (exit code: 2)
+```
+
+Step 1 の unvalidated directory も exit 2 (error) となる:
+
+```plain
+--- [1/5] Unvalidated directory check ---
+
+  ❌ ERROR: Unvalidated directory: broken/
+  Result: 1 unvalidated directory found.
 ```
 
 参照整合性エラーがある場合、Step 3 で以下のように表示される:
@@ -319,11 +363,11 @@ Done in 12ms. (exit code: 2)
 
 ## Exit Code
 
-| code | label   | 意味                                                   |
-| ---- | ------- | ------------------------------------------------------ |
-| 0    | ok      | 全チェック通過                                         |
-| 1    | warning | 警告あり (calendar 期限切れ/間近、空データなど)        |
-| 2    | error   | エラー (ファイル欠損、構造不正、参照整合性違反、fatal) |
+| code | label   | 意味                                                                                          |
+| ---- | ------- | --------------------------------------------------------------------------------------------- |
+| 0    | ok      | 全チェック通過                                                                                |
+| 1    | warning | 警告あり (calendar 期限切れ/間近、空データ、一部ソースの必須バンドル欠落による skip など)     |
+| 2    | error   | エラー (構造不正、参照整合性違反、unvalidated directory、全ソース欠落 = total wipeout、fatal) |
 
 ## 実装構成
 

--- a/pipeline/scripts/pipeline/app-data-v2/__tests__/validate-v2-bundles.test.ts
+++ b/pipeline/scripts/pipeline/app-data-v2/__tests__/validate-v2-bundles.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for validate-v2-bundles.ts existence-check policy.
+ *
+ * Focus: classifyExistenceOutcome — the pure decision that a partial miss
+ * (some sources missing their required bundles) is non-fatal and only a total
+ * wipeout (no source present) is a hard error. This is what lets a single
+ * upstream resource outage skip one source instead of blocking the whole
+ * Blob update.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { classifyExistenceOutcome, type SourcePresence } from '../validate-v2-bundles';
+
+function present(prefix: string): SourcePresence {
+  return { prefix, allRequiredPresent: true };
+}
+
+function missing(prefix: string): SourcePresence {
+  return { prefix, allRequiredPresent: false };
+}
+
+describe('classifyExistenceOutcome', () => {
+  it('all sources present: nothing missing, not fatal', () => {
+    const outcome = classifyExistenceOutcome([present('a'), present('b'), present('c')]);
+
+    expect(outcome.presentPrefixes).toEqual(['a', 'b', 'c']);
+    expect(outcome.missingPrefixes).toEqual([]);
+    expect(outcome.fatal).toBe(false);
+  });
+
+  it('partial miss: skips the missing sources, NOT fatal (the core fix)', () => {
+    // e.g. iyt2 removed upstream while every other source built fine.
+    const outcome = classifyExistenceOutcome([present('kobus'), missing('iyt2'), present('ntbus')]);
+
+    expect(outcome.presentPrefixes).toEqual(['kobus', 'ntbus']);
+    expect(outcome.missingPrefixes).toEqual(['iyt2']);
+    expect(outcome.fatal).toBe(false);
+  });
+
+  it('all sources missing: fatal (total build wipeout)', () => {
+    const outcome = classifyExistenceOutcome([missing('a'), missing('b')]);
+
+    expect(outcome.presentPrefixes).toEqual([]);
+    expect(outcome.missingPrefixes).toEqual(['a', 'b']);
+    expect(outcome.fatal).toBe(true);
+  });
+
+  it('single source present: not fatal', () => {
+    const outcome = classifyExistenceOutcome([present('only')]);
+
+    expect(outcome.fatal).toBe(false);
+    expect(outcome.presentPrefixes).toEqual(['only']);
+  });
+
+  it('single source missing: fatal (every — i.e. the one — source is missing)', () => {
+    const outcome = classifyExistenceOutcome([missing('only')]);
+
+    expect(outcome.fatal).toBe(true);
+    expect(outcome.missingPrefixes).toEqual(['only']);
+  });
+
+  it('one present among many missing: still not fatal', () => {
+    const outcome = classifyExistenceOutcome([
+      missing('a'),
+      missing('b'),
+      present('c'),
+      missing('d'),
+    ]);
+
+    expect(outcome.presentPrefixes).toEqual(['c']);
+    expect(outcome.missingPrefixes).toEqual(['a', 'b', 'd']);
+    expect(outcome.fatal).toBe(false);
+  });
+
+  it('empty target list: not fatal (degenerate — nothing to wipe out)', () => {
+    const outcome = classifyExistenceOutcome([]);
+
+    expect(outcome.presentPrefixes).toEqual([]);
+    expect(outcome.missingPrefixes).toEqual([]);
+    expect(outcome.fatal).toBe(false);
+  });
+
+  it('preserves target order in both partitions', () => {
+    const outcome = classifyExistenceOutcome([
+      present('z'),
+      missing('y'),
+      present('x'),
+      missing('w'),
+    ]);
+
+    expect(outcome.presentPrefixes).toEqual(['z', 'x']);
+    expect(outcome.missingPrefixes).toEqual(['y', 'w']);
+  });
+});

--- a/pipeline/scripts/pipeline/app-data-v2/validate-v2-bundles.ts
+++ b/pipeline/scripts/pipeline/app-data-v2/validate-v2-bundles.ts
@@ -5,7 +5,7 @@
  *
  * Runs validation in up to five steps:
  *   Step 1 — Unvalidated directory check (--targets mode only)
- *   Step 2 — File existence check (required bundles must exist)
+ *   Step 2 — File existence check (missing required bundles: partial = warn/skip, all = error)
  *   Step 3 — Validate each bundle (structure, data quality, referential integrity)
  *   Step 4 — Validate GlobalInsightsBundle (global/insights.json)
  *   Step 5 — Validate DataSourceCatalogBundle (global/data-source-catalog.json)
@@ -14,8 +14,13 @@
  *
  * Exit codes:
  *   0 — all checks passed (info notices, e.g. empty shapes, do not raise this)
- *   1 — warnings (e.g. calendar expiring)
- *   2 — errors (missing files, invalid structure, invalid data)
+ *   1 — warnings: calendar expiring, or SOME (not all) sources missing their
+ *       required bundles this run (upstream removed / build failed). Missing
+ *       sources are skipped; every source that built still validates. The Blob
+ *       uploader never deletes, so a skipped source keeps its last-good copy.
+ *   2 — errors: invalid structure / invalid data, unvalidated directory, or
+ *       EVERY source is missing its required bundles (total build wipeout). A
+ *       single upstream outage must not reach this level and block the update.
  *
  * Usage:
  *   npx tsx pipeline/scripts/pipeline/app-data-v2/validate-v2-bundles.ts <prefix>
@@ -140,6 +145,45 @@ function checkFileExistence(prefix: string): ExistenceResult {
   return { files, allRequiredPresent };
 }
 
+/** Per-source presence of required bundles, in target order. */
+export interface SourcePresence {
+  prefix: string;
+  allRequiredPresent: boolean;
+}
+
+/** Aggregate verdict of the existence check across all target sources. */
+export interface ExistenceOutcome {
+  /** Prefixes whose required bundles all exist (validated in Step 3). */
+  presentPrefixes: string[];
+  /** Prefixes missing >=1 required bundle (skipped: not built this run). */
+  missingPrefixes: string[];
+  /**
+   * Whether the existence check is a hard error (EXIT_ERROR).
+   *
+   * True ONLY on a total build wipeout: at least one source was targeted, yet
+   * none produced its required bundles. A partial miss (some present, some
+   * missing) is NOT fatal — the missing sources are skipped and the rest still
+   * validate and publish, so a single upstream resource outage can never block
+   * the whole update. This mirrors the "all failed = exit 2" convention of the
+   * build steps.
+   */
+  fatal: boolean;
+}
+
+/**
+ * Decide the existence-check verdict from each source's required-bundle
+ * presence. Pure (no I/O) so the exit-code policy is unit-testable.
+ */
+export function classifyExistenceOutcome(sources: SourcePresence[]): ExistenceOutcome {
+  const presentPrefixes = sources.filter((s) => s.allRequiredPresent).map((s) => s.prefix);
+  const missingPrefixes = sources.filter((s) => !s.allRequiredPresent).map((s) => s.prefix);
+  return {
+    presentPrefixes,
+    missingPrefixes,
+    fatal: sources.length > 0 && presentPrefixes.length === 0,
+  };
+}
+
 function printExistenceResult(
   _prefix: string,
   result: ExistenceResult,
@@ -152,8 +196,15 @@ function printExistenceResult(
     if (exists) {
       console.log(`    ${bf.filename} ${pad} OK`);
     } else if (bf.required) {
-      console.log(`    ${bf.filename} ${pad} ❌ MISSING (required)`);
-      state.hasError = true;
+      // A missing required bundle means the source did not build this run (its
+      // upstream resource was removed / 404, or its build failed). This is a
+      // partial-degradation WARNING, not a hard error: the source is skipped
+      // and its last-good copy on Blob is preserved (the uploader never
+      // deletes), while every source that did build still validates and
+      // publishes. Only a TOTAL wipeout (zero sources present) is escalated to
+      // an error, by the aggregate check in main().
+      console.log(`    ${bf.filename} ${pad} ⚠️  MISSING (required — source skipped this run)`);
+      state.hasWarn = true;
     } else {
       console.log(`    ${bf.filename} ${pad} not found (optional, skipped)`);
     }
@@ -456,9 +507,11 @@ function printMarkdownSummary(
     console.log('');
   }
 
-  // Missing required files
+  // Missing required bundles: the source did not build this run (upstream
+  // removed / build failed) and is skipped. A partial miss is a warning; a
+  // total wipeout is reported as a failure by main() separately.
   if (missingFiles.length > 0) {
-    console.log('### ❌ Missing files\n');
+    console.log('### ⚠️ Skipped sources (required bundle missing)\n');
     console.log('| Prefix | File |');
     console.log('|--------|------|');
     for (const m of missingFiles) {
@@ -631,7 +684,7 @@ async function main(): Promise<void> {
   console.log(`--- [${stepNum}/${totalSteps}] File existence check ---\n`);
 
   const existenceResults = new Map<string, ExistenceResult>();
-  let allExistencePassed = true;
+  const sourcePresence: SourcePresence[] = [];
 
   let totalFiles = 0;
   let presentFiles = 0;
@@ -643,9 +696,7 @@ async function main(): Promise<void> {
     existenceResults.set(prefix, result);
     printExistenceResult(prefix, result, state);
 
-    if (!result.allRequiredPresent) {
-      allExistencePassed = false;
-    }
+    sourcePresence.push({ prefix, allRequiredPresent: result.allRequiredPresent });
 
     for (const bf of BUNDLE_FILES) {
       totalFiles++;
@@ -662,12 +713,28 @@ async function main(): Promise<void> {
 
   const skippedNote = optionalSkipped > 0 ? ` (${optionalSkipped} optional skipped)` : '';
   console.log(`  Result: ${presentFiles}/${totalFiles} files present${skippedNote}.`);
+
+  // A source whose required bundles are missing did not build this run (its
+  // upstream resource was removed / failed to download). It is skipped, not
+  // fatal: its last-good copy on Blob is preserved (the uploader never deletes)
+  // and it stays selectable in the app, losing only its catalog metadata until
+  // it returns. printExistenceResult already recorded these as warnings, so the
+  // run still validates and publishes every source that built. Only a TOTAL
+  // wipeout — zero sources present — is a hard error (see classifyExistenceOutcome).
+  const existence = classifyExistenceOutcome(sourcePresence);
+  if (existence.missingPrefixes.length > 0) {
+    console.log(
+      `  ⚠️  ${existence.missingPrefixes.length} source(s) skipped (required bundles missing): ${existence.missingPrefixes.join(', ')}`,
+    );
+  }
   console.log('');
 
-  if (!allExistencePassed) {
-    // Print summary before early return so CI gets missing-files report
+  if (existence.fatal) {
+    // Total wipeout: no source produced its required bundles. Preserve the
+    // "all failed" hard-stop so a catastrophic pipeline failure never publishes
+    // an empty dataset. Print summary before early return so CI gets the report.
     printMarkdownSummary(allIssues, unvalidatedDirs, missingFiles, calendarByPrefix, today);
-    console.log('❌ Validation failed (required files missing).\n');
+    console.log('❌ Validation failed (no source produced its required bundles).\n');
     const elapsed = Math.round(performance.now() - t0);
     console.log(`Done in ${elapsed}ms. (exit code: ${EXIT_ERROR})`);
     process.exitCode = EXIT_ERROR;
@@ -682,9 +749,15 @@ async function main(): Promise<void> {
   console.log(`--- [${stepNum}/${totalSteps}] Validate each bundle ---\n`);
 
   for (const prefix of prefixes) {
+    const existenceResult = existenceResults.get(prefix)!;
+    if (!existenceResult.allRequiredPresent) {
+      // Skipped in Step 2 (required bundles missing this run). There is nothing
+      // to validate; it was already reported as a warning above.
+      console.log(`  ${prefix}: skipped (required bundles missing this run)\n`);
+      continue;
+    }
     console.log(`  ${prefix}:`);
-    const existence = existenceResults.get(prefix)!;
-    const sourceResult = validateSource(prefix, existence.files, state, allIssues);
+    const sourceResult = validateSource(prefix, existenceResult.files, state, allIssues);
     if (sourceResult.calendarServices.length > 0) {
       calendarByPrefix.set(prefix, sourceResult.calendarServices);
     }

--- a/pipeline/scripts/pipeline/app-data-v2/validate-v2-bundles.ts
+++ b/pipeline/scripts/pipeline/app-data-v2/validate-v2-bundles.ts
@@ -203,7 +203,7 @@ function printExistenceResult(
       // deletes), while every source that did build still validates and
       // publishes. Only a TOTAL wipeout (zero sources present) is escalated to
       // an error, by the aggregate check in main().
-      console.log(`    ${bf.filename} ${pad} ⚠️  MISSING (required — source skipped this run)`);
+      console.log(`    ${bf.filename} ${pad} ⚠️  MISSING (required - source skipped this run)`);
       state.hasWarn = true;
     } else {
       console.log(`    ${bf.filename} ${pad} not found (optional, skipped)`);


### PR DESCRIPTION
## Summary

Make v2 validation tolerant of a source whose required bundle is missing, so a
single removed upstream resource can no longer freeze the entire data update.

Previously, if any source's `data.json` / `insights.json` was absent (its upstream
resource was removed / failed to download, so it did not build), the **File
existence check** failed the whole validation step with exit 2. That gated the
Blob upload, so **none** of the healthy sources were published either — one
upstream outage stalled the whole dataset.

Now a missing required bundle is a **partial-degradation warning**: the missing
source is skipped (Step 2 + Step 3), its last-good copy on Blob is preserved (the
uploader never deletes), and every source that built still validates and
publishes. Only a **total wipeout** (no source produced its required bundles) is
fatal (exit 2), mirroring the "all failed = exit 2" convention of the build steps.

This aligns validation with the catalog builder, which was already skip-tolerant —
its documented promise (one upstream outage doesn't block the run) only actually
held once this gate was relaxed.

## Changes

- `validate-v2-bundles.ts`
  - Extract the exit-code decision into a pure `classifyExistenceOutcome()`
    (`fatal` only when `presentSources === 0`).
  - Downgrade a missing required bundle from error to warning; skip the missing
    source in Step 3; log the skipped sources.
  - Update the module exit-code TSDoc.
- `__tests__/validate-v2-bundles.test.ts` (new) — 8 cases for the decision policy
  (partial miss = not fatal, total wipeout = fatal, order preserved, etc.).
- `pipeline/docs/V2_VALIDATE.md` — document the partial/total distinction; new
  exit-1 (partial) and exit-2 (total wipeout) examples; updated exit-code table.
- `CHANGELOG.md` — `[Unreleased] / Fixed`.

## Verification

- `npm run typecheck`, eslint, prettier, markdownlint: clean.
- New unit tests: 8 passed. app-data-v2 test suite: 51 passed (no regression).
- Integration run against local `data-v2` with a phantom missing source:
  the source is reported skipped and the run exits **1** (warning), not 2 — i.e.
  the Blob upload would proceed.

## Notes

Refs #346. Left as a reference (not `Closes`) so the issue can be closed after the
partial-degradation path is confirmed on a real production run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
