### PR TITLE
feat(pipeline): opt-in parallel Build DB (GTFS CSV to SQLite)

### DIFF
--- a/.github/workflows/upload-transit-data-to-vercel-blob.yml
+++ b/.github/workflows/upload-transit-data-to-vercel-blob.yml
@@ -32,6 +32,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # The default runner setup log prints the Azure region but not the CPU /
+      # memory, which matter for tuning the CPU/memory-bound build steps (the
+      # runner allocation is indeterminate per run). Log them explicitly.
+      - name: Runner specs
+        run: |
+          echo "vCPU:   $(nproc)"
+          echo "Memory: $(free -h | awk '/^Mem:/{print $2}')"
+
       # Required: actions/checkout checks out the commit that triggered
       # the run. On rerun, this is the OLD commit — the previous run's
       # push is not included. git pull fetches the latest HEAD so that
@@ -106,6 +114,13 @@ jobs:
       # Build steps use npm run (no --env-file-if-exists, safe for CI).
       - name: Build SQLite DB
         id: build-db
+        env:
+          # Opt-in parallel DB build. Set the repository/environment Variable
+          # PIPELINE_BUILD_DB_CONCURRENCY to enable; unset expands to an empty
+          # string, which the script treats as 1 (sequential). This step is
+          # CPU- and memory-bound, so peak memory scales with concurrency -- keep
+          # the value conservative (e.g. 2-3) and watch the "Runner specs" step.
+          PIPELINE_BUILD_DB_CONCURRENCY: ${{ vars.PIPELINE_BUILD_DB_CONCURRENCY }}
         run: |
           set +e
           npm run pipeline:build:db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Pipeline: Build DB (GTFS CSV -> SQLite) バッチの opt-in 並列実行を追加 (`PIPELINE_BUILD_DB_CONCURRENCY`、既定 1 = 逐次)。GTFS download と同じ行プレフィックス streaming。CPU/メモリ律速のため並列度は控えめ推奨。(#350)
+
 ## [2026.08.02]
 
 ### Added

--- a/pipeline/.env.pipeline.example
+++ b/pipeline/.env.pipeline.example
@@ -41,3 +41,10 @@ VERCEL_V3_BLOB_READ_WRITE_TOKEN=
 # without needing extra CPU cores. Keep it small to respect the ODPT server's
 # rate limits. Values < 1 or invalid fall back to 1.
 # PIPELINE_DOWNLOAD_CONCURRENCY=1
+
+# Parallel Build DB (GTFS CSV -> SQLite) for pipeline:build:db. Default 1
+# (sequential). Unlike download this step is CPU- and memory-bound: peak memory
+# scales with concurrency (each source loads its GTFS into SQLite in a separate
+# process), so keep it conservative (e.g. 2-4) and tune to available memory.
+# Values < 1 or invalid fall back to 1.
+# PIPELINE_BUILD_DB_CONCURRENCY=1

--- a/pipeline/docs/GTFS_TO_RDB.md
+++ b/pipeline/docs/GTFS_TO_RDB.md
@@ -34,6 +34,24 @@ Usage: npx tsx pipeline/scripts/pipeline/build-gtfs-db.ts <source-name>
 
 `npm run pipeline:build:db` は `--targets pipeline/config/targets/build-db.ts` で一括処理する。ダウンロード対象リスト (`pipeline/config/targets/download-gtfs.ts`) とは独立したファイルであり、DB 格納対象のみを管理する。
 
+### 並列実行 (opt-in)
+
+`--targets` バッチは、環境変数 `PIPELINE_BUILD_DB_CONCURRENCY` で並列度を指定できる (GTFS ダウンロードの `PIPELINE_DOWNLOAD_CONCURRENCY` と同じ仕組み)。
+
+- **既定は 1** (逐次)。未設定・不正値・1 未満は 1 にフォールバックするため、**既定の挙動は変わらない** (opt-in)。
+- 各ソースの出力はライブでストリーミングされ、各行に `[source]` プレフィックスが付く (並列でも発生源が識別できる)。エラー分離・Batch Summary (ソース順)・exit code は逐次と同じ。
+- **注意 (ダウンロードとの違い)**: この工程は CPU・メモリ律速 (各ソースが別プロセスで GTFS を SQLite に展開する)。**ピークメモリが並列度に比例**するため、値は控えめ (例: 2-4) にし、ランナーのメモリに合わせて調整する。大きいソースが重なると OOM しうる。
+
+```bash
+# ローカル: pipeline/.env.pipeline.local に PIPELINE_BUILD_DB_CONCURRENCY=3 等を記述
+npm run pipeline:build:db
+
+# 直接実行
+PIPELINE_BUILD_DB_CONCURRENCY=3 npx tsx pipeline/scripts/pipeline/build-gtfs-db.ts --targets pipeline/config/targets/build-db.ts
+```
+
+CI (GitHub Actions) で有効化するには workflow の `env:` で明示的に渡す。既定では未設定 = 逐次なので、設定しない限り CI の挙動は変わらない。
+
 ### ソース名の解決
 
 `<source-name>` は `pipeline/config/resources/gtfs/` 内のリソース定義ファイル名 (拡張子なし) を指定する。

--- a/pipeline/scripts/pipeline/build-gtfs-db.ts
+++ b/pipeline/scripts/pipeline/build-gtfs-db.ts
@@ -41,8 +41,10 @@ import {
 import { INDEXES, SCHEMA } from '../../src/lib/pipeline/gtfs-schema';
 import {
   determineBatchExitCode,
+  parseConcurrencyEnv,
   printBatchSummary,
   runBatch,
+  runBatchConcurrent,
 } from '../../src/lib/pipeline/pipeline-batch';
 import {
   formatExitCode,
@@ -880,7 +882,16 @@ async function main(): Promise<void> {
     const sourceNames = await loadTargetFile(arg.path);
     console.log(`=== Batch build-db (${sourceNames.length} targets) ===\n`);
     const scriptPath = resolve(import.meta.dirname, 'build-gtfs-db.ts');
-    const results = runBatch(scriptPath, sourceNames);
+    // Opt-in parallel build via PIPELINE_BUILD_DB_CONCURRENCY (default 1 =
+    // unchanged sequential behavior). Unlike download, this step is CPU- and
+    // memory-bound (each source loads its GTFS into SQLite in a separate
+    // process), so peak memory scales with concurrency; keep the value
+    // conservative (e.g. 2-4) and tune to the runner's memory.
+    const concurrency = parseConcurrencyEnv('PIPELINE_BUILD_DB_CONCURRENCY');
+    const results =
+      concurrency > 1
+        ? await runBatchConcurrent(scriptPath, sourceNames, { concurrency })
+        : runBatch(scriptPath, sourceNames);
     printBatchSummary(results);
     const exitCode = determineBatchExitCode(results);
     console.log(`\n${formatExitCode(exitCode)}`);


### PR DESCRIPTION
## Summary

Add **opt-in** parallel Build DB (GTFS CSV -> SQLite), reusing the concurrent
batch runner introduced for GTFS download (#349). Follows the plan in #350.

`build-gtfs-db.ts --targets` now runs sources through `runBatchConcurrent` behind
`PIPELINE_BUILD_DB_CONCURRENCY` (default `1` = unchanged sequential behavior).
Logs stream live with each line prefixed by `[source]`.

## Why it is safe under concurrency

Each source builds its own `_build/db/<source>.db` in a **separate process**, via
a **temp file + atomic rename** (`<source>.db.tmp` -> `<source>.db`). So concurrent
builds never touch the same file and there is no shared SQLite resource.

Verified locally: all built DBs pass `PRAGMA integrity_check` (51/51 ok). The one
`foreign_key_check` hit (`itabashi-rin2-bus`, `agency_jp` -> `agency`) reproduces
in a **sequential** build, so it is an upstream GTFS-JP data quirk, not a
concurrency artifact — and the build pipeline does not run `foreign_key_check`
anyway.

## Key difference from download

Download is network/latency-bound; this step is **CPU- and memory-bound** (each
source loads its GTFS into SQLite in its own process). Peak memory scales with
concurrency, so keep the value **conservative (e.g. 2-3)** and tune to the
runner's memory.

## Changes

- `build-gtfs-db.ts` — opt-in `PIPELINE_BUILD_DB_CONCURRENCY` (default 1).
- CI (`upload-transit-data-to-vercel-blob.yml`):
  - Map `PIPELINE_BUILD_DB_CONCURRENCY` into the Build SQLite DB step (no-op until
    the repo/environment Variable is set).
  - Add a **Runner specs** step logging `vCPU` / `Memory` (the default runner log
    prints the Azure region but not CPU/memory, which matter for this
    CPU/memory-bound step).
- `GTFS_TO_RDB.md`, `pipeline/.env.pipeline.example` — document the new knob.
- `CHANGELOG.md`.

## Enabling in CI (after merge)

Set the repository/environment Variable `PIPELINE_BUILD_DB_CONCURRENCY` (e.g. `2`
or `3`). Unset = sequential. Check the "Runner specs" step output first to pick a
value that fits the runner's memory.

## Scope

- Only `build-gtfs-db` opts in. Other per-source build steps still run
  sequentially (candidates in #350).

Refs #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)
