### PR TITLE
chore(resources): update keio-bus and kyoto-bus GTFS to 20260803

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - Pipeline: Build DB (GTFS CSV -> SQLite) バッチの opt-in 並列実行を追加 (`PIPELINE_BUILD_DB_CONCURRENCY`、既定 1 = 逐次)。GTFS download と同じ行プレフィックス streaming。CPU/メモリ律速のため並列度は控えめ推奨。(#350)
 
+### Changed
+
+- Data: keio-bus の GTFS resource を 20260803 版へ更新。
+- Data: kyoto-bus の GTFS resource を 20260803 版へ更新。
+
 ## [2026.08.02]
 
 ### Added

--- a/pipeline/config/resources/gtfs/keio-bus.ts
+++ b/pipeline/config/resources/gtfs/keio-bus.ts
@@ -16,8 +16,8 @@ const keioBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/keio_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/keio_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/07256457-253f-41f3-9355-cc370068885d',
-      resourceId: '07256457-253f-41f3-9355-cc370068885d',
+        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/3089c863-1e58-4ba3-9d24-70b1e03a74eb',
+      resourceId: '3089c863-1e58-4ba3-9d24-70b1e03a74eb',
     },
     provider: {
       name: {
@@ -43,7 +43,7 @@ const keioBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260731',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260803',
   },
   pipeline: {
     outDir: 'keio-bus',

--- a/pipeline/config/resources/gtfs/kyoto-bus.ts
+++ b/pipeline/config/resources/gtfs/kyoto-bus.ts
@@ -17,8 +17,8 @@ const kyotoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/kyoto_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/kyoto_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/03a4087c-1ede-47b6-ac71-3ffb9f1d1f1e',
-      resourceId: '03a4087c-1ede-47b6-ac71-3ffb9f1d1f1e',
+        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/68c3b68c-e8f6-4781-97bf-fdd703943ed8',
+      resourceId: '68c3b68c-e8f6-4781-97bf-fdd703943ed8',
     },
     provider: {
       name: {
@@ -38,7 +38,7 @@ const kyotoBus: GtfsSourceDefinition = {
     routeTypes: ['bus'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260724',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260803',
   },
   pipeline: {
     outDir: 'kyoto-bus',


### PR DESCRIPTION
## Summary

Adopt the `20260803` GTFS revision for two ODPT sources, both now in-period. Triaged from the Check Transit Resources run [30735066535](https://github.com/F88/athenai-transit/actions/runs/30735066535).

| source | date | resourceId | feed window |
| --- | --- | --- | --- |
| keio-bus | 20260731 -> **20260803** | `3089c863-1e58-4ba3-9d24-70b1e03a74eb` | 2026-08-03 - 2026-12-31 |
| kyoto-bus | 20260724 -> **20260803** | `68c3b68c-e8f6-4781-97bf-fdd703943ed8` | 2026-08-03 - 2026-09-30 (Kibune Line summer schedule) |

At the run time (2026-08-02) both `date=20260803` revisions were `before` (not yet started); they became in-period on 2026-08-03. CKAN resource titles confirmed as "京王バス-20260803" / "京都バス-20260803"; the `downloadUrl` date and `resourceId` refer to the same revision.

## Changes

- `pipeline/config/resources/gtfs/keio-bus.ts`: bump `downloadUrl` date + `catalog.resourceUrl` / `catalog.resourceId`
- `pipeline/config/resources/gtfs/kyoto-bus.ts`: same three-field bump
- `CHANGELOG.md`: two entries under `[Unreleased] / Changed`

## Verification

- `npm run typecheck` passes.
- Data build runs in CI (Blob upload workflow) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)