### PR TITLE
chore(pipeline): update GTFS resources (kyoto-city-bus, iyotetsu-bus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Data: kyoto-city-bus の GTFS resource を 20260729 版へ更新。
+- Data: iyotetsu-bus の GTFS resource を 20260803 版へ更新。
+
 ## [2026.08.03]
 
 ### Added

--- a/pipeline/config/resources/gtfs/iyotetsu-bus.ts
+++ b/pipeline/config/resources/gtfs/iyotetsu-bus.ts
@@ -16,8 +16,8 @@ const iyotetsuBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/iyotetsu_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/iyotetsu_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/iyotetsu_bus_all_lines/resource/1c565a07-6b6a-4f77-be81-b3ad59a3fccd',
-      resourceId: '1c565a07-6b6a-4f77-be81-b3ad59a3fccd',
+        'https://ckan.odpt.org/dataset/iyotetsu_bus_all_lines/resource/dccc18d1-fcb7-490d-82f1-7dff57aa11f4',
+      resourceId: 'dccc18d1-fcb7-490d-82f1-7dff57aa11f4',
     },
     provider: {
       name: {
@@ -37,7 +37,7 @@ const iyotetsuBus: GtfsSourceDefinition = {
     routeTypes: ['bus'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/IyotetsuBus/AllLines.zip?date=20260720',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/IyotetsuBus/AllLines.zip?date=20260803',
   },
   pipeline: {
     outDir: 'iyotetsu-bus',

--- a/pipeline/config/resources/gtfs/kyoto-city-bus.ts
+++ b/pipeline/config/resources/gtfs/kyoto-city-bus.ts
@@ -17,8 +17,8 @@ const kyotoCityBus: GtfsSourceDefinition = {
       datasetUrl:
         'https://ckan.odpt.org/dataset/kyoto_municipal_transportation_kyoto_city_bus_gtfs',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/kyoto_municipal_transportation_kyoto_city_bus_gtfs/resource/12faf6c6-3341-4edd-90fe-3a0ebe956d05',
-      resourceId: '12faf6c6-3341-4edd-90fe-3a0ebe956d05',
+        'https://ckan.odpt.org/dataset/kyoto_municipal_transportation_kyoto_city_bus_gtfs/resource/8485100b-ebaa-41c4-9b36-aa07f624890e',
+      resourceId: '8485100b-ebaa-41c4-9b36-aa07f624890e',
     },
     provider: {
       name: {
@@ -37,7 +37,7 @@ const kyotoCityBus: GtfsSourceDefinition = {
     /** GtfsResource */
     routeTypes: ['bus'],
     downloadUrl:
-      'https://api.odpt.org/api/v4/files/odpt/KyotoMunicipalTransportation/Kyoto_City_Bus_GTFS.zip?date=20260630',
+      'https://api.odpt.org/api/v4/files/odpt/KyotoMunicipalTransportation/Kyoto_City_Bus_GTFS.zip?date=20260729',
   },
   pipeline: {
     outDir: 'kyoto-city-bus',


### PR DESCRIPTION
## Summary

Triage of the `check-transit-resources.yml` run [30788837800](https://github.com/F88/athenai-transit/actions/runs/30788837800) (2026-08-03) surfaced two sources whose adopted resource is no longer usable. Both are updated to their newest in-period revision, verified against the CKAN resource pages.

| source | before | after | reason |
| --- | --- | --- | --- |
| kyoto-city-bus | date=20260630 | **date=20260729** | Adopted resource was removed from remote (`ADOPTED_MISSING`). New revision valid 2026-07-29 - 2027-03-31. |
| iyotetsu-bus | date=20260720 | **date=20260803** | Adopted resource returned HTTP 404 (download failing). New revision valid 2026-08-01 - 2026-08-31. |

Each three-field set (`downloadUrl` date, `catalog.resourceUrl`, `catalog.resourceId`) is updated to the same version.

Note: `iyotetsu-bus`'s new feed window is short (about one month), reflecting the source's own publishing cadence.

## Out of scope

The same run also flagged two CRITICAL sources with no valid replacement available, which cannot be fixed by a version bump and need a separate disable-vs-leave decision:

- suginami-gsm (feed expired 2026-05-31, no in-period revision)
- kanto-bus (feed expired 2026-07-26, no in-period revision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)