### PR TITLE
chore(ci): reschedule Check Transit Resources to JST 19:00

### DIFF
--- a/.github/workflows/check-transit-resources.yml
+++ b/.github/workflows/check-transit-resources.yml
@@ -2,8 +2,8 @@ name: Check Transit Resources
 
 on:
   schedule:
-    # JST 14:00 (UTC 05:00) — 1 hour after update-transit-data
-    - cron: '0 5 * * *'
+    # JST 19:00 (UTC 10:00)
+    - cron: '0 10 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - Data: kyoto-city-bus の GTFS resource を 20260729 版へ更新。
 - Data: iyotetsu-bus の GTFS resource を 20260803 版へ更新。
+- CI: Check Transit Resources のスケジュールを JST 19:00 へ変更。
 
 ## [2026.08.03]
 


### PR DESCRIPTION
## Summary

Move the **Check Transit Resources** scheduled run from JST 14:00 to **JST 19:00**.

| workflow | before | after |
| --- | --- | --- |
| Check Transit Resources | `0 5 * * *` (JST 14:00 / UTC 05:00) | `0 10 * * *` (JST 19:00 / UTC 10:00) |
| Update Transit Data (Vercel Blob) | `0 0 * * *` (JST 09:00) | unchanged |

## Notes

- The upload workflow (JST 09:00) is left as-is; only the check run moves.
- Both workflows share `concurrency: gtfs-pipeline`; the new 09:00 / 19:00 spacing keeps them well apart.
- Dropped the stale inline comment (`1 hour after update-transit-data`) that no longer matched the actual timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)