### PR TITLE
chore(data): update suginami-gsm resource to 20260525

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - Data: kyoto-city-bus の GTFS resource を 20260729 版へ更新。
 - Data: iyotetsu-bus の GTFS resource を 20260803 版へ更新。
+- Data: suginami-gsm の GTFS resource を 20260525 版へ更新。
 - CI: Check Transit Resources のスケジュールを JST 19:00 へ変更。
 
 ## [2026.08.03]

--- a/pipeline/config/resources/gtfs/suginami-gsm.ts
+++ b/pipeline/config/resources/gtfs/suginami-gsm.ts
@@ -16,8 +16,8 @@ const suginamiGsm: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/tokyo_suginami_city',
       datasetUrl: 'https://ckan.odpt.org/dataset/tokyo_suginami_city_green_slow_mobility',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/tokyo_suginami_city_green_slow_mobility/resource/bdf054b4-8fe9-4673-a69f-6ac7e56e73aa',
-      resourceId: 'bdf054b4-8fe9-4673-a69f-6ac7e56e73aa',
+        'https://ckan.odpt.org/dataset/tokyo_suginami_city_green_slow_mobility/resource/609d47ae-05e8-4f65-9a45-fe4e8a0c8b7b',
+      resourceId: '609d47ae-05e8-4f65-9a45-fe4e8a0c8b7b',
     },
     provider: {
       name: {
@@ -34,7 +34,7 @@ const suginamiGsm: GtfsSourceDefinition = {
     /** GtfsResource */
     routeTypes: ['bus'],
     downloadUrl:
-      'https://api-public.odpt.org/api/v4/files/odpt/TokyoSuginamiCity/GreenSlowMobility.zip?date=20250524',
+      'https://api-public.odpt.org/api/v4/files/odpt/TokyoSuginamiCity/GreenSlowMobility.zip?date=20260525',
   },
   pipeline: {
     outDir: 'suginami-gsm',


### PR DESCRIPTION
## Summary

Updates the `suginami-gsm` GTFS resource definition from `date=20250524` to `date=20260525`.

The Check Transit Resources run [30902519893](https://github.com/F88/athenai-transit/actions/runs/30902519893) reported two errors for this source:

- `ADOPTED_MISSING`: the adopted resource no longer exists in the remote (the old CKAN resource `bdf054b4-...` is gone from the dataset page).
- `ADOPTED_EXPIRED`: the adopted feed expired on 2026-05-31.

A replacement is now published and currently valid:

| | adopted (before) | adopted (after) |
| --- | --- | --- |
| `date=` | 20250524 | 20260525 |
| feed validity | 2025-05-24 - 2026-05-31 (expired) | 2026-07-24 - 2028-06-30 (`in`) |
| `catalog.resourceId` | `bdf054b4-8fe9-4673-a69f-6ac7e56e73aa` | `609d47ae-05e8-4f65-9a45-fe4e8a0c8b7b` |

The new CKAN resource title is "杉並区グリーンスローモビリティ-20260525 / Suginami City Green Slow Mobility-20260525", confirming the UUID and the `date=` param refer to the same version.

Note: `start_at` (2026-05-25) and the feed validity window (from 2026-07-24) differ for this resource; the value adopted here follows the `date=` param as published.

## Changes

- `pipeline/config/resources/gtfs/suginami-gsm.ts` -- the three-field set (`downloadUrl` date param, `catalog.resourceUrl`, `catalog.resourceId`).
- `CHANGELOG.md` -- one line under `[Unreleased]` / `### Changed`.

## Verification

- `npm run typecheck` passes.
- Data build itself is CI's job after merge.

## Not included

Other sources in the same run are either already on the newest valid revision, or have a newer revision that has not started yet (keio-bus 2026-08-06/08-12/08-15, nishi-tokyo-bus 2026-08-29, meimon-taiyo-ferry 2026-09-01, nagoya-srt 2026-09-11). `kanto-bus` remains `ADOPTED_EXPIRED` with no valid remote replacement available -- it cannot be fixed by a version bump and needs a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)