### PR TITLE
chore(data): update keio-bus resource to 20260806

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Data: keio-bus の GTFS resource を 20260806 版へ更新。
+
 ## [2026.08.05]
 
 ### Changed

--- a/pipeline/config/resources/gtfs/keio-bus.ts
+++ b/pipeline/config/resources/gtfs/keio-bus.ts
@@ -16,8 +16,8 @@ const keioBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/keio_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/keio_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/3089c863-1e58-4ba3-9d24-70b1e03a74eb',
-      resourceId: '3089c863-1e58-4ba3-9d24-70b1e03a74eb',
+        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/e7a4bd95-a1be-4fe2-953d-ba7106f59001',
+      resourceId: 'e7a4bd95-a1be-4fe2-953d-ba7106f59001',
     },
     provider: {
       name: {
@@ -43,7 +43,7 @@ const keioBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260803',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260806',
   },
   pipeline: {
     outDir: 'keio-bus',


### PR DESCRIPTION
## Summary

Adopt the `20260806` revision of the keio-bus GTFS resource. It became
currently valid today (2026-08-06); the previously adopted `20260803`
revision is superseded.

| field | before | after |
| --- | --- | --- |
| `downloadUrl` date param | `20260803` | `20260806` |
| `catalog.resourceId` | `3089c863-1e58-4ba3-9d24-70b1e03a74eb` | `e7a4bd95-a1be-4fe2-953d-ba7106f59001` |
| feed validity | 2026-08-03 - 2026-12-31 | 2026-08-06 - 2026-12-31 |

CKAN resource title for the new id is "京王バス-20260806 / Keio Bus-20260806",
confirmed on the dataset page.

## Triage context

From Check Transit Resources run
https://github.com/F88/athenai-transit/actions/runs/30999073786 (2026-08-05).
At run time `20260806` was still `before` its start date, so it was reported
as UPCOMING rather than an update candidate; it entered its validity period
today.

Not addressed in this PR:

- **kanto-bus** is CRITICAL (adopted feed expired 2026-07-26, remote has
  0 currently valid resources). Re-checked live on 2026-08-06 — still no
  replacement available. Needs a separate decision.
- **suginami-gsm** shows ADOPTED_MISSING / ADOPTED_EXPIRED in that run, but
  the definition was already bumped to `20260525` in a3de56b0. The errors
  come from a state snapshot taken before that merge and will clear on the
  next download run.
- Later keio-bus revisions `20260812` and `20260815` exist but have not
  started yet.

## Verification

- `npm run typecheck` passes.