### PR TITLE
chore(resource): update keio-bus GTFS to 20260812

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [CalVer](https://calver.org/).
 ### Changed
 
 - Data: keio-bus の GTFS resource を 20260806 版へ更新。
+- Data: keio-bus の GTFS resource を 20260812 版へ更新。
 
 ## [2026.08.05]
 

--- a/pipeline/config/resources/gtfs/keio-bus.ts
+++ b/pipeline/config/resources/gtfs/keio-bus.ts
@@ -16,8 +16,8 @@ const keioBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/keio_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/keio_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/e7a4bd95-a1be-4fe2-953d-ba7106f59001',
-      resourceId: 'e7a4bd95-a1be-4fe2-953d-ba7106f59001',
+        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/0a03449f-0f0b-43fb-b19a-84d30cf32848',
+      resourceId: '0a03449f-0f0b-43fb-b19a-84d30cf32848',
     },
     provider: {
       name: {
@@ -43,7 +43,7 @@ const keioBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260806',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260812',
   },
   pipeline: {
     outDir: 'keio-bus',


### PR DESCRIPTION
## Summary

Bump the adopted Keio Bus GTFS resource from `date=20260806` to `date=20260812`.

Triaged from the Check Transit Resources run
https://github.com/F88/athenai-transit/actions/runs/31481653225 — at run time (2026-08-11)
the `20260812` revision was still `before` its `start_at`; it became valid on 2026-08-12.

## Changes

- `pipeline/config/resources/gtfs/keio-bus.ts`: `downloadUrl` / `catalog.resourceUrl` /
  `catalog.resourceId` all moved to the same version.
  - CKAN resource `0a03449f-0f0b-43fb-b19a-84d30cf32848` (title "keio bus-20260812")
- `CHANGELOG.md`: one line appended under `[Unreleased]` / `### Changed`.

## Verification

- CKAN resource page confirms the resource id maps to `date=20260812`.
- Feed validity `2026-08-12 - 2026-12-31` — same end date as the previous `20260806`
  revision, so coverage does not shrink.
- `npm run typecheck` passes.

## Notes

A newer revision `date=20260815` (feed `2026-08-15 - 2026-12-31`) is already published and
will become adoptable on 2026-08-15.

Data build/upload is CI's job after merge; no pipeline was run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)