### PR TITLE
chore(resources): update kyoto-bus GTFS to 20260813

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - Data: keio-bus の GTFS resource を 20260806 版へ更新。
 - Data: keio-bus の GTFS resource を 20260812 版へ更新。
+- Data: kyoto-bus の GTFS resource を 20260813 版へ更新。
 
 ## [2026.08.05]
 

--- a/pipeline/config/resources/gtfs/kyoto-bus.ts
+++ b/pipeline/config/resources/gtfs/kyoto-bus.ts
@@ -17,8 +17,8 @@ const kyotoBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/kyoto_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/kyoto_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/68c3b68c-e8f6-4781-97bf-fdd703943ed8',
-      resourceId: '68c3b68c-e8f6-4781-97bf-fdd703943ed8',
+        'https://ckan.odpt.org/dataset/kyoto_bus_all_lines/resource/18ca0876-acff-4c37-8489-00873c821327',
+      resourceId: '18ca0876-acff-4c37-8489-00873c821327',
     },
     provider: {
       name: {
@@ -38,7 +38,7 @@ const kyotoBus: GtfsSourceDefinition = {
     routeTypes: ['bus'],
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260803',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KyotoBus/AllLines.zip?date=20260813',
   },
   pipeline: {
     outDir: 'kyoto-bus',


### PR DESCRIPTION
## Summary

Adopt the `date=20260813` revision for `kyoto-bus` (feed: 2026-08-13 - 2026-09-30). It became valid today, verified by a live re-run of `check-odpt-resources.ts` (status changed `before` -> `in`).

Previously adopted: `date=20260803` (feed: 2026-08-03 - 2026-09-30).

## Changes

- `pipeline/config/resources/gtfs/kyoto-bus.ts`: the three-field set updated to the same version
  - `downloadUrl`: `date=20260803` -> `date=20260813`
  - `catalog.resourceUrl` / `catalog.resourceId`: `18ca0876-acff-4c37-8489-00873c821327` (CKAN title: 京都バス-20260813 / Kyotobus-20260813)
- `CHANGELOG.md`: one line under `[Unreleased]` / `### Changed`

## Verification

- `npm run typecheck`: pass
- Triage source run: https://github.com/F88/athenai-transit/actions/runs/31587185163

## Notes

Other sources have no adoptable revision today. `keio-bus` (20260815), `nishi-tokyo-bus` (20260829), `meimon-taiyo-ferry` (20260901) and `nagoya-srt` (20260911) are still `before` their start_at. `kanto-bus` remains expired with no valid remote replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)