### PR TITLE
chore(pipeline): update GTFS resources (suginami-gsm, keio-bus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Data: suginami-gsm の GTFS resource を 20260601 版へ更新。
+- Data: keio-bus の GTFS resource を 20260815 版へ更新。
+
 ## [2026.08.13]
 
 ### Changed

--- a/pipeline/config/resources/gtfs/keio-bus.ts
+++ b/pipeline/config/resources/gtfs/keio-bus.ts
@@ -16,8 +16,8 @@ const keioBus: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/keio_bus',
       datasetUrl: 'https://ckan.odpt.org/dataset/keio_bus_all_lines',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/0a03449f-0f0b-43fb-b19a-84d30cf32848',
-      resourceId: '0a03449f-0f0b-43fb-b19a-84d30cf32848',
+        'https://ckan.odpt.org/dataset/keio_bus_all_lines/resource/b0d41c49-6cf8-4682-917b-b9a3c3c8ecae',
+      resourceId: 'b0d41c49-6cf8-4682-917b-b9a3c3c8ecae',
     },
     provider: {
       name: {
@@ -43,7 +43,7 @@ const keioBus: GtfsSourceDefinition = {
     },
     // The date parameter is required and must match a published version on CKAN.
     // Update this value when a new version is published.
-    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260812',
+    downloadUrl: 'https://api.odpt.org/api/v4/files/odpt/KeioBus/AllLines.zip?date=20260815',
   },
   pipeline: {
     outDir: 'keio-bus',

--- a/pipeline/config/resources/gtfs/suginami-gsm.ts
+++ b/pipeline/config/resources/gtfs/suginami-gsm.ts
@@ -16,8 +16,8 @@ const suginamiGsm: GtfsSourceDefinition = {
       organizationUrl: 'https://ckan.odpt.org/organization/tokyo_suginami_city',
       datasetUrl: 'https://ckan.odpt.org/dataset/tokyo_suginami_city_green_slow_mobility',
       resourceUrl:
-        'https://ckan.odpt.org/dataset/tokyo_suginami_city_green_slow_mobility/resource/609d47ae-05e8-4f65-9a45-fe4e8a0c8b7b',
-      resourceId: '609d47ae-05e8-4f65-9a45-fe4e8a0c8b7b',
+        'https://ckan.odpt.org/dataset/tokyo_suginami_city_green_slow_mobility/resource/239b299c-37b0-477d-9b25-7fc4a5efca0d',
+      resourceId: '239b299c-37b0-477d-9b25-7fc4a5efca0d',
     },
     provider: {
       name: {
@@ -34,7 +34,7 @@ const suginamiGsm: GtfsSourceDefinition = {
     /** GtfsResource */
     routeTypes: ['bus'],
     downloadUrl:
-      'https://api-public.odpt.org/api/v4/files/odpt/TokyoSuginamiCity/GreenSlowMobility.zip?date=20260525',
+      'https://api-public.odpt.org/api/v4/files/odpt/TokyoSuginamiCity/GreenSlowMobility.zip?date=20260601',
   },
   pipeline: {
     outDir: 'suginami-gsm',


### PR DESCRIPTION
## Summary

Bump two ODPT GTFS resource definitions. Each change updates the three-field set: `downloadUrl` `date=` param, `catalog.resourceUrl`, `catalog.resourceId`.

| source | before | after | feed period |
| --- | --- | --- | --- |
| `suginami-gsm` | date=20260525 | date=20260601 | 2026-07-24 - 2028-06-30 |
| `keio-bus` | date=20260812 | date=20260815 | 2026-08-15 - 2026-12-31 |

## Why

### suginami-gsm (fixes a failing daily job)

The adopted resource `date=20260525` is no longer served by the Members Portal. The daily "Update Transit Data (Vercel Blob)" run fails on it with `HTTP 404 Not Found` after 3 attempts, and every downstream step is skipped for this source:

```
[suginami-gsm] Downloading .../GreenSlowMobility.zip?date=20260525
[suginami-gsm] FATAL: Failed after 3 attempts: Error: HTTP 404 Not Found
```

All 6 batch steps (GTFS download, DB build, v2 data, v2 shapes, v2 insights, catalog) reported exactly 1 failed/skipped source -- suginami-gsm -- which is what turned on the `Warn on * partial failure` steps in run 31916819722. `date=20260601` is the only currently valid remote resource for this source.

### keio-bus

`date=20260815` is the newest currently valid revision; the adopted `date=20260812` is one row below it.

## Verification

- CKAN resource pages confirm each new UUID maps to the same version as the new `date=` param:
  - suginami-gsm: `239b299c-37b0-477d-9b25-7fc4a5efca0d` -> `?date=20260601`, valid 2026-07-24 - 2028-06-30, version `Suginami_City_Guri_20260724`
  - keio-bus: `b0d41c49-6cf8-4682-917b-b9a3c3c8ecae` -> `?date=20260815`, valid 2026-08-15 - 2026-12-31
- Both match the top `in` row of the corresponding block in the Check Transit Resources run.
- `npm run typecheck` passes.

## Out of scope

`kanto-bus` remains `ADOPTED_EXPIRED` / `REMOTE_NO_VALID_DATA`. Its dataset has exactly one remote resource and it is expired, so there is no replacement to adopt. Left as-is deliberately; the check job stays red for it.

Source run: https://github.com/F88/athenai-transit/actions/runs/31878619496

🤖 Generated with [Claude Code](https://claude.com/claude-code)
