### PR TITLE
feat(search): fold fullwidth Latin and digits in stop search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- のりば検索: 全角の英字・数字を含むのりば名を、半角で入力したクエリでも検索できるようにした (#362)。
+
 ## [2026.08.16]
 
 ### Changed

--- a/src/components/search/stop-search-result-item.tsx
+++ b/src/components/search/stop-search-result-item.tsx
@@ -30,9 +30,12 @@ interface HighlightedNameProps {
  *   1. direct substring,
  *   2. case-insensitive substring,
  *   3. {@link normalizeForSearch} substring — same pipeline as the search
- *      index (case + kana + Latin-diacritic collapsed). The pipeline is a
- *      1:1 character mapping in NFC, so the index found in the normalized
- *      string aligns with the original `name` for the slice below.
+ *      index (width + case + kana + Latin-diacritic collapsed). The pipeline
+ *      is a 1:1 character mapping in NFC, so the index found in the normalized
+ *      string aligns with the original `name` for the slice below. That
+ *      invariant is pinned by a test in the `normalizeForSearch` suite; do not
+ *      add a length-changing step (NFKC, halfwidth-kana folding) without
+ *      reworking the slicing here.
  */
 function HighlightedName({ name, query, normalizedQuery }: HighlightedNameProps) {
   if (!query) {

--- a/src/domain/transit/__tests__/stop-search-index.test.ts
+++ b/src/domain/transit/__tests__/stop-search-index.test.ts
@@ -6,6 +6,15 @@ import {
   normalizeForSearch,
 } from '../stop-search-index';
 
+/**
+ * Build a string from code points. Fullwidth characters are constructed rather
+ * than written literally so the expectations stay unambiguous about which code
+ * point they cover.
+ */
+function cp(...codes: number[]): string {
+  return String.fromCharCode(...codes);
+}
+
 function makeStop(
   partial: Pick<Stop, 'stop_id' | 'stop_name' | 'stop_names'> & Partial<Stop>,
 ): Stop {
@@ -48,6 +57,45 @@ describe('normalizeForSearch', () => {
     // Pre-decomposed input should still come out NFC-recomposed.
     const decomposed = 'Ōyana'; // O + combining macron
     expect(normalizeForSearch(decomposed)).toBe('oyana');
+  });
+
+  it('folds fullwidth Latin letters to halfwidth', () => {
+    // U+FF2E U+FF34 U+FF34 is the fullwidth spelling of "NTT", used in iyt2 /
+    // od9bus / minkuru stop names. Typing halfwidth "ntt" must reach them.
+    expect(normalizeForSearch(cp(0xff2e, 0xff34, 0xff34))).toBe('ntt');
+    expect(normalizeForSearch(cp(0xff2a, 0xff32) + '王子駅')).toBe('jr王子駅');
+  });
+
+  it('folds fullwidth digits to halfwidth', () => {
+    // yhb / ntbus write chome numbers with fullwidth digits.
+    expect(normalizeForSearch('安善町' + cp(0xff12) + '丁目')).toBe('安善町2丁目');
+    expect(normalizeForSearch(cp(0xff10, 0xff19))).toBe('09');
+  });
+
+  it('leaves halfwidth katakana unchanged (folded separately, see TSDoc)', () => {
+    // U+FF7C U+FF9E is halfwidth "si" + voiced mark. kobus stores every
+    // ja-Hrkt reading this way; folding it is out of scope here because the
+    // fold is not 1:1 and would break the highlight offset invariant.
+    const halfwidthKana = cp(0xff7c, 0xff9e);
+    expect(normalizeForSearch(halfwidthKana)).toBe(halfwidthKana);
+  });
+
+  it('preserves length for NFC input, which the search highlight relies on', () => {
+    // Tripwire for HighlightedName: it finds an index in the normalized string
+    // and slices the ORIGINAL name at that index, so the pipeline must map one
+    // character to one character. A switch to NFKC or a halfwidth-kana fold
+    // would break this silently -- the highlight would land on the wrong
+    // characters rather than fall back to "no highlight".
+    const inputs = [
+      cp(0xff2a, 0xff32) + '王子駅', // fullwidth "JR" + kanji
+      '安善町' + cp(0xff12) + '丁目', // fullwidth digit
+      'がっこう', // precomposed kana with dakuten
+      'パーク', // katakana with a prolonged sound mark
+      'Shibuya',
+    ];
+    for (const input of inputs) {
+      expect(normalizeForSearch(input)).toHaveLength(input.length);
+    }
   });
 });
 
@@ -377,6 +425,43 @@ describe('filterStopsByQuery', () => {
     ];
     const result = filterStopsByQuery(stops2.map(buildSearchIndexEntry), 'sta.', 10);
     expect(result.stops.map((s) => s.stop_id)).toEqual(['p1', 'p2', 'p10', 'pNone']);
+  });
+
+  it('matches fullwidth-digit names from a halfwidth query (yhb / ntbus shape)', () => {
+    // Real shape: the ja name carries a fullwidth digit, the en name spells the
+    // number as "N-chome" and ja-Hrkt spells it in kana, so neither rescues a
+    // "2丁目" query. Before the width fold these stops were unreachable unless
+    // the user typed the fullwidth digit, which a mobile IME does not produce.
+    const stops2: Stop[] = [
+      makeStop({
+        stop_id: 'anzen',
+        stop_name: '安善町' + cp(0xff12) + '丁目',
+        stop_names: {
+          ja: '安善町' + cp(0xff12) + '丁目',
+          'ja-Hrkt': 'あんぜんちょうにちょうめ',
+          en: 'Anzencho 2-chome',
+        },
+      }),
+    ];
+    const idx = stops2.map(buildSearchIndexEntry);
+    expect(filterStopsByQuery(idx, '2丁目', 10).stops.map((s) => s.stop_id)).toEqual(['anzen']);
+    expect(filterStopsByQuery(idx, '安善町2', 10).stops.map((s) => s.stop_id)).toEqual(['anzen']);
+  });
+
+  it('matches fullwidth-Latin names from a halfwidth query (iyt2 shape)', () => {
+    // Abbreviations written in fullwidth Latin with no en counterpart have no
+    // fallback candidate name, unlike the JR-prefixed stops that an en
+    // translation happens to rescue.
+    const stops2: Stop[] = [
+      makeStop({
+        stop_id: 'ntt',
+        stop_name: cp(0xff2e, 0xff34, 0xff34) + '研修センター前',
+        stop_names: { ja: cp(0xff2e, 0xff34, 0xff34) + '研修センター前' },
+      }),
+    ];
+    const idx = stops2.map(buildSearchIndexEntry);
+    expect(filterStopsByQuery(idx, 'ntt', 10).stops.map((s) => s.stop_id)).toEqual(['ntt']);
+    expect(filterStopsByQuery(idx, 'NTT', 10).stops.map((s) => s.stop_id)).toEqual(['ntt']);
   });
 
   it('does not match across name boundaries', () => {

--- a/src/domain/transit/stop-search-index.ts
+++ b/src/domain/transit/stop-search-index.ts
@@ -1,14 +1,27 @@
 import type { Stop } from '@/types/app/transit';
 import { katakanaToHiragana } from '@/utils/kana-normalize';
+import { fullwidthAlnumToHalfwidth } from '@/utils/width-normalize';
 
 /**
  * Normalize a string for stop search.
  *
  * Pipeline:
- *   1. `toLowerCase` — collapse case (`NAKA` / `Naka` / `naka` → `naka`).
- *   2. `katakanaToHiragana` — collapse kana script (`ナカ` → `なか`).
- *   3. NFD → strip Latin combining marks (U+0300–U+036F) → NFC —
+ *   1. `fullwidthAlnumToHalfwidth` -- collapse character width for Latin
+ *      letters and digits. Feeds spell the same name both ways (U+FF2E U+FF34
+ *      U+FF34 vs `NTT`, U+FF12 丁目 vs `2丁目`), and a mobile IME produces the
+ *      halfwidth form, so without this the fullwidth spellings are effectively
+ *      unreachable.
+ *   2. `toLowerCase` — collapse case (`NAKA` / `Naka` / `naka` → `naka`).
+ *   3. `katakanaToHiragana` — collapse kana script (`ナカ` → `なか`).
+ *   4. NFD → strip Latin combining marks (U+0300–U+036F) → NFC —
  *      collapse Latin diacritics (`Ōyana` → `oyana`, `café` → `cafe`).
+ *
+ * Halfwidth katakana is deliberately NOT folded here. kobus stores every
+ * `ja-Hrkt` reading in halfwidth katakana, so folding it would be a large
+ * search win, but the fold is not one-to-one (halfwidth "si" plus a voiced
+ * mark is two code points, the composed form is one) and the search highlight
+ * currently depends on this pipeline preserving character offsets. See the
+ * length note below.
  *
  * Why the strip range is narrowed to U+0300–U+036F: kana voicing marks
  * live in U+3099 / U+309A. Stripping `\p{Diacritic}` wholesale would
@@ -17,12 +30,19 @@ import { katakanaToHiragana } from '@/utils/kana-normalize';
  * Marks block keeps kana voicing intact while still catching macron,
  * acute, grave, circumflex, tilde, diaeresis, caron, cedilla, etc.
  *
- * The trailing NFC re-composes any kana that NFD decomposed in step 3
+ * The trailing NFC re-composes any kana that NFD decomposed in step 4
  * (e.g. `が` → `か` + U+3099 → recomposed back to `が`), so callers can
  * rely on the output being canonical (NFC) regardless of input form.
+ *
+ * Length: every step above maps one character to one character for NFC input,
+ * so the output has the same length as the input and an offset found in the
+ * normalized string still points at the right place in the original.
+ * `HighlightedName` relies on this -- it locates a match in the normalized name
+ * and then slices the raw name at that index. Any future step that changes
+ * length (NFKC, halfwidth-kana folding) has to fix the highlight first.
  */
 export function normalizeForSearch(s: string): string {
-  return katakanaToHiragana(s.toLowerCase())
+  return katakanaToHiragana(fullwidthAlnumToHalfwidth(s).toLowerCase())
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .normalize('NFC');
@@ -120,10 +140,12 @@ export interface FilterStopsByQueryResult {
 /**
  * Filter and rank a search index for a free-text query.
  *
- * Matching: case-insensitive + katakana→hiragana normalized substring match
- * against any value of `stop.stop_names`. The query is normalized the same
- * way as the index entries, so e.g. `naka` / `NAKA` / `ナカ` / `なか` all
- * behave identically against an entry containing `Nakanobu` / `なかのぶ`.
+ * Matching: width-, case- and kana-normalized substring match against any
+ * value of `stop.stop_names`. The query is normalized the same way as the
+ * index entries, so e.g. `naka` / `NAKA` / `ナカ` / `なか` all behave
+ * identically against an entry containing `Nakanobu` / `なかのぶ`, and a
+ * halfwidth query reaches a fullwidth name (`ntt` finds U+FF2E U+FF34 U+FF34,
+ * `2丁目` finds U+FF12 丁目).
  *
  * Ranking (each step is a tiebreaker for the previous):
  *   1. Prefix bonus — any normalized name starts with the normalized query.

--- a/src/utils/__tests__/width-normalize.test.ts
+++ b/src/utils/__tests__/width-normalize.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { fullwidthAlnumToHalfwidth } from '../width-normalize';
+
+/**
+ * Build a string from code points. Fullwidth characters are constructed rather
+ * than written literally so this file stays ASCII, which also makes the
+ * boundary cases below unambiguous about which code point they cover.
+ */
+function cp(...codes: number[]): string {
+  return String.fromCharCode(...codes);
+}
+
+const FULLWIDTH_A = 0xff21;
+const FULLWIDTH_Z = 0xff3a;
+const FULLWIDTH_SMALL_A = 0xff41;
+const FULLWIDTH_SMALL_Z = 0xff5a;
+const FULLWIDTH_ZERO = 0xff10;
+const FULLWIDTH_NINE = 0xff19;
+const FULLWIDTH_J = 0xff2a;
+const FULLWIDTH_R = 0xff32;
+const FULLWIDTH_TWO = 0xff12;
+
+describe('fullwidthAlnumToHalfwidth', () => {
+  it('converts fullwidth uppercase letters', () => {
+    expect(fullwidthAlnumToHalfwidth(cp(FULLWIDTH_J, FULLWIDTH_R))).toBe('JR');
+  });
+
+  it('converts fullwidth lowercase letters', () => {
+    expect(fullwidthAlnumToHalfwidth(cp(FULLWIDTH_SMALL_A, FULLWIDTH_SMALL_Z))).toBe('az');
+  });
+
+  it('converts fullwidth digits', () => {
+    expect(fullwidthAlnumToHalfwidth(cp(FULLWIDTH_ZERO, FULLWIDTH_TWO, FULLWIDTH_NINE))).toBe(
+      '029',
+    );
+  });
+
+  it('converts the boundary code points of every range', () => {
+    expect(fullwidthAlnumToHalfwidth(cp(FULLWIDTH_A, FULLWIDTH_Z))).toBe('AZ');
+    expect(fullwidthAlnumToHalfwidth(cp(FULLWIDTH_SMALL_A, FULLWIDTH_SMALL_Z))).toBe('az');
+    expect(fullwidthAlnumToHalfwidth(cp(FULLWIDTH_ZERO, FULLWIDTH_NINE))).toBe('09');
+  });
+
+  it('leaves code points just outside each range unchanged', () => {
+    // U+FF0F is just below fullwidth 0, U+FF1A just above fullwidth 9,
+    // U+FF20 just below fullwidth A, U+FF3B just above fullwidth Z,
+    // U+FF40 just below fullwidth a, U+FF5B just above fullwidth z.
+    const outside = cp(0xff0f, 0xff1a, 0xff20, 0xff3b, 0xff40, 0xff5b);
+    expect(fullwidthAlnumToHalfwidth(outside)).toBe(outside);
+  });
+
+  it('leaves fullwidth parentheses unchanged (out of scope by design)', () => {
+    const parens = cp(0xff08, 0xff09);
+    expect(fullwidthAlnumToHalfwidth(parens)).toBe(parens);
+  });
+
+  it('leaves halfwidth katakana unchanged (handled separately, not 1:1)', () => {
+    // U+FF7C U+FF9E is halfwidth "si" + voiced mark.
+    const halfwidthKana = cp(0xff7c, 0xff9e);
+    expect(fullwidthAlnumToHalfwidth(halfwidthKana)).toBe(halfwidthKana);
+  });
+
+  it('leaves halfwidth ASCII unchanged', () => {
+    expect(fullwidthAlnumToHalfwidth('JR2')).toBe('JR2');
+  });
+
+  it('leaves kanji, hiragana and katakana unchanged', () => {
+    expect(fullwidthAlnumToHalfwidth('王子駅')).toBe('王子駅');
+    expect(fullwidthAlnumToHalfwidth('あおい')).toBe('あおい');
+    expect(fullwidthAlnumToHalfwidth('アオイ')).toBe('アオイ');
+  });
+
+  it('converts only the fullwidth run inside a mixed stop name', () => {
+    expect(fullwidthAlnumToHalfwidth(cp(FULLWIDTH_J, FULLWIDTH_R) + '王子駅')).toBe('JR王子駅');
+    expect(fullwidthAlnumToHalfwidth('安善町' + cp(FULLWIDTH_TWO) + '丁目')).toBe('安善町2丁目');
+  });
+
+  it('preserves length, which the search highlight relies on', () => {
+    const mixed = cp(FULLWIDTH_J, FULLWIDTH_R) + '王子駅' + cp(FULLWIDTH_TWO) + 'abc';
+    expect(fullwidthAlnumToHalfwidth(mixed)).toHaveLength(mixed.length);
+  });
+
+  it('handles empty string', () => {
+    expect(fullwidthAlnumToHalfwidth('')).toBe('');
+  });
+});

--- a/src/utils/width-normalize.ts
+++ b/src/utils/width-normalize.ts
@@ -1,0 +1,48 @@
+/**
+ * Fold fullwidth Latin letters and digits to their halfwidth equivalents by
+ * subtracting 0xFEE0.
+ *
+ * The fullwidth forms sit exactly 0xFEE0 above their ASCII counterparts, so one
+ * subtraction covers all three ranges:
+ *
+ * - U+FF21-U+FF3A: fullwidth A-Z  -> U+0041-U+005A
+ * - U+FF41-U+FF5A: fullwidth a-z  -> U+0061-U+007A
+ * - U+FF10-U+FF19: fullwidth 0-9  -> U+0030-U+0039
+ *
+ * Scope is deliberately limited to letters and digits:
+ *
+ * - Fullwidth punctuation (U+FF08 and friends) is left alone. Parentheses are
+ *   never a search term, so folding them would add churn without adding hits.
+ * - Halfwidth katakana is NOT handled here. That fold is not one-to-one
+ *   (halfwidth "si" plus a voiced mark is two code points, the fullwidth form
+ *   is one), so it cannot share this function's length guarantee.
+ *
+ * The mapping is strictly one character to one character, so callers may rely
+ * on the output having the same length as the input. Stop-name search highlight
+ * depends on that: it locates a match in the normalized string and then slices
+ * the original name at the same offset.
+ *
+ * @param str - Input string potentially containing fullwidth letters or digits.
+ * @returns New string with fullwidth letters and digits replaced by halfwidth.
+ *
+ * @example
+ * Real stop names, with the fullwidth run spelled out because this file is
+ * kept ASCII:
+ *
+ * ```text
+ * U+FF2A U+FF32 王子駅       -> JR王子駅
+ * 安善町 U+FF12 丁目         -> 安善町2丁目
+ * ```
+ */
+export function fullwidthAlnumToHalfwidth(str: string): string {
+  let result = '';
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    const isFullwidthUpper = code >= 0xff21 && code <= 0xff3a;
+    const isFullwidthLower = code >= 0xff41 && code <= 0xff5a;
+    const isFullwidthDigit = code >= 0xff10 && code <= 0xff19;
+    const isFullwidthAlnum = isFullwidthUpper || isFullwidthLower || isFullwidthDigit;
+    result += isFullwidthAlnum ? String.fromCharCode(code - 0xfee0) : str[i];
+  }
+  return result;
+}


### PR DESCRIPTION
Closes #362.

## What

`normalizeForSearch` folded case, kana script and Latin diacritics, but not
character **width**. Stop names written with fullwidth Latin letters or digits
were only reachable by typing those same fullwidth characters, which a mobile
IME does not produce.

This adds a width fold for fullwidth `A-Z` / `a-z` / `0-9` as the first step of
the pipeline. The functional change is one line:

```diff
- return katakanaToHiragana(s.toLowerCase())
+ return katakanaToHiragana(fullwidthAlnumToHalfwidth(s).toLowerCase())
```

Because both the query and the index run through the same pipeline, all four
width combinations now match -- a halfwidth query reaches a fullwidth name and
vice versa. That second direction matters because the same name is spelled both
ways across feeds (`東町３丁目` and `東町3丁目`).

## Why one character to one character matters

`HighlightedName` locates a match in the *normalized* string and then slices the
*original* name at that index, so the pipeline has to preserve character
offsets. Fullwidth-to-halfwidth is strictly 1:1, so the highlight is unaffected.

That invariant was documented in TSDoc but nothing enforced it. This PR adds a
test that pins it, and a comment warning that NFKC or a halfwidth-kana fold
would break the highlight silently -- those folds change length, so the
highlight would land on the wrong characters rather than fall back to "no
highlight".

## Impact (measured 2026-08-16, delivered v2 data)

Queries modelled as the halfwidth form of a delimiter-split token:

| | stops |
| --- | --- |
| Total stops | 33,089 |
| Stops with a fullwidth Latin/digit token | 1,154 |
| ... already findable today | 464 |
| ... **newly findable** | **690** |

Top sources: yhb 193, ntbus 180, od9bus 43, rintan 39, minkuru 37, sbbus 33,
iyt2 31.

Fullwidth digits dominate (`安善町２丁目`, `千人町１丁目`); "N丁目" is a very
common search term. Fullwidth Latin is smaller but has no fallback when there is
no `en` translation (`ＮＴＴ`, `ＪＥＲＡ`), unlike `ＪＲ` which an `en` name
usually rescues.

## Out of scope

Halfwidth katakana. It is the larger gap -- all 2,927 kobus stops carry a
`ja-Hrkt` reading and every one is halfwidth katakana, so typing those readings
finds only 6 of them. It is not a data shortage; the fold is simply not 1:1
(`ｼﾞ` is two code points, `ジ` is one) and `ja-Hrkt` is rendered and highlighted
as a sub-name, so the highlight has to stop depending on offsets first. Tracked
separately.

## Verification

- `typecheck` / `lint` / `format` clean
- `test`: 339 files, 4665 tests pass (18 added)
- `build` clean
- Shipped code run over the real v2 dataset: 145,797 indexed names, zero length
  changes, so the 1:1 invariant holds on real data
- Browser (dev server, `?sources=ntbus`): `2丁目` returns 20 hits against
  fullwidth names and `gmg` finds `ＧＭＧゴルフ場`; the `<mark>` lands exactly on
  the fullwidth run in both. `八王子駅` and `コンセール` behave as before.
